### PR TITLE
feat(paper-gaps): adopt the Wolf notes from TNLean

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -4,7 +4,8 @@ name: Blueprint
 # step (no tenkz diagrams in QICLean's blueprint; see ci/README.md) and the
 # FT-MPS-volume packaging step (that split PDF is TNLean-specific). Otherwise
 # unchanged: same leanblueprint build, same error/warning gating, same
-# generated-page reader-facing check, same Pages deploy handoff.
+# paper-gap reference check, same generated-page reader-facing check, same
+# Pages deploy handoff.
 
 on:
   push:
@@ -16,6 +17,12 @@ on:
       - 'lean-toolchain'
       - 'lake-manifest.json'
       - 'blueprint/src/**'
+      - 'docs/paper-gaps/**'
+      - 'texra-blueprint.toml'
+      # Trees the paper-gap reference check scans (texra-blueprint
+      # paper-gaps check); without these the check never runs
+      # on merge pushes that only touch a scanned file.
+      - 'docs/**/*.md'
       - '.github/workflows/blueprint.yml'
       - '.github/workflows/deploy-pages.yml'
       - 'home_page/**'
@@ -46,7 +53,10 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.1.0'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.1'
+
+      - name: Check paper-gap references resolve
+        run: texra-blueprint paper-gaps check
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.1'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
 
       - name: Check paper-gap references resolve
         run: texra-blueprint paper-gaps check

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.1'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -1,9 +1,9 @@
 name: Full documentation
 
-# Adapted from TNLean's docgen.yml: drops the paper-gap PDF build step (see
-# ci/README.md — QICLean's paper-gaps subset is copied separately, and its
-# PDFs are built the same way if/when QICLean accumulates its own notes) and
-# the FT-MPS split-volume packaging step. Otherwise unchanged.
+# Adapted from TNLean's docgen.yml: drops the FT-MPS split-volume packaging
+# step (that split PDF is TNLean-specific). The paper-gap PDF build and site
+# packaging mirror TNLean's, calling the texra-blueprint CLI directly rather
+# than through TNLean's wrapper scripts. Otherwise unchanged.
 
 on:
   schedule:
@@ -62,10 +62,13 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.1.0'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.1'
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py
+
+      - name: Build paper-gap PDFs
+        run: texra-blueprint --root . paper-gaps build
 
       - name: Build blueprint
         working-directory: blueprint
@@ -104,6 +107,7 @@ jobs:
           cp -r blueprint/web site-blueprint/blueprint
           cp blueprint/print/print.pdf site-blueprint/blueprint.pdf
           cp -r docbuild/.lake/build/doc site-docs/docs
+          texra-blueprint --root . paper-gaps site site-docs/paper-gaps
           python3 scripts/write_badges.py site-badges
 
       - name: Build homepage

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -390,7 +390,7 @@ jobs:
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.1'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
 
       - name: Check paper-gap references resolve
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -41,12 +41,23 @@ on:
       - 'scripts/blueprint_lean_sync.py'
       - 'scripts/test_blueprint_web_render.py'
       - 'scripts/check_reader_facing_prose.py'
+      - 'docs/paper-gaps/**'
+      - 'texra-blueprint.toml'
+      # Trees the paper-gap reference check scans (texra-blueprint
+      # paper-gaps check); without these the check never runs
+      # on merge pushes that only touch a scanned file.
+      - 'docs/**/*.md'
       - 'LICENSE'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - 'docs/paper-gaps/**/*.tex'
       - 'docs/paper-gaps/**/*.bib'
+      - 'texra-blueprint.toml'
+      # Trees the paper-gap reference check scans (texra-blueprint
+      # paper-gaps check); without these the check never runs
+      # on PRs that only touch a scanned file.
+      - 'docs/**/*.md'
       - '**.lean'
       - 'lakefile.*'
       - 'lean-toolchain'
@@ -106,6 +117,7 @@ jobs:
       lean: ${{ steps.filter.outputs.lean }}
       module_policy: ${{ steps.filter.outputs.module_policy }}
       blueprint: ${{ steps.filter.outputs.blueprint }}
+      paper_gaps: ${{ steps.filter.outputs.paper_gaps }}
     steps:
       - uses: dorny/paths-filter@v3
         id: filter
@@ -136,6 +148,14 @@ jobs:
               - 'scripts/blueprint_bibtex.py'
               - 'scripts/check_reader_facing_prose.py'
               - 'scripts/test_blueprint_web_render.py'
+            # Everything the paper-gap reference check reads: the notes,
+            # the trees it scans for references, and its configuration.
+            paper_gaps:
+              - 'docs/paper-gaps/**'
+              - '**.lean'
+              - 'blueprint/src/**'
+              - 'docs/**/*.md'
+              - 'texra-blueprint.toml'
 
   # DROPPED from TNLean's pr-ci.yml: the tenkz-shrink, tenkz-corpus, and
   # tenkz-rmp jobs. TNLean's blueprint draws tensor-network diagrams with a
@@ -321,6 +341,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEX_CHANGED: ${{ github.event_name != 'pull_request' || needs.changes.outputs.blueprint == 'true' }}
+      # The paper-gap reference check also runs when only the notes, the
+      # Lean sources, the Markdown docs, or the configuration changed.
+      PAPER_GAPS_CHANGED: ${{ github.event_name != 'pull_request' || needs.changes.outputs.paper_gaps == 'true' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -361,11 +384,17 @@ jobs:
         if: env.TEX_CHANGED == 'true'
         uses: texra-ai/lean-env-action/blueprint-system-deps@v1
 
+      # Also installed for paper-gap-only changes: the reference check
+      # below runs the texra-blueprint CLI from this step's pip install.
       - name: Install blueprint Python dependencies
-        if: env.TEX_CHANGED == 'true'
+        if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.1.0'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.1'
+
+      - name: Check paper-gap references resolve
+        if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
+        run: texra-blueprint paper-gaps check
 
       # DROPPED from TNLean's blueprint job: every tenkz-specific step
       # (native tenkz source lint, tenkz manual/example compilation, the

--- a/QICLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/QICLean/Algebra/PerronFrobenius/RankOne.lean
@@ -239,7 +239,7 @@ linear independence of the sector tensors; its proof instead uses primitivity
 of the trace matrix, obtained from injectivity of K in the preceding
 construction (lines 1457--1470), in a Perron--Frobenius trace-power argument,
 and primitivity does not entail the independence. Documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the hypothesis `hl` is to be
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_pf_rank_one.pdf`; the hypothesis `hl` is to be
 discharged at the MPDO call site. -/
 theorem mul_self_eq_self_of_pairing_idempotent
     {l : Fin n → V} {r : Fin n → Module.Dual R V} {T : Matrix (Fin n) (Fin n) R}
@@ -272,7 +272,7 @@ linear independence of the sector tensors; its proof instead uses primitivity
 of the trace matrix, obtained from injectivity of K in the preceding
 construction (lines 1457--1470), in a Perron--Frobenius trace-power argument,
 and primitivity does not entail the independence. Documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the hypothesis `hr` is to be
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_pf_rank_one.pdf`; the hypothesis `hr` is to be
 discharged at the MPDO call site. -/
 theorem mul_self_eq_self_of_pairing_idempotent_dual
     {l : Fin n → V} {r : Fin n → Module.Dual R V} {T : Matrix (Fin n) (Fin n) R}
@@ -316,7 +316,7 @@ linear independence of the sector tensors; its proof instead uses primitivity
 of the trace matrix, obtained from injectivity of K in the preceding
 construction (lines 1457--1470), in a Perron--Frobenius trace-power argument,
 and primitivity does not entail the independence. Documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the hypothesis `hl` is to be
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_pf_rank_one.pdf`; the hypothesis `hl` is to be
 discharged at the MPDO call site. -/
 theorem hasRankOneFactorization_of_pairing_idempotent
     {V : Type*} [AddCommGroup V] [Module ℝ V]
@@ -407,7 +407,7 @@ holds without any independence hypothesis on `l` or `r`. Multiplying
 coefficient map turns the two sides directly into `T^2` and `T^3`.
 
 Source: arXiv:1606.00608, lines 1494--1497. This is the pairing computation
-of `docs/paper-gaps/cpgsv17_pf_rank_one.tex`, §3 ("What the operator-valued
+of `https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_pf_rank_one.pdf`, §3 ("What the operator-valued
 ZCL identity implies"). -/
 theorem pow_two_eq_pow_three_of_pairing_idempotent
     {V : Type*} [AddCommGroup V] [Module ℝ V]
@@ -447,7 +447,7 @@ restriction and `trace (T^2)` with the trace of its square, which coincide
 since the restriction is idempotent.
 
 Source: arXiv:1606.00608, lines 1494--1497. This is the "finite-dimensional
-carrier" step of `docs/paper-gaps/cpgsv17_pf_rank_one.tex`, §3. -/
+carrier" step of `https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_pf_rank_one.pdf`, §3. -/
 theorem trace_eq_trace_sq_of_pairing_idempotent
     {V : Type*} [AddCommGroup V] [Module ℝ V]
     {l : Fin n → V} {r : Fin n → Module.Dual ℝ V} {T : Matrix (Fin n) (Fin n) ℝ}

--- a/QICLean/Algebra/RectangularChoi.lean
+++ b/QICLean/Algebra/RectangularChoi.lean
@@ -12,7 +12,7 @@ import Mathlib.LinearAlgebra.Matrix.StdBasis
 # Rectangular Choi matrices and a Hilbert--Schmidt rank estimate
 
 This file contains the algebraic estimate used in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`.  For a linear map
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf`.  For a linear map
 `L : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ`, it defines the unnormalized Choi matrix in the
 natural `α × β` ordering and proves its Frobenius Parseval identity.  It also proves that
 the squared Frobenius norm is at most `finrank ℂ L.range` whenever `L` is a
@@ -260,7 +260,7 @@ private theorem trace_gram_re_le_rank_of_contraction
 
 /-- A Hilbert--Schmidt contraction has squared Choi Frobenius norm at most the
 dimension of its range.  This is the algebraic estimate used in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf`. -/
 theorem rectangularChoi_frobenius_sq_le_finrank_range
     (L : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
     (hL : IsHilbertSchmidtContraction L) :

--- a/QICLean/Algebra/ShiftedTracePowerSpectrum.lean
+++ b/QICLean/Algebra/ShiftedTracePowerSpectrum.lean
@@ -64,7 +64,7 @@ This is the set-spectrum part of arXiv:1703.09188, Proposition
 
 **Scope restriction (set spectrum only):** This theorem proves only that every
 nonzero spectral value equals one; set equality alone does not record algebraic
-multiplicity. See `docs/paper-gaps/cpsv17_transfer_trace_power.tex`. The exact
+multiplicity. See `https://sirui-lu.com/TNLean/paper-gaps/cpsv17_transfer_trace_power.pdf`. The exact
 multiplicity and characteristic-polynomial conclusion is
 `Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt`. -/
 theorem eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
@@ -104,7 +104,7 @@ Proposition `prop:normal-tensor`, lines 349--354.
 
 **Scope restriction (set spectrum only):** This theorem proves only that `1` is
 a spectral value; it does not record algebraic multiplicity. See
-`docs/paper-gaps/cpsv17_transfer_trace_power.tex`. The exact conclusion is
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv17_transfer_trace_power.pdf`. The exact conclusion is
 `Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt`. -/
 theorem one_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
     (A : Matrix n n ℂ)
@@ -134,7 +134,7 @@ Proposition `prop:normal-tensor`, lines 349--354.
 
 **Scope restriction (set spectrum only):** This theorem proves only equality of
 the nonzero spectrum as a set; set equality alone does not assert algebraic
-multiplicity. See `docs/paper-gaps/cpsv17_transfer_trace_power.tex`. The exact
+multiplicity. See `https://sirui-lu.com/TNLean/paper-gaps/cpsv17_transfer_trace_power.pdf`. The exact
 multiplicity and characteristic-polynomial conclusion is
 `Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt`. -/
 theorem spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt

--- a/QICLean/Algebra/TracePowerCharPoly.lean
+++ b/QICLean/Algebra/TracePowerCharPoly.lean
@@ -23,7 +23,7 @@ this statement for the stronger hypothesis
 The paper's exact `N > 1` hypothesis is handled by the companion formalization, which does
 **not** recover `tr(E) = 1`; it proves directly that the nonzero spectrum
 equals `{1}` without computing the first moment.  The bridge between the
-two results is documented in `docs/paper-gaps/cpsv17_transfer_trace_power.tex`.
+two results is documented in `https://sirui-lu.com/TNLean/paper-gaps/cpsv17_transfer_trace_power.pdf`.
 
 The proof is purely algebraic: no spectral radius, positivity, normality, or
 diagonalizability is required.  We construct an explicit rank-one diagonal
@@ -194,7 +194,7 @@ argument in arXiv:1703.09188, Proposition `prop:normal-tensor`, lines
 blocked tensors.  The present theorem uses the stronger hypothesis
 `tr(A^k) = 1` for all `k ≥ 1`; the paper's exact `N > 1` hypothesis is
 handled by the companion formalization, which proves the nonzero spectrum is `{1}` without
-recovering `tr(E) = 1`.  See `docs/paper-gaps/cpsv17_transfer_trace_power.tex`. -/
+recovering `tr(E) = 1`.  See `https://sirui-lu.com/TNLean/paper-gaps/cpsv17_transfer_trace_power.pdf`. -/
 theorem charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one
     (A : Matrix n n ℂ)
     (h : ∀ k : ℕ, 0 < k → trace (A ^ k) = 1) :

--- a/QICLean/Analysis/CfcLogAdditive.lean
+++ b/QICLean/Analysis/CfcLogAdditive.lean
@@ -36,7 +36,7 @@ Applying `CFC.log` to both sides and using `CFC.log_exp` returns the sum.
   `Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Basic`.
 * Algebraic input to the layer-5 ancilla-additivity step of the relative-entropy
   elimination route for strong subadditivity,
-  `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.
+  `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`.
 -/
 
 open scoped MatrixOrder ComplexOrder Matrix.Norms.L2Operator

--- a/QICLean/Analysis/CoisometricCompression.lean
+++ b/QICLean/Analysis/CoisometricCompression.lean
@@ -179,7 +179,7 @@ space of \(V\), extended by the identity on its orthogonal complement.
 This general identity lifts the retained Gibbs factor occurring in CPSV16,
 lines 999–1002, to the ambient physical space. The complement extension is
 not stated in the paper; see
-`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_topological_gibbs_physical_complement.pdf`. -/
 theorem exp_neg_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
     {r d : Type*} [Fintype r] [DecidableEq r] [Fintype d] [DecidableEq d]
     (V : Matrix r d ℂ) (k : Matrix r r ℂ) (hV : V * Vᴴ = 1) :

--- a/QICLean/Analysis/EntropyDecomposition.lean
+++ b/QICLean/Analysis/EntropyDecomposition.lean
@@ -63,7 +63,7 @@ multiplicativity `Real.negMulLog_mul`.
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
   (Distance Measures), Section 8.2 (Entropies)][Wolf2012QChannels]
 * Hayashi, *Quantum Information: An Introduction*, Springer 2006, Theorem 5.24
-* `docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`
+* `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`
 -/
 
 open scoped Matrix Kronecker ComplexOrder

--- a/QICLean/Analysis/EntropyMarkovReverse.lean
+++ b/QICLean/Analysis/EntropyMarkovReverse.lean
@@ -28,7 +28,7 @@ subadditivity cancel.
 ## References
 
 * Hayashi, *Quantum Information: An Introduction*, Springer 2006, Theorem 5.24
-* `docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`
+* `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`
 -/
 
 open scoped Matrix Kronecker ComplexOrder

--- a/QICLean/Analysis/FiniteRangeKnabe.lean
+++ b/QICLean/Analysis/FiniteRangeKnabe.lean
@@ -40,7 +40,7 @@ Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:2011.12127, lines 2194-2197
 (paragraph "The Knabe bound").  The finite-range coefficient above is a
 TNLean derivation obtained by running Knabe's window argument with a general
 range; it is recorded in the note
-`docs/paper-gaps/knabe_finite_range_coefficient.tex`, is not stated in any of
+`https://sirui-lu.com/TNLean/paper-gaps/knabe88_finite_range_coefficient.pdf`, is not stated in any of
 the cited sources, and is not attributed to any of them.
 
 ## Main results
@@ -372,7 +372,7 @@ arXiv:quant-ph/0608197, lines 1483-1489, and Cirac--Perez-Garcia--Schuch--
 Verstraete, arXiv:2011.12127, lines 2194-2197.  The finite-range coefficient
 is a TNLean derivation obtained by running Knabe's window argument with a
 general range; see the paper-gap note
-`docs/paper-gaps/knabe_finite_range_coefficient.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/knabe88_finite_range_coefficient.pdf`. -/
 theorem quadraticForm_sum_projections_of_cyclic_knabe
     {N R m : ℕ} [NeZero N]
     (h : ZMod N → E →ₗ[𝕜] E) (hh : ∀ i, (h i).IsSymmetricProjection)

--- a/QICLean/Analysis/KleinInequality.lean
+++ b/QICLean/Analysis/KleinInequality.lean
@@ -59,7 +59,7 @@ the zero eigenvalues to vanish. No eigenvalue-continuity input is needed.
 * Klein's inequality; see e.g. [M. Wolf, *Quantum Channels & Operations: Guided
   Tour*, Chapter 8 (Distance Measures)][Wolf2012QChannels].
 * Layer 3 of the relative-entropy elimination route for strong subadditivity,
-  `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.
+  `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`.
 -/
 
 open scoped Matrix ComplexOrder Topology
@@ -695,7 +695,7 @@ derived from it by regularizing the reference state and passing to the limit, so
 lemma keeps its standalone eigenbasis/Gibbs proof.
 
 Source: Klein's inequality; layer 3 of the relative-entropy elimination route
-for strong subadditivity, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`;
+for strong subadditivity, `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`;
 blueprint `thm:klein_inequality`. -/
 theorem quantumRelativeEntropy_nonneg {n : Type*} [Fintype n] [DecidableEq n]
     {ρ σ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hρ_tr : ρ.trace = 1)
@@ -751,7 +751,7 @@ inequality passes to the limit.
 Source: Klein's inequality; see e.g. [M. Wolf, *Quantum Channels & Operations:
 Guided Tour*, Chapter 8 (Distance Measures)][Wolf2012QChannels]; layer 3 of the
 relative-entropy elimination route for strong subadditivity,
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`; blueprint
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`; blueprint
 `thm:klein_inequality_general`. -/
 theorem quantumRelativeEntropy_nonneg_general {n : Type*} [Fintype n] [DecidableEq n]
     {ρ σ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hρ_tr : ρ.trace = 1)
@@ -814,7 +814,7 @@ operator Jensen, only the scalar strict Gibbs inequality and the spectral theore
 Source: Klein's inequality (equality case); see e.g. [M. Wolf, *Quantum Channels
 & Operations: Guided Tour*, Chapter 8 (Distance Measures)][Wolf2012QChannels];
 layer 3 of the relative-entropy elimination route for strong subadditivity,
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`; blueprint
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`; blueprint
 `thm:klein_inequality_equality`. -/
 theorem quantumRelativeEntropy_eq_zero_iff {n : Type*} [Fintype n] [DecidableEq n]
     {ρ σ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hρ_tr : ρ.trace = 1)

--- a/QICLean/Analysis/MarginalSupport.lean
+++ b/QICLean/Analysis/MarginalSupport.lean
@@ -59,7 +59,7 @@ annihilates the marginal, so the core lemma applies to the lifted projection.
 ## References
 
 * Layer 6 (instantiation) of the relative-entropy elimination route for strong
-  subadditivity, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, the marginal
+  subadditivity, `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`, the marginal
   support lemma there.
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
   (Distance Measures)][Wolf2012QChannels].
@@ -86,7 +86,7 @@ $\operatorname{tr}(Q \rho) = 0$ forces $Q \rho = 0$.
 This is the operator core of the marginal support lemma: it captures the step
 "$\operatorname{tr}(Q \rho) = \lVert Q \sqrt\rho \rVert_2^2 = 0$ forces
 $Q \sqrt\rho = 0$, hence $Q \rho = 0$" of the marginal support argument in
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`. -/
 theorem PosSemidef.proj_mul_eq_zero_of_trace_eq_zero {ρ Q : Matrix n n ℂ}
     (hρ : ρ.PosSemidef) (hQ : Q.IsHermitian) (hQ2 : Q * Q = Q)
     (htr : (Q * ρ).trace = 0) : Q * ρ = 0 := by
@@ -330,7 +330,7 @@ In particular, taking $Q$ the projection onto $\ker \rho_{BC}$ gives
 $\mathcal H_A \otimes \ker \rho_{BC} \subseteq \ker \rho_{ABC}$, the
 kernel-containment used to place the singular reference state
 $(\mathbf 1_A / d_A) \otimes \rho_{BC}$ in the domain of the relative entropy at
-layer (6) of `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`. -/
+layer (6) of `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`. -/
 theorem marginal_support
     {ρ : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ}
     (hρ : ρ.PosSemidef)

--- a/QICLean/Analysis/TwoProjectionAngleBlock.lean
+++ b/QICLean/Analysis/TwoProjectionAngleBlock.lean
@@ -15,7 +15,7 @@ lines 756–764. It does not assume that the projections commute.
 
 **Local fix (projector label):** Source line 762 repeats `P` for the second projector, where the
 surrounding argument requires `Q`. This typographical correction is documented
-in `docs/paper-gaps/1703_two_projection_projector_typo.tex`.
+in `https://sirui-lu.com/TNLean/paper-gaps/mpu_two_projection_projector_typo.pdf`.
 -/
 
 open scoped InnerProductSpace
@@ -40,7 +40,7 @@ arXiv:1703.09188, Proposition IV.5 (`prop:continuity-index`),
 
 **Local fix (projector label):** Source line 762 repeats `P` for the second
 projector, where the surrounding argument requires `Q`; see
-`docs/paper-gaps/1703_two_projection_projector_typo.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/mpu_two_projection_projector_typo.pdf`. -/
 theorem rangeCompression_isSymmetric {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     (rangeCompression hP (Q := Q)).IsSymmetric := by
@@ -66,7 +66,7 @@ compression eigenvector.
 
 **Local fix (projector label):** Source line 762 repeats `P` for the second projector; the
 surrounding argument requires `Q`. See
-`docs/paper-gaps/1703_two_projection_projector_typo.tex`.
+`https://sirui-lu.com/TNLean/paper-gaps/mpu_two_projection_projector_typo.pdf`.
 
 Writing \(d=Qx-μx\), the conclusions include
 \(Pd=0\), \(Qx=μx+d\),
@@ -130,7 +130,7 @@ theorem angleDefect_block {P Q : E →ₗ[ℂ] E}
 /-- Normalized form of `angleDefect_block`.
 
 **Local fix (projector label):** The second projector in arXiv:1703.09188, line 762 is `Q`, not
-the repeated `P`; see `docs/paper-gaps/1703_two_projection_projector_typo.tex`.
+the repeated `P`; see `https://sirui-lu.com/TNLean/paper-gaps/mpu_two_projection_projector_typo.pdf`.
 
 The vectors `x,w` are orthonormal; on their two-dimensional span, `P` acts as
 the projection onto `x`, while `Q`

--- a/QICLean/Analysis/TwoProjectionAngleOrthogonality.lean
+++ b/QICLean/Analysis/TwoProjectionAngleOrthogonality.lean
@@ -17,7 +17,7 @@ These are the cross-block orthogonality identities in the Jordan-lemma decomposi
 arXiv:1703.09188, Proposition IV.5 (`prop:continuity-index`), lines 759–762.
 
 **Local fix (projector label):** Source line 762 repeats `P` for the second projector, where the
-surrounding argument requires `Q`; see `docs/paper-gaps/1703_two_projection_projector_typo.tex`.
+surrounding argument requires `Q`; see `https://sirui-lu.com/TNLean/paper-gaps/mpu_two_projection_projector_typo.pdf`.
 -/
 
 open scoped InnerProductSpace

--- a/QICLean/Analysis/TwoProjectionCompression.lean
+++ b/QICLean/Analysis/TwoProjectionCompression.lean
@@ -28,7 +28,7 @@ intersection, is at most \(\eta\).
 This is the two-subspace overlap quantity used in the principal-angle argument
 of arXiv:2011.12127 §IV.C, eq:4:martingale-2, and in the Kastoryano–Lucia 2018
 principal-angle estimate. Its application to MPS ground spaces is discussed in
-`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv21_martingale_overlap.pdf`. -/
 def IsFriedrichsBound (U V : Submodule ℂ E) (η : ℝ) : Prop :=
   ∀ x : E, x ∈ U → x ∈ (U ⊓ V)ᗮ →
     ∀ y : E, y ∈ V → y ∈ (U ⊓ V)ᗮ →
@@ -83,7 +83,7 @@ Here the reduced parts of \(U\) and \(V\) are their intersections with
 the principal-angle argument in arXiv:2011.12127 §IV.C,
 eq:4:martingale-2. The later MPS-specific input is the Kastoryano–Lucia 2018
 principal-angle estimate. The precise comparison is recorded in
-`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv21_martingale_overlap.pdf`. -/
 theorem norm_starProjection_le_of_friedrichs_bound
     (U V : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η)
     (hAngle : IsFriedrichsBound U V η)
@@ -117,7 +117,7 @@ This is the generic two-projection norm-compression lemma associated with
 arXiv:2011.12127 §IV.C, eq:4:martingale-2. The MPS-specific input needed later
 is the Kastoryano–Lucia 2018 principal-angle estimate; its source boundary is
 recorded in
-`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv21_martingale_overlap.pdf`. -/
 theorem norm_starProjection_starProjection_le_of_friedrichs_bound
     (U V : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η)
     (hAngle : IsFriedrichsBound U V η)
@@ -285,7 +285,7 @@ principal-angle estimate to arXiv:2011.12127, Section IV.C,
 norm compression bound for the excitation product. The MPS-specific task is only
 to supply the uniform ground-space Friedrichs bound in the chosen blocking
 convention, as recorded
-in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+in `https://sirui-lu.com/TNLean/paper-gaps/cpgsv21_martingale_overlap.pdf`. -/
 theorem re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound
     (U V : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η)
     (hAngle : IsFriedrichsBound U V η) (v : E) :
@@ -322,7 +322,7 @@ not follow from a subspace-angle bound. This is the restricted geometric form
 relevant to arXiv:2011.12127 §IV.C, eq:4:martingale-2; the remaining
 Kastoryano–Lucia 2018 principal-angle estimate for MPS ground spaces is
 described in
-`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv21_martingale_overlap.pdf`. -/
 theorem norm_starProjection_starProjection_le_of_friedrichs_bound_of_mem
     (U V : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η)
     (hAngle : IsFriedrichsBound U V η)
@@ -347,7 +347,7 @@ This is the form in which the generic geometry can be applied to local
 excitation projections. The source is arXiv:2011.12127 §IV.C,
 eq:4:martingale-2; the MPS-specific input is the Kastoryano–Lucia 2018
 principal-angle estimate, whose comparison is recorded in
-`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv21_martingale_overlap.pdf`. -/
 theorem norm_starProjection_orthogonal_comp_le_of_friedrichs_bound
     (K L : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η)
     (hAngle : IsFriedrichsBound Kᗮ Lᗮ η)

--- a/QICLean/Analysis/TwoProjectionCompressionSpectrum.lean
+++ b/QICLean/Analysis/TwoProjectionCompressionSpectrum.lean
@@ -19,7 +19,7 @@ Proposition IV.5 (`prop:continuity-index`), lines 759–762.
 
 **Local fix (projector label):** Source line 762 repeats `P` for the second
 projector, where the surrounding argument requires `Q`; see
-`docs/paper-gaps/1703_two_projection_projector_typo.tex`.
+`https://sirui-lu.com/TNLean/paper-gaps/mpu_two_projection_projector_typo.pdf`.
 -/
 
 open scoped InnerProductSpace

--- a/QICLean/Analysis/TwoProjectionDefectBlockSum.lean
+++ b/QICLean/Analysis/TwoProjectionDefectBlockSum.lean
@@ -19,7 +19,7 @@ This is the orthogonal-sum and commuting-remainder part of Jordan's lemma used i
 arXiv:1703.09188, Proposition IV.5 (`prop:continuity-index`), lines 759–762.
 
 **Local fix (projector label):** Source line 762 repeats `P` for the second projector, where the
-surrounding argument requires `Q`; see `docs/paper-gaps/1703_two_projection_projector_typo.tex`.
+surrounding argument requires `Q`; see `https://sirui-lu.com/TNLean/paper-gaps/mpu_two_projection_projector_typo.pdf`.
 -/
 
 open scoped InnerProductSpace

--- a/QICLean/Analysis/TwoProjectionReducedProjection.lean
+++ b/QICLean/Analysis/TwoProjectionReducedProjection.lean
@@ -29,7 +29,7 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
 It is the orthogonal projection onto `range (P.comp Q)`. The source instead defines
 its projector blockwise in arXiv:1703.09188, Proposition IV.5, line 764. The
 identification with that blockwise projector remains part of the global Jordan
-decomposition; see `docs/paper-gaps/1703_two_projection_projector_typo.tex`. -/
+decomposition; see `https://sirui-lu.com/TNLean/paper-gaps/mpu_two_projection_projector_typo.pdf`. -/
 noncomputable def reducedProjection (P Q : E →ₗ[ℂ] E) : E →ₗ[ℂ] E :=
   (LinearMap.range (P.comp Q)).starProjection
 
@@ -48,7 +48,7 @@ theorem range_reducedProjection (P Q : E →ₗ[ℂ] E) :
 This range identity is a coordinate-free consequence of the projection hypotheses. The
 source defines its reduced projector blockwise, and identifying that projector with
 `reducedProjection P Q` remains part of the global Jordan decomposition; see
-`docs/paper-gaps/1703_two_projection_projector_typo.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/mpu_two_projection_projector_typo.pdf`. -/
 theorem reducedProjection_range_triple {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     LinearMap.range (P.comp (Q.comp P)) = LinearMap.range (P.comp Q) := by

--- a/QICLean/Channel/BreuerHallIndecomposable.lean
+++ b/QICLean/Channel/BreuerHallIndecomposable.lean
@@ -55,7 +55,7 @@ The restriction `d > 2` is necessary, not an artifact of this proof: for `d = 2`
 antisymmetric unitary is a phase times `J = [[0, 1], [-1, 0]]`, and
 `J Xᵀ Jᴴ = Tr(X) 1 - X` for all `2 × 2` matrices `X`, so `T_BH` reduces to the zero map,
 which is trivially decomposable. See
-`docs/paper-gaps/breuer_hall_even_dim_restriction.tex`.
+`docs/paper-gaps/wolf_breuer_hall_even_dim_restriction.tex`.
 
 ## Main declarations
 

--- a/QICLean/Channel/FixedPoint/DirectSumTraceAdjoint.lean
+++ b/QICLean/Channel/FixedPoint/DirectSumTraceAdjoint.lean
@@ -23,7 +23,7 @@ These are supporting trace-adjoint facts, not a formalization of the
 classification conclusion in that passage. Schwarz equality, multiplicativity,
 and the resulting star-algebra equivalence are established in
 `TNLean.Channel.FixedPoint.DirectSumInverseKraus`. The remaining argument,
-recorded in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`, is the
+recorded in `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_vertical_sector_invertibility.pdf`, is the
 relabeling and dimension matching of simple summands and their implementation
 by unitary conjugations.
 

--- a/QICLean/Channel/KoashiImoto/CommonInvariantAlgebra.lean
+++ b/QICLean/Channel/KoashiImoto/CommonInvariantAlgebra.lean
@@ -38,7 +38,7 @@ support on the working Hilbert space by shrinking to the joint support of the `�
 (arXiv:quant-ph/0304007v2, lines 761-763). This file does not derive that reduction; every
 declaration that builds the fixed-point subalgebra instead takes `PosDef (commonAverage ρ)` as
 an explicit hypothesis. Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`.
 
 ## Main declarations
 
@@ -152,7 +152,7 @@ joint-support reduction of lines 761-763 rather than re-deriving it.
 **Scope restriction (joint support):** `hρbar : PosDef (commonAverage ρ)` replaces HJPW's
 source reduction to the joint support of the `ρ_k` (arXiv:quant-ph/0304007v2, lines 761-763);
 that reduction is not derived here. Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`. -/
 noncomputable def commonInvariantStarSubalgebra (ρ : Kidx → Mat)
     (hρbar : (commonAverage ρ).PosDef) : StarSubalgebra ℂ Mat :=
   ⨅ F : PreservingKrausFamily ρ,
@@ -167,7 +167,7 @@ omit [Nonempty Kidx] in
 **Scope restriction (joint support):** inherits the `PosDef (commonAverage ρ)` hypothesis of
 `commonInvariantStarSubalgebra` in place of HJPW's joint-support reduction
 (arXiv:quant-ph/0304007v2, lines 761-763). Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`. -/
 theorem mem_commonInvariantStarSubalgebra (ρ : Kidx → Mat)
     (hρbar : (commonAverage ρ).PosDef) (X : Mat) :
     X ∈ commonInvariantStarSubalgebra ρ hρbar ↔
@@ -185,7 +185,7 @@ A direct specialization of the generic star-subalgebra block form
 **Scope restriction (joint support):** inherits the `PosDef (commonAverage ρ)` hypothesis of
 `commonInvariantStarSubalgebra` in place of HJPW's joint-support reduction
 (arXiv:quant-ph/0304007v2, lines 761-763). Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`. -/
 theorem exists_unitary_conj_blockDiagonal_iff_commonInvariantStarSubalgebra
     (ρ : Kidx → Mat) (hρbar : (commonAverage ρ).PosDef) :
     ∃ (Kc : ℕ) (d m : Fin Kc → ℕ) (e : ((k : Fin Kc) × (Fin (m k) × Fin (d k))) ≃ Fin D)

--- a/QICLean/Channel/KoashiImoto/FamilyFixedPointBlockForm.lean
+++ b/QICLean/Channel/KoashiImoto/FamilyFixedPointBlockForm.lean
@@ -27,7 +27,7 @@ matrices of Property 1 (lines 785--789); those steps begin at lines 857--858.
 
 **Scope restriction (full support):** The common average is assumed positive definite on the
 ambient space, in place of HJPW's reduction to the joint support (lines 761--763).  This is
-documented in `docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+documented in `https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
@@ -56,7 +56,7 @@ that normalization begins at lines 857--858.
 
 **Scope restriction (full support):** `hρbar` replaces HJPW's joint-support reduction
 (lines 761--763).  Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`. -/
 theorem exists_commonInvariant_fixedPointBlockForm_with_algebra
     {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
     (hρbar : (commonAverage ρ).PosDef) :

--- a/QICLean/Channel/KoashiImoto/FiniteRealization.lean
+++ b/QICLean/Channel/KoashiImoto/FiniteRealization.lean
@@ -110,7 +110,7 @@ families.
 **Scope restriction (joint support):** inherits the `PosDef (commonAverage ρ)` hypothesis of
 `commonInvariantStarSubalgebra` in place of HJPW's joint-support reduction
 (arXiv:quant-ph/0304007v2, lines 761-763). Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`. -/
 theorem exists_finset_preservingKrausFamily_iInf_eq (ρ : Kidx → Mat)
     (hρbar : (commonAverage ρ).PosDef) :
     ∃ S : Finset (PreservingKrausFamily ρ), S.Nonempty ∧

--- a/QICLean/Channel/KoashiImoto/MarkovBipartiteBlockForm.lean
+++ b/QICLean/Channel/KoashiImoto/MarkovBipartiteBlockForm.lean
@@ -358,7 +358,7 @@ Theorem 6, equation (14), lines 499--502.
 **Scope restriction (HJPW Theorem 6, equation (14)):** the direct-sum
 coordinates cover only the minimum joint support, not the ambient middle
 subsystem.  This is documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`.
 Elimination: extend the coordinates to the ambient middle subsystem before
 proving the recovery-dilation action of equation (15). -/
 structure MarkovBipartiteBlockForm
@@ -469,7 +469,7 @@ subsystem B or rectangular recovery action is claimed.
 ambient direct-sum equivalence on subsystem B, whereas this theorem supplies
 the block equation only after compression to the minimum joint support.  This
 is documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`.
 Elimination: extend the support coordinates to ambient B before proving the
 recovery-dilation action of equation (15). -/
 theorem exists_markovBipartiteBlockForm_jointSupport

--- a/QICLean/Channel/KoashiImoto/MeanErgodicProjection.lean
+++ b/QICLean/Channel/KoashiImoto/MeanErgodicProjection.lean
@@ -45,7 +45,7 @@ finite-dimensional Schrödinger mean-ergodic theorem entrywise.
 **Scope restriction (joint support):** inherits the `PosDef (commonAverage ρ)` hypothesis of
 `commonInvariantStarSubalgebra` in place of HJPW's joint-support reduction
 (arXiv:quant-ph/0304007v2, lines 761-763). Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`.
 
 As in `SingleWitness.lean`, the declarations below state the finite state-family instances in
 their own signatures so that dependent projections through the bundled witness remain stable

--- a/QICLean/Channel/KoashiImoto/NormalizedFamilyBlockForm.lean
+++ b/QICLean/Channel/KoashiImoto/NormalizedFamilyBlockForm.lean
@@ -28,7 +28,7 @@ on the common factors, beginning at line 860, is not included.
 
 **Scope restriction (full support):** The common average is assumed positive definite on the
 ambient space, in place of HJPW's reduction to the joint support (lines 761--763).  This is
-documented in `docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+documented in `https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
@@ -56,7 +56,7 @@ chosen to be maximally mixed; HJPW does not specify this irrelevant choice.
 
 **Scope restriction (full support):** `hρbar` replaces HJPW's joint-support reduction
 (lines 761--763).  Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`. -/
 theorem exists_commonInvariant_normalizedStateBlockForm_with_algebra
     {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
     (hρpos : ∀ x, (ρ x).PosSemidef) (hρtrace : ∀ x, (ρ x).trace = 1)

--- a/QICLean/Channel/KoashiImoto/PreservingBlockAction.lean
+++ b/QICLean/Channel/KoashiImoto/PreservingBlockAction.lean
@@ -29,7 +29,7 @@ with the commutant argument from lines 860--882.
 **Scope restriction (full support):** The positive-definite common-average
 hypothesis replaces HJPW's reduction to the joint support, lines 761--763.
 Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`.
 
 **Convention (factor order):** TNLean orders each summand as the common
 density factor followed by the member-dependent factor, opposite to HJPW.
@@ -58,7 +58,7 @@ Property `2'`, lines 808--816, proved at lines 860--882.
 
 **Scope restriction (full support):** `hρbar` replaces HJPW's joint-support
 reduction, lines 761--763.  Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`. -/
 theorem exists_adaptedKrausBlocks_of_isPreserving
     {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
     (hρbar : (commonAverage ρ).PosDef)
@@ -446,7 +446,7 @@ operation-level proof at lines 860--882.
 
 **Scope restriction (full support):** `hρbar` replaces HJPW's reduction to
 the joint support, lines 761--763.  Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`.
 
 **Convention (factor order):** TNLean writes `σ_j ⊗ τ_{j|x}`, opposite to
 HJPW's order.  Thus the local channel acts on the first factor. -/

--- a/QICLean/Channel/KoashiImoto/SingleWitness.lean
+++ b/QICLean/Channel/KoashiImoto/SingleWitness.lean
@@ -77,7 +77,7 @@ that finite family (`Kraus.averagedPreservingKrausFamily`).
 **Scope restriction (joint support):** inherits the `PosDef (commonAverage ρ)` hypothesis of
 `commonInvariantStarSubalgebra` in place of HJPW's joint-support reduction
 (arXiv:quant-ph/0304007v2, lines 761-763). Documented in
-`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf`. -/
 theorem exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq
     {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
     (hρbar : (commonAverage ρ).PosDef) :

--- a/QICLean/Channel/PetzProductReference.lean
+++ b/QICLean/Channel/PetzProductReference.lean
@@ -593,7 +593,7 @@ This is the maximally mixed specialization of the tensor-product factorization
 in Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, equation (10).
 
 **Maximally mixed specialization
-(docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex):**
+(https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf):**
 This theorem proves only the $d_A^{-1}\mathbf 1_A\otimes\rho_{BC}$ case.
 The general support-compressed raw identity is
 `partialTraceRightPetzMap_productTensor`; its positive-definite-left corollary
@@ -663,7 +663,7 @@ This is the maximally mixed specialization of equation (10) of
 Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2.
 
 **Maximally mixed specialization
-(docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex):**
+(https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf):**
 This theorem proves only the $d_A^{-1}\mathbf 1_A\otimes\rho_{BC}$ case.
 The general support-compressed raw identity is
 `partialTraceRightPetzMap_productTensor`; its positive-definite-left corollary

--- a/QICLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/QICLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -562,7 +562,7 @@ defect from relative-entropy equality.
 **Scope restriction (positive definite, fixed `t`):** The source equality
 analysis also uses integration in `t` and limiting arguments for singular
 matrices. Those steps are not asserted here. Documented in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`. -/
 theorem weyl_resolvent_defect_identity
     {dS dC : ℕ} [NeZero dC]
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
@@ -743,7 +743,7 @@ displayed defect vanish.
 **Scope restriction (positive definite, fixed `t`):** The implication from
 relative-entropy equality to zero defect, integration in `t`, and singular
 supports remain outside this theorem. Documented in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`. -/
 theorem weyl_resolvent_eq_of_defect_eq_zero
     {dS dC : ℕ} [NeZero dC]
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}

--- a/QICLean/Channel/Schwarz/RelativeEntropyAncillaAdditivity.lean
+++ b/QICLean/Channel/Schwarz/RelativeEntropyAncillaAdditivity.lean
@@ -20,7 +20,7 @@ where $\otimes$ is the Kronecker product.
 
 Ancilla additivity is one of the three ingredients of the data-processing
 inequality under the partial trace (layer 5 of the SSA-from-Lieb elimination
-route, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`), alongside joint
+route, `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`), alongside joint
 convexity (layer 4, `convexOn_quantumRelativeEntropy`) and unitary invariance
 (`quantumRelativeEntropy_conj_unitary`).
 
@@ -57,12 +57,12 @@ entropy of $\rho$ against $\sigma$.
 identity holds for density matrices, whereas this development restricts $\rho$,
 $\sigma$, $\tau$ to positive definite matrices (with $\tau$ of unit trace), the
 domain on which the logarithm split is available. The restriction is recorded in
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, layer 5.
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`, layer 5.
 
 ## References
 
 * Layer 5 (data processing) of the relative-entropy elimination route for strong
-  subadditivity, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.
+  subadditivity, `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`.
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
   (Distance Measures)][Wolf2012QChannels].
 -/
@@ -111,12 +111,12 @@ $\operatorname{tr}(\rho(\log\rho - \log\sigma)) \cdot \operatorname{tr}\tau$
 (`Matrix.trace_kronecker`), and the unit trace of $\tau$ leaves the relative
 entropy of $\rho$ against $\sigma$. This is one of the three ingredients of the
 data-processing inequality under the partial trace (layer 5 of
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`).
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`).
 
 **Scope restriction (positive-definite domain):** the source identity holds for
 density matrices; here $\rho$, $\sigma$, $\tau$ are restricted to positive
 definite matrices (with $\tau$ of unit trace), the domain on which the logarithm
-split holds. Recorded in `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`,
+split holds. Recorded in `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`,
 layer 5. -/
 theorem quantumRelativeEntropy_kronecker
     {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]

--- a/QICLean/Channel/Schwarz/RelativeEntropyConvexity.lean
+++ b/QICLean/Channel/Schwarz/RelativeEntropyConvexity.lean
@@ -48,7 +48,7 @@ convex.
 * Uhlmann, *Relative entropy and the Wigner--Yanase--Dyson--Lieb concavity*,
   Commun. Math. Phys. 54, 1977.
 * Layer 4 of the relative-entropy elimination route for strong subadditivity,
-  `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.
+  `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`.
 -/
 
 open scoped Matrix ComplexOrder
@@ -902,7 +902,7 @@ both-arguments limit `tendsto_relativeEntropyPerturb` yields the inequality for 
 original pairs.
 
 Source: Lieb concavity route, layer 4 of
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`; blueprint theorem
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`; blueprint theorem
 thm:relative_entropy_joint_convexity_support. -/
 theorem convexOn_quantumRelativeEntropy_support :
     ConvexOn ℝ (supportSet (D := D))

--- a/QICLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
+++ b/QICLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
@@ -23,7 +23,7 @@ where $\operatorname{tr}_C$ is the partial trace over the ancilla factor. The
 positive-definite base case is extended to the singular support domain
 $\ker \sigma \subseteq \ker \rho$ by regularizing both arguments and passing to the
 limit. This is layer 5 of the SSA-from-Lieb elimination route,
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`; all of its ingredients are now
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`; all of its ingredients are now
 formalized, leaving only the layer-6 singular-reference tripartite instantiation to
 discharge the standalone strong-subadditivity axiom.
 
@@ -78,12 +78,12 @@ relative entropy of the marginals, themselves affine regularizations of
 $\operatorname{tr}_C \rho, \operatorname{tr}_C \sigma$ with the shift rate scaled by
 $d_C$; the support condition transfers to the marginals by the bipartite marginal
 support fact, so the same limit applies. This is recorded in
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, layer 5.
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`, layer 5.
 
 ## References
 
 * Layer 5 (data processing) of the relative-entropy elimination route for strong
-  subadditivity, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.
+  subadditivity, `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`.
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
   (Distance Measures)][Wolf2012QChannels].
 -/
@@ -359,7 +359,7 @@ support domain $\ker \sigma \subseteq \ker \rho$ is
 `quantumRelativeEntropy_partialTraceRight_le_support`, derived from this base case
 by regularizing both arguments and passing to the limit, so this lemma keeps its
 standalone twirl-and-convexity proof. Recorded in
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, layer 5. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`, layer 5. -/
 theorem quantumRelativeEntropy_partialTraceRight_le
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
     (hρ : ρ.PosDef) (hσ : σ.PosDef) :
@@ -499,7 +499,7 @@ limit lemma applies once the support condition is transferred to the marginals b
 entropies vanish and is handled separately.
 
 Source: Lieb concavity route, layer 5 of
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`; blueprint theorem
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`; blueprint theorem
 thm:relative_entropy_data_processing_support. -/
 theorem quantumRelativeEntropy_partialTraceRight_le_support
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}

--- a/QICLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
+++ b/QICLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
@@ -16,7 +16,7 @@ $D(U\rho U^\dagger \,\|\, U\sigma U^\dagger) = D(\rho\|\sigma)$.
 
 Unitary invariance is one of the three ingredients of the data-processing
 inequality under the partial trace (layer 5 of the SSA-from-Lieb elimination
-route, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`), alongside joint
+route, `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`), alongside joint
 convexity (layer 4, `convexOn_quantumRelativeEntropy`) and ancilla additivity.
 
 ## Main results
