### PR TITLE
ci(release): implement Lake cloud-release archives for tagged builds

### DIFF
--- a/.github/workflows/release-archive.yml
+++ b/.github/workflows/release-archive.yml
@@ -1,0 +1,83 @@
+name: Release Archive
+
+# Builds QICLean at a pushed semantic-version tag and publishes the build
+# output as a Lake cloud-release archive on the corresponding GitHub release,
+# so a dependent package (TNLean, pinning QICLean by tag in lakefile.toml)
+# fetches a prebuilt archive instead of compiling QICLean's modules from
+# source. See docs/UPGRADE_RUNBOOK.md §5 and the `releaseRepo` /
+# `preferReleaseBuild` keys in lakefile.toml.
+#
+# Mechanism (Lake v4.34.0-rc1, verified against the Lake source bundled with
+# the pinned toolchain, `Lake/Build/Package.lean` and `Lake/CLI/Actions.lean`):
+#   - `lake upload <tag>` packs the root package's `buildDir` into
+#     `QICLean-<platform-target>.tar.gz` and runs
+#     `gh release upload <tag> <archive> --clobber -R <releaseRepo>`.
+#   - This requires the GitHub release object for `<tag>` to already exist;
+#     `gh release upload` does not create it.
+#   - The archive name embeds the LLVM target triple of the Lean binary that
+#     built it (`System.Platform.target`), so archives are per-platform.
+#     `ubuntu-latest` here publishes the Linux archive; there is currently no
+#     macOS archive published by CI (a local `lake upload` from a macOS
+#     machine would publish that platform's archive to the same release).
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  BUILD_CACHE_PATHS: |
+    .lake/build
+    .lake/packages/Gametheory/.lake/build
+    .lake/packages/checkdecls/.lake/build
+
+jobs:
+  release-archive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # Restore-only: this workflow runs on rare tag pushes, not every PR, so
+      # it does not save a cache entry of its own (avoiding the per-run
+      # eviction problem `docs/lake_build_cache.md` documents for pr-ci.yml).
+      - name: Restore Lean build cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.BUILD_CACHE_PATHS }}
+          key: qiclean-build-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ github.sha }}
+          restore-keys: |
+            qiclean-build-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-
+
+      - uses: leanprover/lean-action@v1
+        with:
+          build: false
+          use-github-cache: false
+
+      - name: Build Lean project
+        run: lake build
+
+      - name: Ensure the GitHub release exists for this tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --repo "${{ github.repository }}" \
+              --title "$TAG" \
+              --notes "Build archive for Lake cloud release."
+          fi
+
+      - name: Upload the Lake cloud-release archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: lake upload "$TAG"

--- a/docs/UPGRADE_RUNBOOK.md
+++ b/docs/UPGRADE_RUNBOOK.md
@@ -46,18 +46,23 @@ These must hold at every point except the deliberate transition window in
    semantic-version tag `vX.Y.Z` — this is the tag TNLean actually pins, and
    using semver (rather than only the toolchain tag) lets a later
    content-only hotfix land as `vX.Y.(Z+1)` without another toolchain bump.
-   The tag push triggers a release build (`lake build && lake upload
-   vX.Y.Z`), producing a prebuilt archive TNLean's CI can fetch instead of
-   recompiling QICLean from source.
+   The tag push triggers `.github/workflows/release-archive.yml`, which
+   builds QICLean at the tag and runs `lake upload vX.Y.Z` (creating the
+   GitHub release object first if it does not already exist), producing a
+   prebuilt archive TNLean's CI can fetch instead of recompiling QICLean
+   from source.
 3. **TNLean**, one PR:
    - Copy QICLean's `lean-toolchain` byte-for-byte.
    - Bump the `QICLean` requirement to the new tag.
    - Bump the `mathlib` requirement to the same revision now in QICLean's
      manifest (TNLean's root Mathlib requirement must match QICLean's, per
      invariant I2).
-   - `lake update QICLean mathlib`, `lake exe cache get`,
-     `lake build QICLean:release` (or an equivalent prebuilt-archive fetch),
-     then `lake build`.
+   - `lake update QICLean mathlib`, `lake exe cache get`, then `lake build`.
+     No special target or flag is needed on the TNLean side: QICLean's
+     `preferReleaseBuild = true` (lakefile.toml) makes Lake try the GitHub
+     release archive automatically for every non-root build of QICLean,
+     as long as `.lake/packages/QICLean/.lake/build` does not already exist
+     locally and the build is not run with `--no-cache`.
    - Let ordinary CI and the auto-fix loop handle any proof fallout from the
      Mathlib bump; this PR is not required to be a pure version bump if a
      handful of TNLean proofs need adjustment, but it must not touch
@@ -104,12 +109,20 @@ reintroducing the multi-hour CI cost that the shared-cache-eviction fix
 (`docs/lake_build_cache.md`) already solved once for TNLean's own modules.
 The mitigation, in order of preference:
 
