### PR TITLE
docs(kraus): mark the MPS compatibility layer dissolved

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,18 +18,13 @@ vendor or duplicate this source. QICLean itself never imports TNLean —
 channel and Wielandt theory is stated over finite Kraus families and words,
 never over matrix-product-state vocabulary.
 
-**In-progress dissolution of the `QICLean.MPS` compatibility layer** (tracked
-by the layer's dissolution issue): the bulk of the extraction-era
-compatibility layer under `namespace MPSTensor` has been folded into
-`QICLean.Kraus` or deleted as pure delegation. One file remains as a
-deliberate, clearly-marked exception: `QICLean/Kraus/TensorCompat.lean`
-still declares `MPSTensor`-namespaced, genuinely matrix-product-*state*
-vocabulary (`GaugeEquiv`, `SameMPV`, `mpv`, and their relatives) that never
-belonged in this library. It is kept only so `QICLean.MPS` can dissolve; a
-paired TNLean pull request re-homes it in TNLean's tensor-network layer, and
-the QICLean tag after that pull request deletes it. Until then, treat
-`QICLean/Kraus/TensorCompat.lean` as scheduled for removal, not as
-precedent for adding new matrix-product-state content to `QICLean.Kraus`.
+**The extraction-era `QICLean.MPS` compatibility layer is dissolved.** Its
+channel-generic declarations now live under `QICLean.Kraus`; pure delegation
+wrappers were deleted, and genuinely matrix-product-*state* vocabulary was
+re-homed in TNLean. The root-level abbrev `MPSTensor d D` remains in
+`QICLean/Kraus/Word.lean` because TNLean uses it as a synonym for a finite
+Kraus family, but QICLean declares no API under `namespace MPSTensor`. Do not
+add matrix-product-state vocabulary or new compatibility wrappers here.
 
 ## Build Commands and Mathlib Cache Policy
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -27,13 +27,13 @@ one way. See the "Relation to TNLean" section of the top-level
 [`docs/UPGRADE_RUNBOOK.md`](UPGRADE_RUNBOOK.md) for how the two
 repositories stay on the same Lean/Mathlib toolchain.
 
-One extraction-era exception remains mid-dissolution:
-`QICLean/Kraus/TensorCompat.lean` still declares a handful of genuinely
-matrix-product-*state* definitions (`GaugeEquiv`, `SameMPV`, `mpv`) under
-`namespace MPSTensor`, kept only so the rest of the `QICLean.MPS`
-compatibility layer could dissolve. A paired TNLean pull request re-homes
-this content in TNLean's own tensor-network layer, after which a QICLean
-tag removes the file. New contributions should not add to it.
+The extraction-era `QICLean.MPS` compatibility layer has been dissolved.
+Channel-generic declarations live under `QICLean.Kraus`, while genuinely
+matrix-product-*state* definitions such as `GaugeEquiv`, `SameMPV`, and `mpv`
+now live in TNLean. The root-level abbrev `MPSTensor d D` remains in
+`QICLean/Kraus/Word.lean` as a synonym for a finite Kraus family so TNLean can
+state its tensor-network theory over the same underlying type; QICLean does
+not declare an API under `namespace MPSTensor`.
 
 ## What you need
 
@@ -115,16 +115,13 @@ from TNLean and does not track that order (see
 [`blueprint/README.md`](../blueprint/README.md) and
 [`docs/blueprint_style_guide.md`](blueprint_style_guide.md)).
 
-**A namespace note.** QICLean was cut out of TNLean's Lean tree, and a few
-declarations still carry TNLean's `MPSTensor` namespace rather than a
-channel-generic one, pending a rename. `QICLean/Kraus/Injectivity.lean`
-says so directly in its module docstring: the exact word-span API is
-already stated under `namespace Kraus`, but the established injectivity
-and normality declarations remain under `namespace MPSTensor`. The
-top-level `QICLean/Wielandt/` directory is the clearest example of this —
-most of its declarations still open `namespace MPSTensor`, unlike the
-channel-generic `QICLean/Kraus/Wielandt/` directory referenced in the table
-above, which covers overlapping ground without that legacy namespace.
+**A namespace note.** The channel and quantum Wielandt APIs are stated under
+`namespace Kraus`, over finite families of matrices. In particular,
+`QICLean/Kraus/Injectivity.lean` contains injectivity and normality, and
+`QICLean/Kraus/Wielandt/` contains the span-growth and quantum Wielandt
+development. The spelling `MPSTensor d D` may still appear as an argument
+type because it is a reducible root-level abbrev for the same finite-family
+type, but it does not introduce a separate namespace or compatibility API.
 
 ## A first reading path
 


### PR DESCRIPTION
## Summary
- remove stale claims that `QICLean/Kraus/TensorCompat.lean` and `QICLean.MPS` still exist
- document the completed `Kraus` namespace migration accurately
- clarify that only the root-level reducible abbrev `MPSTensor d D` remains for TNLean interoperability, with no QICLean API under `namespace MPSTensor`

This is the final QICLean-side synchronization for #69 after PRs #75/#76, releases v0.2.0/v0.2.1, and TNLean consumer migration PR LionSR/TNLean#6947. The downstream retrospective review findings are separately tracked as LionSR/TNLean#6951, #6952, and #6954.

## Verification
- `git diff --check`
- live-doc stale-reference sweep for `TensorCompat`, `QICLean/MPS`, and the removed `QICLean/Wielandt` path
- `python3 scripts/check_reader_facing_prose.py` reports only the pre-existing Lean-docstring issue-number findings outside these changed Markdown files

No local Lake rebuild, clean, cache deletion, or dependency fetch was run.

Closes #69.