@@ -41,7 +41,7 @@ conjugating unitaries.
 ## References
 
 * Layer 5 (data processing) of the relative-entropy elimination route for strong
-  subadditivity, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.
+  subadditivity, `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`.
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
   (Distance Measures)][Wolf2012QChannels].
 -/
@@ -76,7 +76,7 @@ $$D(U\rho U^\dagger \,\|\, U\sigma U^\dagger)
   = D(\rho\|\sigma),$$
 where the middle equality is trace cyclicity ($U^\dagger U = 1$). This is one of
 the three ingredients of the data-processing inequality under the partial trace
-(layer 5 of `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`). -/
+(layer 5 of `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`). -/
 theorem quantumRelativeEntropy_conj_unitary {n : Type*} [Fintype n] [DecidableEq n]
     {ρ σ : Matrix n n ℂ} (hρ : ρ.IsHermitian) (hσ : σ.IsHermitian)
     (U : unitary (Matrix n n ℂ)) :

--- a/QICLean/Channel/Schwarz/SchurComplement.lean
+++ b/QICLean/Channel/Schwarz/SchurComplement.lean
@@ -39,7 +39,7 @@ substantive when `P` is singular: `P = 0`, `Q = R = 1` is a counterexample.
 
 Conditions (1) and (2) are equivalent as printed. Condition (3) becomes
 equivalent to them after adding `ker(P) ⊆ ker(Q†)`. The printed version is
-false; see `docs/paper-gaps/schur_complement_tfae.tex`.
+false; see `docs/paper-gaps/wolf_schur_complement_tfae.tex`.
 
 ## Implementation notes
 
@@ -425,7 +425,7 @@ normalization is a contraction.
 `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, line 116 omits
 `ker(P) ⊆ ker(Q†)`. Without this condition the implication to block positivity
 is false. The deviation and the scalar counterexample are recorded in
-`docs/paper-gaps/schur_complement_tfae.tex`. -/
+`docs/paper-gaps/wolf_schur_complement_tfae.tex`. -/
 theorem schurComplement_posSemidef_iff_contraction
     (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
     (R : Matrix (Fin D₂) (Fin D₂) ℂ) (hP : P.PosSemidef) (hR : R.PosSemidef)
@@ -478,7 +478,7 @@ off-diagonal block.
 **Local fix (Wolf Theorem 5.2, condition (3)):** The printed condition (3) at
 `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, line 116 contains only
 the right-support condition. The left-support condition displayed here is
-necessary, as documented in `docs/paper-gaps/schur_complement_tfae.tex`. -/
+necessary, as documented in `docs/paper-gaps/wolf_schur_complement_tfae.tex`. -/
 theorem blockMatrix_posSemidef_iff_contraction
     (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
     (R : Matrix (Fin D₂) (Fin D₂) ℂ) (hP : P.PosSemidef) (hR : R.PosSemidef) :
@@ -507,7 +507,7 @@ block positivity in the singular case: take the scalar blocks
 `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, line 116, the printed
 condition lacks `ker(P) ⊆ ker(Q†)`. The normalized matrix is zero in this
 example, whereas the block quadratic form at `(1, -1)` equals `-1`. See
-`docs/paper-gaps/schur_complement_tfae.tex`. -/
+`docs/paper-gaps/wolf_schur_complement_tfae.tex`. -/
 theorem wolf_condition_three_not_sufficient :
     let P : Matrix (Fin 1) (Fin 1) ℂ := 0
     let Q : Matrix (Fin 1) (Fin 1) ℂ := 1

--- a/QICLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
+++ b/QICLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
@@ -13,7 +13,7 @@ import QICLean.Entropy.TripartiteTrace
 
 This file proves **strong subadditivity** of the von Neumann entropy for a
 tripartite density matrix, as the layer-6 instantiation of the relative-entropy
-elimination route, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`. For a density
+elimination route, `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`. For a density
 matrix $\rho_{ABC}$ on $A \otimes B \otimes C$,
 $$S(\rho_{ABC}) + S(\rho_B) \le S(\rho_{AB}) + S(\rho_{BC}),$$
 where the reduced states are the tripartite partial traces. The positive definite
@@ -75,7 +75,7 @@ comes from the singular-domain data-processing inequality
 derives the same inequality for every positive semidefinite unit-trace
 $\rho_{ABC}$, discharging the content of the standalone strong-subadditivity axiom
 on the full density-matrix domain. The development is recorded in
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, layer 6.
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`, layer 6.
 
 ## References
 
@@ -85,7 +85,7 @@ on the full density-matrix domain. The development is recorded in
   subadditivity of quantum entropy with equality", CMP 246, 359–374 (2004),
   arXiv:quant-ph/0304007v2, p. 3, equations (5)–(7).
 * Layer 6 (instantiation) of the relative-entropy elimination route for strong
-  subadditivity, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.
+  subadditivity, `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`.
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
   (Distance Measures)][Wolf2012QChannels].
 -/
@@ -711,7 +711,7 @@ definite matrices, the domain on which the relative-entropy ingredients are
 directly available. The full density-matrix statement is
 `strong_subadditivity_general`, which derives the same inequality for every
 positive semidefinite unit-trace $\rho_{ABC}$ on the singular support domain.
-Recorded in `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, layer 6.
+Recorded in `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`, layer 6.
 
 Source: Lieb, Ruskai, JMP 14, 1938 (1973);
 blueprint `thm:strong_subadditivity_posdef`. -/
@@ -807,7 +807,7 @@ and the singular-domain data processing
 
 Source: Lieb, Ruskai, JMP 14, 1938 (1973);
 blueprint `thm:strong_subadditivity`. Layer 6 of
-`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_from_lieb_route.pdf`. -/
 theorem strong_subadditivity_general
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
     (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1) :

--- a/QICLean/Channel/Schwarz/SupportRelativeModular.lean
+++ b/QICLean/Channel/Schwarz/SupportRelativeModular.lean
@@ -38,7 +38,7 @@ reference matrix is represented as the square of its support inverse square root
 The preceding singular equality-to-resolvent step is formalized downstream in
 `TNLean.Channel.Schwarz.SupportRelativeEntropyEquality`. The later
 support functional-calculus and recovery steps are tracked in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`.
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`.
 -/
 
 open scoped Matrix ComplexOrder Kronecker MatrixOrder

--- a/QICLean/Channel/Schwarz/SupportSourceDefect.lean
+++ b/QICLean/Channel/Schwarz/SupportSourceDefect.lean
@@ -37,7 +37,7 @@ This file also proves the fixed-parameter common generalized-inverse solution
 from vanishing source-\(B\) defect. The entropy-equality and projected
 relative-modular conclusions are assembled downstream; the later recovery
 steps are recorded in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`.
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`.
 -/
 
 open scoped Matrix BigOperators ComplexOrder Kronecker
@@ -381,7 +381,7 @@ theorem in the paper, at lines 761--785, assumes
 This fixed-\(t\) algebraic statement does not assert rigidity, an integral
 identity, or a Petz recovery theorem. The surrounding singular
 entropy-equality gap is documented in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`. -/
 theorem supportSourceBQuadratic_sum_sub_nonneg
     {ι : Type*} [Fintype ι] [Nonempty ι]
     (A B : ι → Matrix n n ℂ)

--- a/QICLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean
+++ b/QICLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean
@@ -178,7 +178,7 @@ arXiv:quant-ph/0304007v2, Theorem 3 and equation (8).
 
 **Scope restriction (positive definite):** The singular-support extension is
 not asserted here. Documented in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`. -/
 theorem weylRelativeEntropyGap_eq_zero_of_partialTraceRight_eq
     {dS dC : ℕ} [NeZero dC]
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
@@ -258,7 +258,7 @@ arXiv:0903.2895v4, §4, at `p=1`.
 
 **Scope restriction (positive definite):** Singular supports and the later
 Petz sandwich are not asserted here. Documented in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`. -/
 theorem weyl_relativeEntropy_gap_integral
     {dS dC : ℕ} [NeZero dC]
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
@@ -540,7 +540,7 @@ arXiv:0903.2895v4, §4, lines 652--674.
 
 **Scope restriction (positive definite):** Singular supports and the Petz
 sandwich remain outside this theorem. Documented in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`. -/
 theorem weyl_sourceB_defect_eq_zero_of_gap_eq_zero
     {dS dC : ℕ} [NeZero dC]
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
@@ -589,7 +589,7 @@ analysis of Jenčová--Ruskai, arXiv:0903.2895v4, §4 and Appendix.
 
 **Scope restriction (positive definite):** The inverse-square-root integral
 and singular-support extension are not asserted here. Documented in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`. -/
 theorem weyl_resolvent_eq_of_relativeEntropy_gap_eq_zero
     {dS dC : ℕ} [NeZero dC]
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
@@ -628,7 +628,7 @@ arXiv:0903.2895v4, §4 and Appendix.
 
 **Scope restriction (positive definite):** The inverse-square-root limit and
 singular-support extension are not asserted here. Documented in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`. -/
 theorem weyl_resolvent_eq_of_partialTraceRight_eq
     {dS dC : ℕ} [NeZero dC]
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
@@ -665,7 +665,7 @@ Jenčová--Ruskai, arXiv:0903.2895v4, lines 658–680.
 
 **Scope restriction (positive definite):** The singular-support extension is
 not asserted here. Documented in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`. -/
 theorem weyl_sqrt_ratio_eq_of_partialTraceRight_eq
     {dS dC : ℕ} [NeZero dC]
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
@@ -774,7 +774,7 @@ arXiv:quant-ph/0304007v2, Theorem 3, equation (8).
 
 **Scope restriction (positive definite):** The singular-support extension is
 not asserted here. Documented in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf`. -/
 theorem weyl_identity_sandwich_of_partialTraceRight_eq
     {dS dC : ℕ} [NeZero dC]
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}

--- a/QICLean/Channel/SupportCompletion.lean
+++ b/QICLean/Channel/SupportCompletion.lean
@@ -34,7 +34,7 @@ map agrees with the original map on matrices supported by the projection.
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Definition 4.1,
   lines 638--660, and Appendix C.4, lines 2065--2085.  The completion supplies
   the otherwise unspecified action on discarded physical complements; see
