### PR TITLE
doc(blueprint): cite paper-gap notes as bibliography references

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
 
       - name: Check paper-gap references resolve
         run: texra-blueprint paper-gaps check

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -5,7 +5,10 @@ name: Blueprint
 # FT-MPS-volume packaging step (that split PDF is TNLean-specific). Otherwise
 # unchanged: same leanblueprint build, same error/warning gating, same
 # paper-gap reference check, same generated-page reader-facing check, same
-# Pages deploy handoff.
+# Pages deploy handoff. Beyond TNLean's version, this push path also builds
+# and packages the paper-gap note PDFs: the blueprint bibliography links to
+# them, so a deploy that published the links without the PDFs would leave
+# them dangling until the next scheduled docgen run.
 
 on:
   push:
@@ -49,6 +52,12 @@ jobs:
 
       - name: Install system dependencies
         uses: texra-ai/lean-env-action/blueprint-system-deps@v1
+        with:
+          # texlive-fonts-extra supplies dsfont, which some paper-gap notes
+          # load; the suffix separates the cache from the extra-package-free
+          # web-v1 set.
+          cache-suffix: web-v2
+          extra-packages: texlive-fonts-extra
 
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
@@ -60,6 +69,13 @@ jobs:
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py
+
+      # The bibliography links every paper-gap note to its published PDF, so
+      # the same deploy that publishes the links must also publish the PDFs;
+      # the weekly docgen run alone would leave links to freshly added notes
+      # dangling until it next succeeds.
+      - name: Build paper-gap PDFs
+        run: texra-blueprint --root . paper-gaps build
 
       - name: Build blueprint
         run: |
@@ -98,6 +114,7 @@ jobs:
           mkdir -p site-blueprint site-badges
           cp -r blueprint/web site-blueprint/blueprint
           cp blueprint/print/print.pdf site-blueprint/blueprint.pdf
+          texra-blueprint --root . paper-gaps site site-blueprint/paper-gaps
           python3 scripts/write_badges.py site-badges
 
       - name: Build homepage

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -390,7 +390,7 @@ jobs:
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
 
       - name: Check paper-gap references resolve
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'

--- a/blueprint/src/chapter/ch01_positive_maps.tex
+++ b/blueprint/src/chapter/ch01_positive_maps.tex
@@ -144,7 +144,7 @@ range, or its adjoint's range, is commutative.
     $\mathcal B$ commutative'' hypothesis that his own proof establishes and
     that his remark immediately after the proof licenses for an arbitrary
     operator system mapping into a commutative algebra. See
-    \path{docs/paper-gaps/wolf_prop16_cp_positivity_commutative_side.tex}
+    \cite{gap:wolf_prop16_cp_positivity_commutative_side}
     for the precise relationship between the two phrasings.
 \end{theorem}
 
@@ -351,7 +351,7 @@ The source states the extension theorem for an operator system inside any
 finite-dimensional $C^*$-algebra, that is, any direct sum of matrix
 algebras. What follows treats the one-summand case, where the ambient
 algebra is a single full matrix algebra $\MN{m}$; see
-\path{docs/paper-gaps/wolf_ch01_operator_system_extension_matrix_scope.tex}.
+\cite{gap:wolf_ch01_operator_system_extension_matrix_scope}.
 
 \begin{theorem}[Left partial trace of a Kronecker product]
     \label{thm:mpdo_left_partial_trace_kronecker}
@@ -499,7 +499,7 @@ algebra is a single full matrix algebra $\MN{m}$; see
     tensor factors. This theorem concerns only the displayed direct-sum
     coordinates; it does not conjugate the subalgebra by an arbitrary unitary
     or corestrict the codomain. This coordinate restriction is documented in
-    \path{docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex}.
+    \cite{gap:wolf_prop1_5_one_factor_scope}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -439,7 +439,7 @@ a common dilation space.
     \end{align}
     This is \cite[Theorem~2.4]{Wolf2012Quantum}, with the nonempty-family condition
     made explicit; see