-1. **Primary**: QICLean's release tags publish a prebuilt archive (`lake
-   upload`); TNLean's CI fetches it (`lake build QICLean:release` or
-   equivalent) instead of compiling from source. Verify the exact `lake
-   upload` / `lake build ...:release` invocation against the pinned Lean
-   toolchain before relying on it in CI — the Lake release-archive feature's
-   exact flags are toolchain-version-sensitive.
+1. **Primary**: QICLean's release tags publish a prebuilt archive via
+   `release-archive.yml` (`lake upload vX.Y.Z`, run against
+   `ubuntu-latest`); an ordinary `lake build` on the TNLean side fetches and
+   unpacks it automatically instead of compiling QICLean from source —
+   `preferReleaseBuild = true` in QICLean's `lakefile.toml` is what makes
+   this automatic for any consumer, no special TNLean-side target or flag
+   required. One caveat verified against Lake v4.34.0-rc1's source
+   (`Lake/Build/Package.lean`): the archive name embeds the platform's LLVM
+   target triple (`System.Platform.target`), so archives are per-platform —
+   `release-archive.yml` publishes only the `ubuntu-latest` (Linux) archive.
+   A contributor building TNLean locally on macOS will not find a matching
+   archive and falls back to compiling QICLean from source there (Lake logs
+   a warning, does not error); this only affects local non-Linux builds, not
+   CI.
 2. **Backstop**: include QICLean's build directory
    (`.lake/packages/QICLean/.lake/build`) in TNLean's `BUILD_CACHE_PATHS`,
    saved only from `main`, same as TNLean's own build cache. This keeps the

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -4,6 +4,19 @@ keywords = ["math"]
 # The default target builds the whole QICLean library.
 defaultTargets = ["QICLean"]
 
+# Lake cloud-release configuration. TNLean pins this package by a semantic-
+# version tag (see docs/UPGRADE_RUNBOOK.md); `preferReleaseBuild` is the flag
+# a *dependent* package's Lake reads to try `optGitHubReleaseFacet` (fetch +
+# unpack a prebuilt `buildDir` archive from this repository's GitHub release
+# for the pinned tag) before falling back to compiling QICLean from source.
+# `releaseRepo` is set explicitly (rather than left to Lake's default, which
+# derives it from the dependent's `git = "...git"` requirement URL and does
+# not strip the `.git` suffix) so the constructed release-asset URL is always
+# `https://github.com/LionSR/QICLean/releases/download/<tag>/<archive>`,
+# independent of how a consumer spells the `require` URL.
+releaseRepo = "https://github.com/LionSR/QICLean"
+preferReleaseBuild = true
+
 [leanOptions]
 pp.unicode.fun = true # pretty-prints `fun a ↦ b`
 relaxedAutoImplicit = false


### PR DESCRIPTION
## Summary

- Implements the Lake cloud-release mechanism that pr-ci.yml's build-job comment and `docs/UPGRADE_RUNBOOK.md` already described as the intended way TNLean avoids recompiling QICLean's ~520 modules from source, but which had no actual configuration or workflow: adds `releaseRepo` / `preferReleaseBuild` to `lakefile.toml`, and a new `.github/workflows/release-archive.yml` triggered on `v*` tag pushes that builds QICLean and runs `lake upload <tag>` (creating the GitHub release object first if needed).
- Corrects `docs/UPGRADE_RUNBOOK.md`, which flagged this as unverified (`lake build QICLean:release` was speculative): verified against the Lake source bundled with the pinned v4.34.0-rc1 toolchain (`Lake/Build/Package.lean`, `Lake/CLI/Actions.lean`) that the consumer side needs **no** special target — `preferReleaseBuild = true` on the dependency makes Lake try the GitHub release archive automatically during a plain `lake build`, as long as the local `buildDir` doesn't already exist and the build isn't run with `--no-cache`.
- `releaseRepo` is set explicitly to `https://github.com/LionSR/QICLean` because Lake's default fallback (a consumer's `require`d `git = "...git"` URL) does not strip the `.git` suffix, which would otherwise construct a broken release-asset download URL.

## Verified locally (backfill, not part of this diff)

Checked out `v0.1.2` and `v0.2.0` in a separate clone, ran `lake exe cache get && lake build`, created the (previously nonexistent) GitHub releases for both tags, and ran `lake upload` for each — confirming `lake upload`'s pack/upload path works end to end against this toolchain. Also verified a fresh TNLean clone's `lake build` fetches and unpacks the `arm64-apple-darwin` archive for `v0.1.2` automatically instead of compiling QICLean, once `preferReleaseBuild` was live on that tag (details in the QICLean/TNLean sync channel, not part of this PR's diff).

## Caveat: archives are per-platform

The release archive name embeds the Lean binary's LLVM target triple (`System.Platform.target`), so this workflow (running on `ubuntu-latest`) only publishes a Linux archive. A contributor building TNLean locally on macOS will not find a matching archive for a CI-only tag and falls back to compiling QICLean from source there (a warning, not an error) unless a macOS archive is also uploaded to that release (as done manually for the backfilled tags above).

## Test plan

- [x] `lakefile.toml` parses (`lake env true` elaborates the config without error)
- [ ] CI green on this PR (`pr-ci.yml`)