### PR TITLE
ci(blueprint): pin texra-blueprint v0.3.7

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.7'
 
       - name: Check paper-gap references resolve
         run: texra-blueprint paper-gaps check

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.7'
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -390,7 +390,7 @@ jobs:
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.7'
 
       - name: Check paper-gap references resolve
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'


### PR DESCRIPTION
Sweeps the three workflow pins `texra-blueprint@v0.3.6` → v0.3.7, the release whose paper-gaps index date column prefers the authored `\date` over git last-modified:

- `.github/workflows/blueprint.yml`
- `.github/workflows/docgen.yml`
- `.github/workflows/pr-ci.yml`

All three pass `yaml.safe_load`; no other change. Companion to #72, which stamps the migrated Wolf notes with their authored dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4