-  `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+  `https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_vertical_isometry_zero_sector.pdf`.
 -/
 
 open scoped ComplexOrder Matrix

--- a/QICLean/Channel/SupportedMarginalChannel.lean
+++ b/QICLean/Channel/SupportedMarginalChannel.lean
@@ -23,7 +23,7 @@ logarithm of this range dimension follows from Beigi's
 weighted Hilbert--Schmidt contraction and order monotonicity, together with
 the order-one limit of Müller-Lennert et al.  The mathematical argument and
 formalization status are recorded in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`; the inequality
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf`; the inequality
 is not asserted here.
 
 ## Main definitions

--- a/QICLean/Channel/WeightedHilbertSchmidt.lean
+++ b/QICLean/Channel/WeightedHilbertSchmidt.lean
@@ -117,7 +117,7 @@ contraction in Beigi, arXiv:1306.5920, Theorem 6, equation (18).
 **Scope restriction (full output support):** The output weight is assumed
 positive definite. The support-compressed form needed for arbitrary output
 support is recorded in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf`. -/
 theorem weightedHilbertSchmidtMap_norm_le
     {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
     {Φ : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}

--- a/QICLean/Channel/WhitenedChoi.lean
+++ b/QICLean/Channel/WhitenedChoi.lean
@@ -363,7 +363,7 @@ positive definite in the displayed coordinates.  The arbitrary-basis result
 follows by unitary diagonalization, and simultaneous compression to both
 marginal supports gives the singular-marginal result.  This restriction and
 its removal are recorded in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf`. -/
 theorem supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
     (hρ : ρ.PosSemidef) (hp : ∀ i, 0 < p i)
@@ -408,7 +408,7 @@ arXiv:1306.5920, Theorem 6, equation (18).
 is the faithful core.  Unitary diagonalization gives the arbitrary-basis
 version, and simultaneous support compression gives the singular-marginal
 version.  This restriction and its removal are recorded in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf`. -/
 theorem supportedMarginalWhitenedState_trace_sq_re_le_operatorSchmidtRank
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
     (hρ : ρ.PosSemidef) (hp : ∀ i, 0 < p i)

--- a/QICLean/Entropy/ClassicalMutualInformation.lean
+++ b/QICLean/Entropy/ClassicalMutualInformation.lean
@@ -266,7 +266,7 @@ marginal.
 row factor `1 + ε * β x` inside a quotient and then evaluates at an endpoint where that
 factor can vanish. Here `Real.negMulLog_mul`, which remains valid at zero, replaces that
 undefined quotient cancellation. The correction is documented in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf`. -/
 private theorem classicalMutualInformation_rowPerturbation
     (P : Matrix X Y ℝ) (β : X → ℝ) (ε : ℝ)
     (hrel : ∀ y, ∑ x, β x * P x y = 0) :

--- a/QICLean/MPS/Defs.lean
+++ b/QICLean/MPS/Defs.lean
@@ -129,7 +129,7 @@ on the length. The empty word is not a physical chain.
 **Local fix (projective proportionality):** The source phrase
 "proportional to each other" is read projectively, so the scalar is nonzero.
 This reading is documented in
-`docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex`. -/
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_nonzero_proportionality_reading.pdf`. -/
 def NonzeroProportionalMPV₂ {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
   ∀ N : ℕ, 0 < N → ∃ c : ℂ, c ≠ 0 ∧ ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ

--- a/blueprint/src/chapter/ch04_channels_choi_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_choi_foundations.tex
@@ -97,7 +97,7 @@ matrix $\tau=(T\otimes\id)\ketbra{\Omega}{\Omega}$ on the doubled space.
 
     % Scope restriction (d=d'): this definition treats only endomorphisms of
     % one matrix algebra.  The different-dimension correspondence is recorded
-    % in docs/paper-gaps/choi_rectangular_scope.tex.
+    % in docs/paper-gaps/wolf_choi_rectangular_scope.tex.
 \end{definition}
 
 \begin{theorem}[Choi matrix of the identity map]\label{thm:choi_matrix_id}
@@ -187,7 +187,7 @@ matrix $\tau=(T\otimes\id)\ketbra{\Omega}{\Omega}$ on the doubled space.
     This is the $d=d'$ specialization of
     \cite[Proposition~2.1]{Wolf2012Quantum}.
     % Scope restriction (d=d'): the different-dimension correspondence is
-    % recorded in docs/paper-gaps/choi_rectangular_scope.tex.
+    % recorded in docs/paper-gaps/wolf_choi_rectangular_scope.tex.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
+++ b/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
@@ -14,7 +14,7 @@
   Here $R^+$ denotes the pseudoinverse (inverse on the support) and the
   square roots $P^{1/2}, R^{1/2}$ are the positive semidefinite square roots,
   with their inverses extended by zero on the kernel.
-% The proof is deferred (paper-gap schur_complement_tfae).
+% The proof is deferred (paper-gap wolf_schur_complement_tfae).
 \end{theorem}
 
 \begin{definition}[Block matrix]\label{def:blockMatrix}

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -436,7 +436,7 @@ in the Choi matrix.
     \cite[Proposition~2.1]{Wolf2012Quantum}.
     % Scope restriction (d=d'): the different-dimension converse and general
     % adjoint partial-trace identity are recorded in
-    % docs/paper-gaps/choi_rectangular_scope.tex.
+    % docs/paper-gaps/wolf_choi_rectangular_scope.tex.
 \end{theorem}
 
 \begin{proof}
@@ -463,7 +463,7 @@ in the Choi matrix.
     This is the equal-dimension case of
     \cite[Proposition~2.1]{Wolf2012Quantum}.
     % Scope restriction (d=d'): the different-dimension statement is recorded
-    % in docs/paper-gaps/choi_rectangular_scope.tex.
+    % in docs/paper-gaps/wolf_choi_rectangular_scope.tex.
 \end{theorem}
 
 \begin{proof}
@@ -487,7 +487,7 @@ in the Choi matrix.
     \cite[Proposition~2.1]{Wolf2012Quantum}.
     % Scope restriction (d=d'): the general identity
     % tr(tau) = tr(T*(Id))/d is recorded in
-    % docs/paper-gaps/choi_rectangular_scope.tex.
+    % docs/paper-gaps/wolf_choi_rectangular_scope.tex.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
@@ -779,7 +779,7 @@
     singular equality theorem at lines~761--785 assumes
     $\ker B_i\subseteq\ker A_i$ and is not asserted here. The subsequent
     singular entropy-equality passage is recorded in
-    \path{docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex}.
+    \path{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf}.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1398,7 +1398,7 @@ algebra of a family of jointly invariant states.
 \end{proof}
 
 % Scope restriction documented in
-% docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex.
+% https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf.
 \begin{definition}[Common invariant algebra]
     \label{def:koashi_imoto_common_invariant_algebra}
     \lean{Kraus.commonInvariantStarSubalgebra,
@@ -1857,7 +1857,7 @@ algebra of a family of jointly invariant states.
     the displayed direct sum is restricted to the minimum joint supporting
     subspace, whereas equation~(14), lines 499--502, decomposes the ambient
     subsystem $B$. This restriction is documented in
-    \path{docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex}.
+    \path{https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf}.
     % The next theorem performs the ambient extension; the subsequent
     % The Markov-dilation theorem supplies equation (15).
 \end{theorem}

--- a/docs/paper-gaps/command.tex
+++ b/docs/paper-gaps/command.tex
@@ -1,0 +1,60 @@
+% Shared commands for the notes in docs/paper-gaps/.
+% Every note loads this file via \input{command}. Project-wide notation
+% belongs here, never in per-note redefinitions.
+
+% --- Project configuration ------------------------------------------------
+\newcommand{\projectIssueBase}{https://github.com/LionSR/QICLean/issues/}
+\newcommand{\projectPrBase}{https://github.com/LionSR/QICLean/pull/}
+\newcommand{\projectDocBase}{https://sirui-lu.com/QICLean/docs/}
+% ---------------------------------------------------------------------------
+
+\DeclareUnicodeCharacter{2080}{\ifmmode{}_{0}\else\textsubscript{0}\fi}
+\DeclareUnicodeCharacter{2081}{\ifmmode{}_{1}\else\textsubscript{1}\fi}
+\DeclareUnicodeCharacter{2082}{\ifmmode{}_{2}\else\textsubscript{2}\fi}
+\DeclareUnicodeCharacter{2099}{\ifmmode{}_{n}\else\textsubscript{n}\fi}
+
+\newcommand{\Lean}{\textsc{Lean}}
+
+% A formal declaration name, upright sans, breakable at underscores.
+\ExplSyntaxOn
+\NewDocumentCommand{\leanid}{m}{
+  \ifmmode
+    \textsf{\detokenize{#1}}
+  \else
+    \group_begin:
+    \urlstyle{sf}
+    \tl_set:Nn \l_tmpa_tl {#1}
+    \tl_replace_all:Nnn \l_tmpa_tl {\_} {_}
+    \exp_args:NV \path \l_tmpa_tl
+    \group_end:
+  \fi
+}
+\ExplSyntaxOff
+
+% Traceability links; use in footnotes, not in the running prose.
+\newcommand{\ghissue}[1]{\href{\projectIssueBase#1}{GitHub issue \##1}}
+\newcommand{\ghpr}[1]{\href{\projectPrBase#1}{PR \##1}}
+\newcommand{\doclink}[1]{\href{\projectDocBase#1.html}{\path{#1}}}
+
+% Domain notation, using \providecommand so a note-local refinement stays
+% possible.
+\providecommand{\tr}{\operatorname{tr}}
+
+% Dirac notation and the identity operator, as in blueprint/src/macros.
+\usepackage{dsfont}
+\providecommand{\ket}[1]{|#1\rangle}
+\providecommand{\bra}[1]{\langle #1|}
+\providecommand{\braket}[2]{\langle #1 | #2 \rangle}
+\providecommand{\ketbra}[2]{|#1\rangle\!\langle #2|}
+\providecommand{\Id}{\mathds{1}}
+\providecommand{\one}{\mathds{1}}
+\providecommand{\C}{\mathbb{C}}
+\providecommand{\MN}[1]{M_{#1}(\C)}
+\providecommand{\MD}{M_D(\C)}
+
+% Verdict marker: \gapnote{<kind>}{<status>}. Kind is the policy
+% classification (clarification, local-correction, scope-restriction,
+% unfaithful, false-source, open-gap); status is open, wip (elimination
+% underway), resolved, or historical. Machine-read by the site index;
+% prints a verdict line.
+\newcommand{\gapnote}[2]{\par\noindent\textbf{Verdict:} #1 (#2).\par}

--- a/docs/paper-gaps/policy.tex
+++ b/docs/paper-gaps/policy.tex
@@ -1,0 +1,162 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Policy for Paper-Gap Notes}
+\author{}
+\date{2026-05-12}
+
+\begin{document}
+\maketitle
+
+\section{Purpose}
+
+A paper-gap note records a mathematical discrepancy between a cited source and
+the statement, proof, or route used in the formal development. The source
+itself should remain intact. If a proof seems to require a hypothesis not
+present in the article, a different scalar, a different normalization, or a
+replacement theorem from the formal library, the change should be explained in a
+separate note under \path{docs/paper-gaps/}.
+
+The note is a mathematical document first. It should be readable by a
+mathematician or mathematical physicist who has not read the corresponding
+issue or pull request. Traceability data such as formal declaration names,
+source-file paths, GitHub issues, and line ranges should support the exposition,
+usually in footnotes, rather than govern the exposition.
+
+\section{When a note is needed}
+
+A note is needed when the formal statement is not literally the cited
+statement. The common case is an implication in the paper,
+\begin{align}
+    \mathcal H \Longrightarrow C,
+    \tag{\path{source}}
+\end{align}
+while the formal proof establishes only
+\begin{align}
+    \mathcal H\wedge\mathcal K \Longrightarrow C.
+    \tag{\path{formal}}
+\end{align}
+The condition $\mathcal K$ must then be accounted for. Either it is derived
+from $\mathcal H$, it is a harmless local correction, or the formal theorem is
+a restricted theorem and should be marked as such.
+
+A note is also needed when the proof is mathematically different even though
+the final conclusion is the same. For example, a source proof might identify a
+coefficient by a finite power-sum identity,
+\begin{align}
+    \sum_{q=1}^{r_a}\mu_q^N
+    =\sum_{q=1}^{r_b}\nu_q^N
+    \qquad (1\leq N\leq m),
+\end{align}
+whereas the formal route might use convergence of a sequence. These are
+different mechanisms, and the note should say which hypotheses each mechanism
+uses.
+
+\section{Form of the note}
+
+The note should introduce the relevant notation before using it. It should
+state the cited assertion in the special case under discussion, then display the
+formal or corrected statement, and finally compare the hypotheses and
+conclusions. Long quotations are usually unnecessary; a precise citation and
+the mathematical formula are better.
+
+Displayed equations should carry the calculation. Use \verb|align| for
+displayed formulae in these notes, especially for multi-line arguments:
+\begin{align}
+    V^{(N)}(A) &= c_N V^{(N)}(B),\\
+    \langle V^{(N)}(B_k),V^{(N)}(A_j)\rangle
+               &\xrightarrow[N\to\infty]{}0,\\
+    \dim\operatorname{span}
+    \left(\{V^{(N)}(A_j)\}_j\cup\{V^{(N)}(B_k)\}\right)
+               &= r_A+1.
+\end{align}
+The contradiction should then be explained in prose, for instance by saying
+which nonzero coefficient is forced to vanish.
+Source tags belong on the right-hand side of the displayed line, using
+\verb|\tag| when a tag is needed. Short definitions may remain inline when the
+sentence is clearer that way.
+
+Formal identifiers should be written with \verb|\leanid| and should usually
+appear in footnotes. For example, the prose may say that the formal theorem is
+the same-dimensional gauge-phase component of a source lemma, and the footnote
+may identify the declaration.\footnote{Formal declaration:
+    \leanid{Model.correctedStatement_of_extra_hypothesis}
+    in \doclink{Project/Path/To/File}.}
+Do not put formal identifiers in displayed equations unless the mathematical
+object itself is a formal declaration.
+
+\section{Shared commands}
+
+All notes in this directory should load \path{docs/paper-gaps/command.tex}.
+Shared notation belongs there. In particular,
+\begin{align}
+    \tr(X),\qquad \leanid{someDeclaration}
+\end{align}
+should be produced by the shared commands \verb|\tr| and \verb|\leanid| rather
+than by local redefinitions in each note. This keeps the documents visually
+consistent and avoids contradictory local conventions.
+
+\section{Naming}
+
+A note's file name has the form \path{<key>_<topic>.tex}. The key names the
+source the note examines: the authors' initials followed by a two-digit year
+(\path{cpsv16}, \path{pgvwc07}, \path{spwc10}), or an established short name
+for a book or review (\path{wolf}, \path{rmp}, \path{mpu}). A note that
+audits the formal development itself, with no single external source, takes
+a reserved key for the project itself (for QICLean, \path{qiclean}). The
+registry of keys, each with the source it names, is maintained in the
+repository configuration (\path{texra-blueprint.toml}), and the index
+generator rejects an unregistered key.
+
+The topic part states the mathematical subject, not the history of the note.
+A file name is permanent once other documents cite it; version suffixes are
+not used, since a note is revised in place (see Revision below) and its
+history is preserved by the repository.
+
+\section{Classification}
+
+The conclusion of a note should give a verdict. The usual classifications are:
+a notational clarification, a local correction, a scope restriction, an
+unfaithful theorem, a source claim that is false as printed, or an open gap.
+The classification should follow the mathematics, not the amount of formal
+work required. Each note declares its classification and its status
+machine-readably with \verb|\gapnote{<kind>}{<status>}| directly after
+\verb|\maketitle|: the kind in the kebab-cased vocabulary above
+(\path{clarification}, \path{local-correction}, \path{scope-restriction},
+\path{unfaithful}, \path{false-source}, \path{open-gap}) and the status
+one of \path{open}, \path{wip}, \path{resolved}, or \path{historical};
+\path{wip} marks a gap whose elimination is actively underway and still
+counts as live. Severity is derived from the kind, so it is never stated
+separately. A resolved note keeps its classification and changes only its
+status; the published index lists live notes first and dims the resolved
+ones.
+
+A local correction records a small adjustment whose corrected statement is still
+available in the cited argument. A scope restriction records a theorem proved
+only in a special case of the source theorem. An unfaithful theorem is more
+serious: it relies on a hypothesis or intermediate result that the cited source
+does not provide. Such a theorem must carry an in-source marker pointing to the
+paper-gap note. A source claim is false as printed when a counterexample
+satisfies the stated source hypotheses and contradicts its conclusion. This
+classification concerns the cited assertion itself, rather than a mismatch
+introduced by the formal statement or proof.
+
+\section{Revision}
+
+A note may begin provisionally, but revisions should keep it as a coherent
+account of the present mathematical understanding. It should not become a
+chronological log. If later work proves that $\mathcal K$ follows from
+$\mathcal H$, the note should be rewritten to show that derivation. If later
+work confirms that the extra hypothesis is unavoidable, the note should state
+the restricted theorem explicitly.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -1,0 +1,39 @@
+@misc{Wolf2012Quantum,
+  author       = {Wolf, Michael M.},
+  title        = {Quantum Channels \& Operations: Guided Tour},
+  year         = {2012},
+  howpublished = {Lecture notes},
+  url          = {https://mediatum.ub.tum.de/doc/1099654/1099654.pdf},
+}
+
+@article{Yamagami1993Cyclic,
+  author       = {Yamagami, Shigeru},
+  title        = {Cyclic Inequalities},
+  journal      = {Proceedings of the American Mathematical Society},
+  volume       = {118},
+  number       = {2},
+  pages        = {521--527},
+  year         = {1993},
+  doi          = {10.1090/S0002-9939-1993-1128732-7},
+}
+
+@article{TanahashiTomiyama1988Indecomposable,
+  author       = {Tanahashi, Kotaro and Tomiyama, Jun},
+  title        = {Indecomposable Positive Maps in Matrix Algebras},
+  journal      = {Canadian Mathematical Bulletin},
+  volume       = {31},
+  number       = {3},
+  pages        = {308--317},
+  year         = {1988},
+  doi          = {10.4153/CMB-1988-044-4},
+}
+
+@article{Osaka1991Indecomposable,
+  author       = {Osaka, Hiroyuki},
+  title        = {Indecomposable Positive Maps in Low Dimensional Matrix
+                  Algebras},
+  journal      = {Linear Algebra and its Applications},
+  volume       = {153},
+  pages        = {73--83},
+  year         = {1991},
+}

--- a/docs/paper-gaps/template.tex
+++ b/docs/paper-gaps/template.tex
@@ -1,0 +1,99 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Model Note: Comparing a Cited Argument with a Formal Statement}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+\gapnote{unfaithful}{open}
+
+% This file is a model for notes in docs/paper-gaps/.
+% When making a real note, replace the abstract toy assertion below by the actual
+% mathematical assertion, source citation, issue link, and formal declarations.
+% The visible document should remain a coherent mathematical note, not a form.
+% If the issue is a scalar correction, a missing term, a counterexample, or a
+% different formal-library route, specialize the middle sections accordingly.
+% If a Mathlib theorem or construction replaces a step from the paper, explain
+% that theorem in ordinary mathematics before naming the formal declaration.
+% In a real note, the first paragraph should identify the cited assertion and
+% the part of the argument in which it is used.  Put issue links, pull requests,
+% source files, line ranges, labels, and formal declaration names in footnotes
+% when they are only traceability data.
+
+\section{The assertion}
+
+This note concerns a hypothetical proposition, of the sort one might encounter
+in a cited argument such as \cite{Wolf2012Quantum}.  The proposition is used
+later in the same argument.
+
+Let \(\mathcal H\) denote the hypotheses available at a certain point of the
+argument, and let \(C\) denote the conclusion needed there.  Suppose the cited
+source states the implication
+\begin{align}
+  \mathcal H \Longrightarrow C.
+  \tag{\path{thm:model-source}}
+\end{align}
+The notation in the displayed implication has now been fixed: \(\mathcal H\) is
+the available hypothesis set, and \(C\) is the conclusion required by the later
+argument.
+
+\section{The point at issue}
+
+Assume that the proof of the displayed implication invokes a lemma which, in the
+special case being used, proves
+\begin{align}
+  \mathcal H \wedge \mathcal K \Longrightarrow C,
+  \tag{\path{lem:model-input}}
+\end{align}
+where \(\mathcal K\) is an additional hypothesis.  If the surrounding argument
+does not prove \(\mathcal K\), then the displayed implication
+\(\mathcal H\Rightarrow C\) has not been justified by that proof.  The
+mathematical question is whether \(\mathcal K\) follows from \(\mathcal H\), must
+be added to the statement, or can be avoided by a different argument.
+
+Thus the proof supplies the desired conclusion only after the additional
+hypothesis \(\mathcal K\) has been accounted for.
+
+\section{The corrected statement}
+
+In this model, suppose that \(\mathcal K\) is not known to follow from
+\(\mathcal H\), but that the later proof only uses the theorem in situations
+where \(\mathcal K\) is available.  The corrected statement is then
+\begin{align}
+  \mathcal H \wedge \mathcal K \Longrightarrow C.
+\end{align}
+This is a strengthening of the hypotheses, not a derivation of \(\mathcal K\)
+from the original assumptions.
+
+If the formal development proves this corrected statement, the note should state
+that fact in prose and identify the exact formal declaration in a footnote.  For
+example, the declaration might be recorded as \leanid{modelCorrected} in
+\doclink{QICLean/Path/To/File}.  The formal declaration is evidence for the
+corrected mathematical statement; it is not a substitute for explaining the
+statement.
+
+The same principle applies if the formal proof uses a theorem from a library
+which is not present in the cited source.  The note should first state that
+theorem as a mathematical assertion, then explain how its hypotheses are verified
+in the present notation, and only then identify the corresponding formal
+declaration.
+
+\section{Conclusion}
+
+The verdict in this model is that the original proof uses an additional
+hypothesis \(\mathcal K\).  The corrected statement is sufficient for the
+surrounding argument only in the cases where \(\mathcal K\) is supplied.  Without
+such a derivation or a different proof of \(C\), the original implication
+\(\mathcal H\Rightarrow C\) remains unjustified.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_breuer_hall_even_dim_restriction.tex
+++ b/docs/paper-gaps/wolf_breuer_hall_even_dim_restriction.tex
@@ -1,0 +1,121 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Even-Dimension Restriction in the Indecomposability\\
+of the Breuer--Hall Map (Wolf Example~3.1)}
+\author{}
+\date{2026-08-06}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\section{Source statement}
+
+Wolf's Chapter~3, Example~3.1 introduces the Breuer--Hall
+map\footnote{\cite[Chapter~3, Example~3.1]{Wolf2012Quantum}; local source:
+\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex}, lines
+344--355. Formalization issue:
+\href{https://github.com/LionSR/TNLean/issues/5471}{issue \#5471}.}
+\begin{align}
+  T_{\mathrm{BH}}(X)=\operatorname{tr}[X]\,\mathbb 1-X-UX^{T}U^{\dagger}.
+  \tag{3.19}
+\end{align}
+Here $U$ may be any antisymmetric contraction satisfying $U^{T}=-U$ and
+$U^{\dagger}U\le\mathbb 1$.  The source then states: ``For $d$ even there are
+anti-symmetric unitaries
+$U^{\dagger}=U^{-1}=-\overline{U}$ \dots\ If $U$ is an anti-symmetric unitary
+$T_{\mathrm{BH}}$ is not decomposable.''  The final sentence has no dimension
+hypothesis.  Thus the source uses two distinct hypothesis regimes: the map is
+defined and proved positive for antisymmetric contractions
+$U^{\dagger}U\le\mathbb 1$, whereas its indecomposability assertion concerns
+antisymmetric unitaries $U^{\dagger}U=\mathbb 1$.  The formalization proves
+indecomposability only in the unitary case; extending that conclusion to general
+antisymmetric contractions remains open.
+
+\section{The point at issue}
+
+The blanket statement fails at $d=2$. Every antisymmetric $2\times2$ matrix
+is a scalar multiple of
+\begin{align}
+  J=\begin{pmatrix} 0 & 1 \\ -1 & 0 \end{pmatrix},
+\end{align}
+so every antisymmetric unitary at $d=2$ is a phase $e^{i\theta}J$, and the
+twisted-transpose term is independent of the phase. A direct computation
+gives, for $X=(\begin{smallmatrix} a & b \\ c & d\end{smallmatrix})$,
+\begin{align}
+  JX^{T}J^{\dagger}
+  =\begin{pmatrix} d & -b \\ -c & a\end{pmatrix}
+  =\operatorname{tr}[X]\,\mathbb 1-X,
+\end{align}
+so $T_{\mathrm{BH}}$ is the zero map on $\mathcal M_2$. The zero map is
+completely positive, hence decomposable. The hypothesis $d>2$ is therefore
+necessary, and the source's sentence must be read with the restriction
+$d\ge4$ (recall that antisymmetric unitaries exist only for even $d$: taking
+determinants in $U^{T}=-U$ gives $\det U=(-1)^{d}\det U$, and $\det U\ne0$).
+
+\section{The corrected statement}
+
+The proved statement is: if $d>2$ and $U$ is an antisymmetric unitary on
+$\mathbb C^{d}$, then $T_{\mathrm{BH}}$ is an indecomposable positive
+map.\footnote{Formal declarations:
+\leanid{Matrix.breuerHallMap\_isIndecomposablePositiveMap} and
+\leanid{Matrix.breuerHallMap\_not\_isDecomposablePositiveMap} in
+\doclink{QICLean/Channel/BreuerHallIndecomposable}; positivity is
+\leanid{Matrix.breuerHallMap\_isPositiveMap} in
+\doclink{QICLean/Channel/BreuerHallMap}.}
+The source gives no proof; the formalized argument is the standard PPT
+detection route. Write $F$ for the swap operator on
+$\mathbb C^{d}\otimes\mathbb C^{d}$ and $\ket{\Psi}$ for the $U$-twisted
+maximally entangled vector, $\Psi(i,k)=U(i,k)$, with unnormalized projector
+$P_{0}=\ket{\Psi}\bra{\Psi}$. The witness state
+\begin{align}
+  \rho=(\mathbb 1+F)+P_{0}
+\end{align}
+is a sum of positive semidefinite terms, and antisymmetry with unitarity of
+$U$ gives the partial-transpose evaluations
+$(\mathbb 1+F)^{T_{1}}=\mathbb 1+P_{1}$ and
+$P_{0}^{T_{1}}=(U^{\dagger}\otimes\mathbb 1)(\mathbb 1+F)(U\otimes\mathbb 1)
+-\mathbb 1$, where $P_{1}$ is the untwisted maximally entangled projector.
+Hence
+\begin{align}
+  \rho^{T_{1}}=P_{1}+(U^{\dagger}\otimes\mathbb 1)(\mathbb 1+F)(U\otimes\mathbb 1)
+  \ge0,
+\end{align}
+so $\rho$ is a PPT state. Expanding all tensor indices and contracting
+against $U^{\dagger}U=\mathbb 1$ yields the carrying identity, valid for
+every bipartite $\sigma$,
+\begin{align}
+  \operatorname{tr}[(T_{\mathrm{BH}}\otimes\mathrm{id})(\sigma)\,P_{0}]
+  =\operatorname{tr}(\sigma)-\operatorname{tr}(\sigma P_{0})
+  -\operatorname{tr}(F\sigma).
+\end{align}
+At $\sigma=\rho$ the three traces are $d^{2}+2d$, $d^{2}$, and $d^{2}$ ---
+the last two because antisymmetry gives $F\ket{\Psi}=-\ket{\Psi}$ --- so the
+pairing equals $d(2-d)<0$ for $d>2$, and
+$(T_{\mathrm{BH}}\otimes\mathrm{id})(\rho)$ is not positive semidefinite.
+Since decomposable maps preserve positivity on PPT
+states,\footnote{Formal declarations:
+\leanid{IsDecomposablePositiveMap.tensorMapId\_posSemidef\_of\_isPPT} and
+\leanid{not\_isDecomposablePositiveMap\_of\_isPPT\_not\_tensorMapId\_posSemidef}
+in \doclink{QICLean/Channel/DecomposablePPT}.}
+$T_{\mathrm{BH}}$ is not decomposable.
+
+\section{Conclusion}
+
+The source's indecomposability claim for the Breuer--Hall map is correct
+exactly in the dimensions where antisymmetric unitaries exist and $d>2$,
+i.e.\ for even $d\ge4$; at $d=2$ the map vanishes. The formalization proves
+the corrected statement with the explicit hypothesis $d>2$, and the
+blueprint entry records the restriction in its statement.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_brouwer_general_compact_convex.tex
+++ b/docs/paper-gaps/wolf_brouwer_general_compact_convex.tex
@@ -1,0 +1,92 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The General Compact-Convex Brouwer Fixed-Point Theorem}
+\author{}
+\date{2026-08-04}
+
+\begin{document}
+\maketitle
+\gapnote{open-gap}{open}
+
+\section{The assertion}
+
+Wolf's Theorem~6.10 states the Brouwer fixed-point theorem in its general
+compact-convex form:\footnote{\cite[Theorem~6.10]{Wolf2012Quantum}; local source
+\path{Notes/WolfNoteTexSource/ch06\_spectral\_properties.tex},
+lines~1143--1151.}
+\begin{align}
+  T : S \to S,\qquad
+  S \subset \mathbb{R}^n \text{ nonempty, compact, convex},\qquad
+  T \text{ continuous}
+  \ \Longrightarrow\
+  \exists\, x \in S,\ T(x) = x.
+\end{align}
+
+\section{What is formalized}
+
+The vendored Gametheory library (LionSR/Brouwer) proves the Brouwer fixed-point
+theorem for the standard simplex~$\Delta^n$:
+\leanid{Brouwer}.
+TNLean extends this to products of simplices, closed cubes, and compact retracts
+of finite-dimensional real normed spaces.\footnote{Formal declarations:
+\leanid{exists\_fixedPoint\_closedCube} in
+\doclink{QICLean/Topology/BrouwerProduct},
+\leanid{fixedPoint\_of\_compact\_retract} in
+\doclink{QICLean/Topology/CompactRetractFixedPoint},
+and \leanid{brouwer\_fixedPoint\_densityMatrices} in
+\doclink{QICLean/Channel/FixedPoint/BrouwerDensityMatrices}.}  The density-matrix specialization
+is the only form used in the existing formalization of Wolf Theorem~6.11
+(Stationary states).
+
+\section{What is missing}
+
+The general statement with an \emph{arbitrary} nonempty compact convex subset
+\(S \subset \mathbb{R}^n\) is not yet proved.  Three natural routes would close
+this gap:
+
+\begin{enumerate}
+  \item \textbf{Metric projection.}  For a nonempty closed convex set~\(K\) in a
+    finite-dimensional Euclidean space, the nearest-point map
+    \(\operatorname{proj}_K(x) = \operatorname*{argmin}_{p \in K} \lVert x-p\rVert\) is unique,
+    1-Lipschitz, and restricts to the identity on~\(K\).  This provides the
+    retraction required by the existing retract-based fixed-point theorem.  The
+    existence, uniqueness, and continuity of the metric projection for convex
+    sets in Euclidean space is not yet in Mathlib.
+
+  \item \textbf{Convex-body homeomorphism.}  A nonempty compact convex~\(K\)
+    with nonempty interior in its affine hull is homeomorphic to the closed
+    unit ball, which is homeomorphic to a simplex.
+
+  \item \textbf{Triangulation.}  Refine \(K\) into a simplicial complex and
+    apply the Sperner-lemma / simplicial Brouwer argument directly (the route
+    taken by the Gametheory library for the standard simplex).
+\end{enumerate}
+
+\section{Impact}
+
+The missing general statement does \emph{not} block the formalization of Wolf
+Theorem~6.11 (Stationary states), Proposition~6.8 (Positive fixed-points), or
+Corollary~6.5 (spanning by stationary density matrices).  These results rely
+only on the density-matrix version of Brouwer, which is already proved.
+The general compact-convex Brouwer is not used anywhere in the current
+formalization.
+
+\section{Verdict}
+
+\textbf{Open gap.}  The general compact-convex Brouwer theorem (Wolf's
+formulation) remains unformalized.  The simplex specialization and its
+extensions to closed cubes, compact retracts, and density matrices are formalized
+and suffice for the current applications.  The metric-projection route is the
+most natural starting point and would be reusable beyond this theorem.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch01_operator_system_extension_matrix_scope.tex
+++ b/docs/paper-gaps/wolf_ch01_operator_system_extension_matrix_scope.tex
@@ -1,0 +1,94 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Wolf's Operator-System Extension: Matrix-Algebra Realization}
+\author{}
+\date{2026-08-08}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{The source statement}
+
+Wolf's proposition "Extending cp maps from operator systems" quantifies over
+two arbitrary finite-dimensional $C^\ast$-algebras $\mathcal A,\mathcal B$: let
+$T:S\to\mathcal B$ be a completely positive linear map from an operator system
+$S\subseteq\mathcal A$; then there is a completely positive map
+$\tilde T:\mathcal A\to\mathcal B$ agreeing with $T$ on $S$
+\cite[Proposition, lines~614--626]{Wolf2012Quantum}. The local source is
+\path{Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex}, lines~617--619
+(statement) and 620--626 (proof). Neither $\mathcal A$ nor $\mathcal B$ is
+assumed to be a full matrix algebra: a finite-dimensional $C^\ast$-algebra is,
+by the finite-dimensional structure theorem, a direct sum
+$\bigoplus_k M_{d_k}(\mathbb C)$, and the proposition covers every such
+algebra, not only the one-summand case $\mathcal A=M_m(\mathbb C)$.
+
+\section{The formalized scope}
+
+The domain algebra $\mathcal A$ is now formalized at the source's stated
+generality: a finite direct sum $\mathcal A=\bigoplus_{k<r} M_{d_k}(\mathbb C)$,
+represented literally as the dependent function type
+$\forall k, \MN{d_k}$. \leanid{Matrix.IsOperatorSystemDirectSum} and
+\leanid{Matrix.IsCPOnOperatorSystemDirectSum}
+(\doclink{QICLean/Channel/OperatorSystemExtensionDirectSum}) are the
+direct-sum-domain operator-system and complete-positivity-at-every-level
+predicates, defined entrywise (block by block), matching the single-summand
+predicates \leanid{Matrix.IsOperatorSystem}/\leanid{Matrix.IsCPOnOperatorSystem}
+(\doclink{QICLean/Channel/OperatorSystem}) verbatim when $r=1$. The extension
+theorem \leanid{Matrix.exists_cp_extension_of_operatorSystem_directSum}
+produces $\tilde T:\bigoplus_k \MN{d_k}\to\MN{p}$ agreeing with $T$ on $S$,
+completely positive in the same block-by-block sense
+(\leanid{Matrix.IsCPMapDirectSum}). The proof transports the single-summand
+theorem \leanid{Matrix.exists_cp_extension_of_operatorSystem}
+(\doclink{QICLean/Channel/OperatorSystemExtension}) along the block-diagonal
+embedding $\bigoplus_k M_{d_k}(\mathbb C)\hookrightarrow M_M(\mathbb C)$,
+$M=\sum_k d_k$ (\leanid{Matrix.directSumEmbedFin}, built from
+\leanid{Matrix.directSumDiagonalEmbedding}, the same block-diagonal embedding
+used for Wolf's Theorem~6.14 block structure, composed with the canonical
+reindexing \leanid{finSigmaFinEquiv}): complete positivity at every tensor
+level descends through this embedding
+(\leanid{Matrix.bipartiteSlice_directSumEmbedFinLevel}), because a
+block-diagonal matrix is positive semidefinite exactly when each of its
+diagonal blocks is.
+
+The codomain is now allowed to be any unital $*$-subalgebra
+$\mathcal B\subseteq\MN{p}$. The theorem
+\leanid{Matrix.exists_cp_extension_of_operatorSystem_directSum_starSubalgebra}
+(\doclink{QICLean/Channel/OperatorSystemExtensionStarSubalgebra}) starts with a
+map $T:S\to\mathcal B$ and returns an extension
+$\widetilde T:\bigoplus_k\MN{d_k}\to\mathcal B$. Complete positivity is stated
+after the canonical inclusion $\mathcal B\hookrightarrow\MN{p}$, because the
+direct-sum complete-positivity predicate has a full matrix codomain.
+
+The construction supplies the final step left implicit in the source's proof.
+First, \leanid{Matrix.exists_cp_extension_of_operatorSystem_directSum} gives an
+ambient extension $F:\bigoplus_k\MN{d_k}\to\MN{p}$. Next,
+\leanid{StarSubalgebra.exists_krausCPTP_conditionalExpectation} gives a
+trace-preserving completely positive conditional expectation
+$E:\MN{p}\to\MN{p}$ with range in $\mathcal B$ and $E|_{\mathcal B}=\mathrm{id}$.
+The map $E\circ F$ remains completely positive, takes values in $\mathcal B$,
+and agrees with $T$ on $S$. Restricting its codomain gives $\widetilde T$.
+
+\section{Verdict}
+
+\textbf{Closed for matrix-realized finite-dimensional algebras.} The domain is
+a finite direct sum $\bigoplus_{k<r}M_{d_k}(\mathbb C)$ and the codomain is a
+concrete unital $*$-subalgebra of a full matrix algebra, exactly the
+representation chosen in Wolf's displayed proof. The formal theorem does not
+quantify over an abstract finite-dimensional $C^*$-algebra type lacking a
+specified matrix representation, and it should not be cited as such an
+abstract theorem. It closes the matrix-algebra scope gap tracked in
+\href{https://github.com/LionSR/TNLean/issues/5645}{TNLean issue \#5645}: neither the domain nor the codomain is required to be a single
+full matrix algebra.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex
+++ b/docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex
@@ -1,0 +1,73 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Zero Multiplicities in Wolf's Two-Pure-State Spectrum Shorthand}
+\author{}
+\date{2026-08-08}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\section{The source display}
+
+In the proof of the spectrum-preserver consequence following Wigner's theorem,
+Wolf considers Hermitian rank-one projections $P,Q\in M_d(\mathbb C)$ and
+writes that the spectrum of $P+Q$ is
+\begin{align}
+  1\pm\sqrt{\tr(PQ)}.
+\end{align}
+The statement appears in Chapter~1, lines 289--296 of the local source,
+\path{Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex}.
+
+\section{The suppressed eigenvalues}
+
+The range of $P+Q$ lies in the span of the two one-dimensional ranges of $P$
+and $Q$. Hence $P+Q$ vanishes on a subspace of dimension at least $d-2$.
+Counting algebraic multiplicities, its characteristic polynomial is
+\begin{align}
+  \chi_{P+Q}(X)
+  =X^{d-2}((X-1)^2-\tr(PQ))
+  \qquad(d\geq2).
+\end{align}
+The displayed values are precisely the two roots of
+$(X-1)^2-\tr(PQ)$. The factor $X^{d-2}$ supplies the guaranteed additional
+zero multiplicity. If $P=Q$, then the quadratic is $X(X-2)$ and contributes
+one further zero, so the total zero multiplicity is $d-1$. In dimension one
+the separate formula is
+\begin{align}
+  \chi_{P+Q}(X)=X-2,
+\end{align}
+because every normalized rank-one projection is the identity. In dimension
+zero there are no projective pure states.
+
+\section{Formal correction}
+
+The declaration
+\leanid{Projectivization.charpoly_add_pureStateMatrix_of_two_le} proves the
+multiplicity-aware formula through a $d\times2$ and $2\times d$ factorization.
+The declaration
+\leanid{Projectivization.trace_pureStateMatrix_mul_eq_of_charpoly_add_eq}
+then recovers $\tr(PQ)$ from equality of two such characteristic polynomials.
+Both are in
+\doclink{QICLean/Channel/Wigner/TwoPureStateCharpoly}; the low-dimensional cases
+are stated explicitly there. This correction is tracked by \href{https://github.com/LionSR/TNLean/issues/5683}{TNLean issue \#5683}.
+
+\section{Classification}
+
+This is a local correction to a spectrum shorthand, not a claim that Wolf's
+intended spectrum-preserver argument is false. The roots of the quadratic
+factor retain the transition-probability information used in that argument.
+The formal statement uses characteristic polynomials because they retain all
+zero eigenvalues and all algebraic multiplicities without ambiguity.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex
+++ b/docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex
@@ -1,0 +1,94 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Trace Sign in Wolf's Lorentz-Cone Converse}
+\author{}
+\date{2026-06-23}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\section{The assertion}
+
+Wolf's Proposition~3.7 states two elementary trace inequalities for Hermitian
+matrices.\footnote{\cite[Proposition~3.7]{Wolf2012Quantum};
+local source \path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex},
+lines 693--722.}  The forward implication says that a positive semidefinite
+matrix satisfies
+\begin{align}
+  \tr(A^2) \le \tr(A)^2.
+\end{align}
+The converse is printed as
+\begin{align}
+  \tr(A)^2 \ge (d-1)\tr(A^2) \Longrightarrow A \ge 0.
+  \tag{\path{Wolf Prop. 3.7 converse}}
+\end{align}
+
+\section{The point at issue}
+
+The printed converse cannot be true without a sign condition on the trace.  For
+example, if \(A=-I_d\) and \(d\geq 1\), then \(A\) is Hermitian and not positive
+semidefinite, while
+\begin{align}
+  \tr(A)^2=d^2 \ge d(d-1)=(d-1)\tr(A^2).
+\end{align}
+Thus the squared inequality only controls the Lorentz cone up to time
+orientation; it does not distinguish the positive and negative trace sheets.
+
+This is also visible in the proof printed after the proposition.  The argument
+decomposes \(A=A_+-A_-\) and uses the estimate
+\begin{align}
+  \tr(A) \le \tr(A_+).
+\end{align}
+To contradict the squared inequality one needs the left hand side to have the
+same orientation as the nonnegative quantity being bounded.  A nonnegative
+trace hypothesis supplies exactly this orientation.
+
+\section{Corrected statement}
+
+The formal theorem proves the trace-nonnegative version:
+\begin{align}
+  A=A^\dagger,\qquad
+  \tr(A)\ge 0,\qquad
+  (d-1)\tr(A^2)\le \tr(A)^2
+  \Longrightarrow A\ge 0.
+\end{align}
+In the complex matrix formalization the traces are written with real parts,
+which agrees with the displayed real quantities for Hermitian \(A\).\footnote{
+Formal declaration
+\leanid{Matrix.IsHermitian.posSemidef_of_trace_re_nonneg_of_card_sub_one_mul_trace_sq_re_le}
+in \doclink{QICLean/Analysis/MatrixTraceInequalities}; tracked by
+\href{https://github.com/LionSR/TNLean/issues/3402}{TNLean issue \#3402}.}
+
+The proof is a finite eigenvalue argument.  If some eigenvalue \(\lambda_0\) is
+negative, write
+\begin{align}
+  T=\sum_i\lambda_i,\qquad
+  R=\sum_{i\ne 0}\lambda_i .
+\end{align}
+Since \(T\ge0\) and \(T=\lambda_0+R\), one has \(T<R\), and hence
+\(T^2<R^2\).  Cauchy's inequality for the remaining \(d-1\) eigenvalues gives
+\begin{align}
+  R^2\le (d-1)\sum_{i\ne 0}\lambda_i^2
+       \le (d-1)\sum_i\lambda_i^2,
+\end{align}
+contradicting the assumed Lorentz inequality.  Therefore all eigenvalues are
+nonnegative.
+
+\section{Conclusion}
+
+The unrestricted printed converse should not be marked as formalized.  The
+formal development records the future-cone, trace-nonnegative converse as the
+mathematically valid statement used in the positive-map discussion.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch5_abstract_multiplicative_domains.tex
+++ b/docs/paper-gaps/wolf_ch5_abstract_multiplicative_domains.tex
@@ -1,0 +1,92 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Wolf Chapter~5: Abstract Multiplicative-Domain Hypotheses}
+\author{}
+\date{2026-07-18}
+
+\begin{document}
+\maketitle
+\gapnote{clarification}{resolved}
+
+\section{Source statement}
+
+Let $E:M_D(\mathbb C)\to M_D(\mathbb C)$ be a complex-linear map satisfying
+the Schwarz inequality
+\begin{align}
+  E(A^*A)-E(A^*)E(A)\succeq 0
+  \qquad (A\in M_D(\mathbb C)).
+  \tag{Wolf, Equation (5.2)}
+\end{align}
+Wolf defines
+\begin{align}
+  \mathcal A_R
+    &=\{A:E(XA)=E(X)E(A)\text{ for every }X\},\\
+  \mathcal A_L
+    &=\{A:E(AX)=E(A)E(X)\text{ for every }X\},
+\end{align}
+and proves
+\begin{align}
+  A\in\mathcal A_R
+    &\iff E(A^*A)=E(A^*)E(A),\\
+  A\in\mathcal A_L
+    &\iff E(AA^*)=E(A)E(A^*).
+  \tag{Wolf, Equations (5.13)--(5.14)}
+\end{align}
+The local source for Equation~(5.2) is
+\path{Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex},
+lines~156--164; the local source for Equations~(5.11)--(5.14) is
+lines~383--410 of the same file.  No Kraus representation, complete
+positivity, or $2$-positivity occurs in this statement.
+
+\section{Earlier specialization}
+
+The existing one-sided characterizations use a unital Kraus family.
+\footnote{See
+\leanid{KadisonSchwarz.mem_rightMultiplicativeDomain_iff} and
+\leanid{KadisonSchwarz.mem_leftMultiplicativeDomain_iff} in
+\doclink{QICLean/Channel/Schwarz/MultiplicativeDomainFull}.}
+They are mathematically correct specializations, but the
+Kraus representation and unitality are absent from Wolf's abstract
+multiplicative-domain theorem.  Their names also use the convention that the
+subscript records the side on which the varying factor is appended; this
+interchanges the labels ``left'' and ``right'' relative to Wolf's convention,
+where the subscript records the side occupied by the fixed element.
+
+The source-faithful formulation now uses only complex linearity and the
+displayed Schwarz inequality.
+\footnote{Formal declarations:
+\leanid{IsSchwarzMap},
+\leanid{SchwarzMap.rightMultiplicativeDomain},
+\leanid{SchwarzMap.leftMultiplicativeDomain},
+\leanid{SchwarzMap.mem_rightMultiplicativeDomain_iff}, and
+\leanid{SchwarzMap.mem_leftMultiplicativeDomain_iff} in
+\doclink{QICLean/Channel/Schwarz/AbstractMultiplicativeDomain}.}
+The Kraus declarations remain available as specialized results and are no
+longer used as the blueprint witness for the unrestricted source theorem.
+
+\section{Remaining Chapter 5 boundary}
+
+Wolf's preceding two-variable operator Schwarz inequality and its equality
+criterion, involving the inverse of $E(B^*B)$ on its range, remain separate
+work.  The one-variable multiplicative-domain theorem above does not assume
+those results: its polarization proof applies the one-variable Schwarz
+inequality directly to $A+tY$.
+
+\section{Verdict}
+
+The interchange of the one-sided domain names is a notational clarification:
+the two conventions define the same pair of sets with opposite labels, and
+their full intersections agree.  The source-faithful one-variable theorem is
+complete.  The two-variable inverse-on-range inequality and its equality
+criterion remain an open gap.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
+++ b/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
@@ -1,0 +1,327 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Wolf Chapter~5 Operator Jensen and Lieb Concavity Boundary}
+\author{}
+\date{2026-06-23}
+
+\begin{document}
+\maketitle
+\gapnote{open-gap}{resolved}
+
+\section{Scope}
+
+This note records the mathematical content of the Chapter~5
+operator-convexity boundary\footnote{%
+    The declarations are
+    \leanid{posMap_rpow_concave_jensen}, \leanid{posMap_rpow_convex_jensen},
+    \leanid{posMap_log_concave_jensen}, and \leanid{lieb_concavity_posDef} in
+    \doclink{QICLean/Analysis/LiebConcavity}; the first, third, and fourth are
+    now theorems (the Lieb declaration in its positive-definite, boundary-exponent
+    scope, see Section~\ref{sec:lieb}); none remains an axiom.}
+together with the cited sources, the precise gaps, and the first concrete step
+toward eliminating each remaining gap.  The positive-map Jensen declarations
+underlie \cite[Corollary~5.2]{Wolf2012Quantum} (the second corollary of Wolf's
+\S5.4) and rest on the operator-convexity and
+operator-monotonicity-versus-positive-maps results
+\cite[Theorems~5.10--5.13]{Wolf2012Quantum}; the Lieb declaration is the
+Ando--Lieb trace functional \cite[Theorem~5.15]{Wolf2012Quantum}.  (Wolf's Theorem~5.1 is
+Douglas' theorem and is unrelated to this development.)
+
+The notation is fixed throughout.  Operators act on a finite-dimensional Hilbert
+space, identified with $D\times D$ complex matrices.  The order $A\le B$ is the
+Loewner order ($B-A$ positive semidefinite).  A linear map $T$ on matrices is
+\emph{positive} if it sends positive semidefinite operators to positive
+semidefinite operators, \emph{subunital} if $T(\mathbf 1)\le\mathbf 1$, and
+\emph{unital} if $T(\mathbf 1)=\mathbf 1$.  The power $A^p$ for $A\ge 0$ and the
+logarithm $\log A$ for $A>0$ are defined by the continuous functional calculus.
+
+\section{The positive-map Jensen declarations}
+
+\subsection{The assertions}\label{ssec:assertions}
+
+For a positive subunital map $T$ the development asserts the operator Jensen
+inequalities
+\begin{align}
+  T(A^p) &\le (T A)^p, & p&\in[0,1], \ A\ge 0, \tag{\path{posMap_rpow_concave_jensen}}\\
+  (T A)^p &\le T(A^p), & p&\in[1,2], \ A\ge 0, \tag{\path{posMap_rpow_convex_jensen}}
+\end{align}
+and, for a positive \emph{unital} map $T$ and $A>0$,
+\begin{align}
+  T(\log A) &\le \log(T A). \tag{\path{posMap_log_concave_jensen}}
+\end{align}
+These are the operator-valued Jensen inequalities behind Wolf
+Corollary~5.2.\footnote{%
+    They were consumed by
+    \leanid{cor52_item1_rpow_of_subunital},
+    \leanid{cor52_item2_rpow_of_subunital}, and
+    \leanid{cor52_item3_log_of_unital} in
+    \path{Channel/Schwarz/OperatorMonotone}, corollary wrappers since removed
+    as unused in
+    \href{https://github.com/LionSR/QICLean/pull/56}{QICLean PR \#56}.}
+The first and third are concavity inequalities (for the operator-concave
+functions $x\mapsto x^p$ on $[0,1]$ and $x\mapsto\log x$); the second is a
+convexity inequality (for the operator-convex function $x\mapsto x^p$ on
+$[1,2]$).  The logarithmic case requires $T$ unital, not merely subunital: with
+$T$ only subunital the inequality fails because $\log$ is unbounded below near
+$0$.
+
+\subsection{The point at issue: the genuine gap is positive-map Jensen}
+
+Mathlib~4.31 supplies the integral
+representation\footnote{%
+    \leanid{CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁}
+    and its $[1,2]$ companion in
+    \path{Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/IntegralRepresentation.lean},
+    together with the Bochner-integral convexity transfer for C\textsuperscript{*}-algebras.}
+and, through it, the operator concavity of $x\mapsto x^p$ on $[0,1]$
+(\leanid{CFC.concaveOn_rpow}) and of $\log$ (\leanid{CFC.concaveOn_log}).  The
+scalar input of the convex case, operator convexity of $x\mapsto x^p$ on
+$[1,2]$, is also now present as \leanid{CFC.convexOn_rpow} in
+\doclink{QICLean/Analysis/RpowConvexity}.  Thus the scalar functional-calculus
+inputs for the three Jensen declarations are available in the formal
+development.
+
+The remaining gap is the step \emph{from} operator concavity (a statement about a
+single operator) \emph{to} the Jensen inequality $T(fA)\le f(TA)$ for a positive
+map.  This is the Choi--Davis--Jensen inequality (the positive-map form of the
+Hansen--Pedersen operator Jensen inequality): for an operator-concave $f$ and a
+positive unital map $T$ one has $T(fA)\le f(TA)$, with the subunital version
+obtained by dilating $T$ to a unital map.  Mathlib~4.31 contains no such
+general theorem for positive maps.  The concave real-power case has now been
+discharged by the special Löwner-integrand route recorded in
+\leanid{TNLean.OperatorJensen.positiveMap_rpowIntegrand₀₁_jensen}, together
+with ordered Bochner integral monotonicity.  The logarithmic case has also been
+discharged, not by a general Choi--Davis--Jensen theorem, but by taking the
+right limit $p\to 0^+$ in the concave real-power inequality and using
+\leanid{CFC.tendsto_cfc_rpow_sub_one_log}.  The convex real-power case is now
+likewise proved, by the same positive-map Jensen step applied to the convex
+integrand of $x\mapsto x^p$ on $[1,2]$.
+
+\subsection{The compression scaffold is faithful to bare
+positivity}\label{ssec:caveat}
+
+A faithfulness worry would arise if the only available proof route needed a
+\emph{completely positive} $T$, since the statements assume only that $T$ is
+positive (the hypothesis recorded in the formal statements is
+\leanid{IsPositiveMap}) and a complete-positivity hypothesis would be the
+stronger-hypothesis variant forbidden by the faithfulness rule.  That worry does
+not apply here.
+
+Wolf's own proof of the positive-map operator Jensen results
+(\cite[Theorems~5.10--5.13]{Wolf2012Quantum}) proves them first for completely
+positive maps, then \emph{reduces} the bare positive-map case to the completely
+positive case: $A$ and $f(A)$ lie in the abelian $C^*$-algebra generated by $A$
+and $\mathbf 1$, on which every positive map is automatically completely
+positive (Wolf Prop.~1.6) and admits a completely positive extension to all of
+$\mathcal M_d$ (Wolf Prop.~1.7).  Thus no obstruction specific to maps that are
+positive but not completely positive survives, and the source corollary itself
+is stated for
+positive subunital maps, not for channels: \cite[Corollary~5.2]{Wolf2012Quantum}
+hypothesises a positive map with $T(\mathbf 1)\le\mathbf 1$, which is exactly the
+\leanid{IsPositiveMap} plus subunitality recorded in the two power companions
+\leanid{cor52_item1_rpow_of_subunital} and
+\leanid{cor52_item2_rpow_of_subunital}.
+
+\paragraph{Local fix (log unitality).}  The logarithmic companion
+\leanid{cor52_item3_log_of_unital} departs from this subunital hypothesis: it
+assumes $T$ \emph{unital}, $T(\mathbf 1)=\mathbf 1$, rather than $T(\mathbf
+1)\le\mathbf 1$.  This is a deliberate strengthening, not an exact match to the
+subunital form of the source corollary: as recorded in \S\ref{ssec:assertions},
+the subunital logarithmic inequality $T(\log A)\le\log(TA)$ fails because $\log$
+is unbounded below near $0$, so the unital restriction is the mathematically
+correct domain for the logarithmic case.  This is a local fix (a hypothesis
+sharpened to the regime where the inequality holds), documented here so the
+deviation from the verbatim subunital reading of
+\cite[Corollary~5.2]{Wolf2012Quantum} is auditable; the two power companions
+above retain the bare subunital hypothesis.
+
+The partial scaffold already present in the repository for the concave power
+case\footnote{%
+    \doclink{QICLean/Channel/Schwarz/OperatorJensenAux} (finite-POVM compression,
+    Schur-complement inverse bound, and the resolvent inequality).}
+realises this reduction at the matrix level.  It is a finite-POVM compression
+argument in terms of a positive family $\{C_i\}$ and a defect block, not a global
+Kraus or Stinespring representation of $T$.  Its POVM elements are supplied by
+the positive matrices $T(P_i)$, where the $P_i$ are the spectral projections of
+$A$; these exist for any positive map (indeed $\sum_i T(P_i)=T(\mathbf 1)$, the
+identity used in Wolf's block-positivity step in the proof of
+  \cite[Theorem~5.12]{Wolf2012Quantum}).  The scaffold
+  therefore applies to a bare positive map in the finite-POVM resolvent reduction
+  under the \leanid{IsPositiveMap} hypothesis --- it does not require, and must not
+  be relabelled with, complete positivity.  It now proves the concave
+  real-power Jensen inequality after integration.  The logarithmic Jensen theorem
+  follows from this real-power result by the right-limit formula for
+  $(A^p-\mathbf 1)/p$ as $p\to 0^+$.  The convex real-power Jensen declaration
+  is now proved the same way, with the convex integrand on $[1,2]$.
+
+For the concave real-power case, the analytic step has now been supplied: the
+Löwner-integral argument carries the pointwise finite-POVM resolvent inequality
+(\leanid{povm_resolvent_inv_le}) through the integral representation of
+\texttt{rpow} to the operator inequality
+\leanid{posMap_rpow_concave_jensen}.  The logarithmic inequality
+\leanid{posMap_log_concave_jensen} is then obtained by applying
+\leanid{CFC.tendsto_cfc_rpow_sub_one_log} to both $A$ and $T(A)$ and closing the
+Loewner inequality by the closedness of the finite-dimensional order graph.
+
+\subsection{Current formal inputs}\label{ssec:formal-inputs}
+
+The auxiliary ingredients needed before the remaining positive-map Jensen
+assemblies are now present.  The theorem \leanid{CFC.convexOn_rpow} supplies operator
+convexity of $x\mapsto x^p$ for $p\in[1,2]$, completing the scalar
+functional-calculus input for \leanid{posMap_rpow_convex_jensen}.
+
+The closedness of the finite-dimensional Loewner cone also gives the ordered
+Bochner integral step needed for the integral route.  The positive-cone
+specialization is recorded as
+\leanid{TNLean.OperatorJensen.integral_nonneg_matrix_of_ae}: a matrix-valued
+Bochner integral of an almost-everywhere positive semidefinite function is
+positive semidefinite.  Almost-everywhere Loewner inequalities are integrated
+directly by the general ordered Bochner theorem \leanid{integral_mono_ae}.
+
+\subsection{Verdict}
+
+The three positive-map Jensen statements are mathematically standard
+\cite[Theorems~5.10--5.13 and Corollary~5.2]{Wolf2012Quantum}.  The concave
+real-power statement \leanid{posMap_rpow_concave_jensen} has been discharged by
+the finite-POVM resolvent scaffold, the pointwise integrand inequality, and
+ordered Bochner integral monotonicity.  The logarithmic statement
+\leanid{posMap_log_concave_jensen} has been discharged as the right limit of the
+concave real-power result.  The convex real-power statement
+\leanid{posMap_rpow_convex_jensen} has likewise been discharged, by the same
+positive-map operator Jensen step applied to the convex integrand.
+The integral representation of the power integrand, previously named as the
+obstruction, is present.
+
+\section{The Lieb concavity theorem (boundary exponent)}\label{sec:lieb}
+
+\subsection{The assertion}
+
+For $s\in[0,1]$, an arbitrary matrix $K$, and positive-definite $A,B$, the map
+\begin{align}
+  (A,B)\ \longmapsto\ \tr\!\bigl(K^\dagger A^s K B^{1-s}\bigr)
+  \tag{\path{lieb_concavity_posDef}}
+\end{align}
+is jointly concave on pairs of positive-definite matrices.  This is the
+boundary-exponent specialization of the Lieb concavity theorem
+(\cite[Theorem~5.15, the Ando--Lieb functional]{Wolf2012Quantum}), the trace
+functional underlying the Wigner--Yanase--Dyson conjecture.  It is now
+\emph{proved} --- \leanid{lieb_concavity_posDef} is a theorem,
+derived from the commuting-superoperator integral representation
+(\S\ref{ssec:lieb-gap}) --- and \leanid{lieb_concavity_psd} extends it to
+positive-semidefinite inputs by regularization.  The theorem
+\leanid{lieb_concavity_subboundary} now derives the two-exponent region
+$x,y\ge 0$, $x+y\le 1$, by reducing to the boundary theorem after the change of
+variables $r=x+y$, $s=x/r$ when $r>0$.  Thus the finite-dimensional matrix
+formalization now covers the exponent range of Wolf's Theorem~5.15.
+
+\paragraph{Sub-boundary exponents (resolved).}  Wolf's Theorem~5.15 is stated
+for two exponents $x,y\ge 0$ with $x+y\le 1$.  The first formal theorem
+\leanid{lieb_concavity_posDef} records only the boundary line $x=s$, $y=1-s$,
+where $x+y=1$, and \leanid{lieb_concavity_psd} extends that boundary theorem to
+positive-semidefinite inputs.  The sub-boundary theorem
+\leanid{lieb_concavity_subboundary} removes the exponent restriction: for
+$r=x+y=0$ the functional is constant, and for $0<r\le 1$ it rewrites
+$A^x,B^y$ as $(A^r)^s,(B^r)^{1-s}$ and combines operator concavity of
+$C\mapsto C^r$, monotonicity of the boundary trace functional, and
+\leanid{lieb_concavity_psd}.
+
+\paragraph{Positive-definite versus positive semidefinite (resolved).}  Wolf's
+Theorem~5.15 states the Ando--Lieb concavity for positive (semidefinite)
+operators, including singular ones.  The first formalization
+\leanid{lieb_concavity_posDef} was stated only for positive-\emph{definite}
+$A,B$ (its hypotheses are \leanid{Matrix.PosDef}).  The positive-semidefinite
+case is now also proved, as \leanid{lieb_concavity_psd}, with hypotheses
+\leanid{Matrix.PosSemidef} on $A_1,A_2,B_1,B_2$.  The proof is by
+regularization: each input is replaced by $A_i+\varepsilon\Id$ (positive
+definite for $\varepsilon>0$), the positive-definite theorem is applied for
+every $\varepsilon>0$, and the limit $\varepsilon\to 0^+$ recovers the
+semidefinite inequality.  The regularized powers converge because $x\mapsto x^s$
+is continuous on the nonnegative reals for $0<s<1$, including at the origin ---
+the logarithmic singularity that obstructs the entropy-continuity route does not
+arise here --- and the trace functional is continuous.  This scope restriction
+is therefore eliminated; the exponent restriction is eliminated by
+\leanid{lieb_concavity_subboundary}.
+
+\subsection{The point at issue}\label{ssec:lieb-gap}
+
+The matrix identity
+$A^s B^{1-s}=\tfrac{\sin(\pi s)}{\pi}\int_0^\infty t^{s-1}A\,(A+tB)^{-1}B\,\mathrm dt$
+holds only when $A$ and $B$ commute; for noncommuting $A,B$ the product
+$A^sB^{1-s}$ is not even self-adjoint, and this resolvent formula is \emph{not}
+the representation behind the Lieb functional.  The standard route works instead
+with the \emph{left and right multiplication superoperators} on $\mathcal M_d$,
+\begin{align}
+  L_A : X \longmapsto AX, \qquad R_B : X \longmapsto XB,
+\end{align}
+which always commute ($L_A R_B = R_B L_A$) and are positive on the
+Hilbert--Schmidt space $(\mathcal M_d,\langle X,Y\rangle = \tr(X^\dagger Y))$
+when $A,B\ge 0$.  The Lieb functional is the Hilbert--Schmidt pairing
+\begin{align}
+  \tr\!\bigl(K^\dagger A^s K B^{1-s}\bigr)
+    = \bigl\langle K,\ L_A^{\,s}\,R_B^{\,1-s}\,K\bigr\rangle,
+\end{align}
+and the Ando/Lieb integral representation is the commuting-superoperator identity
+\begin{align}
+  L_A^{\,s}\,R_B^{\,1-s}
+    = \frac{\sin(\pi s)}{\pi}\int_0^\infty t^{s-1}\,
+      L_A\,(L_A + t\,R_B)^{-1}\,R_B\ \mathrm dt .
+\end{align}
+Joint concavity of the superoperator integrand in $(A,B)$ for each fixed $t$ ---
+via operator monotonicity of the resolvent $(L_A+tR_B)^{-1}$ in $A,B$ --- followed
+by pairing against $K$ in the Hilbert--Schmidt inner product, integration, and
+linearity, yields the result.
+
+Mathlib~4.31 contains neither this superoperator integral representation nor a
+matrix-mean / resolvent-monotonicity API of the required form for the commuting
+pair $(L_A,R_B)$.  Both were therefore developed within the formalization
+itself rather than drawn from the library.
+
+\subsection{Verdict}
+
+The Lieb concavity statement is correct
+\cite[Theorem~5.15]{Wolf2012Quantum}.  Its elimination required the Ando
+integral representation of the commuting left/right multiplication superoperators
+$L_A^{\,s}R_B^{\,1-s}$ (not the matrix product $A^sB^{1-s}$, whose resolvent
+formula holds only when $A,B$ commute) together with resolvent monotonicity of
+$(L_A+tR_B)^{-1}$.  Both were formalized over a sequence of steps --- the scalar
+boundary integral, the operator integral representation on the Kronecker model,
+the concavity of the resolvent integrand, and the resulting operator concavity ---
+and \leanid{lieb_concavity_posDef} is now a theorem in its positive-definite,
+boundary-exponent scope.  The positive-semidefinite case is also proved, as
+\leanid{lieb_concavity_psd}, by regularizing each input to positive definite and
+passing to the limit, and \leanid{lieb_concavity_subboundary} derives the full
+two-exponent range $x,y\ge 0$, $x+y\le 1$.  Three downstream corollaries build on
+the positive-definite version (the $K=\mathbf 1$ case and separate concavity in
+each argument); these are now axiom-free.  The former positive-semidefinite and
+sub-boundary exponent restrictions for the finite-dimensional matrix
+Ando--Lieb theorem have both been eliminated.
+
+\section*{References}
+
+Beyond \cite{Wolf2012Quantum}, the underlying matrix-analysis facts are:
+E.~H.\ Lieb, \emph{Convex trace functions and the Wigner--Yanase--Dyson
+conjecture}, Adv.\ Math.\ \textbf{11} (1973) 267--288;
+T.~Ando, \emph{Concavity of certain maps on positive definite matrices and
+applications to Hadamard products}, Linear Algebra Appl.\ \textbf{26} (1979)
+203--241;
+F.~Hansen and G.~K.\ Pedersen, \emph{Jensen's operator inequality}, Bull.\
+London Math.\ Soc.\ \textbf{35} (2003) 553--564;
+R.~Bhatia, \emph{Matrix Analysis}, Springer GTM~169 (1997), Chapter~V.
+The relevant formal-library inputs now available are
+\leanid{CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁},
+\leanid{CFC.concaveOn_rpow}, \leanid{CFC.convexOn_rpow}, and
+\leanid{CFC.concaveOn_log}.  Thus the scalar functional-calculus inputs are
+available, and all four positive-map Jensen and Lieb declarations of this
+boundary are now proved theorems.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex
+++ b/docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex
@@ -1,0 +1,124 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Inverse on the Range in the Two-Variable Operator Schwarz Inequality}
+\author{}
+\date{2026-08-21}
+
+\begin{document}
+\maketitle
+\gapnote{open-gap}{resolved}
+
+\section{Source statement}
+
+Let $E=T^*\colon M_{d'}(\mathbb C)\to M_d(\mathbb C)$ be a positive linear
+map, where the reverse-direction map
+$T\colon M_d(\mathbb C)\to M_{d'}(\mathbb C)$ is two-positive.
+Theorem~5.3 of Wolf's \emph{Quantum Channels \& Operations: Guided Tour},
+Chapter~5, asserts that for every $A,B\in M_{d'}(\mathbb C)$,
+\begin{align}
+  E(A^\dagger B)\,E(B^\dagger B)^{-1}\,E(B^\dagger A)
+  &\leq E(A^\dagger A),
+  \label{eq:schwarz}
+\end{align}
+where the inverse is taken on the range of $E(B^\dagger B)$.  The local
+source is
+\path{Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex}, lines
+180--190.
+
+Rectangular two-positivity is invariant under the trace adjoint, so $E=T^*$
+is two-positive. The formal theorem records Wolf's hypotheses with the same
+independent input and output dimensions and does not assume an additional
+witness. The inverse on the range is represented by the Moore--Penrose inverse.
+
+\section{The range inverse}
+
+Put
+\begin{align}
+  P &= E(A^\dagger A), &
+  Z &= E(A^\dagger B), &
+  R &= E(B^\dagger B).
+\end{align}
+Two-positivity gives
+\begin{align}
+  \begin{pmatrix}
+    P & Z\\
+    Z^\dagger & R
+  \end{pmatrix}
+  &\geq 0.
+  \label{eq:block-positive}
+\end{align}
+The kernel clause of the Schur-complement theorem applied to
+\eqref{eq:block-positive} yields
+\begin{align}
+  \ker R &\subseteq \ker Z.
+  \label{eq:kernel-inclusion}
+\end{align}
+Let $R^+$ be the Moore--Penrose inverse of $R$, and let
+\begin{align}
+  s_R &= RR^+=R^+R
+\end{align}
+be the orthogonal projection onto the support of $R$.  Since $R$ is positive
+semidefinite, its support is $(\ker R)^\perp$.  Equation
+\eqref{eq:kernel-inclusion} is therefore equivalent to
+\begin{align}
+  Zs_R &= Z,
+  &
+  s_RZ^\dagger &= Z^\dagger.
+  \label{eq:support-absorption}
+\end{align}
+In particular,
+\begin{align}
+  R\bigl(R^+Z^\dagger\bigr) &= Z^\dagger.
+  \label{eq:range-witness}
+\end{align}
+Thus $R^+Z^\dagger v$ is the required preimage of $Z^\dagger v$ under $R$
+for every vector $v$.  This is precisely the meaning of the inverse on the
+range in \eqref{eq:schwarz}; no separate range--kernel duality argument is
+needed.
+
+The formal proof establishes \eqref{eq:kernel-inclusion}, then
+\eqref{eq:support-absorption}, and finally
+\eqref{eq:range-witness}.
+
+\section{Derivation of the inequality}
+
+For a fixed vector $v$, set
+\begin{align}
+  w &= R^+Z^\dagger v.
+\end{align}
+Equation~\eqref{eq:range-witness} gives $Rw=Z^\dagger v$.  The
+pseudoinverse-free quadratic-form consequence of
+\eqref{eq:block-positive} then gives
+\begin{align}
+  v^\dagger Pv
+  &\geq v^\dagger Zw
+   = v^\dagger ZR^+Z^\dagger v.
+\end{align}
+Since this holds for every $v$,
+\begin{align}
+  ZR^+Z^\dagger &\leq P,
+\end{align}
+which is \eqref{eq:schwarz}.\footnote{Formal declaration:
+  \leanid{schwarz_two_variable_unconditional_of_traceAdjointMap} in the namespace
+  \leanid{SchwarzTwoVariable}.}
+
+\section{Verdict}
+
+There is no remaining hypothesis or dimensional restriction relative to
+Wolf's statement.  The formal theorem records the positive map as the trace
+adjoint $E=T^*$ of a two-positive reverse-direction map $T$; rectangular
+two-positivity of $E$ follows from invariance under the trace adjoint.  The
+phrase ``inverse on the range'' is realized by the
+Moore--Penrose inverse, and the required range inclusion follows from
+support-projection absorption.  The earlier proposed use of an explicit
+Euclidean-space range--kernel duality is unnecessary.  Thus the former gap is
+resolved.
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex
+++ b/docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex
@@ -1,0 +1,99 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Phase Index in the Weighted Ces\`aro Formula, Wolf Equation~(6.15)}
+\author{}
+\date{2026-08-16}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\section{The source sentence}
+
+After expressing $T_\infty$ as a Ces\`aro mean in his Equation~(6.14), Wolf
+writes, for a trace-preserving positive linear map $T:\MN{D}\to\MN{D}$,
+\begin{align}
+  T_\phi
+  & = \lim_{N\to\infty}\frac{1}{N}\sum_{n=1}^N
+  \sum_{k:|\lambda_k|=1} (\overline{\lambda_k}T)^n.
+  \tag{Wolf eq.~6.15}
+\end{align}
+The local source is
+\path{Notes/WolfNoteTexSource/ch06_spectral_properties.tex},
+lines~258--264 \cite{Wolf2012Quantum}. Throughout the chapter the index $k$
+runs over the Jordan blocks of the superoperator $\widehat T$: by
+Equations~(6.4)--(6.5) of the same source (lines~111--139),
+$\widehat T=X(\bigoplus_{k=1}^K J_k(\lambda_k))X^{-1}$, and ``the number of
+Jordan blocks with eigenvalue $\lambda$ is the geometric multiplicity of
+$\lambda$'' (lines~140--142); several blocks may carry the same eigenvalue.
+
+\section{Correction forced by the multiplicities}
+
+The summand $(\overline{\lambda_k}T)^n$ depends on the eigenvalue $\lambda_k$
+only, not on the block carrying it, so the literal block-indexed inner sum
+counts each peripheral eigenvalue with its geometric multiplicity. Take the
+identity channel $T=\one$ on $\MN{D}$ with $D>1$: every matrix is an eigenvector
+for the eigenvalue $1$, the Jordan decomposition of $\widehat T$ consists of
+$D^2$ one-dimensional blocks all carrying $\lambda_k=1$, and the literal
+right-hand side of Equation~(6.15) is
+\[
+  \lim_{N\to\infty}\frac{1}{N}\sum_{n=1}^N D^2\,\one
+  = D^2\,\one
+  \neq T_\phi=\one.
+\]
+So read literally, with $k$ a block index, the equation is false. The reading
+under which it is true --- plainly the intended one, since the same chapter
+characterizes $T_\phi$ as the projection onto the span of the peripheral
+eigenvectors - is that $k$ runs over the \emph{distinct} peripheral
+eigenvalues,
+\[
+  T_\phi
+  = \lim_{N\to\infty}\frac{1}{N}\sum_{n=1}^N
+  \sum_{\substack{\lambda\ \text{eigenvalue of }T\\ |\lambda|=1}}
+  (\bar\lambda T)^n ,
+\]
+each phase counted once. This is consistent with the rest of the chapter:
+peripheral Jordan blocks of a trace-preserving positive map are
+one-dimensional (source, proposition on lines~181--186), so the peripheral
+subspace is the direct sum of the eigenspaces of the distinct peripheral
+eigenvalues, and on the eigenspace of $\lambda$ the summand indexed by $\mu$
+acts as the scalar $(\bar\mu\lambda)^n$, whose Ces\`aro mean is
+$\delta_{\mu\lambda}$; a single summand per distinct eigenvalue therefore
+suffices to recover the projection. The neighbouring sums
+$\widehat T_\infty$, $\widehat T_\phi$, $\widehat T_\varphi$ of
+Equations~(6.11)--(6.13) are indexed by blocks as well, but they involve the
+block projections $P_k$ and are correct as printed; only Equation~(6.15),
+whose summand lost the block dependence, requires the deduplicated index.
+
+The formal development averages over the set of eigenvalues of modulus one, so
+each distinct phase appears once.\footnote{Formal declarations:
+  \leanid{Module.End.weightedCesaroMean} for the average, and the convergence
+  statements
+  \leanid{IsPositiveMap.tendsto_weightedCesaroMean_peripheralProjection},
+  \leanid{IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_peripheralProjection},
+  \leanid{IsPositiveMap.tendsto_weightedCesaroMean_toFinset_peripheralProjection},
+  and
+  \leanid{IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_toFinset_peripheralProjection}
+  in \doclink{QICLean/Channel/Peripheral/WeightedCesaro}.}
+This correction changes no hypothesis of Equation~(6.15); it adjusts the
+multiplicity convention of the inner summation index.
+
+\section{Verdict}
+
+This is a local correction of the summation index in the source equation: $k$
+is reinterpreted from a Jordan-block index to an index of the distinct
+peripheral eigenvalues. It does not alter the hypotheses or the conclusion of
+Equation~(6.15), which is false under the literal block-indexed reading, as
+the identity channel shows.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch6_spectral_radius_eigenvalue.tex
+++ b/docs/paper-gaps/wolf_ch6_spectral_radius_eigenvalue.tex
@@ -1,0 +1,114 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Spectral-Radius Identification in Wolf Theorem 6.5}
+\author{}
+\date{2026-08-04}
+
+\begin{document}
+\maketitle
+\gapnote{open-gap}{open}
+
+\section{Source statement}
+
+Wolf's Theorem~6.5 asserts that the spectral radius of a positive map is
+itself an eigenvalue, attained on a positive semidefinite eigenvector. We
+write $X\succeq0$ for positive semidefinite, $X\succ0$ for positive definite,
+and $\varrho(T)$ for the spectral radius. The theorem states: for every
+positive linear map $T:\MN{d}\to\MN{d}$,
+\begin{align}
+  T(X)&=\varrho(T)\,X
+  \qquad\text{for some }X\succeq0,\ X\neq0.
+  \tag{Wolf Thm.~6.5}
+\end{align}
+The local source is
+\path{Notes/WolfNoteTexSource/ch06_spectral_properties.tex}, lines~743--747
+\cite{Wolf2012Quantum}.
+
+\section{What is formalized}
+
+Two formal statements cover separate parts of the assertion. First, every
+positive linear map $E:\MN{D}\to\MN{D}$ has some nonnegative eigenvalue with
+a positive semidefinite eigenvector:
+\begin{align}
+  E(\rho)&=r\rho,
+  \qquad \rho\succeq0,\ \rho\neq0,\ r\ge0.
+  \tag{formal existence}
+\end{align}
+\footnote{Formal declaration:
+  \leanid{exists_posSemidef_eigenvector_general} in
+  \doclink{QICLean/Channel/PerronFrobenius/Existence}. The stronger variant
+  \leanid{exists_posSemidef_eigenvector} assumes that $E$ does not annihilate
+  any nonzero positive semidefinite matrix and returns $r>0$.}
+Second, for an irreducible completely positive map, any positive eigenvalue
+with a positive definite eigenvector equals the spectral radius:
+\begin{align}
+  E(\rho)=r\rho,\quad \rho\succ0,\ r>0
+  \quad\Longrightarrow\quad
+  \varrho(E)=r,
+  \tag{formal identification}
+\end{align}
+provided $E$ is irreducible and completely positive.\footnote{Formal
+  declaration:
+  \leanid{spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp} in
+  \doclink{QICLean/Channel/Irreducible/SpectralRadius}. This is the
+  irreducible-map statement of Wolf Theorem~6.3(4), formalized in the
+  completely positive case.}
+
+\section{Comparison}
+
+The existence statement does not identify its eigenvalue with the spectral
+radius, and no such conclusion is possible for an arbitrary nonnegative
+eigenvalue of a positive map. On $\MN{2}$, the completely positive map
+\begin{align}
+  E(X)&=X_{11} \one
+\end{align}
+satisfies $E(\one)=\one$, so $\varrho(E)=1$; yet the nonzero positive
+semidefinite matrix $X=\ketbra{2}{2}$ lies in the kernel of $E$, so an
+existence theorem may return $r=0<\varrho(E)$. Conversely, the
+identification statement assumes irreducibility and complete positivity, both
+absent from Wolf Theorem~6.5, and requires a positive definite eigenvector.
+
+Closing the general positive-map case requires one of the following:
+\begin{enumerate}
+\item a resolvent argument: for $\lambda>\varrho(T)$ the resolvent
+  $(\lambda-T)^{-1}$ preserves positivity, and the pole at
+  $\lambda=\varrho(T)$ produces a positive semidefinite eigenvector; this
+  route needs holomorphic functional calculus and spectral projections;
+\item lifting from the irreducible case through the invariant-face
+  decomposition of the positive cone: apply the Perron--Frobenius theorem to
+  each irreducible component and select the component of maximal spectral
+  radius; this route needs the invariant-face decomposition of positive maps.
+\end{enumerate}
+
+The planned first step is Wolf Theorem~6.3 for irreducible positive maps
+without complete-positivity hypotheses, via the extremal functionals of Wolf
+Equations~(6.29)--(6.30).\footnote{The scaffold declarations
+  \leanid{PerronFrobeniusExtremal.r},
+  \leanid{PerronFrobeniusExtremal.rTilde},
+  \leanid{PerronFrobeniusExtremal.rMax}, and
+  \leanid{PerronFrobeniusExtremal.rTildeMax} in
+  \path{Channel/PerronFrobenius/ExtremalQuantities} were removed as unused in
+  \href{https://github.com/LionSR/QICLean/pull/56}{QICLean PR \#56};
+  tracked in
+  \href{https://github.com/LionSR/TNLean/issues/3976}{TNLean issue \#3976}
+  (milestone M3).}
+
+\section{Verdict}
+
+Wolf Theorem~6.5 is an \emph{open gap}: the existence of a nonnegative
+eigenvalue with a positive semidefinite eigenvector is formalized for every
+positive map, but the identification of that eigenvalue with the spectral
+radius is available only as a \emph{scope restriction} to irreducible
+completely positive maps with a positive definite eigenvector.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex
+++ b/docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex
@@ -1,0 +1,112 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Wolf Theorem~8.6 --- the Doubly-Substochastic Half of Birkhoff}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{The source statement}
+
+Wolf's Theorem~8.6 (``Birkhoff's theorem'') states two characterizations
+in the same theorem environment
+\cite[Chapter~8, Theorem~8.6]{Wolf2012Quantum}.  The local source is
+\path{Notes/WolfNoteTexSource/ch08_distance_measures.tex}, lines~263--266.
+
+\begin{enumerate}
+  \item[\textbf{DS}] The set of $d\times d$ doubly stochastic matrices is the
+    convex hull of the $d\times d$ permutation matrices, and its extreme
+    points are exactly the permutation matrices.
+  \item[\textbf{Sub}] The set of $d\times d$ doubly substochastic matrices is
+    the convex hull of the $d\times d$ partial permutation matrices, and its
+    extreme points are exactly the partial permutation matrices.
+\end{enumerate}
+
+\section{Formalized component}
+
+The doubly-stochastic half (DS) is formalized as two declarations:
+\begin{itemize}
+  \item \leanid{TNLean.wolf_birkhoff_doublyStochastic_convexHull}
+    --- the set of doubly stochastic matrices is the convex hull of the
+    permutation matrices, in \doclink{QICLean/Analysis/Birkhoff};
+  \item \leanid{TNLean.wolf_birkhoff_extremePoints_doublyStochastic}
+    --- the extreme points of the doubly stochastic matrices are exactly the
+    permutation matrices, likewise in \doclink{QICLean/Analysis/Birkhoff}.
+\end{itemize}
+Both are direct reuse of Mathlib's existing Birkhoff theorems
+(\leanid{doublyStochastic_eq_convexHull_permMatrix} and
+\leanid{extremePoints_doublyStochastic}) without reproof.
+
+\section{Missing component}
+
+The doubly-substochastic half (Sub) has not been formalized.  It requires
+the following definitions and results:
+\begin{enumerate}
+  \item Define the predicate ``doubly substochastic'': a nonnegative square
+    matrix whose row sums and column sums are each bounded by~$1$.
+  \item Define the partial permutation matrices: square $\{0,1\}$-matrices
+    with at most one~$1$ in each row and each column, all other entries~$0$.
+  \item Prove that the set of doubly substochastic matrices is the convex hull
+    of the partial permutation matrices, and that its extreme points are
+    exactly the partial permutation matrices.  This is the substochastic
+    analogue of Birkhoff's theorem.
+\end{enumerate}
+The substochastic polytope is larger (containing the stochastic polytope as a
+face) and the extreme-point argument differs from the stochastic case:
+permutation matrices are replaced by partial permutation matrices, and the
+support of a substochastic matrix may omit rows or columns.
+
+\section{Elimination plan}
+
+\begin{enumerate}
+  \item Port the predicate \leanid{doublyStochastic} from Mathlib to a
+    ``doubly substochastic'' predicate \leanid{doublySubstochastic}, borrowing
+    the nonnegativity, row-sum, and column-sum structure with $\le 1$ bounds
+    instead of~$=1$.
+  \item Define the set of partial permutation matrices over
+    $\operatorname{Fin} d$ and establish that each is doubly substochastic.
+  \item Carry out a Birkhoff-style decomposition by completing a
+    $d\times d$ doubly substochastic matrix $M$ to a $2d\times 2d$
+    doubly stochastic block matrix.  Write
+    \begin{align}
+      u_i&=\sum_j M_{ij}, & v_j&=\sum_i M_{ij}, &
+      r_i&=1-u_i, & c_j&=1-v_j, & s&=\sum_{i,j}M_{ij}.
+    \end{align}
+    For $s>0$, set $S_{ji}=v_ju_i/s$; for $s=0$, set $S=0$.  Then
+    \begin{align}
+      \sum_i S_{ji}&=v_j, & \sum_j S_{ji}&=u_i, \\
+      \widetilde M&=
+      \begin{pmatrix}M&\operatorname{diag}(r)\\
+      \operatorname{diag}(c)&S\end{pmatrix}, &
+      \sum_b\widetilde M_{ab}&=1, &
+      \sum_a\widetilde M_{ab}&=1.
+    \end{align}
+    Thus $\widetilde M$ is doubly stochastic.  Applying Birkhoff's theorem
+    to this completion and restricting permutation matrices to the original
+    block yields partial permutation matrices.
+  \item Prove that the extreme points of the doubly substochastic set are
+    exactly the partial permutation matrices, adapting the extreme-point
+    argument from the stochastic case.
+\end{enumerate}
+
+\section{Verdict}
+
+This is a \emph{scope restriction}.  The doubly-stochastic half of Wolf
+Theorem~8.6 (the two Birkhoff characterizations for stochastic matrices) is
+fully formalized and linked to the blueprint.  The doubly-substochastic half
+(definition, polytope structure, and extreme partial-permutation-matrix
+characterization) is not yet formalized.  Tracking: \href{https://github.com/LionSR/TNLean/issues/3959}{TNLean issue \#3959}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch8_eq_8_103_negative_exponent.tex
+++ b/docs/paper-gaps/wolf_ch8_eq_8_103_negative_exponent.tex
@@ -1,0 +1,83 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Wolf Equation~(8.103) --- Small-Power Exponent Scope}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{The source statement}
+
+Wolf considers an upper-triangular matrix $X=\Lambda+N\in M_D(\mathbb C)$,
+where $\Lambda$ is diagonal and $N$ is strictly upper triangular.  For an
+arbitrary submultiplicative norm satisfying $\lVert\Lambda\rVert\le 1$, the
+notes state for every $n\in\mathbb N$ that
+\begin{align}
+  \lVert X^n\rVert
+  \le \lVert\Lambda^n\rVert
+  +(D-1)n^{D-1}\lVert\Lambda\rVert^{n-D+1}
+    \max\{\lVert N\rVert,\lVert N\rVert^{D-1}\}.
+\end{align}
+The local source is
+\path{Notes/WolfNoteTexSource/ch08_distance_measures.tex}, lines~1189--1210,
+especially Equation~(8.103) and its derivation from Equation~(8.105).
+
+\section{The exponent defect}
+
+When $n<D-1$, the exponent $n-D+1$ is negative.  The source gives no
+convention for this negative power.  In particular, if $\Lambda=0$, then the
+factor $\lVert\Lambda\rVert^{n-D+1}$ is not defined in the usual real-power
+interpretation.  Replacing the exponent by truncated natural subtraction
+would silently change the displayed statement.
+
+The derivation from Equation~(8.105) also factors
+\begin{align}
+  \lVert\Lambda\rVert^{n-k}
+  =\lVert\Lambda\rVert^{n-(D-1)}
+   \lVert\Lambda\rVert^{(D-1)-k},
+\end{align}
+which uses natural exponents only when $D-1\le n$ (and $k\le D-1$).
+Thus the proof printed in the notes establishes the displayed natural-power
+bound in that range, but does not supply an all-$n$ interpretation.
+
+\section{Formalization scope}
+
+Equation~(8.105), whose exponents satisfy $k\le n$, is formalized for every
+$n\in\mathbb N$.  Equation~(8.103) is formalized with the explicit hypothesis
+$D-1\le n$.  Its refined constant $(D-1)\binom{n}{D-1}$ is formalized under
+the source's stated hypothesis $2(D-1)\le n$, which implies the first range
+condition.  Both results retain the arbitrary submultiplicative seminorm
+parameter; no particular matrix norm replaces it.  The corresponding Lean
+declarations are:
+\begin{itemize}
+  \item \leanid{Matrix.wolf_eq_105_seminorm} for the unrestricted
+    Equation~(8.105) word bound;
+  \item \leanid{Matrix.wolf_eq_103} for the natural-power form under
+    $D-1\le n$;
+  \item \leanid{Matrix.wolf_eq_103_refined} for the refined constant under
+    $2(D-1)\le n$.
+\end{itemize}
+
+\section{Verdict}
+
+\textbf{Verdict: source scope restriction.}
+
+This is not a missing Lean proof.  The
+formal statement records exactly the range in which the printed
+natural-exponent derivation is meaningful.  Eliminating the restriction would
+require Wolf to specify an interpretation for negative powers, including the
+case $\lVert\Lambda\rVert=0$.  Tracking: \href{https://github.com/LionSR/TNLean/issues/5837}{TNLean issue \#5837}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_choi_rectangular_scope.tex
+++ b/docs/paper-gaps/wolf_choi_rectangular_scope.tex
@@ -1,0 +1,172 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Rectangular Choi--Jamiolkowski Correspondence:\\
+Resolution of the Square-Dimensional Scope Restriction}
+\author{}
+\date{2026-08-04}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{The source statement}
+
+Let $T:\MN{d}\to\MN{d'}$ be linear and let
+$\Omega_d\in\C^d\otimes\C^d$ be maximally entangled.  Wolf
+Proposition~2.1 associates to $T$ the operator
+\begin{align}
+    \tau_T
+      &= (T\otimes\operatorname{id}_d)
+         \bigl(\ketbra{\Omega_d}{\Omega_d}\bigr)
+       \in \MN{d'}\otimes\MN{d},
+    \tag{Wolf 2.1}\\
+    \tr\!\bigl(A\,T(B)\bigr)
+      &= d\,\tr\!\bigl(\tau_T(A\otimes B^{T})\bigr)
+    \qquad
+    (A\in\MN{d'},\ B\in\MN{d}).
+    \tag{Wolf 2.1}
+\end{align}
+These two formulas give mutually inverse correspondences between linear maps
+and bipartite operators.  They identify Hermiticity preservation with
+$\tau_T=\tau_T^\dagger$, complete positivity with $\tau_T\geq0$, unitality
+with
+\begin{align}
+    \tr_B(\tau_T)&=\frac{\Id_{d'}}{d},
+\end{align}
+and trace preservation with
+\begin{align}
+    \tr_A(\tau_T)&=\frac{\Id_d}{d}.
+\end{align}
+More generally, without assuming trace preservation, the source gives
+\begin{align}
+    \tr_A(\tau_T)
+      &= \frac{\bigl(T^*(\Id_{d'})\bigr)^T}{d},
+    &
+    \tr(\tau_T)
+      &= \frac{\tr\!\bigl(T^*(\Id_{d'})\bigr)}{d}.
+\end{align}
+It also gives the corresponding proportional-identity criterion for a
+doubly-stochastic map \cite[Proposition~2.1]{Wolf2012Quantum}.
+
+Wolf Theorem~2.1 states that $T$ is completely positive if and only if it
+has a rectangular Kraus representation
+\begin{align}
+    T(X)&=\sum_{j=1}^{r}K_jXK_j^\dagger,
+    &K_j&\in M_{d'\times d}(\C),
+    \tag{Wolf 2.8}
+\end{align}
+and identifies the trace-preserving and unital normalizations, the minimal
+value $r=\operatorname{rank}(\tau_T)\leq dd'$, an orthogonal minimal family,
+and the unitary freedom after padding the smaller family with zero
+operators \cite[Theorem~2.1]{Wolf2012Quantum}.
+
+\section{Resolution}
+
+The different-dimension statements are now formalized.  The rectangular
+Choi development\footnote{Formal module:
+\doclink{QICLean/Channel/ChoiRectangular}; namespace
+\leanid{ChoiRectangular}.} defines the Choi matrix
+\leanid{choiMatrix} on $\C^{d'}\otimes\C^{d}$ and proves
+\begin{itemize}
+    \item the mutual-inverse pair \leanid{mapOfChoiMatrix_choiMatrix} and
+        \leanid{choiMatrix_mapOfChoiMatrix};
+    \item the trace-pairing formula \leanid{trace_pairing};
+    \item the Hermiticity clause
+        \leanid{choiMatrix_isHermitian_iff_hermiticityPreserving};
+    \item the complete-positivity clause
+        \leanid{isKrausCP_iff_choiMatrix_posSemidef};
+    \item the unitality clause
+        \leanid{unital_iff_traceRight_choiMatrix}, from the identity
+        \leanid{traceRight_choiMatrix} ($\tr_B(\tau_T)=T(\Id)/d$);
+    \item the trace-preservation clause
+        \leanid{tracePreserving_iff_traceLeft_choiMatrix}, from the identity
+        \leanid{traceLeft_choiMatrix}
+        ($\tr_A(\tau_T)=(T^*(\Id))^{T}/d$);
+    \item the normalization clause \leanid{trace_choiMatrix}
+        ($\tr(\tau_T)=\tr(T^*(\Id))/d$);
+    \item the doubly-stochastic clause
+        \leanid{doublyStochastic_iff_partialTraces_proportional}.
+\end{itemize}
+The rectangular Kraus development\footnote{Formal module:
+\doclink{QICLean/Channel/KrausRectangular}; same namespace.} proves the
+normalization equivalences \leanid{kraus_tp_iff_sum_conjTranspose_mul} and
+\leanid{kraus_unital_iff_sum_mul_conjTranspose}, the minimality of the
+Kraus rank \leanid{choiRank_isLeast_hasKrausCard_of_isKrausCP} with bound
+\leanid{choiRank_le_mul} ($r=\operatorname{rank}(\tau_T)\leq dd'$), and the
+orthogonal minimal family \leanid{exists_kraus_orthogonal_of_isKrausCP}.
+The padded unitary freedom is formalized by the dimension-generic
+\leanid{kraus_isometry_freedom_iff} and \leanid{kraus_unitary_freedom_iff}
+in \doclink{QICLean/Channel/KrausUnitaryFreedom}.
+
+The complete-positivity predicate is \leanid{IsKrausCP}, the existence of
+rectangular Kraus operators, which is the notion used elsewhere in the
+development; the Choi correspondence is phrased relative to it.
+
+\section{Surviving square-only declarations}
+
+The dimension-generic Kraus API states the cardinality,
+rank, and freedom declarations once, for rectangular Kraus
+operators $K_j\in M_{d'\times d}(\C)$, and the square development is the
+specialization $d=d'$.  Concretely, \leanid{Channel.HasKrausCard},
+\leanid{Channel.HasKrausRankLE}, \leanid{Channel.choiRank},
+\leanid{Channel.hasKrausCard_mono},
+\leanid{Channel.choiMatrix_eq_sum_vecMulVec_of_kraus},
+\leanid{Channel.choiRank_le_of_hasKrausCard}, and
+\leanid{Channel.hasKrausCard_choiRank_of_cp} live in
+\doclink{QICLean/Channel/KrausRank}; the normalization lemmas
+\leanid{kraus_sum_conjTranspose_mul_of_tp},
+\leanid{kraus_sum_mul_conjTranspose_of_unital}, and
+\leanid{kraus_same_map_of_isometry_combination} live in
+\doclink{QICLean/Channel/KrausRepresentation}; the dual/Gramian and
+necessary-direction freedom lemmas \leanid{kraus_dual_eq_of_map_eq},
+\leanid{kraus_conjTranspose_mul_eq_of_map_eq},
+\leanid{kraus_rectangular_freedom}, and \leanid{kraus_rectangular_freedom'}
+live in \doclink{QICLean/Channel/KrausFreedom}; and the freedom
+equivalences \leanid{kraus_isometry_freedom_iff} and
+\leanid{kraus_unitary_freedom_iff} live in
+\doclink{QICLean/Channel/KrausUnitaryFreedom}.  Their former
+\leanid{ChoiRectangular}-namespace duplicates have been removed.
+
+The following declarations remain square-only.  Each is the $d=d'$
+specialization of a rectangular or dimension-generic result, not an
+independent scope gap; they are retained because existing callers use
+them.
+
+\begin{itemize}
+    \item \leanid{ChoiJamiolkowski.choiMatrix} and its correspondence
+        clauses.  The square Choi matrix is definitionally the rectangular
+        one at $d=d'$ (\leanid{ChoiRectangular.choiMatrix_eq_choiJamiolkowski}),
+        and each square clause is the specialization of the rectangular
+        clause with the same name.
+    \item \leanid{IsTracePreservingMap} and \leanid{IsChannel}.  These
+        predicates are stated for endomorphisms of a single matrix algebra.
+        The rectangular development states trace preservation pointwise,
+        $\tr(T(X))=\tr(X)$; the channel structure (complete positivity
+        plus trace preservation) is covered for rectangular maps by
+        \leanid{IsKrausCPTP}.
+    \item \leanid{Channel.hasKrausRankLE_choiRank_of_cptp} and
+        \leanid{kraus_transition_unitary_of_hs_orthonormal}.  These two
+        lemmas have no rectangular counterpart: the first is phrased via
+        the square-only \leanid{IsChannel} structure, and the second is a
+        square linear-algebraic core lemma with square-only call sites.
+\end{itemize}
+
+\section{Verdict}
+
+The scope restriction recorded here on 2026-07-30 is \emph{lifted}: Wolf
+Proposition~2.1 and Theorem~2.1 are formalized at the source's generality,
+with independent input and output dimensions and all displayed clauses.
+No hypothesis strengthening remains, and no source-level gap survives in
+this area.  Resolved in \href{https://github.com/LionSR/TNLean/issues/3987}{TNLean issue \#3987}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex
+++ b/docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex
@@ -1,0 +1,67 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Complete Positivity in the Projected Support Corner Star-Algebra}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{The assertion}
+
+Corollary 6.6 of \emph{Quantum Channels \& Operations} (Wolf 2012), stated at
+lines 1380--1510 of \texttt{Notes/WolfNoteTexSource/ch06\_spectral\_properties.tex},
+concerns a positive trace-preserving linear map $T$ on $M_D(\mathbb{C})$ whose trace
+adjoint $T^{*}$ is unital and satisfies the Schwarz inequality. For a positive
+semidefinite fixed point $\rho$ of $T$ with support projection $Q$, the corner-restricted
+fixed-point set
+\[
+    \{\, Y \in Q\,M_D(\mathbb{C})\,Q \;\mid\; Q\,T^{*}(Y)\,Q = Y \,\}
+\]
+is a $*$-subalgebra of the corner algebra $Q\,M_D(\mathbb{C})\,Q$.
+
+Wolf offers complete positivity as an \emph{example} of a map meeting the hypothesis,
+not as part of the hypothesis. The Schwarz inequality for the adjoint is strictly weaker:
+every completely positive unital map satisfies it, but positive maps that are not
+completely positive can satisfy it as well.
+
+\section{The restriction in the formalization}
+
+The available Lean statement is \leanid{Kraus.cornerFixedPointsStarSubalgebra}, with the
+membership characterization \leanid{Kraus.mem\_cornerFixedPointsStarSubalgebra}, both in
+\texttt{QICLean/Channel/FixedPoint/CornerFixedPoints.lean}. Its hypotheses are a family
+$K$ of Kraus operators with \leanid{IsTP} $K$ and a positive semidefinite fixed point of
+the induced map. Presenting the map by a Kraus family assumes complete positivity, so the
+Lean hypothesis set is strictly stronger than the source's. Under the repository
+faithfulness rule this declaration establishes the completely positive case of
+Corollary 6.6 and is not a formalization of the corollary itself.
+
+The corresponding Blueprint entry states the Kraus form explicitly in its hypotheses, so
+its \leanid{\textbackslash leanok} is honest for the restricted statement; it must not be
+read as the unrestricted corollary. The analogous restriction for Corollary 6.7 is
+recorded separately in \texttt{wolf\_cor67\_maximal\_support\_restriction.tex}.
+
+\section{Elimination plan}
+
+No further material is needed from the source: the corollary is stated in full at the
+lines cited above, and the machinery to express its hypothesis without Kraus data already
+exists. The multiplicative domain of a bare linear map
+$E : M_D(\mathbb{C}) \to M_D(\mathbb{C})$ is available as \leanid{multiplicativeDomain} in
+\texttt{QICLean/Channel/Schwarz/AbstractMultiplicativeDomain.lean}, together with its
+membership characterization, so the Schwarz hypothesis can be carried directly.
+
+The elimination is therefore to restate the corollary for a positive trace-preserving map
+whose trace adjoint is unital and Schwarz, discharging it through the general support
+compression and the now-available Theorem 6.14, and then to recover the present Kraus
+declarations as specializations rather than maintaining a parallel development. The
+source-general statement is the one that may carry a source-facing Blueprint entry for
+Corollary 6.6.
+
+\end{document}

--- a/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
+++ b/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
@@ -1,0 +1,101 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Corner-Support Restriction in the Weighted Fixed-Point Star-Algebra}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{The assertion}
+
+Corollary 6.7 of \emph{Quantum Channels \& Operations} (Wolf 2012) states: for a
+trace-preserving, positive, linear map $T$ on $M_d(\mathbb{C})$ whose adjoint satisfies
+the Schwarz inequality, and for any density matrix $\rho$ which is a \emph{maximum-rank}
+fixed point of $T$, the set
+\[
+    \rho^{-1/2}\,\mathcal{F}_T\,\rho^{-1/2},
+    \qquad \mathcal{F}_T = \{X \mid T(X) = X\},
+\]
+is a $*$-algebra, with the inverse square root taken on the support of $\rho$.
+
+The corollary rests on the maximal-support property of fixed points stated earlier in
+Section~6.4 of the reference: every fixed point of $T$ has support and range within the
+support of the maximum-rank fixed point, so conjugation by $\rho^{-1/2}$ loses nothing.
+
+\section{The formalization}
+
+Two layers are established, both for a Kraus map (the completely positive case of the
+Schwarz hypothesis, as in the other results of this section).
+
+For an \emph{arbitrary} positive semidefinite fixed point $\rho$ with support
+projection $Q$ (\leanid{Kraus.weightedCornerFixedPointsStarSubalgebra} and
+\leanid{Kraus.exists\_weightedCorner\_sqrt\_eq\_of\_fixedPoint} in
+\leanid{QICLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean}), the set
+\[
+    \rho^{-1/2}\,\{X \mid T(X) = X,\ Q X Q = X\}\,\rho^{-1/2}
+\]
+is a $*$-subalgebra of the corner algebra $Q M_D(\mathbb{C}) Q$; for a non-maximal
+$\rho$ the conjugated set is restricted to the fixed points supported on the support
+of $\rho$. The positive definite case without any support restriction is
+\leanid{Kraus.weightedFixedPointsStarSubalgebra}.
+
+At a fixed point of maximal support the restriction disappears
+(\leanid{Kraus.exists\_maximalSupport\_weightedCorner\_sqrt\_eq} in
+\leanid{QICLean/Channel/FixedPoint/MaximalSupport.lean}): there is a positive
+semidefinite fixed point $\rho_0$ at which the conjugated set is
+\[
+    \rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2},
+\]
+the set of the corollary, with the inverse square root taken on the support of
+$\rho_0$.
+
+\section{The maximal-support property}
+
+The removal of the restriction rests on the maximal-support property
+(\leanid{Kraus.exists\_maximalSupport\_fixedPoint}): there is a positive semidefinite
+fixed point $\rho_0$ whose support projection $Q_0$ satisfies $Q_0 X Q_0 = X$ for every
+fixed point $X$. The witness is the sum of the positive parts of the Hermitian and
+anti-Hermitian components of a basis $X_0, \ldots, X_{m-1}$ of the fixed-point space
+(the reference instead takes the image of the identity under the projection onto the
+fixed-point space). Writing
+$H_{1,j} = X_j + X_j^{\dagger}$ and $H_{2,j} = i(X_j - X_j^{\dagger})$ for the fixed
+Hermitian components and $H_{k,j} = P^{+}_{k,j} - P^{-}_{k,j}$ for their positive parts
+(\leanid{IsChannel.posSemidef\_parts\_of\_hermitian\_fixedPoint}), the witness
+\begin{align*}
+    \rho_0 &= \sum_{j=0}^{m-1}
+        \bigl(P^{+}_{1,j} + P^{-}_{1,j} + P^{+}_{2,j} + P^{-}_{2,j}\bigr)
+\end{align*}
+dominates every summand in the Loewner order, domination transfers the support
+(\leanid{Kraus.stationaryProj\_absorb\_of\_le}, from
+$0 \preceq (\mathbf 1-Q_0)P(\mathbf 1-Q_0) \preceq (\mathbf 1-Q_0)\rho_0(\mathbf 1-Q_0) = 0$),
+and linearity extends the absorption from the parts to every fixed point.
+
+\section{Verdict}
+
+The restriction is eliminated. The maximal-support property holds at the constructed
+witness (\leanid{Kraus.exists\_maximalSupport\_fixedPoint}), and the transfer to every
+maximum-rank fixed point is
+\leanid{Kraus.maximalSupport\_of\_maximalRank} in
+\leanid{QICLean/Channel/FixedPoint/MaximalRank.lean}: for any positive semidefinite fixed
+point $\rho$ whose rank bounds the rank of every fixed-point density matrix, the support
+projection of $\rho$ carries every fixed point, because the support projection of a
+positive semidefinite matrix has the rank of the matrix and its trace is that rank, so
+the two support projections have equal traces, one absorbs the other, and they coincide.
+The conjugated set $\rho^{-1/2}\,\{X \mid T(X) = X\}\,\rho^{-1/2}$ of the corollary is
+realized at every such $\rho$
+(\leanid{Kraus.exists\_weightedCorner\_sqrt\_eq\_of\_maximalRank}), with the inverse
+square root taken on the support of $\rho$. Unit trace of $\rho$ itself is not needed for
+the conclusion and is not assumed; the maximality hypothesis quantifies over fixed-point
+density matrices, as in the source. The remaining scope convention is the Kraus
+(completely positive) case of the source's Schwarz hypothesis, shared by the other
+formalized results of the section.
+
+\end{document}

--- a/docs/paper-gaps/wolf_eq8104_shift_norm_one_dimensional.tex
+++ b/docs/paper-gaps/wolf_eq8104_shift_norm_one_dimensional.tex
@@ -1,0 +1,80 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Jordan-Block Norm Estimate: the Shift Norm in One Dimension}
+\author{}
+\date{2026-08-13}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\section{Source passage}
+
+Fix an integer $D\ge 1$, let $N\in\MN{D}$ be the strict upper shift
+$N_{i,j}=1$ if $j=i+1$ and $N_{i,j}=0$ otherwise, let
+$J_{D}(\lambda)=\lambda\Id+N$ be the Jordan block with eigenvalue
+$\lambda\in\C$, and write $\|\cdot\|_{\infty}$ for the largest singular value.
+Chapter~8 of \cite{Wolf2012Quantum} derives, for every $n\in\mathbb N$ and
+every natural number $k_{0}\le\min\{n,D-1\}$, the two-sided estimate
+\begin{align}
+  |\lambda|^{\,n-k_{0}}\binom{n}{k_{0}}
+    \le \bigl\|J_{D}(\lambda)^{n}\bigr\|_{\infty}
+    \le \sum_{k=0}^{\min\{n,D-1\}}|\lambda|^{\,n-k}\binom{n}{k}
+\end{align}
+of Equation~(8.104), at lines 1197--1215 of the local source file. The upper
+bound is obtained from the binomial expansion
+$J_{D}(\lambda)^{n}=\sum_{k}\binom{n}{k}\lambda^{n-k}N^{k}$ by the triangle
+inequality, using the assertion $\|N\|_{\infty}=1$ for the strict upper shift
+$N$ at line~1215.
+
+\section{The deviation}
+
+The equality $\|N\|_{\infty}=1$ holds for $D\ge 2$ but fails at $D=1$: the
+strict upper shift on a one-dimensional space is the zero matrix, so
+$\|N\|_{\infty}=0$. Wolf states the equality without a dimension restriction.
+The Jordan block itself is defined for every $D\ge 1$, and Equation~(8.104) is
+asserted for every such $D$, so the intermediate assertion is one degenerate
+case wider than its proof supports.
+
+\section{Formalized interpretation}
+
+Only the direction $\|N\|_{\infty}\le 1$ enters the derivation: the triangle
+inequality is followed by
+$\|N^{k}\|_{\infty}\le\|N\|_{\infty}^{k}\le 1$, which is what discards the
+shift factors from the expansion. The formalization therefore states
+\leanid{Matrix.l2_opNorm_nilpotentShift_le_one} as the inequality
+$\|N\|_{\infty}\le 1$, valid for every $D$, and derives
+\leanid{Matrix.l2_opNorm_nilpotentShift_pow_le_one} from it. The proof is the
+one Wolf indicates: the Gram identity
+$N^{\dagger}N=\operatorname{diag}(0,1,\dots,1)$, which is
+\leanid{Matrix.conjTranspose_nilpotentShift_mul_self}, gives a matrix whose
+largest singular value is at most $1$, and the C*-identity
+$\|N\|_{\infty}^{2}=\|N^{\dagger}N\|_{\infty}$ transfers the bound.
+
+At $D=1$ the two sides of Equation~(8.104) coincide: the hypothesis
+$k_{0}\le\min\{n,D-1\}$ forces $k_{0}=0$, and both bounds read
+$|\lambda|^{n}\le\|\lambda^{n}\|_{\infty}\le|\lambda|^{n}$. The theorems
+\leanid{Matrix.le_l2_opNorm_jordanBlock_pow},
+\leanid{Matrix.l2_opNorm_jordanBlock_pow_le} and
+\leanid{Matrix.l2_opNorm_jordanBlock_pow_bounds} therefore carry Wolf's
+hypothesis set unchanged, with no dimension restriction beyond $D\ge 1$, which
+the Jordan block presupposes.
+
+\section{Verdict}
+
+\textbf{Verdict: resolved local fix (shift norm at $D=1$).} Replacing the
+source's intermediate equality $\|N\|_{\infty}=1$ by the inequality
+$\|N\|_{\infty}\le 1$ removes a false degenerate case without weakening
+Equation~(8.104), which is formalized with the source's own hypotheses.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -1,0 +1,153 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Scope of the Choi-Type Positivity Subcases (Wolf Example~3.1)}
+\author{}
+\date{2026-07-02, revised 2026-07-10}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{Source statement}
+
+Wolf's Chapter~3, Example~3.1 introduces the Choi-type maps
+\cite{Wolf2012Quantum}\footnote{Local source:
+\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex}, lines
+357--365.}  With \(D\) the diagonal projection on \(\mathcal M_d\) and
+\(U_{k0}\) the cyclic shift, the map is
+\begin{align}
+  T_C(X)
+  =(d-n)D(X)-X+\sum_{k=1}^{n}D(U_{k0}XU_{k0}^{\dagger}).
+  \tag{3.20}
+\end{align}
+The source states that \(T_C\) is positive and indecomposable for every
+\(1\le n\le d-2\).  No nonzero-coordinate hypothesis is present.
+
+\section{Restricted statement now proved}
+
+The present development proves two slices of the positivity assertion.
+
+First, for \(d=3\), \(n=1\), and an arbitrary vector \(v=(v_0,v_1,v_2)\), it
+proves
+\begin{align}
+  T_C(|v\rangle\langle v|)\ge 0.
+\end{align}
+The scalar input is the boundary-inclusive cyclic reciprocal inequality
+\begin{align}
+  \frac{x}{2x+z}+\frac{y}{2y+x}+\frac{z}{2z+y}\le 1,
+  \qquad x,y,z\ge 0,
+\end{align}
+with zero-denominator summands read as \(0\).  Away from the boundary this is
+proved by clearing denominators and applying AM--GM to \(x^2y,y^2z,z^2x\); the
+boundary cases reduce to a single half-bound.\footnote{Formal declarations:
+\leanid{Matrix.choiType\_cyclic\_reciprocal\_three\_one\_of\_nonneg} and
+\leanid{Matrix.choiTypeMap\_vecMulVec\_posSemidef\_three\_one}
+in \doclink{QICLean/Channel/ChoiTypeMap}.}
+Using the spectral decomposition of a positive semidefinite matrix into
+rank-one positive semidefinite summands, the development then proves that this
+first Choi map is positive on all positive semidefinite inputs.\footnote{Formal
+declaration: \leanid{Matrix.choiTypeMap\_isPositiveMap\_three\_one}.}
+
+Second, at the top of the source's range, \(n=d-2\), the development proves
+positivity of \(T_C\) on all positive semidefinite inputs for every dimension
+\(d\ge3\); this family subsumes the \(d=3,n=1\)
+case.\footnote{Formal declarations:
+\leanid{Matrix.perm\_reciprocal\_sum\_le\_one},
+\leanid{Matrix.choiTypeMap\_vecMulVec\_posSemidef\_sub\_two}, and
+\leanid{Matrix.choiTypeMap\_isPositiveMap\_sub\_two} in
+\doclink{QICLean/Channel/ChoiTypeMap}.}  For \(n=d-2\) the backward window
+\(x_{i-1},\dots,x_{i-n}\) misses exactly the entries at \(i\) and \(i+1\), so
+with \(T=\sum_j x_j\) the diagonal weight collapses to
+\(a_i=T+x_i-x_{i+1}\), and the cyclic reciprocal estimate becomes an instance
+of a reciprocal inequality valid for an arbitrary permutation \(\sigma\):
+\begin{align}
+  \sum_i \frac{x_i}{T+x_i-x_{\sigma(i)}}\le 1,
+  \qquad x_i\ge 0 .
+\end{align}
+Each summand is at most \((x_iT-x_i\delta_i+\delta_i^2/2)/T^2\) with
+\(\delta_i=x_i-x_{\sigma(i)}\), by the pair bound
+\(x_i+x_{\sigma(i)}\le T\), and the bounds sum to \(1\) exactly because
+\(\sum_i x_i\delta_i=\tfrac12\sum_i\delta_i^2\) for a permutation.  This case
+of the cyclic estimate is classical: it is due to Ando (\emph{Positivity of
+certain maps}, seminar notes, 1985), as recorded in the introduction of
+\cite{Yamagami1993Cyclic}.
+
+\section{Missing hypotheses and elimination plan}
+
+This is a scope restriction, not the source theorem.  The full positivity
+statement still requires the nonnegative cyclic reciprocal estimate
+\begin{align}
+  \sum_{i\in\mathbb Z/d\mathbb Z}
+  \frac{x_i}{(d-n)x_i+\sum_{k=1}^{n}x_{i-k}}\le 1
+  \qquad (x_i\ge0,\;1\le n\le d-3),
+\end{align}
+with the usual zero-term convention; the case \(n=d-2\) is done, as is
+\(n=d-1\), which lies outside the source's range.  Once this estimate is
+available, it should be applied to \(x_i=|v_i|^2\) to obtain the rank-one
+statement for the full parameter range; the spectral decomposition
+step\footnote{\leanid{Matrix.isPositiveMap\_of\_forall\_vecMulVec\_posSemidef}.}
+already extends any such rank-one statement to positivity of \(T_C\) on all
+positive semidefinite matrices.
+
+The remaining estimate is genuinely harder than the proved cases.  The case
+\(n=1\) is due to Tanahashi and
+Tomiyama~\cite{TanahashiTomiyama1988Indecomposable}, and the full range
+\(1\le n\le d-1\) to Yamagami~\cite{Yamagami1993Cyclic}, whose proof is
+variational: it combines Nowosad's uniqueness theorem for critical points of
+\(x\mapsto\sum_i x_i/(Sx)_i\) on the positive cone, a spectral condition on
+the Hessian at the constant vector (checked through the eigenvalues of the
+cyclic matrix \(S\)), and an analysis of the boundary of the projective
+simplex with a combinatorial count of vanishing summands.
+
+Two verifiable computations locate the obstruction to elementary summand
+bounds in the remaining range.  First, the estimate is tight in two distinct
+regimes: at the constant vector, where every summand equals \(1/d\), and
+along the geometric configurations \(x_i=t^i\) (\(i=0,\dots,d-1\)) as
+\(t\to\infty\), where each of the \(d-n\) summands whose backward window
+avoids the wrap-around tends to \(1/(d-n)\) and the remaining summands
+vanish, so the sum again approaches \(1\).  A usable summand bound must be
+exact in both regimes.  Second, the argument proving \(n=d-2\) does not
+extend.  With \(m=d-n\) and
+\(\delta_i=\sum_{k=1}^{m-1}(x_i-x_{i+k})\), the weight is \(a_i=T+\delta_i\)
+for every \(n\), and the estimate is equivalent (for \(T>0\) and positive
+weights \(a_i\)) to \(\sum_i x_i\delta_i^2/a_i\le\sum_i x_i\delta_i\).  The proved case reaches
+this through the two intermediate steps
+\begin{align}
+  \sum_i \frac{x_i\delta_i^2}{a_i}\le\frac1m\sum_i\delta_i^2
+  \qquad\text{and}\qquad
+  \frac1m\sum_i\delta_i^2
+  \le\frac12\sum_{k=1}^{m-1}\sum_i\bigl(x_i-x_{i+k}\bigr)^2
+  =\sum_i x_i\delta_i .
+\end{align}
+The first step, from \(a_i\ge m x_i\), holds for every \(m\); the second, in
+Fourier form
+\(\bigl|\sum_{k=1}^{m-1}(1-\zeta^k)\bigr|^2
+\le\tfrac m2\sum_{k=1}^{m-1}|1-\zeta^k|^2\) over \(d\)-th roots of unity
+\(\zeta\), holds with equality for \(m=2\) but fails for \(m=3\) at
+\(\zeta=e^{i\pi/3}\), where the two sides are \(7\) and \(6\).  This failure
+is consistent with the historical record: the case \((d,n)=(5,2)\) required a
+separate argument~\cite{Osaka1991Indecomposable}, and the full range was
+settled only by Yamagami's variational proof.  A formalization of the
+remaining range must therefore either follow the variational route or find a
+new proof.  This is tracked by \href{https://github.com/LionSR/TNLean/issues/3622}{TNLean issue \#3622}.  The indecomposability
+assertion of the same source paragraph is separate and is tracked by
+\href{https://github.com/LionSR/TNLean/issues/3623}{TNLean issue \#3623}.
+
+\section{Classification}
+
+\emph{Scope restriction.}  The current theorems are mathematically correct as
+the \(d=3,n=1\) and \(n=d-2\) positive-map cases, but they should not be cited
+as the formalization of Wolf's full Choi-type positivity theorem, whose range
+is \(1\le n\le d-2\).
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -1,0 +1,299 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Formalization-Derived Corrections to Wolf's \emph{Quantum Channels \& Operations}}
+\author{}
+\date{2026-07-13}
+
+\begin{document}
+\sloppy
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\begin{abstract}
+This note records only discrepancies in Michael M.~Wolf's \emph{Quantum
+Channels \& Operations: Guided Tour} that were exposed by the present Lean
+formalization or by a paper-gap analysis required to state a formal theorem
+faithfully. It is not a general errata list for the lecture notes. Its main
+body records only formalization-derived corrections; the final appendix records
+three separately audited local PDF--transcription errors. Each item quotes the
+relevant printed statement, gives the locally correct replacement, and explains
+why the correction is necessary.
+\end{abstract}
+
+\section{Scope}
+
+The source PDFs are stored in \path{Notes/WolfNotePDF/}; the local
+transcription is in \path{Notes/WolfNoteTexSource/}. The corresponding
+formalization and paper-gap records are named explicitly below. A distinction
+is essential:
+\begin{itemize}
+  \item a \emph{source error} is a printed mathematical assertion that is false
+    as stated;
+  \item a \emph{well-posedness correction} makes an implicit boundary convention
+    explicit, without changing the substantive theorem;
+  \item a \emph{formalization scope gap} is not an erratum: it records that the
+    current Lean theorem is narrower than the source or that an auxiliary proof
+    remains incomplete.
+\end{itemize}
+
+Only the first two kinds belong in the formalization-derived main body. The
+appendix keeps transcription errors visibly separate from that record.
+
+\section{The trace sign in the Lorentz-cone converse}
+\label{sec:lorentz}
+
+\paragraph{Formalization trigger.}
+The formal proof of the converse trace inequality requires nonnegativity of the
+trace. Its declaration is
+\path{Matrix.IsHermitian.posSemidef_of_trace_re_nonneg_of_card_sub_one_mul_trace_sq_re_le}
+in \doclink{QICLean/Analysis/MatrixTraceInequalities}. The discrepancy is
+tracked in \path{docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex}.
+
+\paragraph{Printed source and its role.}
+The proposition occurs at the end of the discussion of automorphisms of the
+positive cone in Chapter~3.  Its first part gives the elementary necessary
+inequality for a positive semidefinite Hermitian matrix; the second part is
+intended to characterize the corresponding Lorentz cone.  Chapter~3,
+Proposition~3.7 in the local PDF (book p.~66) states, for Hermitian $A$,
+\begin{equation}\tag{printed converse}
+  \operatorname{tr}(A)^2\geq(d-1)\operatorname{tr}(A^2)
+  \quad\Longrightarrow\quad A\geq0.
+\end{equation}
+
+\paragraph{Correction.}
+The valid converse is
+\begin{equation}\tag{formalized converse}
+  A=A^\dagger,\qquad
+  \operatorname{tr}(A)\geq0,\qquad
+  \operatorname{tr}(A)^2\geq(d-1)\operatorname{tr}(A^2)
+  \quad\Longrightarrow\quad A\geq0.
+\end{equation}
+In the complex-matrix Lean statement the traces are expressed through real
+parts; for Hermitian matrices these are the same real quantities.
+
+\paragraph{Why the correction is necessary.}
+Take $A=-I_d$. It is Hermitian and not positive semidefinite, but
+\begin{equation}
+  \operatorname{tr}(A)^2=d^2
+  \geq d(d-1)=(d-1)\operatorname{tr}(A^2).
+\end{equation}
+Thus the squared inequality alone describes both orientations of the Lorentz
+cone. The condition $\operatorname{tr}(A)\geq0$ selects the positive sheet.
+It is also used by the proof: when a negative eigenvalue is present, the source
+bounds $\operatorname{tr}(A)$ above by a nonnegative quantity and then squares
+that bound. Squaring is justified only after fixing the sign of the trace.
+
+\paragraph{Classification.}
+This is a genuine source error. The unrestricted printed converse should not
+be claimed as formalized; the formal theorem proves the corrected,
+trace-nonnegative statement.
+
+\section{The nonempty-family boundary in the Radon--Nikodym theorem}
+\label{sec:radon-nikodym}
+
+\paragraph{Formalization trigger.}
+The Lean theorem
+\leanid{IsCPMap.radon_nikodym_of_stinespring} makes the finite index type
+nonempty. The boundary is documented in
+\path{docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex}.
+
+\paragraph{Printed source and its role.}
+This theorem is the immediate instrument-valued corollary of the preceding
+comparison theorem for ordered completely positive maps.  A supplied
+Stinespring representation of the total map is held fixed, and the theorem
+resolves each CP component by a positive effect on the same dilation space.
+Chapter~2, Theorem~2.4 (book p.~39) says:
+\begin{quote}
+``Let $\{T_i\}$ be a set of completely positive linear maps such that
+$\sum_iT_i=T$ \ldots\ Then there is a set of positive operators $P_i\in M_r$
+which sum up to $I_r$ such that
+$T_i(A)=V^\dagger(A\otimes P_i)V$.''
+\end{quote}
+
+\paragraph{Formal statement.}
+The formal theorem uses a \emph{nonempty finite family}
+$\{T_i\}_{i\in\iota}$ and concludes
+\begin{equation}
+  \sum_{i\in\iota}P_i=I_r,
+  \qquad
+  T_i(A)=V^\dagger(A\otimes P_i)V.
+\end{equation}
+
+\paragraph{Why the boundary is needed.}
+If the index type is empty, then $\sum_iT_i=T$ forces $T=0$. Taking the zero
+Stinespring matrix $V=0$ still satisfies the representation hypothesis, but the
+printed conclusion would require
+\begin{equation}
+  0=\sum_iP_i=I_r,
+\end{equation}
+which is false when the dilation space has nonzero dimension. For the intended
+notion of a quantum instrument, a nonempty finite outcome family is the
+substantive case.
+
+\paragraph{Classification.}
+This is a local well-posedness correction, not an assertion that the
+nonempty-case Radon--Nikodym theorem is false. The source's word ``set'' and
+summation notation leave the boundary implicit; Lean must state it.
+
+\section{Suppressed zero multiplicities in the two-pure-state spectrum}
+\label{sec:two-pure-state-spectrum}
+
+\paragraph{Formalization trigger.}
+The Lean theorem
+\leanid{Projectivization.charpoly_add_pureStateMatrix_of_two_le} keeps the full
+characteristic polynomial of a sum of two normalized pure-state matrices. The
+correction is documented in
+\path{docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex}.
+
+\paragraph{Printed source and its role.}
+In the spectrum-preserver argument following Wigner's theorem, Chapter~1 says
+that the spectrum of two Hermitian rank-one projections $P,Q$ is
+\begin{equation}
+  1\pm\sqrt{\operatorname{tr}(PQ)}.
+\end{equation}
+These values are the two roots of the quadratic
+$(X-1)^2-\operatorname{tr}(PQ)$.
+
+\paragraph{Correction.}
+For $d\geq2$, the multiplicity-aware statement is
+\begin{equation}
+  \chi_{P+Q}(X)
+  =X^{d-2}\bigl((X-1)^2-\operatorname{tr}(PQ)\bigr).
+\end{equation}
+The factor $X^{d-2}$ supplies the guaranteed additional zero multiplicity.
+If $P=Q$, then the quadratic is $X(X-2)$ and contributes one further zero, so
+the total zero multiplicity is $d-1$. Dimension one has the separate formula
+$\chi_{P+Q}(X)=X-2$, and dimension zero has no projective pure states.
+
+\paragraph{Classification.}
+This is a local correction to the displayed spectrum shorthand, not a claim
+that Wolf's intended spectrum-preserver argument is false. The two displayed
+values contain the transition-probability information used in that argument;
+the characteristic polynomial records the complete multiplicity data.
+
+\section{Formalization gaps that are not source corrections}
+
+The following Wolf-specific paper-gap notes are intentionally \emph{not}
+errata entries:
+\begin{itemize}
+  \item \path{wolf_prop28_square_case.tex}: the current normal-form theorem is
+    the square-dimensional special case of Wolf's rectangular statement;
+  \item \path{wolf_lemma_3_1_top_index_scope.tex},
+    \path{wolf_prop_3_2_top_index_scope.tex}, and
+    \path{wolf_t_eta_top_index_scope.tex}: endpoint Schmidt-rank cases that
+    were formalization scope gaps and are now resolved;
+  \item \path{wolf_reduction_criterion_schmidt_premise.tex}: the
+    Schmidt-number premise was a formalization dependency and is now resolved;
+  \item \path{wolf_ex3_1_choi_positivity_subcase_scope.tex}: the development
+    proves selected parameter families, not the full source range;
+  \item \path{wolf_ch5_operator_jensen_lieb.tex} and
+    \path{wolf_cor67_maximal_support_restriction.tex}: these describe
+    formalization boundaries and their resolution, not a false printed theorem.
+\end{itemize}
+
+\section{Conclusion}
+
+At present the formalization-derived record contains one genuine mathematical
+source error (Section~\ref{sec:lorentz}), one explicit boundary convention
+(Section~\ref{sec:radon-nikodym}), and one local correction to a spectrum
+shorthand (Section~\ref{sec:two-pure-state-spectrum}). These are the corrections
+asserted by the Lean documentation itself.
+
+\appendix
+\section{Corrected errors in the local LaTeX transcription}
+\label{app:transcription}
+
+This appendix is deliberately placed last.  Its entries were found by comparing
+the source PDFs with the local transcription; they are \emph{not} claims that a
+Lean proof forced a correction to Wolf's statement.  Each was a mathematically
+material transcription error and has now been corrected in the local TeX.
+
+\subsection{The Choi marginal: $\tau_B$ versus $\operatorname{tr}_B\tau$}
+
+\textbf{Source context.}  In Chapter~2, immediately after deriving the
+coordinate expression for the Choi--Jamiolkowski correspondence in
+Eq.~(2.4), Wolf explains the channel--state dictionary.  For a channel
+$T:M_d\to M_{d'}$, the first factor is the output factor $A$ and the second is
+the untouched input/reference factor $B$.  The PDF (book p.~34) states:
+\begin{quote}
+``If $T$ is a quantum channel in the Schr\"odinger picture, then $\tau$ is a
+density operator with reduced density matrix $\tau_B=\one/d$.''
+\end{quote}
+Thus $\tau_B$ denotes $\operatorname{tr}_A\tau$.
+
+\textbf{Transcription and correction.}  A previous local transcription at
+\path{ch02_representations.tex:113--114} changed the displayed marginal to
+$\operatorname{tr}_B\tau=\one/d$.  It has been corrected to retain Wolf's
+notation; equivalently, one may spell out
+\begin{equation}
+  \tau_B=\operatorname{tr}_A\tau=\frac{\one_d}{d}.
+\end{equation}
+
+\textbf{Reason.}  Trace preservation is equivalent to the last identity.  The
+other marginal satisfies $\operatorname{tr}_B\tau=T(\one)/d$ and is maximally
+mixed precisely when $T$ is unital.  Hence the local transcription accidentally
+turns a trace-preserving assertion into a stronger and generally false unitality
+assertion.
+
+\subsection{The conjugation in the proof of Kramer's theorem}
+
+\textbf{Source context.}  Chapter~3 proves Kramer's theorem for a Hermitian
+$H$ commuting with an anti-unitary symmetry $T=\Gamma V$, where $V^T=-V$.
+After showing that $V^\dagger\lvert\overline\psi\rangle$ is another eigenvector,
+the PDF (book p.~62, Eq.~(3.29)) establishes orthogonality by the chain
+\begin{equation}\tag{PDF (3.29)}
+ \langle\psi\mid V^\dagger\mid\overline\psi\rangle
+ =-\langle\psi\mid\overline V\mid\overline\psi\rangle
+ =-\overline{\langle\overline\psi\mid V\mid\psi\rangle}.
+\end{equation}
+The final conjugation is then identified with
+$\langle\psi\mid V^\dagger\mid\overline\psi\rangle$, proving that this scalar
+is its own negative.
+
+\textbf{Transcription and correction.}  A previous local TeX version at
+\path{ch03_positive_not_completely.tex:515} omitted the outer bar in the final
+term.  It has been corrected to the source-faithful and mathematically
+necessary term $-\overline{\langle\overline\psi\mid V\mid\psi\rangle}$.
+
+\textbf{Reason.}  Componentwise,
+\begin{equation}
+ \langle\psi\mid\overline V\mid\overline\psi\rangle
+ =\overline{\langle\overline\psi\mid V\mid\psi\rangle}.
+\end{equation}
+Without the conjugation the equality is false in general, and the final
+self-cancellation in the orthogonality argument does not follow.
+
+\subsection{The order of the conjugated factors in Example~5.3}
+
+\textbf{Source context.}  Chapter~5 studies the adjoint of the map
+$T(X)=\tfrac12(X^T+\tfrac12\operatorname{tr}(X)\one)$ as an example of a
+Schwarz map that need not be $2$-positive.  In the traceless case, the PDF
+(book p.~77, Eq.~(5.10)) subtracts the product
+\begin{equation}\tag{PDF (5.10), relevant term}
+  \frac14\,\overline A A^T
+\end{equation}
+from $T^*(A^\dagger A)$.
+
+\textbf{Transcription and correction.}  A previous local TeX version at
+\path{ch05_schwarz_inequalities.tex:373,377} instead wrote
+$A\overline A^{\,T}$.  It has been corrected to $\overline A A^T$, as in the
+source.
+
+\textbf{Reason.}  Since $T^*(A)=A^T/2$ for traceless $A$,
+\begin{equation}
+ T^*(A^\dagger)T^*(A)
+ =\frac14(A^\dagger)^T A^T
+ =\frac14\,\overline A A^T.
+\end{equation}
+The transcribed matrix $A\overline A^{\,T}=AA^\dagger$ is generally a
+different operator, even though both matrices are positive semidefinite and
+the final positivity conclusion in the example survives.
+
+\end{document}

--- a/docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex
@@ -1,0 +1,77 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Top-index scope of the maximal-overlap lemma (Wolf Lemma 3.1)}
+\author{}
+\date{2026-06-24}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{Source statement}
+
+Lemma~3.1 of Wolf's \emph{Quantum Channels \& Operations}
+(\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex}, lines
+119--128) states that, for a normalized vector
+$\phi\in\mathbb{C}^{D'}\otimes\mathbb{C}^{D}$ with reduced density matrix
+$\rho=\tr_2|\phi\rangle\langle\phi|$ on the first factor $\mathbb{C}^{D'}$,
+\begin{align}
+  \sup_{\psi}|\langle\phi|\psi\rangle|^2 = \|\rho\|_{(n)},
+\end{align}
+where the supremum runs over normalized vectors $\psi$ of Schmidt rank $n$ and
+$\|\cdot\|_{(n)}$ is the Ky-Fan $n$-norm. Since $\rho$ acts on the first factor
+$\mathbb{C}^{D'}$, its Ky-Fan $n$-norm is meaningful for $1\le n\le D'$. In the
+application (n-positivity, Wolf Prop.~3.2) the Schmidt rank $n$ ranges over
+$1\le n\le D'$, so the top value $n=D'$ is within the source's scope.
+
+\section{Formalized statement}
+
+The formal theorem\footnote{Formal declaration:
+    \leanid{Matrix.maximalSchmidtOverlap_eq_kyFanNorm} in
+    \doclink{QICLean/Channel/MaximalOverlap}.} establishes the same identity,
+strengthened to attainment (the \Lean{} \texttt{IsGreatest} predicate), under
+the hypotheses $1\le n$ and $n<D'$, where $D'$ is the dimension of the first
+tensor factor on which $\rho$ acts.
+
+\section{The gap}
+
+The formalization omits the top index $n=D'$. At $n=D'$ the Schmidt-rank
+constraint is vacuous and $\|\rho\|_{(D')}=\tr\rho=1$; the supremum equals $1$
+and is attained at $\psi=\phi$.
+
+The restriction is inherited from the underlying maximum principle,\footnote{Formal
+    declaration: \leanid{Matrix.IsHermitian.kyFanNorm_eq_sup_trace}.} which
+characterizes the Ky-Fan $k$-norm as a maximum over rank-exactly-$k$ orthogonal
+projections only for $k<D'$. At $k=D'$ the only rank-$D'$ projection is the
+identity, and the eigenvalue sum already equals the trace; the variational
+statement degenerates rather than fails.
+
+\section{Elimination plan}
+
+Add a top-index case to the Ky-Fan maximum principle (or a companion lemma)
+covering $k=D'$, where the maximizing projection is the identity and the value
+is $\operatorname{Re}\tr(A)$. The overlap lemma then extends to $1\le n\le D'$
+by feeding that case into the same transfer argument.
+
+\section{Classification}
+
+\emph{Resolved.} The top index $n=D'$ is now formalized as the companion theorem
+\leanid{Matrix.maximalSchmidtOverlap_eq_kyFanNorm_top}: there the Schmidt-rank
+constraint is vacuous, the Ky-Fan $D'$-norm collapses to the trace
+$\|\rho\|_{(D')}=\tr\rho=1$, and the value is attained at $\psi=\phi$ with the
+upper bound supplied by Cauchy--Schwarz. Together with
+\leanid{Matrix.maximalSchmidtOverlap_eq_kyFanNorm} (the range $1\le n<D'$) this
+covers the full source range $1\le n\le D'$ of Wolf's Lemma~3.1, exactly as the
+elimination plan above anticipated.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_prop16_cp_positivity_commutative_side.tex
+++ b/docs/paper-gaps/wolf_prop16_cp_positivity_commutative_side.tex
@@ -1,0 +1,88 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Wolf Proposition~1.6: Complete Positivity from Positivity, Commutative Side}
+\author{}
+\date{2026-08-05}
+
+\begin{document}
+\maketitle
+\gapnote{clarification}{resolved}
+
+\section{The source statement}
+
+Wolf's Proposition~1.6 reads: let $T:\mathcal A\to\mathcal B$ be a positive
+linear map between unital $C^*$-algebras; if either $\mathcal A$ or
+$\mathcal B$ is commutative then $T$ is completely positive
+\cite[Proposition~1.6]{Wolf2012Quantum}. The local source is
+\path{Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex},
+lines~600--612. Wolf proves only the finite-dimensional case, reduces to
+$\mathcal B$ commutative (the $\mathcal A$-commutative case follows because
+$T$ is completely positive iff its dual $T^*$ is), and then argues by
+simultaneously diagonalizing the pairwise-commuting family
+$\{T(a_{ij})\}$. His remark immediately after the proof states that the
+algebra structure of $\mathcal A$ was never used, so the same argument gives
+complete positivity for any positive map out of an operator system into a
+commutative $C^*$-algebra.
+
+\section{Formalized component}
+
+\Lean's ambient objects for this proposition are linear endomorphisms of
+$M_D(\mathbb C)$: \leanid{IsPositiveMap} and \leanid{IsCPMap} in
+\leanid{QICLean/Channel/Basic.lean} both fix $\mathcal A=\mathcal B=M_D(\mathbb
+C)$. Reading Wolf's ``$\mathcal B$ commutative'' hypothesis literally in this
+ambient setting would force $M_D(\mathbb C)$ itself to be commutative, i.e.\
+$D\le 1$, which is not the statement Wolf's proof establishes and not a
+useful specialization. The formalization instead uses the range-only
+hypothesis that Wolf's own remark licenses:
+\leanid{PositiveOnAbelian.HasCommutingRange T}, defined as
+$\forall\,X\,Y,\ \operatorname{Commute}(T(X))(T(Y))$, in
+\leanid{QICLean/Channel/Schwarz/PositiveOnAbelian/CompletePositivity.lean}.
+Since a family of pairwise-commuting elements generates a commutative
+subalgebra, \leanid{HasCommutingRange T} is exactly the statement that $T$
+maps into some commutative subalgebra of $M_D(\mathbb C)$ -- the hypothesis
+Wolf's proof actually consumes, not an invented strengthening or weakening
+of it.
+
+\leanid{PositiveOnAbelian.isCPMap_of_isPositiveMap_of_hasCommutingRange}
+proves the commutative-codomain case:
+\leanid{IsPositiveMap T} together with \leanid{HasCommutingRange T} implies
+\leanid{IsCPMap T}. The proof follows Wolf's route: it reduces complete
+positivity to nonnegativity of the block quadratic form built from the Choi
+matrix, and this reduces to the already-proved simultaneous-diagonalization
+lemma \leanid{PositiveOnAbelian.quadraticForm_nonneg_of_isPositiveMap_of_}
+\leanid{commuting_images} (\href{https://github.com/LionSR/TNLean/issues/5468}{TNLean issue \#5468} closes the wrapping gap left open
+after that lemma was proved sorry-free).
+
+\leanid{PositiveOnAbelian.isCPMap_of_isPositiveMap_of_hasCommutingRange_adjoint}
+proves the commutative-domain case by the same duality argument Wolf invokes:
+$T$ is completely positive iff its trace-pairing adjoint
+\leanid{Matrix.traceAdjointMap T} is, and the codomain case applies to
+\leanid{Matrix.traceAdjointMap T} when its range is commutative.
+\leanid{PositiveOnAbelian.isCPMap_of_isPositiveMap_of_commutingRange_or}
+combines both disjuncts into the ``either side'' statement.
+
+\section{Relationship to the source hypothesis}
+
+\leanid{HasCommutingRange T} is implied by, but strictly weaker than, ``the
+ambient codomain algebra is commutative'' when the ambient codomain is the
+full matrix algebra $M_D(\mathbb C)$ with $D>1$: a map with commutative range
+need not have commutative full codomain, since $M_D(\mathbb C)$ itself is
+never commutative for $D>1$. This is the correct reading of Wolf's
+proposition for an ambient setting where $\mathcal A$ and $\mathcal B$ are
+not themselves varied as commutative or noncommutative algebras but are
+fixed as $M_D(\mathbb C)$; it matches the generalization Wolf's own remark
+grants (operator system to commutative algebra), not a separately restricted
+theorem. No hypothesis absent from Wolf's argument is added, so the theorems
+above formalize Proposition~1.6 as Wolf actually proves it, not a
+corollary of it.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex
+++ b/docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex
@@ -1,0 +1,88 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Wolf Proposition~1.5: Factor and Coordinate Direct-Sum Scope Restrictions}
+\author{}
+\date{2026-07-18}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{The source statement}
+
+Wolf's Proposition~1.5 classifies positive linear retractions onto an arbitrary
+unital finite-dimensional $*$-subalgebra
+\cite[Proposition~1.5 and Equation~(1.40)]{Wolf2012Quantum}.  After unitary
+conjugation, the subalgebra has the form
+\[
+    \bigoplus_{k=1}^{K} M_{d_k}(\mathbb C)\otimes\mathbf 1_{m_k},
+\]
+and the proposition asserts that the retraction is a direct sum of weighted
+partial traces, one for each summand.  The proof first removes inputs between
+distinct summands and outputs in the wrong summand, and then proves the
+weighted-partial-trace formula separately on each factor.  The corresponding
+local source is
+\path{Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex}, lines~536--570.
+
+\section{Formalized component}
+
+The theorem
+\leanid{Matrix.exists_density_of_positive_retraction_onto_right_factor} proves
+the complete factor argument for a positive retraction whose range is
+\[
+    \mathbf 1_m\otimes M_d(\mathbb C).
+\]
+It introduces no hypothesis absent from the one-factor specialization of the
+source proposition.  In particular, the representing matrix is only required
+to be positive semidefinite and to have trace one.  Thus the theorem is a
+faithful scope-restricted case, but it is not the full direct-sum
+classification of Proposition~1.5.
+
+The theorem
+\leanid{Matrix.coordinateDirectSumConditionalExpectation_isKrausCPTP_and_isConditionalExpectation}
+constructs the normalized trace-preserving choice simultaneously on all
+summands in displayed direct-sum coordinates.  In the tensor-factor order used
+by QICLean, its range is
+\[
+    \bigoplus_{k=1}^{K}\mathbf 1_{m_k}\otimes M_{d_k}(\mathbb C),
+\]
+and its formula is obtained from Wolf's order by interchanging the two tensor
+factors.  This theorem includes the coordinatewise partial traces and removal
+of off-diagonal blocks, but it neither conjugates an arbitrary represented
+subalgebra into these coordinates nor corestricts the ambient matrix-valued map
+to that subalgebra.  It is therefore a coordinate construction, not the full
+unitarily transported statement of Proposition~1.5.
+
+\section{Resolution of the direct-sum argument}
+
+The theorem
+\leanid{StarSubalgebra.exists_block_densities_of_positive_retraction} combines
+the one-factor theorem with the finite-dimensional block description.  Its
+proof:
+\begin{enumerate}
+    \item conjugate and reindex the ambient matrices by the unitary block data;
+    \item prove that the positive retraction annihilates inputs between
+          distinct central summands;
+    \item prove that an input supported in one summand has no output in another
+          summand;
+    \item apply the one-factor theorem to each diagonal summand; and
+    \item conjugate the resulting direct sum of weighted partial traces back to
+          the original subalgebra.
+\end{enumerate}
+The second and third items are the off-diagonal positivity arguments in Wolf's
+proof preceding Equation~(1.42).  They are now proved using the complementary
+central projection of each summand.  The remaining distinction between the
+classification of a given retraction and the later construction of a
+fixed-point projection is recorded in
+\path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_prop28_square_case.tex
+++ b/docs/paper-gaps/wolf_prop28_square_case.tex
@@ -1,0 +1,113 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Square-Dimension Restriction in Wolf's Generic Normal Form\\
+{\large (restriction resolved 2026-08-04)}}
+\author{}
+\date{2026-06-30, updated 2026-08-04}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{The assertion}
+
+Wolf's Proposition~2.9 is a normal-form statement for completely positive maps
+with full Kraus rank.\footnote{\cite[Proposition~2.9]{Wolf2012Quantum};
+local source \path{Notes/WolfNoteTexSource/ch02_representations.tex},
+lines 923--929.}  In the source it reads: let
+\begin{align}
+  T : \mathcal{M}_{d_1} \to \mathcal{M}_{d_2}
+\end{align}
+be a completely positive map with full Kraus rank.  Then there exist invertible
+completely positive maps \(\Phi_i \in \mathcal B(\mathcal{M}_{d_i})\) of Kraus
+rank one such that \(T' := \Phi_2 T \Phi_1\) is doubly-stochastic, i.e.\ both
+\(T'(\one)\) and \(T'^{*}(\one)\) are proportional to the identity matrix.
+
+The two filterings act on \emph{different} matrix algebras: \(\Phi_1\) on the
+input algebra \(\mathcal{M}_{d_1}\) and \(\Phi_2\) on the output algebra
+\(\mathcal{M}_{d_2}\), with no constraint relating \(d_1\) and \(d_2\).
+
+\section{The point at issue}
+
+The formal development states the proposition only in the equal-dimension case
+\(d_1 = d_2 = D\):
+\begin{align}
+  T : \MN{D} \to \MN{D},
+\end{align}
+with both filterings acting on the same algebra \(\MN{D}\).\footnote{Formal
+declaration \leanid{Wolf.exists\_normal\_form\_generic} in
+\doclink{QICLean/Channel/LorentzNormalForm}.}  The Choi matrix
+\(\tau = (T \otimes \mathrm{id})(\ketbra{\Omega}{\Omega})\) is then a square
+matrix on \(\C^{D} \otimes \C^{D}\), and the minimisation runs over
+\(\mathrm{SL}(D,\C) \times \mathrm{SL}(D,\C)\) filterings of a single dimension.
+The compactness lemma \leanid{Wolf.infimum\_is\_attained} and the
+trace--determinant AM--GM equality
+\leanid{Matrix.PosSemidef.pow\_card\_mul\_det\_re\_eq\_trace\_re\_pow\_iff}
+that drive the proof are likewise written for a square Choi matrix on
+\(\C^{D} \otimes \C^{D}\).
+
+For \(D=2\), the square theorem supplies the full-Kraus-rank minimisation result
+used in the diagonal case of the qubit Lorentz normal form.  The existence theorem
+covering the diagonal, non-diagonal, and singular cases is not yet formalized; in
+particular, it is not a specialization of a current declaration.  Its additional
+scalar-normalization and Lorentz-orbit gap is described in
+\path{docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex}.
+
+\section{The restricted statement}
+
+The formal theorem proves the square instance:
+\begin{align}
+  T : \MN{D} \to \MN{D}, \qquad
+  \tau = \mathrm{choi}(T) \succ 0
+  \ \Longrightarrow\
+  \exists\, \Phi_1, \Phi_2,\
+  \Phi_2 \circ T \circ \Phi_1\ \text{doubly-stochastic},
+\end{align}
+with both \(\Phi_1, \Phi_2\) SL-filterings on \(\MN{D}\).  This is a sub-case of
+the source proposition, obtained by setting \(d_1 = d_2\); it is mathematically
+correct as stated, just narrower than Wolf's rectangular formulation.
+
+\section{Resolution}
+
+The elimination steps above are now carried out (2026-08-04, \href{https://github.com/LionSR/TNLean/issues/3616}{TNLean issue \#3616}):
+\begin{itemize}
+  \item \leanid{Wolf.infimum\_is\_attained} is generalized in place: it ranges
+    over a positive-definite operator on \(\C^{d_2} \otimes \C^{d_1}\) with
+    filterings in \(\mathrm{SL}(d_1,\C) \times \mathrm{SL}(d_2,\C)\), the
+    Frobenius confinement using per-factor dimension constants.  The square
+    caller is unaffected (the two dimensions simply unify).
+  \item The rectangular proposition is formalized as
+    \leanid{Wolf.exists\_normal\_form\_generic\_rect}: for a completely
+    positive map \(T : \mathcal{M}_{d_1} \to \mathcal{M}_{d_2}\) (in the
+    rectangular Kraus sense \leanid{IsKrausCP}) whose rectangular Choi matrix
+    \leanid{ChoiRectangular.choiMatrix} is positive definite, there exist
+    filterings \(\Phi_1\) on \(\mathcal{M}_{d_1}\) and \(\Phi_2\) on
+    \(\mathcal{M}_{d_2}\), each of Kraus rank one with determinant-one
+    filtering matrix, such that \(\Phi_2 \circ T \circ \Phi_1\) is
+    doubly-stochastic in the source's sense
+    (\leanid{Wolf.DoublyStochasticRect}: both \(T'(\one)\) and
+    \(T'^{*}(\one)\) proportional to the identity, with the trace-pairing
+    adjoint).
+\end{itemize}
+
+\section{Verdict}
+
+The scope restriction is \emph{resolved}: Wolf Proposition~2.9 is formalized at
+the source's generality with independent input and output dimensions.  The
+square \leanid{Wolf.exists\_normal\_form\_generic} remains as the
+equal-dimension specialization; its statement and proof are unchanged.  The
+remaining gap in this area is Proposition~2.11 (the qubit Lorentz
+classification), recorded separately in
+\path{docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex
+++ b/docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex
@@ -1,0 +1,118 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Scalar Normalization in Wolf's Lorentz Normal Form}
+\author{}
+\date{2026-07-16}
+
+\begin{document}
+\maketitle
+\gapnote{open-gap}{open}
+
+\section{The assertion}
+
+Wolf's Proposition~2.11 states that every qubit channel
+$T:\MN{2}\to\MN{2}$ admits invertible completely positive maps
+$\Phi_1,\Phi_2$, each of Kraus rank one, such that
+\begin{align}
+  T' = \Phi_2\circ T\circ\Phi_1
+\end{align}
+is again a qubit channel and belongs to one of three Lorentz normal forms:
+diagonal, non-diagonal, or singular.\footnote{\cite[Proposition~2.11]{Wolf2012Quantum};
+local source \path{Notes/WolfNoteTexSource/ch02_representations.tex},
+lines 1021--1035.}  Each filtering has the form
+\begin{align}
+  \Phi_X(A)=XAX^\dagger,
+  \qquad X\in\mathrm{GL}(2,\C).
+\end{align}
+Thus the proposition allows every invertible Kraus-rank-one completely positive
+filter, not only those represented by determinant-one matrices.
+
+\section{Determinant-one action and scalar freedom}
+
+Choose a square root $c^2=\det X$ and write $X=cS$, where
+$S\in\mathrm{SL}(2,\C)$. Then
+\begin{align}
+  \Phi_X(A)
+    &= |c|^2\Phi_S(A),\\
+  |c|^2
+    &= |\det X|.
+\end{align}
+Consequently, if $X_i=c_iS_i$ for the two filters, then
+\begin{align}
+  \Phi_{X_2}\circ T\circ\Phi_{X_1}
+  = |c_1c_2|^2
+    (\Phi_{S_2}\circ T\circ\Phi_{S_1}).
+  \label{eq:scalar-factor}
+\end{align}
+The matrices $S_1,S_2$ determine the determinant-one Lorentz action. The
+positive factor $|c_1c_2|^2$ selects the normalization on the resulting ray of
+completely positive maps.
+
+This distinction is immaterial when only the Lorentz orbit up to positive scale
+is considered. It is essential when the representative is required to be a
+channel. If the determinant-one representative satisfies
+\begin{align}
+  \tr\!\left(\Phi_{S_2}\circ T\circ\Phi_{S_1}(A)\right)
+  = \alpha\,\tr(A),
+\end{align}
+then it is trace preserving only when $\alpha=1$. General invertible filters
+can multiply the map by $\alpha^{-1}$ through the scalar in
+\eqref{eq:scalar-factor}; determinant-one filters have no such freedom. The
+minimisation in Propositions~2.8 and~2.9 produces partial traces proportional to
+the identity, but the proportionality scalar must still be chosen so that the
+qubit representative is trace preserving.
+
+\section{The point at issue}
+
+A former local statement required both filters to be determinant-one while also
+requiring the filtered map to be a qubit channel in one of the three canonical
+forms.\footnote{The removed declaration was
+\leanid{Wolf.exists_lorentz_normal_form_qubit} in
+\doclink{QICLean/Channel/LorentzNormalForm}.}  Equation~\eqref{eq:scalar-factor}
+shows why the determinant-one restriction does not justify the normalization in
+Wolf's proposition. The source theorem permits general invertible filters, and
+its channel conclusion uses their scalar freedom. The restricted local
+statement was therefore removed rather than treated as a formalization of
+Proposition~2.11.
+
+The three canonical-form predicates and the square full-Kraus-rank minimisation
+theorem are formalized.\footnote{Formal declarations
+\leanid{Wolf.IsLorentzDiagonal}, \leanid{Wolf.IsLorentzNonDiagonal},
+\leanid{Wolf.IsLorentzSingular}, and
+\leanid{Wolf.exists_normal_form_generic} in
+\doclink{QICLean/Channel/LorentzNormalForm}.}  The theorem asserting existence of
+a canonical representative for every qubit channel remains open.
+
+\section{Elimination plan}
+
+A source-faithful proof requires the following steps.
+\begin{enumerate}
+  \item Define general invertible Kraus-rank-one completely positive filters and
+    separate each filter into a determinant-one factor and a nonzero scalar.
+  \item Use the minimisation argument of Propositions~2.8 and~2.9 for the
+    full-Kraus-rank case, retaining the proportionality constants of the two
+    marginals.
+  \item Formalize the Lorentz action of $\mathrm{SL}(2,\C)$ on the Pauli
+    transfer matrix and classify its diagonal, non-diagonal, and singular orbits.
+  \item Choose the scalar factors so that the canonical representative is trace
+    preserving, and verify complete positivity and the stated parameter bounds.
+  \item Prove the three-case existence theorem using the general filters and link
+    it to the existing canonical-form predicates.
+\end{enumerate}
+
+The discrepancy is an open gap: the canonical forms are defined, and the generic
+minimisation theorem is available in square dimension, but the scalar-normalized
+Lorentz-orbit classification required by Proposition~2.11 has not yet been
+formalized.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_prop61_russo_dye_factor.tex
+++ b/docs/paper-gaps/wolf_prop61_russo_dye_factor.tex
@@ -1,0 +1,84 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Wolf Proposition~6.1 --- The Russo--Dye Factor}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{The assertion}
+
+Wolf, \emph{Quantum Channels \& Operations}, Proposition~6.1:
+``If $T$ is a positive map on $\mathcal M_d(\mathbb C)$, then its
+spectral radius satisfies $\varrho(T)\le\|T(\mathbf 1)\|_\infty$.  If in
+addition $T$ is unital or trace-preserving, then there is an eigenvalue
+$\lambda=1$.''
+
+The proof invokes the Russo--Dye theorem
+$\|T(X)\|_\infty\le\|T(\mathbf 1)\|_\infty\,\|X\|_\infty$ to bound
+every eigenvalue modulus by $\|T(\mathbf 1)\|_\infty$, and hence the
+spectral radius.
+
+\section{The formalization}
+
+The trace-preserving case is the one needed by the rest of the chapter.
+It is established by two theorems:
+\begin{itemize}
+\item \leanid{IsPositiveMap.eigenvalue\_norm\_le\_one\_of\_tracePreserving}
+  in \doclink{QICLean/Channel/Determinant/Bound} proves $|\lambda|\le1$ for
+  every eigenvalue of a positive trace-preserving map via an orbit-and-trace
+  argument that decomposes an eigenvector into Hermitian parts and
+  difference-of-density-matrices components;
+\item \leanid{IsPositiveMap.eigenvalue\_one\_exists\_of\_tracePreserving}
+  in \doclink{QICLean/Channel/Peripheral/SpectralRadius} proves that
+  $1$ is an eigenvalue with a nonzero positive-semidefinite eigenvector,
+  using the Perron--Frobenius theorem
+  (\leanid{exists\_posSemidef\_eigenvector} in
+  \doclink{QICLean/Channel/PerronFrobenius/Existence}) together with trace
+  preservation to force the Perron eigenvalue to~$1$.
+\end{itemize}
+Together these give $\varrho(T)=1$ for the trace-preserving case, which is the
+statement required by Proposition~6.3 (Ces\`aro means) and later results.
+
+The unital case follows by duality: the trace adjoint $T^*$ is
+trace-preserving, its spectrum coincides with that of~$T$, and the
+eigenvalue-$1$ conclusion carries over.  This dual implication has not yet been
+wired as a separate lemma.
+
+The general ``$\varrho(T)\le\|T(\mathbf 1)\|_\infty$ for every positive map''
+has not been formalized.  A possible elimination plan would follow the
+Russo--Dye route for the matrix algebra by: (a) using
+\leanid{PositiveLinearMap.norm\_apply\_le\_of\_nonneg} from Mathlib to obtain
+the factor-$1$ bound on positive-semidefinite inputs; (b) decomposing an
+arbitrary matrix into four positive-semidefinite parts via the standard
+Hermitian/anti-Hermitian and positive/negative-part decomposition; (c) obtaining
+$\|T(X)\|\le 4\|T(\mathbf 1)\|\|X\|$ and, from it, a characterisation of
+the spectral radius.  Steps (a) and (b) are available; step~(c) would yield
+a factor-$4$ certificate, weaker than the source's factor~$1$.  To recover
+the optimal factor one would need the full Russo--Dye theorem
+$\|T\|=\|T(\mathbf 1)\|$ for positive maps on C$^\ast$-algebras, which
+is not yet present in Mathlib.\footnote{Mathlib~\texttt{PositiveLinearMap.norm\_apply\_le\_of\_nonneg}
+already proves $\|T(X)\|\le\|T(\mathbf 1)\|\|X\|$ for $X\ge0$; the missing
+step is the extension to arbitrary $X$ without the factor~$4$.}
+
+\section{Verdict}
+
+This is a \emph{scope restriction}.  The trace-preserving and unital cases of
+Wolf Proposition~6.1 are fully proved; the general bound
+$\varrho(T)\le\|T(\mathbf 1)\|_\infty$ for arbitrary positive maps is not
+yet formalized.  The trace-preserving case is the one invoked throughout the
+remainder of Chapter~6 and is complete.\footnote{Tracking: \href{https://github.com/LionSR/TNLean/issues/3984}{TNLean issue \#3984}.}
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_prop62_jordan_blocks.tex
+++ b/docs/paper-gaps/wolf_prop62_jordan_blocks.tex
@@ -1,0 +1,94 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Wolf Proposition~6.2 --- Trivial Jordan Blocks for Peripheral Eigenvalues}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{The assertion}
+
+Wolf, \emph{Quantum Channels \& Operations}, Proposition~6.2:
+``Let $T:\mathcal M_d(\mathbb C)\to\mathcal M_d(\mathbb C)$ be a
+trace-preserving (or unital) positive linear map.  If $\lambda$ is an
+eigenvalue of $T$ with $|\lambda|=1$, then its geometric multiplicity
+equals its algebraic multiplicity, i.e., all Jordan blocks for $\lambda$
+are one-dimensional.''
+
+The proof observes that the iterates $T^n$ are uniformly bounded in
+operator norm (positivity together with either trace preservation or
+unitality keeps every forward orbit bounded) and that powers of a
+nontrivial Jordan block grow without bound when the eigenvalue has
+modulus~$1$, giving a contradiction.
+
+\section{The formalization}
+
+The bounded-orbit lemma is formalized for both hypotheses of the
+proposition. \leanid{IsPositiveMap.hasBoundedOrbits\_of\_tracePreserving} in
+\doclink{QICLean/Channel/FixedPoint/MeanErgodicProjection} proves
+that every forward orbit $\{T^n X\}_{n\in\mathbb N}$ is bounded in norm
+for a positive trace-preserving $T$, and
+\leanid{IsPositiveMap.hasBoundedOrbits\_of\_unital} in
+\doclink{QICLean/Channel/Peripheral/JordanBlocks} proves the same for a
+positive unital $T$. Both share the reduction from an arbitrary matrix to
+a positive semidefinite one
+(\leanid{IsPositiveMap.hasBoundedOrbits\_of\_posSemidef\_orbit\_bounded} in
+\doclink{QICLean/Channel/FixedPoint/MeanErgodicProjection}) and differ only
+in the positive-semidefinite-orbit step: trace preservation bounds the trace
+of each iterate directly, while unitality bounds each iterate above by
+$(\operatorname{tr}X)\cdot 1$ in the Loewner order and then bounds its trace.
+This is exactly Wolf's own argument: the bound
+$\operatorname{tr}[A\,T(B)] \le \|A\|_\infty \|B\|_\infty
+\operatorname{tr}[1\,T(1)] = d\|A\|_\infty\|B\|_\infty$ holds verbatim for
+trace-preserving \emph{or} unital positive maps because
+$\operatorname{tr}[1\,T(1)] = d$ under either hypothesis (trace preservation
+gives $\operatorname{tr}[T(1)] = \operatorname{tr}[1] = d$; unitality gives
+$T(1) = 1$, so $\operatorname{tr}[1\cdot 1] = d$ directly). No duality
+argument through the adjoint map is needed or used.
+
+The binomial-expansion ingredient is formalized once and shared between the
+two cases. A rank-$2$ generalized eigenvector $(T-\lambda)X=Y\neq0$ with
+$(T-\lambda)Y=0$ gives, by induction on the decomposition
+$T=\lambda I+(T-\lambda I)$ (\leanid{IsPositiveMap.pow\_apply\_rank\_two\_genEig}),
+\[
+    T^n X = \lambda^n X + n\lambda^{n-1}Y,
+\]
+whose norm grows linearly with $n$. Extracting the norm bound
+$\|T^n X\|\ge n\|Y\|-\|X\|$ from this identity and applying the bounded-orbit
+lemma (either hypothesis) reaches the contradiction that closes the rank-$2$
+case; the full statement for higher-rank generalized eigenvectors reduces to
+rank~$2$ by induction on $k$.
+
+\section{Verdict}
+
+Both hypotheses of Proposition~6.2 are \emph{closed}.  The rank-2 binomial
+expansion (\leanid{IsPositiveMap.pow\_apply\_rank\_two\_genEig}) is shared
+between the two cases; the rank-2 generalized-eigenvector prohibition and
+the full $k$-step reduction are each proved once per hypothesis
+(\leanid{IsPositiveMap.no\_rank\_two\_genEigenvector\_of\_tracePreserving},
+\leanid{IsPositiveMap.no\_rank\_two\_genEigenvector\_of\_unital},
+\leanid{IsPositiveMap.peripheral\_Jordan\_trivial\_of\_tracePreserving},
+\leanid{IsPositiveMap.peripheral\_Jordan\_trivial\_of\_unital}), all in
+\doclink{QICLean/Channel/Peripheral/JordanBlocks}.
+
+The unital case was formerly recorded as a \emph{scope restriction} pending a
+duality argument through the trace adjoint. That plan was not taken up:
+Wolf's own proof bounds $\operatorname{tr}[A\,T(B)]$ uniformly for
+trace-preserving \emph{or} unital positive maps by the same computation, so
+the unital case is proved directly, in parallel with the trace-preserving
+case, rather than by transport through $T^*$. See \href{https://github.com/LionSR/TNLean/issues/3984}{TNLean issue \#3984}
+(tracking) and \href{https://github.com/LionSR/TNLean/issues/5447}{TNLean issue \#5447} (this closure).
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex
+++ b/docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex
@@ -1,0 +1,138 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{The Schmidt-rank set in the spectral $n$-positivity criterion
+  (Wolf Prop.~3.2)}
+\author{}
+\date{2026-08-13}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{The assertion}
+
+Wolf's criterion for $n$-positivity\footnote{%
+  \path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex}, line 153,
+  equations (3.7) and (3.8).}
+bounds an infimum. For a Hermitian $\tau\in\mathcal M_{D'}\otimes\mathcal M_{D}$
+with spectral decomposition $\tau=\sum_i\nu_i\ketbra{\phi_i}{\phi_i}$, reduced
+densities $\rho_i=\tr_2\ketbra{\phi_i}{\phi_i}$, smallest positive eigenvalue
+$\nu_0$ and largest eigenvalue $\nu$, write $\|\cdot\|_{(n)}$ for the Ky-Fan
+$n$-norm, the sum of the $n$ largest eigenvalues of a positive semidefinite
+matrix. When exactly one eigenvalue $\nu_-$ of $\tau$ is non-positive, write
+$\rho_-$ for the reduced density of its eigenvector. Then
+\begin{align}
+  \inf_\psi\bra{\psi}\tau\ket{\psi}
+   & \ge \nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)\|\rho_i\|_{(n)},
+  \tag{3.7}                                                       \\
+  \inf_\psi\bra{\psi}\tau\ket{\psi}
+   & \le \nu+(\nu_--\nu)\|\rho_-\|_{(n)},
+  \tag{3.8}
+\end{align}
+the second under the hypothesis that all eigenvalues but $\nu_-$ are strictly
+positive. In both displays ``the infimum is taken over all normalized vectors of
+Schmidt rank $n$''.
+
+\section{The point at issue}
+
+The phrase ``Schmidt rank $n$'' admits two readings: the vectors whose Schmidt
+rank equals $n$, and the vectors whose Schmidt rank is at most $n$. The two sets
+differ, and the infimum is taken over whichever one is meant.
+
+The source fixes the reading in the proof of the preceding
+proposition.\footnote{Same file, Prop.~3.1 and its proof.} There $n$-positivity
+of $T$ is expressed as
+$(T\otimes\mathrm{id}_n)(\ketbra{\phi}{\phi})\ge0$ for all
+$\phi\in\C^{D}\otimes\C^{n}$, and the embedding $\C^{n}\subseteq\C^{D}$ turns
+this into a condition on the vectors of $\C^{D}\otimes\C^{D}$ that the source
+calls ``of Schmidt rank $n$''. That image is the set of vectors of Schmidt rank
+\emph{at most} $n$: a vector $\phi\in\C^{D}\otimes\C^{n}$ of Schmidt rank $r<n$
+is not excluded from the quantifier. The same identification is made once more
+at the end of the proof, where $\ket{\psi}=(\one\otimes X)^\dagger\ket{\tilde
+\psi}$ with $\operatorname{rank}X=n$ is called a vector of Schmidt rank $n$, although its
+Schmidt rank is only bounded by $n$.
+
+The bounded-rank reading is also the one carrying the operational content:
+$n$-positivity of a Hermitian map is equivalent to nonnegativity of
+$\bra{\psi}\tau\ket{\psi}$ on the vectors of Schmidt rank at most $n$, and it is
+this set that the criterion is applied to.
+
+\section{The two readings compared}
+
+Write $S_{\le n}$ for the normalized vectors of Schmidt rank at most $n$ and
+$S_{=n}$ for those of Schmidt rank exactly $n$, so $S_{=n}\subseteq S_{\le n}$.
+
+Inequality (3.7) is proved pointwise: every $\psi\in S_{\le n}$ satisfies
+$\bra{\psi}\tau\ket{\psi}\ge\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)\|\rho_i\|_{(n)}$,
+using $|\braket{\phi_i}{\psi}|^2\le\|\rho_i\|_{(n)}$. The bound therefore holds
+at every vector of $S_{=n}$ as well, and the bounded-rank statement of (3.7) is
+the stronger of the two.
+
+Inequality (3.8) is the reverse comparison, and there the two readings part. The
+vector realizing $|\braket{\phi_-}{\psi}|^2=\|\rho_-\|_{(n)}$ is built from the
+$n$ largest eigenvalues of $\rho_-$, so its Schmidt rank is
+$\min(n,\operatorname{rank}\rho_-)$. When $\operatorname{rank}\rho_-<n$ the
+witness lies in $S_{\le n}$ but not in $S_{=n}$, and the value $\nu+(\nu_--\nu)\|\rho_-\|_{(n)}=\nu_-$ is not
+attained on $S_{=n}$: a vector of $S_{=n}$ attaining it would lie in the
+$\nu_-$ eigenspace, which is spanned by $\phi_-$ and contains no vector of
+Schmidt rank $n$. The infimum over $S_{=n}$ still equals $\nu_-$, because
+$\phi_-$ is a limit of vectors of Schmidt rank exactly $n$ whenever
+$n\le\min(D',D)$ and the quadratic form is continuous, but it is a limit and not
+a witness.
+
+Consequently $\inf_{S_{\le n}}=\inf_{S_{=n}}$ for $1\le n\le\min(D',D)$, the two
+readings give the same two inequalities, and the difference is only which of
+them is proved by exhibiting a vector.
+
+\section{The formalized statement}
+
+The formalization takes the set named by the source, the normalized vectors of
+Schmidt rank at most $n$, and states both inequalities for the infimum of the
+expectations over that set.\footnote{Formal declarations:
+  \leanid{Matrix.schmidtRankLEExpectations},
+  \leanid{Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations} for (3.7),
+  \leanid{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_le} for (3.8), and
+  \leanid{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top} for the top
+  index, all in
+  \doclink{QICLean/Channel/NPositivitySpectralCriterion}.} No hypothesis absent
+from the source is used.
+
+What is not formalized is the identity $\inf_{S_{\le n}}=\inf_{S_{=n}}$ of the
+previous section. Formalizing it needs two ingredients: a normalized vector of
+Schmidt rank exactly $n$ for every $n\le\min(D',D)$, which makes the infimum over
+$S_{=n}$ meaningful, and the perturbation
+$\psi_\varepsilon=(1-\varepsilon^2)^{1/2}\psi+\varepsilon\,u\otimes v$ with
+$u,v$ orthogonal to the Schmidt vectors of $\psi$, which raises the Schmidt rank
+by one. The expectation changes by
+$2\varepsilon\sqrt{1-\varepsilon^2}\,\Re\bra{\psi}\tau\ket{u\otimes v}
++O(\varepsilon^2)$, hence by $O(\varepsilon)$ in general: the cross term
+vanishes only under an orthogonality condition on $\tau$ that the argument does
+not need. Iterating the perturbation and letting $\varepsilon\to0$ gives the
+missing inequality $\inf_{S_{=n}}\le\inf_{S_{\le n}}$.
+
+\section{Verdict}
+
+\textbf{Classification: resolved reading, with a scope restriction on (3.8).}
+The source's ``vectors of Schmidt rank $n$'' are the vectors of Schmidt rank at
+most $n$, as its own proof of Prop.~3.1 shows, and the formalized inequalities
+are (3.7) and (3.8) over that set. No hypothesis foreign to the source enters.
+
+The scope restriction concerns (3.8) alone. Under the exact-rank reading the
+same two inequalities hold, with (3.7) an immediate consequence of the
+bounded-rank statement and (3.8) requiring the limiting argument sketched above
+in place of a witness. That limiting argument, equivalently the identity
+$\inf_{S_{\le n}}=\inf_{S_{=n}}$, is not formalized; it is not needed for either
+bound as stated. The Lean statement of (3.8) carries a
+\textbf{Scope restriction (Schmidt rank at most $n$)} marker pointing at this
+note.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
@@ -1,0 +1,125 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Top-index scope of the spectral n-positivity criterion (Wolf Prop.~3.2)}
+\author{}
+\date{2026-06-24}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{Source statement}
+
+Proposition~3.2 of Wolf's \emph{Quantum Channels \& Operations}
+(\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex}, lines
+153--179) bounds the expectation of a Hermitian operator
+$\tau\in\mathcal{M}_{D'}\otimes\mathcal{M}_{D}$ in vectors of fixed Schmidt
+rank. Writing $\tau=\sum_i\nu_i|\phi_i\rangle\langle\phi_i|$ with normalized
+eigenvectors, $\rho_i=\tr_2|\phi_i\rangle\langle\phi_i|$ the reduced density on
+the first factor $\mathbb{C}^{D'}$, $\nu_0$ the smallest positive eigenvalue and
+$\nu$ the largest one, the infimum over normalized vectors $\psi$ of Schmidt
+rank $n$ obeys
+\begin{align}
+  \inf_{\psi}\langle\psi|\tau|\psi\rangle
+  &\ge \nu_0 + \sum_{i:\nu_i\le 0}(\nu_i-\nu_0)\,\|\rho_i\|_{(n)},
+  \tag{3.7}
+\end{align}
+and, when a single eigenvalue $\nu_-$ is non-positive,
+\begin{align}
+  \inf_{\psi}\langle\psi|\tau|\psi\rangle
+  &\le \nu + (\nu_- - \nu)\,\|\rho_-\|_{(n)}.
+  \tag{3.8}
+\end{align}
+Each $\rho_i$ acts on the first factor $\mathbb{C}^{D'}$, so its Ky-Fan
+$n$-norm $\|\rho_i\|_{(n)}$ is meaningful for $1\le n\le D'$. Proposition~3.1 of
+the same chapter restricts the positivity index to $1\le n\le D$, the dimension
+of the second factor (same file, lines 90--92), and that is the range the source
+asserts. The value $n=D'$ therefore lies inside the source's range exactly when
+$D'\le D$; when $D'>D$ it lies beyond, and the formal endpoint below is an
+extension of the source rather than an instance of it. What matters for coverage
+is that the formal statements together hold at every $n\ge1$, hence at every $n$
+the source speaks about.
+
+\section{Formalized statement}
+
+For Schmidt ranks $1\le n<D'$ the formal theorems\footnote{Formal declarations:
+    \leanid{Matrix.IsHermitian.spectral_lower_bound} and
+    \leanid{Matrix.IsHermitian.exists_le_spectral_upper_bound} in
+    \doclink{QICLean/Channel/NPositivitySpectralCriterion}.}
+establish these bounds in the per-vector form: every normalized vector $\psi$ of
+Schmidt rank at most $n$ satisfies the lower bound~(3.7), and some such $\psi$
+realizes the upper bound~(3.8).
+
+The source's infimum form of the same two bounds is stated for the infimum of
+the expectations $\bra{\psi}\tau\ket{\psi}$ over the normalized vectors of
+Schmidt rank at most $n$.\footnote{Formal declarations:
+    \leanid{Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations}~(3.7),
+    \leanid{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_le}~(3.8), and
+    \leanid{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top} for the top
+    index, in \doclink{QICLean/Channel/NPositivitySpectralCriterion}.} The
+reading of the source's phrase ``vectors of Schmidt rank $n$'' is discussed in
+\path{docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex}.
+
+\section{Status}
+
+The top index $n=D'$ is resolved by a route that bypasses the $n<D'$ restriction
+of the maximal-overlap and Ky-Fan principles. At $n=D'$ the Schmidt-rank
+constraint is vacuous: every normalized vector qualifies and
+$\|\rho_i\|_{(D')}=\tr\rho_i=1$. Both bounds therefore constrain the same quantity,
+the infimum of $\langle\psi|\tau|\psi\rangle$ over all normalized vectors:
+\begin{itemize}
+  \item The Rayleigh estimate gives $\nu_{\min}\le\langle\psi|\tau|\psi\rangle$
+  for every normalized $\psi$, so $\inf_\psi\langle\psi|\tau|\psi\rangle\ge
+  \nu_{\min}$. The right-hand side of~(3.7) reads
+  $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$ there, which is at most $\nu_{\min}$
+  and can be strictly below it: for the spectrum $(-2,-1,3)$ with $\nu_0=3$ it is
+  $-6$ while $\nu_{\min}=-2$. So~(3.7) at the top index follows from the Rayleigh
+  estimate, but is not the same inequality.
+  \item The upper bound~(3.8) on the infimum becomes the existence of a normalized
+  vector with $\langle\psi|\tau|\psi\rangle=\nu_{\min}$, namely a least-eigenvalue
+  eigenvector, so $\inf_\psi\langle\psi|\tau|\psi\rangle\le\nu_{\min}$; and under
+  the hypothesis of~(3.8) that $\nu_-$ is the only non-positive eigenvalue, the
+  right-hand side $\nu+(\nu_--\nu)\|\rho_-\|_{(D')}$ is exactly $\nu_-=\nu_{\min}$.
+\end{itemize}
+Together they give $\inf_\psi\langle\psi|\tau|\psi\rangle=\nu_{\min}$. Both facts
+follow directly from the Rayleigh expansion $\langle\psi|\tau|\psi\rangle=\sum_i
+\nu_i|\langle\phi_i|\psi\rangle|^2$ and Parseval's identity $\sum_i
+|\langle\phi_i|\psi\rangle|^2=1$, comparing each $\nu_i$ against $\nu_{\min}$ and
+evaluating at the least-eigenvalue eigenvector; the Ky-Fan machinery of the $n<D'$
+proof is not invoked.
+
+The top-index endpoint is recorded as
+\leanid{Matrix.IsHermitian.spectral_lower_bound_top} and
+\leanid{Matrix.IsHermitian.exists_spectral_lower_bound_top}, which together
+state $\min_\psi\langle\psi|\tau|\psi\rangle=\nu_{\min}$. Inequality~(3.7)
+itself at the top index, in the infimum form, is
+\leanid{Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top}, and~(3.8) is
+the corresponding half of
+\leanid{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top}.
+
+\section{Classification}
+
+\emph{Resolved.} Bounds~(3.7) and~(3.8) are now formalized at every index
+$n\ge1$, hence over the source's range $1\le n\le D$ whatever the two dimensions
+are, and beyond it when $D'>D$: the per-vector bounds
+\leanid{Matrix.IsHermitian.spectral_lower_bound} and
+\leanid{Matrix.IsHermitian.exists_le_spectral_upper_bound} for $1\le n<D'$, and
+their endpoints
+\leanid{Matrix.IsHermitian.spectral_lower_bound_top} and
+\leanid{Matrix.IsHermitian.exists_spectral_lower_bound_top} for $n\ge D'$, by
+the route detailed in the Status above. The infimum form of the source's
+statement is available over the same range,
+\leanid{Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top} carrying~(3.7)
+at the top indices. No hypothesis foreign to the source is used.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex
+++ b/docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex
@@ -1,0 +1,72 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{./command}
+\providecommand{\leanid}[1]{\path{#1}}
+
+\title{The nonempty-family condition in Wolf's Radon--Nikodym theorem}
+\author{}
+\date{2026-06-16}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\section{Source statement}
+
+Wolf's Radon--Nikodym theorem for quantum instruments states that, if
+\(\{T_i\}\) is a family of completely positive maps satisfying
+\(\sum_i T_i=T\) and
+\[
+  T(A)=V^\dagger(A\otimes \mathbf 1_r)V,
+\]
+then there are positive operators \(P_i\in\mathcal M_r\) such that
+\[
+  \sum_i P_i=\mathbf 1_r,
+  \qquad
+  T_i(A)=V^\dagger(A\otimes P_i)V.
+\]
+The local source is
+\path{Notes/WolfNoteTexSource/ch02_representations.tex}:402--407, titled
+``Radon--Nikodym for quantum instruments'' in
+\cite{Wolf2012Quantum}.
+
+\section{Local boundary}
+
+The Lean theorem \leanid{IsCPMap.radon_nikodym_of_stinespring} makes the index
+type nonempty.  This is not a strengthening of a mathematical hypothesis in the
+substantive case; it is the finite-type boundary needed for the identity
+\[
+  \sum_i P_i=\mathbf 1_r
+\]
+to be meaningful as a resolution of the identity by instrument components.  If
+the index type were empty, then the hypotheses \(\sum_i T_i=T\) force
+\(T=0\).  One may still supply the zero Stinespring matrix
+\(V=0\), but the conclusion would ask
+\[
+  0=\mathbf 1_r
+\]
+in \(\mathcal M_r\), which is false for a nonzero dilation dimension.
+
+Thus the formal theorem states the source theorem in the nonempty instrument
+case.  The blueprint entry records the same boundary explicitly by saying
+``nonempty finite family.''
+
+\section{Elimination plan}
+
+No mathematical proof gap is expected for the nonempty case.  An empty-index
+variant would need a different conclusion, for example a vacuous statement with
+zero dilation space or no identity resolution.  Such a statement is not the
+instrument theorem used in the development.
+
+Verdict: local correction of a well-posedness boundary in the printed finite-family
+statement.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
+++ b/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
@@ -1,0 +1,155 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Schmidt-number premise of Wolf's reduction criterion (Wolf eq.~(3.18))}
+\author{}
+\date{2026-06-24}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{Source statement}
+
+The reduction-criterion paragraph of Wolf's \emph{Quantum Channels \&
+Operations} (\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex},
+lines 329--338) introduces the maps $T_n(X)=\tr(X)\,\mathbf 1-X/n$, notes that
+each is $n$-positive and self-dual, and concludes that
+\begin{align}
+  n\,\rho_1\otimes\mathbf 1\ge\rho
+  \qquad\text{and}\qquad
+  n\,\mathbf 1\otimes\rho_2\ge\rho
+  \tag{3.18}
+\end{align}
+is \emph{necessary for a bipartite state $\rho$ to have Schmidt number $n$},
+with $\rho_1$ and $\rho_2$ the two reduced density matrices. The source assertion
+is the implication
+\begin{align}
+  \operatorname{sn}(\rho)\le n
+  \;\Longrightarrow\;
+  \bigl(n\,\rho_1\otimes\mathbf 1\ge\rho\ \text{and}\
+  n\,\mathbf 1\otimes\rho_2\ge\rho\bigr),
+  \tag{\path{source}}
+\end{align}
+where $\operatorname{sn}(\rho)$ is the Schmidt number of $\rho$. Its proof has
+two steps. A state of Schmidt number at most $n$ is a convex combination of
+pure states of Schmidt rank at most $n$, so $n$-positivity of $T_n$ gives
+\begin{align}
+  \operatorname{sn}(\rho)\le n
+  \;\Longrightarrow\;
+  (T_n\otimes\operatorname{id})(\rho)\ge 0,
+  \tag{step 1}
+\end{align}
+and the algebraic identity $(T_n\otimes\operatorname{id})(\rho)=\mathbf 1\otimes\rho_2-n^{-1}\rho$
+then yields
+\begin{align}
+  (T_n\otimes\operatorname{id})(\rho)\ge 0
+  \;\Longrightarrow\;
+  n\,\mathbf 1\otimes\rho_2\ge\rho,
+  \tag{step 2}
+\end{align}
+with the companion inequality obtained from the swapped state.
+
+\section{Formalized statement}
+
+The formal theorems\footnote{Formal declarations:
+    \leanid{Matrix.reductionCriterion_left} and
+    \leanid{Matrix.reductionCriterion_right} in
+    \doclink{QICLean/Channel/ReductionCriterion}.} establish step~2 only. For a
+bipartite matrix $\rho$ and $n\ge 1$,
+\begin{align}
+  (T_n\otimes\operatorname{id})(\rho)\ge 0
+  &\;\Longrightarrow\;
+  n\,\mathbf 1\otimes\rho_2\ge\rho,\\
+  (T_n\otimes\operatorname{id})(\rho^{F})\ge 0
+  &\;\Longrightarrow\;
+  n\,\rho_1\otimes\mathbf 1\ge\rho,
+\end{align}
+where $\rho^{F}$ is the image of $\rho$ under the factor swap and the second
+hypothesis equals Wolf's symmetric condition $(\operatorname{id}\otimes T_n)(\rho)\ge 0$. The
+underlying identity $(T_n\otimes\operatorname{id})(\rho)=\mathbf 1\otimes\rho_2-n^{-1}\rho$ is
+also formalized.\footnote{Formal declaration:
+    \leanid{Matrix.tensorMapId_tEta_eq}.}
+
+\section{Resolution}
+
+Step~1 is now formalized. A Schmidt-number predicate for mixed
+states\footnote{Formal declaration: \leanid{Matrix.HasSchmidtNumberLE} in
+    \doclink{QICLean/Channel/SchmidtNumber}.} records that $\rho$ is a finite sum
+of pure-state projectors of Schmidt rank at most $n$, which is Wolf's convex
+decomposition up to normalization. At $n=1$ this predicate coincides with
+separability.\footnote{Formal declaration:
+    \leanid{Matrix.hasSchmidtNumberLE_one_iff_isSeparable}.}
+
+The pure-state step shows that for a vector $\psi$ of Schmidt rank at most $n$
+(with $1\le n<D$) the ampliation $(T_n\otimes\operatorname{id})(\ketbra\psi\psi)$ is positive
+semidefinite,\footnote{Formal declaration:
+    \leanid{Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE}.} by writing
+$\psi$ through the maximally entangled vector as a square right-factor matrix of
+rank equal to the Schmidt rank of $\psi$, identifying the ampliation with the
+right-factor Choi compression, and using the $n$-positivity of $T_n$ on the
+resulting Schmidt-rank-$\le n$ vector. Summing over the pure terms gives step~1:
+a state of Schmidt number at most $n$ has
+$(T_n\otimes\operatorname{id})(\rho)\ge 0$.\footnote{Formal declaration:
+    \leanid{Matrix.HasSchmidtNumberLE.tensorMapId_tEta_posSemidef}.} Composing
+step~1 with the formalized step~2 yields Wolf's eq.~(3.18) with its
+Schmidt-number premise.\footnote{Formal declarations:
+    \leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
+    \leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE}.}
+
+The $n$-positivity content used in the pure-state step is the threshold theorem:
+the map $T_n$ is $n$-positive for all $1\le n<D$.\footnote{Formal declaration:
+    \leanid{Matrix.isNPositiveMap_tEta_iff} in
+    \doclink{QICLean/Channel/NPositivityChainStrict}, the reduction map being
+    $T_\eta$ at $\eta=n$ by \leanid{Matrix.reductionMap_eq_tEta}.}
+
+The pure-state step writes $\psi$ through the maximally entangled vector as a
+\emph{square} right-factor matrix, so the $T_n$-specialised \emph{criterion} theorems
+still fix the two tensor factors to a common dimension $D$. The general bipartite
+\emph{forward step} itself, however, no longer carries that restriction: padding the
+bipartite state to the square system $\mathbb{C}^D\otimes\mathbb{C}^D$ with
+$D=\max(d,d')$ — padding the smaller factor by zero rows or columns and, when the
+first factor grows, extending the map by a corner sandwich that preserves
+$n$-positivity — reduces the general case to the square one. Thus
+$(T\otimes\operatorname{id})(\rho)\ge 0$ holds on a general
+$\mathbb{C}^d\otimes\mathbb{C}^{d'}$ for every $n$-positive map $T$, with no relation
+between the factors.\footnote{Formal declaration:
+    \leanid{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general} in
+    \doclink{QICLean/Channel/SchmidtNumberFactors}, with the $n$-positivity-preserving
+    corner extension \leanid{Matrix.isNPositiveMap_cornerExtendMap}.}
+
+\section{Classification}
+
+\emph{Resolved.} The general bipartite forward step
+$\operatorname{sn}(\rho)\le n\Rightarrow(T\otimes\operatorname{id})(\rho)\ge 0$ holds
+for every $n$-positive map $T$ on $\mathbb{C}^d\otimes\mathbb{C}^{d'}$ with no relation
+between the factors, at
+\leanid{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general}.
+
+The $T_n$-specialised reduction \emph{criterion} is likewise now general: the
+inequalities $n\,\mathbf 1\otimes\rho_2\ge\rho$ and $n\,\rho_1\otimes\mathbf 1\ge\rho$
+hold on a general $\mathbb{C}^d\otimes\mathbb{C}^{d'}$ at
+\leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE_general} and
+\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE_general}, obtained by
+composing the general forward step with the dimension-general operator-half theorems
+\leanid{Matrix.reductionCriterion_left} and \leanid{Matrix.reductionCriterion_right}.
+The square-restricted \leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
+\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE} remain as the $d=d'$
+specialisations.
+
+The only residual scope is the $n$-positivity threshold of $T_n$ itself: the left
+inequality needs $1\le n<d$ and the right needs $1\le n<d'$ (Wolf eq.~(3.11)), whose
+top index ($n=d$ for the left form, $n=d'$ for the right; complete positivity) is
+documented in \path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}. The bipartite-dimension
+restriction recorded in this note is thereby fully eliminated.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_schur_complement_tfae.tex
+++ b/docs/paper-gaps/wolf_schur_complement_tfae.tex
@@ -1,0 +1,108 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Schur Complement TFAE --- Missing Left-Support Condition}
+\author{}
+\date{2026-08-21}
+
+\begin{document}
+\maketitle
+\gapnote{false-source}{resolved}
+
+\section{Source statement}
+Wolf, \textit{Quantum Channels \& Operations}, Theorem~5.2 (Block matrices and
+Schur complements). Let $P$, $R$ be positive semi-definite complex matrices
+and $Q$ a complex matrix of compatible dimensions. Then the following are
+equivalent:
+\begin{enumerate}
+  \item the block matrix
+    $\begin{pmatrix} P & Q \\ Q^\dagger & R \end{pmatrix}$
+    is positive semi-definite;
+  \item $\ker(R) \subseteq \ker(Q)$ and
+    \begin{align}
+      P \ge Q R^{+} Q^\dagger,
+      \tag{Wolf, Theorem 5.2 (2)}
+    \end{align}
+    where $R^{+}$ is the pseudo-inverse (the inverse on the support);
+  \item $\ker(R) \subseteq \ker(Q)$ and
+    $\|P^{-1/2} Q R^{-1/2}\|_\infty \le 1$.
+\end{enumerate}
+
+The third condition is false as printed when $P$ is singular. Indeed, take
+$P=0$ and $Q=R=1$ in dimension one. Then
+$\ker(R)\subseteq\ker(Q)$ and the support inverse gives
+$P^{-1/2}QR^{-1/2}=0$, so the printed contraction bound holds. On the other
+hand,
+\begin{align}
+  \begin{pmatrix}1&-1\end{pmatrix}
+  \begin{pmatrix}0&1\\1&1\end{pmatrix}
+  \begin{pmatrix}1\\-1\end{pmatrix}=-1,
+\end{align}
+and hence the block matrix is not positive semi-definite. The missing
+condition is
+\begin{align}
+  \ker(P)\subseteq\ker(Q^\dagger).
+  \tag{left-support condition}
+\end{align}
+
+\section{What is formalized}
+The objects entering the statement are formalised: the block matrix itself,
+its self-adjointness for Hermitian diagonal blocks, and the pseudoinverse
+Schur complement $P - Q R^{+} Q^\dagger$.\footnote{Formal declarations:
+\leanid{SchurComplement.blockMatrix}, \leanid{SchurComplement.blockMatrix_isHermitian},
+and \leanid{SchurComplement.schurComplement} in
+\doclink{QICLean/Channel/Schwarz/SchurComplement}.}
+Conditions (1) and (2) are equivalent with the source's exact hypotheses:
+the block matrix is PSD if and only if $\ker(R)\subseteq\ker(Q)$ and
+$P-QR^+Q^\dagger$ is PSD.\footnote{Formal declaration:
+\leanid{SchurComplement.blockMatrix_posSemidef_iff}.}
+The forward implication combines the kernel inclusion
+\leanid{SchurComplement.ker_subset_of_block_psd} with quadratic-form
+minimisation at $y=-R^+Q^\dagger x$. The reverse implication uses the completed
+square
+\begin{align}
+  \begin{pmatrix}x\\y\end{pmatrix}^{\!\dagger}
+  \begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}
+  \begin{pmatrix}x\\y\end{pmatrix}
+  &=(R^+Q^\dagger x+y)^\dagger R(R^+Q^\dagger x+y)
+    +x^\dagger(P-QR^+Q^\dagger)x.
+\end{align}
+This identity is formalized as
+\leanid{SchurComplement.schur_complement_quadratic_form}. It rests on the
+support absorption $Q\operatorname{supp}(R)=Q$ and the pseudoinverse identities
+$RR^+=R^+R=\operatorname{supp}(R)$ and $(R^+)^\dagger=R^+$.
+
+The scalar counterexample is formalized as
+\leanid{SchurComplement.wolf_condition_three_not_sufficient}. With the
+left-support condition added, all three conditions are equivalent. More
+precisely, let
+\begin{align}
+  K=P^{-1/2}QR^{-1/2},
+\end{align}
+where both inverse square roots vanish on their respective kernels. Under the
+two support conditions,
+\begin{align}
+  KK^\dagger
+    =P^{-1/2}(QR^+Q^\dagger)P^{-1/2}.
+\end{align}
+Consequently, $P-QR^+Q^\dagger\ge0$ is equivalent to $\lVert K\rVert_\infty\le1$.
+The corrected contraction equivalence is formalized as
+\leanid{SchurComplement.schurComplement_posSemidef_iff_contraction}, and its
+block-matrix form as
+\leanid{SchurComplement.blockMatrix_posSemidef_iff_contraction}.
+
+\section{Verdict}
+Conditions (1) and (2) of Wolf Theorem~5.2 are correct as printed and are
+formalized without additional hypotheses. Condition (3) is false as printed;
+the scalar counterexample above is decisive. After adjoining the necessary
+left-support condition $\ker(P)\subseteq\ker(Q^\dagger)$, the three-way
+equivalence is formalized. Thus \href{https://github.com/LionSR/TNLean/issues/5501}{TNLean issue \#5501} is resolved by a source
+correction rather than by asserting the false printed statement.
+
+\end{document}

--- a/docs/paper-gaps/wolf_sic_povm_linear_independence.tex
+++ b/docs/paper-gaps/wolf_sic_povm_linear_independence.tex
@@ -1,0 +1,84 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{SIC--POVM Equality Families: the One-Dimensional Degeneracy}
+\author{}
+\date{2026-08-21}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\section{Source passage}
+
+Let $P_1,\ldots,P_n\in\MN{d}$ be positive semidefinite matrices satisfying
+$\tr(P_i^2)=1$, where $d\le n$. Chapter~2 of
+\cite{Wolf2012Quantum}, Proposition ``SIC POVMs'', proves the bound
+\begin{align}
+  \sum_{i\ne j}|\tr(P_iP_j)|^2
+  \ge \frac{n(n-d)^2}{(n-1)d^2}.
+  \label{eq:wolf-sic-bound}
+\end{align}
+At equality, the argument gives
+\begin{align}
+  P_i^2&=P_i, & \operatorname{rank}(P_i)&=1, \\
+  \sum_iP_i&=\frac nd\Id, &
+  \tr(P_iP_j)&=\frac{n-d}{(n-1)d}\qquad(i\ne j).
+  \label{eq:wolf-sic-equality}
+\end{align}
+The source then asserts, at lines 816--823 of the local Chapter~2 source file,
+that the matrices in an equality family are linearly independent.
+
+\section{The deviation}
+
+The concluding assertion fails when $d=1$ and $n>1$. In one dimension the
+unit-purity and positivity hypotheses force every $P_i$ to be the matrix
+$[1]$. This family attains equality in~\eqref{eq:wolf-sic-bound}: both sides
+are $n(n-1)$. It is nevertheless linearly dependent as soon as it contains
+more than one member.
+
+The coefficient calculation in the source also isolates the precise
+degeneracy. If $\sum_i c_iP_i=0$, taking the trace and then pairing with
+$P_j$ gives
+\begin{align}
+  \sum_i c_i&=0, \\
+  \left(1-\frac{n-d}{(n-1)d}\right)c_j&=0.
+\end{align}
+For $n>1$, the prefactor vanishes exactly when $d=1$. Thus an equality family
+is linearly independent under the corrected condition $d>1$. When $n=1$,
+Equation~\eqref{eq:wolf-sic-bound} is not stated because of its denominator,
+but the singleton family is linearly independent whenever its sole matrix has
+unit purity.
+
+\section{Formalized interpretation}
+
+The formalization separates three statements. The inequality
+\leanid{Matrix.sicPOVM_offDiag_overlap_sq_bound} and its equality criterion
+\leanid{Matrix.sicPOVM_offDiag_overlap_sq_eq_iff} retain the source's
+nondegenerate hypotheses $n\ge2$ and $1\le d\le n$; in particular, their
+validity at $d=1$ is preserved. The corrected consequence
+\leanid{Matrix.sicPOVM_linearIndependent_of_overlap_bound_eq} assumes $d\ge2$.
+The complementary singleton statement is
+\leanid{Matrix.singleton_linearIndependent_of_trace_sq_eq_one}.
+
+Consequently, the combined nondegeneracy condition for linear independence is
+$d>1$ or $n=1$, while the equality theorem itself is not artificially
+restricted.
+
+\section{Verdict}
+
+\textbf{Verdict: resolved local fix (one-dimensional equality family).}
+Wolf's overlap bound and equality characterization are correct in one
+dimension. Only the final linear-independence consequence requires the
+qualification $d>1$, with the singleton case treated separately.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
@@ -1,0 +1,105 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Top Schmidt-rank index in the $n$-positivity threshold of $T_\eta$
+(Wolf Chapter 3)}
+\author{}
+\date{2026-06-24}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{resolved}
+
+\section{Source statement}
+
+In Chapter~3 of Wolf's lecture notes \cite{Wolf2012Quantum}, the one-parameter
+family
+\begin{align}
+  T_\eta(\rho)=\tr(\rho)\,\mathbf 1-\frac{\rho}{\eta},
+  \qquad \eta\in\mathbb R_+,
+  \tag{3.11}
+\end{align}
+on $M_D(\mathbb C)$ (the formal map is written $\tr(\rho)\,\mathbf 1-\eta^{-1}\rho$,
+which agrees on $\eta>0$ and is moreover defined at $\eta=0$) is analyzed
+through its Choi--Jamiolkowski operator
+$\tau_\eta=D^{-1}\mathbf 1-\eta^{-1}\ket\Omega\bra\Omega$.  All positive
+eigenvalues of $\tau_\eta$ equal $1/D$, and the single non-positive eigenvalue
+is $\nu_-=1/D-1/\eta$ with reduced density $\rho_-=\mathbf 1/D$, so its
+Ky--Fan $n$-norm is $\|\rho_-\|_{(n)}=n/D$.  The source concludes:
+\begin{align}
+  T_\eta\ \text{is $n$-positive}\iff \eta\ge n,
+  \qquad n=1,\dots,D,
+\end{align}
+where the range of $n$ runs up to the dimension $D$, in which case
+$n$-positivity is complete positivity.  This proves that every inclusion in
+Wolf's chain
+\begin{align}
+  \mathcal T_{\mathrm{cp}}=\mathcal T_D\subseteq
+  \mathcal T_{D-1}\subseteq\cdots\subseteq\mathcal T_2\subseteq\mathcal T_1
+  \tag{3.3}
+\end{align}
+is strict.\footnote{Local source:
+\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex:181--193},
+equation label \path{eq:ch3:3.11}.}
+
+\section{Point at issue}
+
+The formal statement establishes the equivalence
+\begin{align}
+  T_\eta\ \text{is $k$-positive}\iff \eta\ge k
+\end{align}
+for Schmidt-rank index $1\le k<D$, omitting the top index $k=D$.  The
+restriction is inherited, not introduced here: the equivalence is derived from
+the maximal-overlap principle (Wolf Lemma~3.1), whose formal version
+$\sup_\psi|\braket{\Omega}{\psi}|^2=\|\rho\|_{(k)}$ over Schmidt-rank-$k$
+normalized vectors is available only for $1\le k<D$.  That bound in turn rests
+on the Ky--Fan maximum principle, stated for orthogonal projections of rank
+exactly $k$ with $k<D$.  At the top index $k=D$ the Ky--Fan $D$-norm is the
+full trace and the maximizing projection is the identity; the present
+formalization of the maximum principle does not cover that boundary case.
+
+Consequently the strictness witness produced here, a $k$-positive map that fails
+to be $(k+1)$-positive, is available for $1\le k$ with $k+1<D$.  This covers
+every inclusion in the chain~(3.3) except the topmost one,
+$\mathcal T_D\subseteq\mathcal T_{D-1}$, which compares complete positivity with
+$(D-1)$-positivity and requires the $k=D$ index.
+
+\section{Status}
+
+The boundary case $k=D$ is resolved by a route that bypasses the $k<D$
+restriction of the maximal-overlap and Ky--Fan principles entirely.  On
+$M_D(\mathbb C)$, $D$-positivity is complete positivity
+(\leanid{isCPMap_iff_isNPositiveMap_card}), which is positive semidefiniteness of
+the Choi operator $\tau_\eta$.  Its quadratic form on a vector $\psi$ is
+$D^{-1}\|\psi\|^2-\eta^{-1}|\braket{\Omega}{\psi}|^2$, and since $\ket\Omega$ is
+normalized the Cauchy--Schwarz bound $|\braket{\Omega}{\psi}|^2\le\|\psi\|^2$
+(saturated at $\psi=\Omega$) makes that form nonnegative for every $\psi$ exactly
+when $\eta\ge D$.  Hence $T_\eta$ is $D$-positive iff $\eta\ge D$, the equivalence
+at the top index.
+
+The formal declarations are \leanid{Matrix.isNPositiveMap_tEta_iff} for the
+range $1\le k<D$ and \leanid{Matrix.isNPositiveMap_tEta_card_iff} for the top
+index $k=D$, together covering the full equivalence~(3.11) over $1\le k\le D$, in
+\doclink{QICLean/Channel/NPositivityChainStrict}.  The strictness witness
+\leanid{Matrix.exists_isNPositiveMap_not_succ} remains stated for $k+1<D$; the
+strictness of the top inclusion $\mathcal T_D\subsetneq\mathcal T_{D-1}$ follows
+from the $k=D-1$ and $k=D$ thresholds but is not recorded as a separate witness.
+
+\section{Classification}
+
+\emph{Resolved.} The full source range $1\le k\le D$ of equivalence~(3.11) is now
+formalized: \leanid{Matrix.isNPositiveMap_tEta_iff} for $1\le k<D$ and
+\leanid{Matrix.isNPositiveMap_tEta_card_iff} for the completely-positive endpoint
+$k=D$, the latter by the Choi-operator route detailed in the Status above.  No
+hypothesis foreign to the source is used.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -1,0 +1,232 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Wolf Theorem~6.14: Fixed-Point Classification Completion Record}
+\author{}
+\date{2026-07-19}
+
+\begin{document}
+\maketitle
+\gapnote{open-gap}{resolved}
+
+\section{The completed classification theorem}
+
+Wolf's Proposition~1.5 assumes a positive linear retraction onto a unital
+finite-dimensional $*$-subalgebra and classifies that retraction
+\cite[Proposition~1.5 and Equation~(1.40)]{Wolf2012Quantum}.  The local source
+is \path{Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex},
+lines~536--570.
+
+The theorem
+\leanid{StarSubalgebra.exists_block_densities_of_positive_retraction} proves
+the full proposition.  It assumes exactly that the given linear map is
+positive, that its image is contained in the subalgebra, and that it fixes
+every member of the subalgebra.  It obtains the unitary direct-sum
+representation, removes off-diagonal inputs by positivity, and gives a
+positive semidefinite trace-one matrix for each summand.  No assumption of
+complete positivity, trace preservation, or a Schwarz inequality is added.
+
+\section{The fixed-point theorem}
+
+Let $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be positive and trace preserving,
+write $T^*$ for its trace-pairing adjoint, and suppose that $T^*$ satisfies the
+Schwarz inequality.
+Wolf's Theorem~6.14 asserts that there are a unitary $U$, a decomposition
+\begin{align}
+    \mathbb C^D
+      &= \mathcal H_0\oplus
+        \bigoplus_{k=1}^K\mathbb C^{d_k}\otimes\mathbb C^{m_k},
+\end{align}
+and positive definite density matrices $\rho_k\in M_{m_k}(\mathbb C)$ such
+that
+\begin{align}
+    \operatorname{Fix}(T)
+      &= U\left(0\oplus\bigoplus_{k=1}^K
+          M_{d_k}(\mathbb C)\otimes\rho_k\right)U^*.
+    \tag{Wolf, Theorem 6.14 and Equation (6.63)}
+\end{align}
+Here $\mathcal H_0$ is a genuine zero summand: every fixed point vanishes on
+this subspace.  This is the statement in
+\cite[Theorem~6.14]{Wolf2012Quantum}; the local source is
+\path{Notes/WolfNotePDF/wolf_ch6_sections.txt}, lines~896--905.
+
+The mean-ergodic part is now formalized.  A positive trace-preserving
+endomorphism has bounded forward orbits on every matrix, and its
+mean-ergodic projection is a positive trace-preserving retraction whose range
+is exactly $\operatorname{Fix}(T)$.
+\footnote{Formal declarations:
+\leanid{IsPositiveMap.hasBoundedOrbits_of_tracePreserving},
+\leanid{IsPositiveMap.meanErgodicProjection_isPositiveMap}, and
+\leanid{IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap}.}
+If the original map is unital, this projection is also unital.
+
+The trace-pairing adjoint of this projection is now identified as a positive
+unital idempotent retraction onto $\operatorname{Fix}(T^*)$.
+\footnote{Formal declarations:
+\leanid{LinearMap.HasBoundedOrbits.range_traceAdjointMap_meanErgodicProjection}
+and
+\leanid{IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction}.}
+The proof uses the complementary decomposition for the original
+mean-ergodic projection and trace-pairing nondegeneracy; it requires no
+bounded-orbit or spectral hypothesis for $T^*$.
+
+The full-support retraction step is also formalized.  If $T$ has a positive
+definite fixed point and $T^*$ satisfies the Schwarz inequality, then the
+Schwarz equality argument makes $\operatorname{Fix}(T^*)$ a unital
+$*$-algebra, and the adjoint mean-ergodic projection is a positive retraction
+onto it.  Applying Proposition~1.5 gives the weighted partial-trace block
+form of this projection.\footnote{Formal declaration:
+\leanid{IsPositiveMap.exists_block_densities_of_adjoint_meanErgodicProjection}
+in
+\doclink{QICLean/Channel/FixedPoint/FullSupportBlockRetraction}.}
+This is the conditional-expectation step in the proof of Theorem~6.14,
+local source lines~1483--1492.
+
+The trace-adjoint calculation is also formalized.  In the convention used by
+the formalization, each summand is ordered as
+$\mathbb C^{m_k}\otimes\mathbb C^{d_k}$ and the adjoint fixed-point algebra is
+$\Id_{m_k}\otimes M_{d_k}(\mathbb C)$.  Consequently, the partial trace is
+over the first, multiplicity factor and
+\begin{align}
+  P_T(B)
+    =U\left(\bigoplus_k \sigma_k\otimes
+      \operatorname{tr}_{m_k}((U^*BU)_{kk})\right)U^*.
+\end{align}
+Writing $\operatorname{tr}_{d_k}$ here would reverse the factor convention
+and would be dimensionally inconsistent.  The range of this projection is
+$U(\bigoplus_k\sigma_k\otimes M_{d_k}(\mathbb C))U^*$, hence this is also
+$\operatorname{Fix}(T)$ under the full-support hypothesis.
+\footnote{Formal declaration:
+\leanid{IsPositiveMap.exists_block_densities_of_meanErgodicProjection}
+in
+\doclink{QICLean/Channel/FixedPoint/TraceAdjointDensityBlocks}.}
+
+The maximal-support witness required for the reduction is now formalized for the
+source's full generality: for every positive trace-preserving map,
+$\rho_0=T_\infty(\mathbf 1)$ is positive semidefinite and its support contains the
+support and range of every fixed point.
+\footnote{Formal declaration:
+\leanid{IsPositiveMap.exists_maximalSupport_fixedPoint} in
+\doclink{QICLean/Channel/FixedPoint/MaximalSupportBasic}.}
+
+The restriction to this support is also formalized in the same generality.
+If $\rho\succeq0$ is any fixed point and $Q$ is its support projection, then
+every positive matrix in $Q M_D(\mathbb C)Q$ is mapped back into that corner.
+Decomposition into four positive matrices extends the conclusion to every
+matrix in the corner.  Hence, for an isometry $V$ with $V^*V=\mathbf 1$ and
+$VV^*=Q$, the map
+\begin{align}
+  \widetilde T(X)=V^*T(VXV^*)V
+\end{align}
+is positive and trace preserving, has a positive definite fixed point, and
+satisfies
+\begin{align}
+  T(VXV^*)=V\widetilde T(X)V^*.
+  \tag{Wolf, Equation (6.52)}
+\end{align}
+When $\rho=T_\infty(\mathbf 1)$, maximal support further gives
+\begin{align}
+  \operatorname{Fix}(T)=V\operatorname{Fix}(\widetilde T)V^*.
+  \tag{Wolf, Equation (6.51)}
+\end{align}
+Thus every ambient fixed point has zero complementary block.
+The auxiliary fixed-space equivalence is also retained in conditional form:
+for a general stationary $\rho$, it assumes
+$QXQ=X$ for every $X\in\operatorname{Fix}(T)$.  This is the hypothesis named
+\texttt{hmax} in
+\leanid{IsPositiveMap.fixedPoint_iff_exists_fixedPoint_stationarySupportCompression}.
+The source-faithful theorem
+\leanid{IsPositiveMap.exists_maximalSupportCompression} has no such exposed
+hypothesis: it takes $\rho_0=T_\infty(\mathbf 1)$ and derives the support property
+from \leanid{IsPositiveMap.exists_maximalSupport_fixedPoint}.
+\footnote{Formal declarations:
+\leanid{IsPositiveMap.map_supported_on_fixedPoint_support},
+and
+\leanid{IsPositiveMap.exists_maximalSupportCompression}
+in
+\doclink{QICLean/Channel/FixedPoint/StationarySupportRestriction}.}
+
+The full-support fixed-point theorem is now applied to $\widetilde T$.  The
+trace adjoint commutes with the isometric compression,
+\begin{align}
+  \widetilde T^*(A)=V^*T^*(VAV^*)V,
+\end{align}
+and the Schwarz defect of this map is the compression of the Schwarz defect
+of $T^*$ plus a positive term supported on $\mathbf 1-VV^*$.  Hence the
+Schwarz hypothesis passes to $\widetilde T^*$ using only the positivity of
+$T$ already assumed in Theorem~6.14.  The full-support density-block theorem
+therefore gives
+\begin{align}
+  \operatorname{Fix}(\widetilde T)
+    =U\left(\bigoplus_k\sigma_k\otimes M_{d_k}(\mathbb C)\right)U^*,
+\end{align}
+where every $\sigma_k$ has trace one.  To see that these matrices are positive
+definite, apply this formula to the positive definite fixed point
+$\rho_{\mathrm{full}}$ retained by the compression theorem:
+\begin{align}
+  U^*\rho_{\mathrm{full}}U
+    =\bigoplus_k\sigma_k\otimes X_k.
+\end{align}
+Every principal block $\sigma_k\otimes X_k$ is positive definite.  Taking the
+two partial traces gives
+\begin{align}
+  \operatorname{tr}_{m_k}(\sigma_k\otimes X_k)&=X_k,\\
+  \operatorname{tr}_{d_k}(\sigma_k\otimes X_k)
+    &=\operatorname{tr}(X_k)\sigma_k.
+\end{align}
+Thus $X_k$ is positive definite, so $\operatorname{tr}(X_k)>0$, and the second
+identity implies that $\sigma_k$ is positive definite.  No block dimension is
+changed and no additional kernel summand is introduced.
+\footnote{Formal declarations:
+\leanid{Matrix.traceAdjointMap_stationarySupportCompression},
+\leanid{IsSchwarzMap.traceAdjointMap_stationarySupportCompression}, and
+\leanid{IsPositiveMap.exists_block_densities_of_maximalSupportCompression}
+in
+\doclink{QICLean/Channel/FixedPoint/SupportCompressedDensityBlocks}; the
+positive-definite partial-trace facts are
+\leanid{Matrix.PosDef.partialTraceRight},
+\leanid{Matrix.PosDef.partialTraceLeft}, and
+\leanid{Matrix.PosDef.left_of_kronecker_of_trace_eq_one} in
+\doclink{QICLean/Channel/PartialTrace}.}
+
+The ambient transport is now formalized.  If $U_c$ is the compressed block
+unitary, then $W=VU_c$ is an isometry from the compressed space into the
+original space.  Compare it with the canonical inclusion of
+$\mathbb C^n$ into
+$\mathbb C^{D-n}\oplus\mathbb C^n$.  The two inclusions have the same Gram
+matrix.  The finite-dimensional unitary extension theorem therefore gives an
+ambient unitary $U$ satisfying
+\begin{align}
+    WAW^*=U(0_{D-n}\oplus A)U^*
+\end{align}
+for every $A\in M_n(\mathbb C)$.  Applying the retained fixed-space
+equivalence and substituting the compressed density-block formula yields
+\begin{align}
+    \operatorname{Fix}(T)
+      =U\left(0_{D-n}\oplus\bigoplus_k
+        \sigma_k\otimes M_{d_k}(\mathbb C)\right)U^*.
+\end{align}
+The first block is exactly the orthogonal complement of maximal stationary
+support, so it is one zero summand.  There are no further kernel blocks,
+because every $\sigma_k$ is positive definite.
+\footnote{Formal declarations:
+\leanid{Matrix.exists_unitary_zero_extension_eq} in
+\doclink{QICLean/Algebra/MatrixGramUnitary}, and
+\leanid{IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero} in
+\doclink{QICLean/Channel/FixedPoint/WolfTheorem614}.}
+
+Consequently, the statement and hypotheses of Wolf's Theorem~6.14 are now
+formalized in full.  The theorem assumes precisely positivity and trace
+preservation of $T$ and the Schwarz inequality for $T^*$; the fixed-point
+space has exactly the single complementary zero summand asserted in
+Equation~(6.63).  This document therefore records a closed paper gap.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex
+++ b/docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex
@@ -1,0 +1,110 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Abstract Schwarz-Map Hypotheses in Wolf Theorem 6.12}
+\author{}
+\date{2026-07-18}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{Source statement}
+
+Wolf introduces a Schwarz map as a positive unital matrix map satisfying
+\begin{align}
+  E(A^\dagger A)-E(A^\dagger)E(A)&\succeq0
+  \qquad\text{for every }A.
+  \tag{5.2}
+\end{align}
+This terminology is stated in Chapter~5 immediately before Example~5.3
+(local source lines 347--352).  Theorem~6.12 then assumes a unital map satisfying
+this Schwarz inequality and an arbitrary full-rank fixed point of its
+trace-pairing adjoint.  Its algebraic conclusion is
+\begin{align}
+  \operatorname{Fix}(E)&=\{X:E(X)=X\}
+  \quad\text{is a unital $*$-subalgebra.}
+  \tag{6.12}
+\end{align}
+The proof is at local source lines 1395--1417.  It invokes the proposition on
+positive fixed points (local lines 1161--1192, cited there as Proposition~6.9)
+to replace the full-rank witness by a positive-definite fixed point before
+performing the weighted-trace argument.
+The complete theorem also invokes the explicit block realization in
+Equation~(1.39); the present increment concerns only the displayed
+$*$-algebra conclusion.
+
+The word ``positive'' is not repeated in the theorem statement because it is
+part of the Chapter~5 definition of a Schwarz map.  Exposing positivity as a
+separate formal hypothesis therefore does not strengthen the source theorem.
+
+\section{The weighted equality}
+
+Let $\rho>0$ satisfy $E^*(\rho)=\rho$, and let $E(X)=X$.  Positivity implies
+$E(X^\dagger)=X^\dagger$.  For the Schwarz gap
+\begin{align}
+  \Delta_X&=E(X^\dagger X)-E(X^\dagger)E(X)\succeq0,
+\end{align}
+the trace-pairing identity gives Wolf's Equation~(6.60):
+\begin{align}
+  \tr(\rho\Delta_X)
+    &=\tr\!\left(E^*(\rho)X^\dagger X\right)
+      -\tr\!\left(\rho X^\dagger X\right)\\
+    &=0.
+\end{align}
+Faithfulness of the positive-definite weight forces $\Delta_X=0$.  Repeating
+the calculation for $X^\dagger$ gives equality in both one-sided Schwarz
+inequalities.  The abstract multiplicative-domain theorem then yields
+\begin{align}
+  E(XY)&=E(X)E(Y)=XY
+\end{align}
+for fixed points $X$ and $Y$.
+
+This argument is formalized for arbitrary positive unital Schwarz maps once a
+positive-definite invariant weight has been supplied explicitly.
+\footnote{Formal declarations:
+  \leanid{SchwarzMap.schwarz_equality_of_mem_fixedPoints},
+  \leanid{SchwarzMap.mem_multiplicativeDomain_of_mem_fixedPoints}, and
+  \leanid{SchwarzMap.fixedPointsStarSubalgebra} in
+  \doclink{QICLean/Channel/FixedPoint/AbstractAlgebra}.}
+
+\section{Comparison with the Kraus specialization}
+
+The earlier declaration assumed a Kraus representation.
+\footnote{Formal declaration:
+  \leanid{Kraus.fixedPointsStarSubalgebra} in
+  \doclink{QICLean/Channel/FixedPoint/Algebra}.}
+That result is mathematically correct, but complete positivity is stronger than
+the Schwarz-map hypothesis in Theorem~6.12.  It is retained as a useful
+specialization of the post-reduction lemma and is not presented as the literal
+formalization of the theorem.
+
+\section{Verdict}
+
+The earlier Kraus-only attribution was a \emph{scope restriction}, and the
+abstract lemma removes that restriction.  A second scope restriction remains:
+the formal signature assumes a positive-definite fixed point, while Wolf
+Theorem~6.12 assumes only a full-rank fixed point and derives the faithful
+positive witness from its proposition on positive fixed points.  Consequently,
+the present result is the source-faithful post-reduction algebra lemma, not yet
+the literal formalization of Theorem~6.12.
+
+The elimination plan is to formalize the positive-fixed-parts proposition for
+the abstract positive trace-preserving trace adjoint, derive a positive-definite
+fixed point from the full-rank witness, and wrap the present lemma.  The
+explicit trace-adjoint Equation~(1.39) realization remains open at this level
+of generality.  The downstream Schrödinger-picture density-block
+classification, support reduction, and zero-block assembly required for
+Theorem~6.14 are complete; see
+\path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_thm6_3_positive_map_cp_scope.tex
+++ b/docs/paper-gaps/wolf_thm6_3_positive_map_cp_scope.tex
@@ -1,0 +1,53 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{./command.tex}
+
+\title{Complete-Positivity Scope of the Fixed-Point Case of Wolf Theorem 6.3}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{The source theorem}
+
+Wolf Theorem~6.3(2)--(3), at lines 112--123 of
+\path{Notes/WolfNotePDF/wolf_ch6_sections.txt}, concerns an irreducible positive
+map $T:M_D(\mathbb C)\to M_D(\mathbb C)$. It states that the spectral radius is
+a simple eigenvalue with a strictly positive eigenvector. In particular, if a
+nonzero positive semidefinite matrix $\rho$ satisfies $T(\rho)=\rho$, then
+$\rho$ is positive definite. Complete positivity is not assumed.
+
+\section{The restriction in the formalization}
+
+The declaration
+\leanid{posDef_of_posSemidef_fixedPoint_irreducible_cp} in
+\path{QICLean/Channel/Irreducible/FixedPoint.lean} proves the fixed-point
+consequence for an irreducible completely positive map. Its proof uses support
+invariance for completely positive maps: the support projection of $\rho$
+defines an invariant compression, and irreducibility forces that projection to
+be the identity. Thus the conclusion agrees with the fixed-point specialization
+of Wolf Theorem~6.3(2)--(3), but the formal hypothesis is stronger than the source
+hypothesis.
+
+\section{Elimination plan}
+
+Prove support invariance, or an equivalent kernel-invariance statement, for an
+arbitrary positive map. Irreducibility would then force the support of every
+nonzero positive semidefinite fixed point to be all of $\mathbb C^D$, giving the
+source-general fixed-point theorem. The present completely positive theorem
+should remain as a specialization of that result.
+
+\section{Verdict}
+
+\textbf{Verdict: scope restriction.} The formal declaration proves the
+completely positive specialization of the fixed-point consequence of Wolf
+Theorem~6.3(2)--(3). The extension from completely positive maps to arbitrary
+positive maps remains open.
+
+\end{document}

--- a/docs/paper-gaps/wolf_thm6_6_kraus_scope.tex
+++ b/docs/paper-gaps/wolf_thm6_6_kraus_scope.tex
@@ -1,0 +1,76 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{./command.tex}
+
+\title{Complete-Positivity Scope of the Peripheral Cyclicity Theorem}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{The source theorem}
+
+Theorem 6.6 of \emph{Quantum Channels \& Operations} (Wolf 2012), stated at
+lines 244--252 of \texttt{Notes/WolfNotePDF/wolf\_ch6\_sections.txt}, concerns
+an irreducible positive unital map $T:\MN{D}\to\MN{D}$ that
+satisfies the Schwarz inequality. Item~(1) concludes that the peripheral
+spectrum is a finite cyclic group of order $m\leq D^2$; items~(2)--(4) give
+nondegeneracy, a peripheral unitary, and cyclic spectral projections.
+Complete positivity and a Kraus representation are not hypotheses of the
+theorem.
+
+\section{The restriction in the formalization}
+
+The available Lean statement is
+\leanid{Kraus.peripheralEigenvalues_eq_range_primitiveRoot} in
+\texttt{QICLean/Channel/Peripheral/CyclicGroupKraus.lean}. It is stated for a finite
+matrix family $K$ and its Kraus map
+\[
+    E(X)=\sum_i K_iXK_i^\dagger.
+\]
+It assumes that this Kraus map is unital and irreducible and that its adjoint
+has a positive-definite fixed point. A finite Kraus presentation implies
+complete positivity, which is strictly stronger than Wolf's positive Schwarz
+hypothesis. The adjoint fixed point is also an extra signature-level datum:
+Wolf's theorem does not assume it. In the finite-dimensional Kraus setting it
+should instead be derived from unitality and irreducibility, but the present
+Lean declaration requires it explicitly. Thus the Lean theorem proves the
+completely positive specialization of the cyclicity conclusion in Wolf
+Theorem 6.6(1), but not its bound $m\leq D^2$. This particular declaration does
+not state items~(2)--(4). Separate finite-Kraus companion declarations establish
+nondegeneracy, peripheral unitaries, and cyclic projections under corresponding
+Kraus hypotheses. They do not supply the abstract positive unital Schwarz-map
+form of Wolf's theorem. The corresponding Blueprint entry uses its own
+specialization title.
+
+\section{Elimination plan}
+
+First remove the extra fixed-point input from the finite-Kraus statement:
+derive a positive-semidefinite adjoint fixed point from trace preservation of
+the adjoint map, then use irreducibility to prove that it is positive definite.
+Next formulate peripheral eigenvectors and their multiplicative-domain
+relations for an abstract positive unital Schwarz map. The proof must establish
+invertibility of peripheral eigenvectors and closure of peripheral eigenvalues
+under multiplication without choosing Kraus operators. The finite-group
+argument in the present cyclicity theorem then applies unchanged. Once that
+abstract result exists, the Kraus theorem should be retained as a
+specialization rather than serving as the source-facing form of Wolf Theorem
+6.6.
+
+\section{Verdict}
+
+\textbf{Verdict: scope restriction.} The cyclicity declaration proves Wolf
+Theorem 6.6(1) under the stronger complete-positivity hypothesis supplied by a
+finite Kraus representation and with an additional positive-definite adjoint
+fixed point as explicit input. It does not include the bound $m\leq D^2$.
+Finite-Kraus companion specializations cover conclusions corresponding to
+items~(2)--(4), but the abstract Schwarz-map formulation of all four items and
+the item-(1) order bound remain open at the source-facing interface.
+
+\end{document}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -71,7 +71,7 @@ project import.
     is the specialization `d = d'` ✓
   - Remaining square-only declarations (the `ChoiJamiolkowski.choiMatrix`
     API, `IsTracePreservingMap`, `IsChannel`) are documented as specializations
-    in `docs/paper-gaps/choi_rectangular_scope.tex`.
+    in `docs/paper-gaps/wolf_choi_rectangular_scope.tex`.
 
 * **Theorem 2.1** (Kraus representation, dimension-generic development):
   the root/`Channel`-namespace Kraus API is stated for rectangular Kraus
@@ -692,7 +692,7 @@ In `QICLean.Channel.FixedPoint.Algebra`:
 * `fixedPoint_of_compact_retract` — `QICLean.Topology.CompactRetractFixedPoint`;
   extends Brouwer to compact retracts of finite-dimensional real normed spaces.
 * The general compact-convex statement (Wolf's formulation) is not yet proved;
-  see `docs/paper-gaps/brouwer_general_compact_convex.tex`.
+  see `docs/paper-gaps/wolf_brouwer_general_compact_convex.tex`.
 
 #### Wolf Theorem 6.11 (Stationary states) — FORMALIZED
 
@@ -902,7 +902,7 @@ The full Wolf statement is therefore complete.  Its application to the
 transported sector maps of arXiv:1606.00608 is a separate tensor-attached
 problem: one must still prove the channel hypotheses for those maps on the
 whole direct-sum algebras.  This remaining boundary is recorded in
-`docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`.
+`https://sirui-lu.com/TNLean/paper-gaps/cpsv16_vertical_sector_invertibility.pdf`.
 
 #### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED (Kraus case)
 

--- a/home_page/_layouts/default.html
+++ b/home_page/_layouts/default.html
@@ -28,6 +28,7 @@
     <a href="blueprint" class="btn">Blueprint (web)</a>
     <a href="blueprint.pdf" class="btn">Blueprint (pdf)</a>
     <a href="docs" class="btn">Documentation</a>
+    <a href="paper-gaps" class="btn">Paper-gap notes</a>
     {% if site.github.is_project_page %}
     <a href="{{ site.github.repository_url }}" class="btn">GitHub</a>
     {% endif %}

--- a/home_page/index.md
+++ b/home_page/index.md
@@ -25,6 +25,16 @@ of matrix product states; its blueprint and documentation are published at
 [sirui-lu.com/TNLean](https://sirui-lu.com/TNLean/). TNLean builds on
 QICLean as an ordinary Lake dependency.
 
+## Paper-Gap Notes
+
+Where the formalization deviates from a cited source &mdash; a missing
+hypothesis, a scalar correction, a scope restriction, a replacement proof
+route &mdash; the deviation is recorded as a standalone mathematical note.
+The [paper-gap notes](paper-gaps/) are indexed by source paper; each note has
+a stable link, a PDF, and a citation entry. The notes on Wolf's *Quantum
+Channels & Operations* moved here from TNLean together with the
+channel-theory library.
+
 ## Companion Paper
 
 S. Lu, E. Tjoa, J. I. Cirac, *Multi-agent Autoformalization of Tensor Network

--- a/texra-blueprint.toml
+++ b/texra-blueprint.toml
@@ -1,0 +1,22 @@
+# Configuration for the shared texra-blueprint tooling.
+# https://github.com/LionSR/texra-blueprint
+
+[paper_gaps]
+dir         = "docs/paper-gaps"
+site_base   = "https://sirui-lu.com/QICLean"
+blob_base   = "https://github.com/LionSR/QICLean/blob/main/docs/paper-gaps"
+bib_author  = "The {QICLean} contributors"
+institution = "QICLean"
+title       = "QICLean paper-gap notes"
+scan_roots  = ["QICLean", "blueprint/src", "docs"]
+skip        = ["command.tex", "template.tex"]
+# Every note must carry a \gapnote{kind}{status} verdict marker.
+require_verdict = true
+
+# The source-key registry: every note is named <key>_<topic>.tex. Author
+# initials plus two-digit year, or a canonical short name for a book or
+# review; qiclean marks internal theorem-surface audits with no single
+# external source. Enforced by `texra-blueprint paper-gaps check`.
+[paper_gaps.sources]
+qiclean = "internal theorem-surface audit, no single external source"
+wolf    = "Wolf, Quantum Channels & Operations (2012 lecture notes)"


### PR DESCRIPTION
## The domain move

Wolf's *Quantum Channels & Operations* is QICLean's source since the channel-theory extraction (#6865 in TNLean), so the 36 `wolf_*` paper-gap notes move here from TNLean's `docs/paper-gaps/`. This PR adds the notes, the paper-gap infrastructure, and the CI wiring:

- `docs/paper-gaps/`: the 36 `wolf_*.tex` notes, `command.tex` (TNLean's Dirac/matrix notation, QICLean issue/PR/doc link bases, the v0.2.2 `\gapnote` definition with the `wip` status vocabulary), `policy.tex` and `template.tex` instantiated from the shared paper-gap-notes skill assets (internal-audit key `qiclean`), and `references.bib` trimmed to the four entries the moved notes cite (`Wolf2012Quantum`, `Yamagami1993Cyclic`, `TanahashiTomiyama1988Indecomposable`, `Osaka1991Indecomposable`).
- `texra-blueprint.toml`: `[paper_gaps]` with QICLean's identity and the `wolf` + `qiclean` source registry. No aliases.
- CI: `texra-blueprint paper-gaps check` in the pr-ci and blueprint workflows (texra-blueprint pin bumped v0.1.0 → v0.3.1, matching TNLean's CI), paper-gap PDF build + `site site-docs/paper-gaps` packaging in docgen (`assemble-pages-site.sh` already deploys that directory), and a "Paper-gap notes" home-page button plus an index.md section.

## Reference fixes in the moved notes

- 15 `\ghissue{N}` occurrences referred to TNLean issues; with QICLean's link bases they would silently point at the wrong repo. Each is now an absolute `https://github.com/LionSR/TNLean/issues/N` link labelled "TNLean issue #N". (No `\ghpr` occurrences existed.)
- 62 `\doclink{TNLean/...}` arguments now read `\doclink{QICLean/...}` — every one of those modules lives in QICLean since the extraction. Two footnotes cited modules that exist in neither repo (`Channel/Schwarz/OperatorMonotone`, `Channel/PerronFrobenius/ExtremalQuantities`, both deleted as dead code in #56); they now say so instead of linking.
- 9 plain-text file-path mentions (`\texttt`/`\path`/`\leanid` with `.lean` suffix) updated `TNLean/` → `QICLean/`.

## QICLean-side citation fixes (surfaced by the new check)

The first `paper-gaps check` run also flagged every pre-existing dangling reference in QICLean sources:

- References to the four pre-registry alias slugs (`breuer_hall_even_dim_restriction`, `choi_rectangular_scope`, `schur_complement_tfae`, `brouwer_general_compact_convex`) now use the canonical local `wolf_*` file names.
- References to notes that stay in TNLean (`cpsv16_*`, `cpgsv17_*`, `cpgsv21_martingale_overlap`, `cpsv17_transfer_trace_power`, `hjpw04_petz_factorization_maximally_mixed_scope`, `knabe88_finite_range_coefficient`, `mpu_two_projection_projector_typo`) now use absolute `https://sirui-lu.com/TNLean/paper-gaps/<slug>.pdf` URLs — 88 occurrences across 40 Lean modules, 3 blueprint chapters, and `docs/wolf_numbering_coverage.md`. (Long doc-string lines carrying URLs are exempt from the `longLine` linter.)

## Verification

- `texra-blueprint --root . paper-gaps check`: passes — "33 referenced slugs resolve, all note names carry registered source keys".
- `paper-gaps build` + `site`: "36 notes, 37 PDFs, 133 citations resolved" (all 36 notes and policy.tex compile under the new command.tex; artifacts cleaned up).
- Three sample notes latexmk-compiled individually; `actionlint` clean on the three changed workflows.

The companion TNLean PR (removal + citation-URL migration) is cross-linked in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4