-    \path{docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex}.
+    \cite{gap:wolf_radon_nikodym_nonempty_family}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
@@ -778,8 +778,8 @@
     lines~254--262. The paper does not state this extension. Its later
     singular equality theorem at lines~761--785 assumes
     $\ker B_i\subseteq\ker A_i$ and is not asserted here. The subsequent
-    singular entropy-equality passage is recorded in
-    \path{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf}.
+    singular entropy-equality passage is recorded in the TNLean paper-gap
+    note \cite{gap:cpsv16_ssa_equality_hayashi_markov}.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1856,8 +1856,8 @@ algebra of a family of jointly invariant states.
     \textbf{Scope restriction (HJPW Theorem~6, equation~(14)):}
     the displayed direct sum is restricted to the minimum joint supporting
     subspace, whereas equation~(14), lines 499--502, decomposes the ambient
-    subsystem $B$. This restriction is documented in
-    \path{https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf}.
+    subsystem $B$. This restriction is documented in the TNLean paper-gap
+    note \cite{gap:hjpw04_petz_factorization_maximally_mixed_scope}.
     % The next theorem performs the ambient extension; the subsequent
     % The Markov-dilation theorem supplies equation (15).
 \end{theorem}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -233,3 +233,69 @@
   eprint       = {1903.05373},
   eprinttype   = {arxiv},
 }
