### PR TITLE
doc(blueprint): fix paper-gap bibliography labels and title casing

### DIFF
--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -244,7 +244,7 @@
 
 @techreport{gap:cpsv16_ssa_equality_hayashi_markov,
   author      = {The {TNLean} contributors},
-  title       = {Closure Record for the Strong-Subadditivity Equality Characterization and Hayashi--Markov Decomposition},
+  title       = {Closure Record for the Strong-Subadditivity Equality Characterization and {Hayashi}--{Markov} Decomposition},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {cpsv16\_ssa\_equality\_hayashi\_markov},
@@ -254,7 +254,7 @@
 
 @techreport{gap:hjpw04_petz_factorization_maximally_mixed_scope,
   author      = {The {TNLean} contributors},
-  title       = {Support scope of the HJPW product-reference Petz factorization},
+  title       = {Support scope of the {HJPW} product-reference {Petz} factorization},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {hjpw04\_petz\_factorization\_maximally\_mixed\_scope},
@@ -294,7 +294,7 @@
 
 @techreport{gap:wolf_radon_nikodym_nonempty_family,
   author      = {The {QICLean} contributors},
-  title       = {The nonempty-family condition in Wolf's Radon--Nikodym theorem},
+  title       = {The nonempty-family condition in {Wolf}'s {Radon}--{Nikodym} theorem},
   institution = {QICLean},
   type        = {Paper-gap note},
   number      = {wolf\_radon\_nikodym\_nonempty\_family},

--- a/scripts/blueprint_bibtex.py
+++ b/scripts/blueprint_bibtex.py
@@ -42,7 +42,19 @@ def bibtex_alpha_abbrev(parts: list[str]) -> str:
 
 
 class BibTeXAlphaLabelStyle(AlphaLabelStyle):
-    """Alpha labels with BibTeX-like initials for TeX-accented surnames."""
+    """Alpha labels with BibTeX-like initials for TeX-accented surnames.
+
+    Paper-gap notes (``type = {Paper-gap note}``) are labelled by their entry-key
+    slug instead of the author/year alpha label: every such note shares the same
+    contributor author and year, so alpha labels degenerate into indistinct
+    ``con26a``/``con26b``-style suffixes that identify nothing.
+    """
+
+    def format_label(self, entry):
+        if entry.fields.get("type") == "Paper-gap note":
+            slug = entry.key.split(":", 1)[-1]
+            return slug.replace("_", r"\_")
+        return super().format_label(entry)
 
     def format_lab_names(self, persons):
         numnames = len(persons)


### PR DESCRIPTION
## Summary

Fixes, for the six `@techreport{gap:<slug>, ...}` entries added by #61, the two bibliography defects tracked in the TNLean sibling issues LionSR/TNLean#6913 (title-case corruption) and LionSR/TNLean#6914 (colliding alpha citation labels). The design is identical to the TNLean fix so the two repositories stay in sync.

### Title casing (LionSR/TNLean#6913)

Both consumers of `blueprint/src/references.bib` — real BibTeX with `\bibliographystyle{alpha}` (`print.tex`) and pybtex's alpha style (`scripts/blueprint_bibtex.py` for the web build) — sentence-case titles, so unprotected acronyms and proper nouns were lower-cased on render ("hjpw", "petz", "radon–nikodym", "hayashi–markov"). Each acronym/proper noun is now wrapped in its own `{}` group, matching the pre-existing entries in the file.

### Citation labels (LionSR/TNLean#6914)

All gap entries share `author = {The {TNLean/QICLean} contributors}` and `year = {2026}`, so the alpha label degenerates to the same `con26` base for every note; both render paths then fall back to opaque `con26a`/`con26b`… suffixes, and the suffix assignment even differs between the web and PDF builds (the paths sort entries differently). The pybtex label style in `scripts/blueprint_bibtex.py` now labels `type = {Paper-gap note}` entries by their entry-key slug (the option recommended in LionSR/TNLean#6914), e.g. `[wolf_radon_nikodym_nonempty_family]` — distinct, stable, and self-identifying.

A per-entry `key` field was investigated first and ruled out by direct test: `alpha.bst` only consults `key` when `author` is absent, and even then it uses only the first three characters of the key, so it cannot disambiguate these entries in the PDF path. No pure-`.bib` mechanism can override alpha labels while keeping the author field, and vendoring a modified `alpha.bst` was judged too invasive; the PDF build therefore keeps real BibTeX's native suffix disambiguation (`con26a`–`con26f`, verified distinct), where the rendered entry's report number still carries the slug.

## Verification

- `python3 scripts/blueprint_bibtex.py` regenerates `web.bbl` (gitignored, not committed) with distinct slug labels for all six gap entries.
- `leanblueprint web` (miniforge environment with the texra_blueprint plugin) from a clean `blueprint/web`: the rendered bibliography shows the six distinct slug labels and case-preserved titles ("Wolf's Radon–Nikodym theorem", "Hayashi–Markov", "HJPW", "Petz"), and every inline `\cite{gap:...}` renders with its slug label.
- Standalone `pdflatex`+`bibtex` (alpha style, as in `print.tex`) on a scratch document citing all six gap entries: labels `con26a`–`con26f` are distinct and titles render with case preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4