### PR TITLE
doc(paper-gaps): authored dates for the migrated Wolf notes

### DIFF
--- a/docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex
+++ b/docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex
@@ -9,7 +9,7 @@
 
 \title{Wolf Theorem~8.6 --- the Doubly-Substochastic Half of Birkhoff}
 \author{}
-\date{\today}
+\date{2026-08-09}
 
 \begin{document}
 \maketitle

--- a/docs/paper-gaps/wolf_ch8_eq_8_103_negative_exponent.tex
+++ b/docs/paper-gaps/wolf_ch8_eq_8_103_negative_exponent.tex
@@ -9,7 +9,7 @@
 
 \title{Wolf Equation~(8.103) --- Small-Power Exponent Scope}
 \author{}
-\date{\today}
+\date{2026-08-09}
 
 \begin{document}
 \maketitle

--- a/docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex
+++ b/docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex
@@ -8,7 +8,7 @@
 
 \title{Complete Positivity in the Projected Support Corner Star-Algebra}
 \author{}
-\date{\today}
+\date{2026-07-30}
 
 \begin{document}
 \maketitle

--- a/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
+++ b/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
@@ -8,7 +8,7 @@
 
 \title{Corner-Support Restriction in the Weighted Fixed-Point Star-Algebra}
 \author{}
-\date{\today}
+\date{2026-07-12}
 
 \begin{document}
 \maketitle

--- a/docs/paper-gaps/wolf_prop61_russo_dye_factor.tex
+++ b/docs/paper-gaps/wolf_prop61_russo_dye_factor.tex
@@ -9,7 +9,7 @@
 
 \title{Wolf Proposition~6.1 --- The Russo--Dye Factor}
 \author{}
-\date{\today}
+\date{2026-08-04}
 
 \begin{document}
 \maketitle

--- a/docs/paper-gaps/wolf_prop62_jordan_blocks.tex
+++ b/docs/paper-gaps/wolf_prop62_jordan_blocks.tex
@@ -9,7 +9,7 @@
 
 \title{Wolf Proposition~6.2 --- Trivial Jordan Blocks for Peripheral Eigenvalues}
 \author{}
-\date{\today}
+\date{2026-08-05}
 
 \begin{document}
 \maketitle

--- a/docs/paper-gaps/wolf_thm6_3_positive_map_cp_scope.tex
+++ b/docs/paper-gaps/wolf_thm6_3_positive_map_cp_scope.tex
@@ -8,7 +8,7 @@
 
 \title{Complete-Positivity Scope of the Fixed-Point Case of Wolf Theorem 6.3}
 \author{}
-\date{\today}
+\date{2026-08-09}
 
 \begin{document}
 \maketitle

--- a/docs/paper-gaps/wolf_thm6_6_kraus_scope.tex
+++ b/docs/paper-gaps/wolf_thm6_6_kraus_scope.tex
@@ -8,7 +8,7 @@
 
 \title{Complete-Positivity Scope of the Peripheral Cyclicity Theorem}
 \author{}
-\date{\today}
+\date{2026-08-09}
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
The wolf-notes migration (TNLean #6906) reset the git last-modified dates that the paper-gaps index date column used, so the eight transferred notes still carrying `\date{\today}` were indistinguishable by age. texra-blueprint v0.3.7 now prefers the authored `\date` over git last-modified; this PR stamps each note with the date of its last real content commit, recovered from TNLean's pre-migration history (excluding the #6906 deletion and the #6879 registry-rename commits):

| Note | Date | TNLean commit |
|---|---|---|
| wolf_cor67_maximal_support_restriction | 2026-07-12 | 3efc9e93c |
| wolf_cor66_kraus_hypothesis_restriction | 2026-07-30 | 68db63141 |
| wolf_prop61_russo_dye_factor | 2026-08-04 | 9dfb15382 |
| wolf_prop62_jordan_blocks | 2026-08-05 | b047be56a |
| wolf_ch8_birkhoff_doubly_substochastic_gap | 2026-08-09 | d70e38493 |
| wolf_ch8_eq_8_103_negative_exponent | 2026-08-09 | 1f1d5c9ad |
| wolf_thm6_3_positive_map_cp_scope | 2026-08-09 | eb4ed15a1 |
| wolf_thm6_6_kraus_scope | 2026-08-09 | 32256bfdb |

template.tex and command.tex stay on `\today` (skip list).

Verified with texra-blueprint v0.3.7: `paper-gaps check` exits 0; `paper-gaps site` renders the index with 20 distinct dates and every row above showing its authored date, none dated with the build date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4