+
+% -------------------------------------------------------------------------
+%  Paper-gap notes (cite as \cite{gap:<slug>}; the url field carries the
+%  published PDF of the note, on this repository's site for local notes and
+%  on the owning repository's site for cross-repository citations).
+% -------------------------------------------------------------------------
+
+@techreport{gap:cpsv16_ssa_equality_hayashi_markov,
+  author      = {The {TNLean} contributors},
+  title       = {Closure Record for the Strong-Subadditivity Equality Characterization and Hayashi--Markov Decomposition},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_ssa\_equality\_hayashi\_markov},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf},
+}
+
+@techreport{gap:hjpw04_petz_factorization_maximally_mixed_scope,
+  author      = {The {TNLean} contributors},
+  title       = {Support scope of the HJPW product-reference Petz factorization},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {hjpw04\_petz\_factorization\_maximally\_mixed\_scope},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf},
+}
+
+@techreport{gap:wolf_ch01_operator_system_extension_matrix_scope,
+  author      = {The {QICLean} contributors},
+  title       = {Wolf's Operator-System Extension: Matrix-Algebra Realization},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_ch01\_operator\_system\_extension\_matrix\_scope},
+  year        = {2026},
+  url         = {https://sirui-lu.com/QICLean/paper-gaps/wolf_ch01_operator_system_extension_matrix_scope.pdf},
+}
+
+@techreport{gap:wolf_prop1_5_one_factor_scope,
+  author      = {The {QICLean} contributors},
+  title       = {Wolf Proposition 1.5: Factor and Coordinate Direct-Sum Scope Restrictions},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_prop1\_5\_one\_factor\_scope},
+  year        = {2026},
+  url         = {https://sirui-lu.com/QICLean/paper-gaps/wolf_prop1_5_one_factor_scope.pdf},
+}
+
+@techreport{gap:wolf_prop16_cp_positivity_commutative_side,
+  author      = {The {QICLean} contributors},
+  title       = {Wolf Proposition 1.6: Complete Positivity from Positivity, Commutative Side},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_prop16\_cp\_positivity\_commutative\_side},
+  year        = {2026},
+  url         = {https://sirui-lu.com/QICLean/paper-gaps/wolf_prop16_cp_positivity_commutative_side.pdf},
+}
+
+@techreport{gap:wolf_radon_nikodym_nonempty_family,
+  author      = {The {QICLean} contributors},
+  title       = {The nonempty-family condition in Wolf's Radon--Nikodym theorem},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_radon\_nikodym\_nonempty\_family},
+  year        = {2026},
+  url         = {https://sirui-lu.com/QICLean/paper-gaps/wolf_radon_nikodym_nonempty_family.pdf},
+}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -235,9 +235,11 @@
 }
 
 % -------------------------------------------------------------------------
-%  Paper-gap notes (cite as \cite{gap:<slug>}; the url field carries the
-%  published PDF of the note, on this repository's site for local notes and
-%  on the owning repository's site for cross-repository citations).
+%  Paper-gap notes (cite as \cite{gap:<slug>}; the note field carries the
+%  published PDF of the note as a \url link, because the alpha bibliography
+%  style omits the url field for techreport entries in the PDF build. The
+%  link points to this repository's site for local notes and to the owning
+%  repository's site for cross-repository citations).
 % -------------------------------------------------------------------------
 
 @techreport{gap:cpsv16_ssa_equality_hayashi_markov,
@@ -247,7 +249,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_ssa\_equality\_hayashi\_markov},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ssa_equality_hayashi_markov.pdf}},
 }
 
 @techreport{gap:hjpw04_petz_factorization_maximally_mixed_scope,
@@ -257,7 +259,7 @@
   type        = {Paper-gap note},
   number      = {hjpw04\_petz\_factorization\_maximally\_mixed\_scope},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf}},
 }
 
 @techreport{gap:wolf_ch01_operator_system_extension_matrix_scope,
@@ -267,7 +269,7 @@
   type        = {Paper-gap note},
   number      = {wolf\_ch01\_operator\_system\_extension\_matrix\_scope},
   year        = {2026},
-  url         = {https://sirui-lu.com/QICLean/paper-gaps/wolf_ch01_operator_system_extension_matrix_scope.pdf},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_ch01_operator_system_extension_matrix_scope.pdf}},
 }
 
 @techreport{gap:wolf_prop1_5_one_factor_scope,
@@ -277,7 +279,7 @@
   type        = {Paper-gap note},
   number      = {wolf\_prop1\_5\_one\_factor\_scope},
   year        = {2026},
-  url         = {https://sirui-lu.com/QICLean/paper-gaps/wolf_prop1_5_one_factor_scope.pdf},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_prop1_5_one_factor_scope.pdf}},
 }
 
 @techreport{gap:wolf_prop16_cp_positivity_commutative_side,
@@ -287,7 +289,7 @@
   type        = {Paper-gap note},
   number      = {wolf\_prop16\_cp\_positivity\_commutative\_side},
   year        = {2026},
-  url         = {https://sirui-lu.com/QICLean/paper-gaps/wolf_prop16_cp_positivity_commutative_side.pdf},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_prop16_cp_positivity_commutative_side.pdf}},
 }
 
 @techreport{gap:wolf_radon_nikodym_nonempty_family,
@@ -297,5 +299,5 @@
   type        = {Paper-gap note},
   number      = {wolf\_radon\_nikodym\_nonempty\_family},
   year        = {2026},
-  url         = {https://sirui-lu.com/QICLean/paper-gaps/wolf_radon_nikodym_nonempty_family.pdf},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_radon_nikodym_nonempty_family.pdf}},
 }

--- a/docs/paper-gaps/policy.tex
+++ b/docs/paper-gaps/policy.tex
@@ -119,6 +119,12 @@ A file name is permanent once other documents cite it; version suffixes are
 not used, since a note is revised in place (see Revision below) and its
 history is preserved by the repository.
 
+Blueprint prose cites a note like any other source, with
+\verb|\cite{gap:<slug>}|; the bibliography entry carries the published URL
+of the note, whether the note lives in this repository or in another one.
+Lean docstrings and comments use the repository path form
+\path{docs/paper-gaps/<slug>.tex}.
+
 \section{Classification}
 
 The conclusion of a note should give a verdict. The usual classifications are:

--- a/docs/paper-gaps/policy.tex
+++ b/docs/paper-gaps/policy.tex
@@ -122,8 +122,9 @@ history is preserved by the repository.
 Blueprint prose cites a note like any other source, with
 \verb|\cite{gap:<slug>}|; the bibliography entry carries the published URL
 of the note, whether the note lives in this repository or in another one.
-Lean docstrings and comments use the repository path form
-\path{docs/paper-gaps/<slug>.tex}.
+Lean docstrings and comments cite a note owned by this repository by its
+repository path \path{docs/paper-gaps/<slug>.tex}; a note owned by another
+repository has no source file here, so they cite its published URL.
 
 \section{Classification}
 

--- a/scripts/assemble-pages-site.sh
+++ b/scripts/assemble-pages-site.sh
@@ -3,9 +3,14 @@
 # Usage: assemble-pages-site.sh COMPONENTS_DIR OUT_DIR
 #
 # COMPONENTS_DIR may contain:
-#   site-blueprint/  Jekyll-built homepage, blueprint web + PDFs  (required)
+#   site-blueprint/  Jekyll-built homepage, blueprint web + PDFs,
+#                    paper-gap PDFs                               (required)
 #   site-docs/       doc-gen4 API docs and paper-gap PDFs         (optional)
 #   site-badges/     badge endpoint JSON                          (optional)
+#
+# Paper-gap PDFs come from site-blueprint when present: the blueprint job
+# rebuilds them on every push that touches a note, so its copy is at least
+# as fresh as the weekly docgen's site-docs copy, which remains a fallback.
 set -euo pipefail
 
 COMPONENTS="$1"
@@ -38,8 +43,11 @@ if [ -d "$COMPONENTS/site-docs/docs" ]; then
 else
   echo "::warning::site-docs component missing — deploying without API docs (the next docgen run restores them)"
 fi
-if [ -d "$COMPONENTS/site-docs/paper-gaps" ]; then
-  echo "==> Paper-gap PDFs..."
+if [ -d "$COMPONENTS/site-blueprint/paper-gaps" ]; then
+  echo "==> Paper-gap PDFs (blueprint component)..."
+  cp -r "$COMPONENTS/site-blueprint/paper-gaps" "$OUT/paper-gaps"
+elif [ -d "$COMPONENTS/site-docs/paper-gaps" ]; then
+  echo "==> Paper-gap PDFs (docs component)..."
   cp -r "$COMPONENTS/site-docs/paper-gaps" "$OUT/paper-gaps"
 fi
 


### PR DESCRIPTION
Blueprint prose now cites a paper-gap note like any other source, with `\cite{gap:<slug>}` (natbib); the bibliography entry carries the published URL of the note. The URL lives only in the bibliography, never in prose.

- Converts the four repository-path prose citations of local Wolf notes (`ch01_positive_maps.tex` x3, `ch16_channel_representations_dilations_and_ordered_cp.tex`) to `\cite{gap:<slug>}`.
- Converts the two absolute-URL prose citations of TNLean notes (`ch19_entropy_tripartite_and_ssa_i.tex`, `ch19_entropy_tripartite_and_ssa_ii.tex`) to the same cite form; their bibliography entries point at the TNLean site.
- Adds six `@techreport{gap:<slug>, ...}` entries to `blueprint/src/references.bib` (four local QICLean notes, two TNLean notes), copied from the generated `paper-gaps.bib`; `web.bbl` regenerated via `scripts/blueprint_bibtex.py`.
- Traceability references inside `%` comments keep the repository path form (20 comment mentions untouched).
- Records the convention in `docs/paper-gaps/policy.tex` (Naming section).
- Bumps the texra-blueprint pins v0.3.2 -> v0.3.4 (pr-ci.yml, docgen.yml, blueprint.yml).

Verified locally: `texra-blueprint --root . paper-gaps check` passes (33 referenced slugs resolve); `leanblueprint web` exits 0 with no errors, the converted citations render as bibliography references (anchor `sect0001.html#gap:<slug>`), and the bibliography entries link the published PDFs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4