### PR TITLE
ci(workflows): adopt texra-blueprint web and bump the pin to v0.3.6

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
 
       - name: Check paper-gap references resolve
         run: texra-blueprint paper-gaps check
@@ -84,10 +84,10 @@ jobs:
 
           leanblueprint pdf
 
-          set +o pipefail
-          leanblueprint web 2>&1 | tee "$tmp_output_file"
-          cmd_status=${PIPESTATUS[0]}
-          set -o pipefail
+          # texra-blueprint web wraps leanblueprint web and fails when the
+          # renderer meets a command it does not know; the log is kept for
+          # the label checks below.
+          texra-blueprint web 2>&1 | tee "$tmp_output_file"
 
           if grep -q "^ERROR:" "$tmp_output_file"; then
             echo "::warning::Blueprint has unresolved labels (see ERROR lines above)"
@@ -95,9 +95,6 @@ jobs:
           if grep -q "WARNING: File not found:" "$tmp_output_file"; then
             echo "::error::Blueprint has missing files (see WARNING lines above)"
             exit 1
-          fi
-          if [ "$cmd_status" -ne 0 ]; then
-            exit "$cmd_status"
           fi
 
       # A zero exit status says the build ran, not that the pages read. The

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py
@@ -77,17 +77,14 @@ jobs:
           set -o pipefail
           tmp_output_file="$(mktemp)"
 
-          set +o pipefail
-          leanblueprint web 2>&1 | tee "$tmp_output_file"
-          cmd_status=${PIPESTATUS[0]}
-          set -o pipefail
+          # texra-blueprint web wraps leanblueprint web and fails when the
+          # renderer meets a command it does not know; the log is kept for
+          # the label check below.
+          texra-blueprint web 2>&1 | tee "$tmp_output_file"
 
           if grep -q "^ERROR:" "$tmp_output_file"; then
             echo "::error::Blueprint has unresolved labels (see ERROR lines above)"
             exit 1
-          fi
-          if [ "$cmd_status" -ne 0 ]; then
-            exit "$cmd_status"
           fi
 
       - name: Test generated blueprint pages

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -390,7 +390,7 @@ jobs:
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
 
       - name: Check paper-gap references resolve
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
@@ -428,25 +428,22 @@ jobs:
         if: env.TEX_CHANGED == 'true'
         run: python3 scripts/blueprint_bibtex.py
 
-      - name: Run leanblueprint web and check for errors
+      - name: Run texra-blueprint web and check for errors
         if: env.TEX_CHANGED == 'true'
         working-directory: blueprint
         run: |
           set -o pipefail
           tmp_output_file="$(mktemp)"
-          set +o pipefail
-          leanblueprint web 2>&1 | tee "$tmp_output_file"
-          cmd_status=${PIPESTATUS[0]}
-          set -o pipefail
+          # texra-blueprint web wraps leanblueprint web and fails when the
+          # renderer meets a command it does not know; the log is kept for
+          # the label checks below.
+          texra-blueprint web 2>&1 | tee "$tmp_output_file"
           if grep -q "^ERROR:" "$tmp_output_file"; then
             echo "::error::Blueprint has unresolved labels (see ERROR lines above)"
             exit 1
           fi
           if grep -q "WARNING: File not found:" "$tmp_output_file"; then
             echo "::warning::Blueprint has missing file references (see WARNING lines above)"
-          fi
-          if [ "$cmd_status" -ne 0 ]; then
-            exit "$cmd_status"
           fi
 
       # A zero exit status says the build ran, not that the pages read. This


### PR DESCRIPTION
Migrates the repo to texra-blueprint v0.3.6, whose `texra-blueprint web` subcommand is the canonical strict wrapper around `leanblueprint web` (fails on `WARNING: unrecognized command/environment` and `WARNING: Using default renderer`).

## Changes

- **Pin bump v0.3.4 → v0.3.6** at all 3 sites: `pr-ci.yml`, `docgen.yml`, `blueprint.yml`.
- **`leanblueprint web` → `texra-blueprint web`** in the same three workflows. Note: QICLean's gates never contained the renderer-vocabulary grep — they only checked `^ERROR:` and `WARNING: File not found:` — so this swap *adds* the renderer strictness the other repos already had, rather than replacing an inline grep.
- **Extra greps kept**, running right after `texra-blueprint web` in the same step: `^ERROR:` unresolved labels (error in pr-ci/docgen, warning in blueprint.yml) and `WARNING: File not found:` (warning in pr-ci, hard failure in blueprint.yml). The `tee` into the log file is kept because these checks read it. The `set +o pipefail` / `PIPESTATUS` dance is replaced by `set -o pipefail`.

## Verification

With v0.3.6 installed locally:

- `texra-blueprint web` from `blueprint/` (after `scripts/blueprint_bibtex.py`): exit 0 on the current tree.
- `texra-blueprint paper-gaps check`: exit 0 (33 referenced slugs resolve).
- `yaml.safe_load` passes on all three touched workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4
