### PR TITLE
feat(lorentz): formalize Pauli-block truncation

### DIFF
--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -51,6 +51,7 @@ import QICLean.Channel.LorentzNormalForm
 import QICLean.Channel.LorentzNormalForm.Basic
 import QICLean.Channel.LorentzNormalForm.Infimum
 import QICLean.Channel.LorentzNormalForm.NormalForm
+import QICLean.Channel.LorentzNormalForm.PauliBlockTruncation
 import QICLean.Channel.LorentzNormalForm.QubitNormalForm
 import QICLean.Channel.MarginalSupportAbsorption
 import QICLean.Channel.MarginalSupportWhitenedChoi

--- a/QICLean/Channel/LorentzNormalForm.lean
+++ b/QICLean/Channel/LorentzNormalForm.lean
@@ -6,24 +6,27 @@ Authors: TNLean contributors
 import QICLean.Channel.LorentzNormalForm.Basic
 import QICLean.Channel.LorentzNormalForm.Infimum
 import QICLean.Channel.LorentzNormalForm.NormalForm
+import QICLean.Channel.LorentzNormalForm.PauliBlockTruncation
 import QICLean.Channel.LorentzNormalForm.QubitNormalForm
 
 /-!
 # Lorentz normal form for quantum channels (Wolf Section 2.4, Propositions 2.8–2.11)
 
 Thin module assembling the normal-form development for quantum channels under
-filtering operations from four focused sub-modules.
+filtering operations from five focused submodules.
 
-* `TNLean.Channel.LorentzNormalForm.Basic` — SL-filtering operations, the
+* `QICLean.Channel.LorentzNormalForm.Basic` — SL-filtering operations, the
   doubly-stochastic predicates, and the shared Kronecker-conjugation and
   partial-trace identities.
-* `TNLean.Channel.LorentzNormalForm.Infimum` — the compactness/minimisation
+* `QICLean.Channel.LorentzNormalForm.Infimum` — the compactness/minimisation
   argument (Wolf Equation (2.36)): attainment of the infimum and the AM–GM
   optimality lemmas.
-* `TNLean.Channel.LorentzNormalForm.NormalForm` — Wolf Proposition 2.9, the
+* `QICLean.Channel.LorentzNormalForm.NormalForm` — Wolf Proposition 2.9, the
   generic normal form for CP maps with full Kraus rank, in square and
   rectangular forms.
-* `TNLean.Channel.LorentzNormalForm.QubitNormalForm` — the Pauli-basis
+* `QICLean.Channel.LorentzNormalForm.PauliBlockTruncation` — the valid forward
+  implications of Wolf Proposition 2.10 for Pauli-block truncation.
+* `QICLean.Channel.LorentzNormalForm.QubitNormalForm` — the Pauli-basis
   predicates for the qubit Lorentz normal form (Wolf Proposition 2.11;
   existence pending).
 

--- a/QICLean/Channel/LorentzNormalForm/PauliBlockTruncation.lean
+++ b/QICLean/Channel/LorentzNormalForm/PauliBlockTruncation.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Channel.LorentzNormalForm.QubitNormalForm
+import QICLean.Channel.PositiveExamples
+import QICLean.Channel.Semigroup.CPClosure
+
+/-!
+# Pauli-block truncation of qubit maps
+
+This module formalizes the forward implications in Wolf Proposition 2.10,
+following Equation (2.39) in Section 2.4.  Qubit Pauli time reversal is
+the reduction map `Θ(X) = tr(X) 1 - X`; averaging a map with its double
+time-reversal sandwich deletes precisely the two off-diagonal blocks of its
+Pauli transfer matrix.  Positivity and complete positivity are preserved.
+
+## References
+
+* `Notes/WolfNoteTexSource/ch02_representations.tex`, Section 2.4,
+  Proposition 2.10, lines 984--998. Only the forward implications actually
+  proved in lines 992--998 are formalized here.
+-/
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+open Matrix Finset
+
+namespace Wolf
+
+private abbrev QubitMatrix := Matrix (Fin 2) (Fin 2) ℂ
+private abbrev QubitMap := QubitMatrix →ₗ[ℂ] QubitMatrix
+
+/-- Qubit Pauli time reversal, `Θ(X) = tr(X) 1 - X`, realized by the existing
+reduction map `Matrix.reductionMap 2 1`.
+
+Source: `Notes/WolfNoteTexSource/ch02_representations.tex`, Section 2.4,
+Proposition 2.10, lines 984--998. -/
+noncomputable def pauliTimeReversal : QubitMap :=
+  Matrix.reductionMap 2 1
+
+/-- The Pauli-block truncation
+`T' = (1/2) • (T + Θ ∘ T ∘ Θ)` from Wolf's proof. -/
+noncomputable def pauliBlockDiagonalTruncation (T : QubitMap) : QubitMap :=
+  ((1 / 2 : ℂ) •
+    (T + pauliTimeReversal.comp (T.comp pauliTimeReversal)))
+
+/-- Pauli time reversal fixes `σ₀`. -/
+@[simp] theorem pauliTimeReversal_pauli_zero :
+    pauliTimeReversal (pauliMatrices 0) = pauliMatrices 0 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pauliTimeReversal, Matrix.reductionMap_apply, pauliMatrices,
+      Matrix.trace_fin_two]
+
+/-- Pauli time reversal negates every nonidentity Pauli matrix. -/
+theorem pauliTimeReversal_pauli_ne_zero (i : Fin 4) (hi : i ≠ 0) :
+    pauliTimeReversal (pauliMatrices i) = -pauliMatrices i := by
+  fin_cases i <;> simp_all [pauliTimeReversal, Matrix.reductionMap_apply,
+    pauliMatrices, Matrix.trace_fin_two]
+
+/-- The diagonal entries of `D = diag(1,-1,-1,-1)`, the Pauli transfer
+matrix of qubit time reversal. -/
+def pauliTimeReversalDiagonal (i : Fin 4) : ℂ :=
+  if i = 0 then 1 else -1
+
+private theorem pauliTimeReversal_pauli (i : Fin 4) :
+    pauliTimeReversal (pauliMatrices i) =
+      pauliTimeReversalDiagonal i • pauliMatrices i := by
+  by_cases hi : i = 0
+  · subst i
+    simp [pauliTimeReversalDiagonal]
+  · simp [pauliTimeReversalDiagonal, hi, pauliTimeReversal_pauli_ne_zero i hi]
+
+/-- Entrywise form of Wolf's identity `D T̂ D`, where
+`D = diag(1,-1,-1,-1)` is the Pauli matrix of time reversal. -/
+theorem pauliTransferEntry_timeReversal_comp (T : QubitMap) (i j : Fin 4) :
+    pauliTransferEntry (pauliTimeReversal.comp (T.comp pauliTimeReversal)) i j =
+      pauliTimeReversalDiagonal i * pauliTransferEntry T i j * pauliTimeReversalDiagonal j := by
+  rw [pauliTransferEntry, LinearMap.comp_apply, LinearMap.comp_apply,
+    pauliTimeReversal_pauli]
+  simp only [map_smul]
+  rw [pauliTimeReversal_pauli]
+  simp [pauliTransferEntry, Matrix.smul_mul, Matrix.trace_smul, mul_assoc, mul_comm,
+    mul_left_comm]
+
+/-- The truncation keeps the `(0,0)` entry and the lower-right `3 × 3` Pauli
+block, and zeros the two off-diagonal blocks.  This is the public entrywise
+summary of `(T̂ + D T̂ D)/2 = T̂₀₀ ⊕ Δ`.
+
+Source: `Notes/WolfNoteTexSource/ch02_representations.tex`, Section 2.4,
+Proposition 2.10, lines 984--998. -/
+theorem pauliTransferEntry_pauliBlockDiagonalTruncation (T : QubitMap) (i j : Fin 4) :
+    pauliTransferEntry (pauliBlockDiagonalTruncation T) i j =
+      if (i = 0 ↔ j = 0) then pauliTransferEntry T i j else 0 := by
+  rw [pauliBlockDiagonalTruncation, pauliTransferEntry]
+  simp only [LinearMap.smul_apply, LinearMap.add_apply, Matrix.mul_add, Matrix.trace_add,
+    smul_eq_mul, Matrix.smul_mul, Matrix.trace_smul]
+  rw [show ((1 : ℂ) / 2) * ((1 : ℂ) / 2) = 1 / 4 by norm_num]
+  change 1 / 4 * (Matrix.trace (pauliMatrices i * T (pauliMatrices j)) +
+    Matrix.trace (pauliMatrices i *
+      (pauliTimeReversal.comp (T.comp pauliTimeReversal)) (pauliMatrices j))) = _
+  rw [show Matrix.trace (pauliMatrices i *
+      (pauliTimeReversal.comp (T.comp pauliTimeReversal)) (pauliMatrices j)) =
+      2 * (pauliTimeReversalDiagonal i * pauliTransferEntry T i j *
+        pauliTimeReversalDiagonal j) by
+    rw [pauliTransferEntry_timeReversal_comp]
+    simp [pauliTransferEntry]]
+  rw [show Matrix.trace (pauliMatrices i * T (pauliMatrices j)) =
+      2 * pauliTransferEntry T i j by simp [pauliTransferEntry]]
+  by_cases hi : i = 0 <;> by_cases hj : j = 0 <;>
+    simp [pauliTimeReversalDiagonal, hi, hj]
+
+/-- Pauli time reversal is positive. -/
+theorem pauliTimeReversal_isPositiveMap : IsPositiveMap pauliTimeReversal := by
+  simpa [pauliTimeReversal] using
+    (Matrix.reductionMap_one_isPositiveMap (D := 2))
+
+private theorem isPositiveMap_comp {S T : QubitMap}
+    (hS : IsPositiveMap S) (hT : IsPositiveMap T) : IsPositiveMap (S.comp T) := by
+  intro X hX
+  exact hS _ (hT X hX)
+
+private theorem isPositiveMap_add {S T : QubitMap}
+    (hS : IsPositiveMap S) (hT : IsPositiveMap T) : IsPositiveMap (S + T) := by
+  intro X hX
+  simpa using (hS X hX).add (hT X hX)
+
+/-- The forward positivity implication actually proved in Wolf Proposition 2.10:
+if `T` is positive, deleting its two off-diagonal Pauli blocks by time-reversal
+averaging remains positive. The source's Hermiticity-preserving hypothesis is
+retained explicitly.
+
+Source: `Notes/WolfNoteTexSource/ch02_representations.tex`, Section 2.4,
+Proposition 2.10, lines 984--998. -/
+theorem pauliBlockDiagonalTruncation_isPositiveMap
+    (T : QubitMap)
+    (_hHerm : ∀ X : QubitMatrix, X.IsHermitian → (T X).IsHermitian)
+    (hT : IsPositiveMap T) : IsPositiveMap (pauliBlockDiagonalTruncation T) := by
+  rw [pauliBlockDiagonalTruncation]
+  have hsandwich : IsPositiveMap (pauliTimeReversal.comp (T.comp pauliTimeReversal)) :=
+    isPositiveMap_comp pauliTimeReversal_isPositiveMap
+      (isPositiveMap_comp hT pauliTimeReversal_isPositiveMap)
+  intro X hX
+  simpa [LinearMap.smul_apply] using
+    (isPositiveMap_add hT hsandwich X hX).smul (show (0 : ℝ) ≤ 1 / 2 by norm_num)
+
+private theorem pauliTimeReversal_singleKraus_sandwich
+    (A X : QubitMatrix) :
+    pauliTimeReversal (A * pauliTimeReversal X * Aᴴ) =
+      (pauliMatrices 2 * A.map star * pauliMatrices 2) * X *
+        (pauliMatrices 2 * A.map star * pauliMatrices 2)ᴴ := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pauliTimeReversal, Matrix.reductionMap_apply, pauliMatrices,
+      Matrix.trace_fin_two, Matrix.mul_apply]
+    <;> ring
+
+private theorem pauliTimeReversal_comp_comp_isCPMap
+    {T : QubitMap} (hT : IsCPMap T) :
+    IsCPMap (pauliTimeReversal.comp (T.comp pauliTimeReversal)) := by
+  obtain ⟨r, K, hK⟩ := hT
+  refine ⟨r, fun i => pauliMatrices 2 * (K i).map star * pauliMatrices 2, ?_⟩
+  intro X
+  rw [LinearMap.comp_apply, LinearMap.comp_apply, hK, map_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  exact pauliTimeReversal_singleKraus_sandwich (K i) X
+
+/-- The forward complete-positivity implication actually proved in Wolf
+Proposition 2.10. Although time reversal itself is not completely positive,
+its double sandwich around a Kraus map has Kraus
+operators `σ₂ · conj(Kᵢ) · σ₂`; CP is then preserved by addition and the
+nonnegative scalar factor `1/2`.  The source's Hermiticity-preserving
+hypothesis is retained explicitly.
+
+Source: `Notes/WolfNoteTexSource/ch02_representations.tex`, Section 2.4,
+Proposition 2.10, lines 984--998.  This theorem is
+only the forward implication actually proved there; no converse is asserted. -/
+theorem pauliBlockDiagonalTruncation_isCPMap
+    (T : QubitMap)
+    (_hHerm : ∀ X : QubitMatrix, X.IsHermitian → (T X).IsHermitian)
+    (hT : IsCPMap T) : IsCPMap (pauliBlockDiagonalTruncation T) := by
+  rw [pauliBlockDiagonalTruncation]
+  exact (hT.add (pauliTimeReversal_comp_comp_isCPMap hT)).smul_nonneg (by norm_num)
+
+end Wolf

--- a/QICLean/Channel/LorentzNormalForm/PauliBlockTruncation.lean
+++ b/QICLean/Channel/LorentzNormalForm/PauliBlockTruncation.lean
@@ -72,6 +72,20 @@ private theorem pauliTimeReversal_pauli (i : Fin 4) :
     simp [pauliTimeReversalDiagonal]
   · simp [pauliTimeReversalDiagonal, hi, pauliTimeReversal_pauli_ne_zero i hi]
 
+private theorem trace_pauli_mul_pauliTimeReversal (i : Fin 4) (X : QubitMatrix) :
+    Matrix.trace (pauliMatrices i * pauliTimeReversal X) =
+      pauliTimeReversalDiagonal i * Matrix.trace (pauliMatrices i * X) := by
+  calc
+    Matrix.trace (pauliMatrices i * pauliTimeReversal X) =
+        Matrix.trace (Matrix.traceAdjointMap pauliTimeReversal (pauliMatrices i) * X) :=
+      (Matrix.trace_traceAdjointMap_mul pauliTimeReversal (pauliMatrices i) X).symm
+    _ = Matrix.trace (pauliTimeReversal (pauliMatrices i) * X) := by
+      rw [show Matrix.traceAdjointMap pauliTimeReversal = pauliTimeReversal by
+        simpa [pauliTimeReversal] using Matrix.traceAdjointMap_reductionMap 2 1]
+    _ = pauliTimeReversalDiagonal i * Matrix.trace (pauliMatrices i * X) := by
+      rw [pauliTimeReversal_pauli, Matrix.smul_mul, Matrix.trace_smul]
+      rfl
+
 /-- Entrywise form of Wolf's identity `D T̂ D`, where
 `D = diag(1,-1,-1,-1)` is the Pauli matrix of time reversal. -/
 theorem pauliTransferEntry_timeReversal_comp (T : QubitMap) (i j : Fin 4) :
@@ -79,10 +93,9 @@ theorem pauliTransferEntry_timeReversal_comp (T : QubitMap) (i j : Fin 4) :
       pauliTimeReversalDiagonal i * pauliTransferEntry T i j * pauliTimeReversalDiagonal j := by
   rw [pauliTransferEntry, LinearMap.comp_apply, LinearMap.comp_apply,
     pauliTimeReversal_pauli]
-  simp only [map_smul]
-  rw [pauliTimeReversal_pauli]
-  simp [pauliTransferEntry, Matrix.smul_mul, Matrix.trace_smul, mul_assoc, mul_comm,
-    mul_left_comm]
+  simp only [map_smul, Matrix.mul_smul, Matrix.trace_smul]
+  rw [trace_pauli_mul_pauliTimeReversal]
+  simp [pauliTransferEntry, mul_comm, mul_left_comm]
 
 /-- The truncation keeps the `(0,0)` entry and the lower-right `3 × 3` Pauli
 block, and zeros the two off-diagonal blocks.  This is the public entrywise
@@ -94,22 +107,29 @@ theorem pauliTransferEntry_pauliBlockDiagonalTruncation (T : QubitMap) (i j : Fi
     pauliTransferEntry (pauliBlockDiagonalTruncation T) i j =
       if (i = 0 ↔ j = 0) then pauliTransferEntry T i j else 0 := by
   rw [pauliBlockDiagonalTruncation, pauliTransferEntry]
-  simp only [LinearMap.smul_apply, LinearMap.add_apply, Matrix.mul_add, Matrix.trace_add,
-    smul_eq_mul, Matrix.smul_mul, Matrix.trace_smul]
-  rw [show ((1 : ℂ) / 2) * ((1 : ℂ) / 2) = 1 / 4 by norm_num]
-  change 1 / 4 * (Matrix.trace (pauliMatrices i * T (pauliMatrices j)) +
+  simp only [LinearMap.smul_apply, LinearMap.add_apply, Matrix.mul_smul, Matrix.trace_smul,
+    smul_eq_mul, Matrix.mul_add, Matrix.trace_add]
+  rw [← mul_assoc, show ((1 : ℂ) / 2) * ((1 : ℂ) / 2) = 1 / 4 by norm_num]
+  change (1 / 4 : ℂ) * (Matrix.trace (pauliMatrices i * T (pauliMatrices j)) +
     Matrix.trace (pauliMatrices i *
       (pauliTimeReversal.comp (T.comp pauliTimeReversal)) (pauliMatrices j))) = _
   rw [show Matrix.trace (pauliMatrices i *
       (pauliTimeReversal.comp (T.comp pauliTimeReversal)) (pauliMatrices j)) =
       2 * (pauliTimeReversalDiagonal i * pauliTransferEntry T i j *
         pauliTimeReversalDiagonal j) by
-    rw [pauliTransferEntry_timeReversal_comp]
-    simp [pauliTransferEntry]]
+    calc
+      Matrix.trace (pauliMatrices i *
+          (pauliTimeReversal.comp (T.comp pauliTimeReversal)) (pauliMatrices j)) =
+          2 * pauliTransferEntry
+            (pauliTimeReversal.comp (T.comp pauliTimeReversal)) i j := by
+        simp [pauliTransferEntry]
+      _ = 2 * (pauliTimeReversalDiagonal i * pauliTransferEntry T i j *
+          pauliTimeReversalDiagonal j) := by
+        rw [pauliTransferEntry_timeReversal_comp]]
   rw [show Matrix.trace (pauliMatrices i * T (pauliMatrices j)) =
       2 * pauliTransferEntry T i j by simp [pauliTransferEntry]]
   by_cases hi : i = 0 <;> by_cases hj : j = 0 <;>
-    simp [pauliTimeReversalDiagonal, hi, hj]
+    simp [pauliTimeReversalDiagonal, hi, hj] <;> ring
 
 /-- Pauli time reversal is positive. -/
 theorem pauliTimeReversal_isPositiveMap : IsPositiveMap pauliTimeReversal := by
@@ -142,19 +162,49 @@ theorem pauliBlockDiagonalTruncation_isPositiveMap
     isPositiveMap_comp pauliTimeReversal_isPositiveMap
       (isPositiveMap_comp hT pauliTimeReversal_isPositiveMap)
   intro X hX
-  simpa [LinearMap.smul_apply] using
-    (isPositiveMap_add hT hsandwich X hX).smul (show (0 : ℝ) ≤ 1 / 2 by norm_num)
+  have hsum := isPositiveMap_add hT hsandwich X hX
+  have hhalf := hsum.smul (show (0 : ℝ) ≤ 1 / 2 by norm_num)
+  convert hhalf using 1
+  ext i j
+  simp [LinearMap.smul_apply, LinearMap.add_apply, Complex.real_smul]
+
+private theorem pauliTimeReversal_eq_pauli_two_mul_transpose_mul (X : QubitMatrix) :
+    pauliTimeReversal X = pauliMatrices 2 * X.transpose * pauliMatrices 2 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pauliTimeReversal, Matrix.reductionMap_apply, pauliMatrices,
+      Matrix.trace_fin_two, Matrix.mul_apply, Matrix.vecMul_apply_eq_sum,
+      Fin.sum_univ_two]
+  all_goals
+    ring_nf
+    simp [Complex.I_sq]
+
+private theorem pauli_two_transpose :
+    (pauliMatrices 2).transpose = -(pauliMatrices 2) := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [pauliMatrices]
+
+private theorem pauli_two_conjTranspose :
+    (pauliMatrices 2)ᴴ = pauliMatrices 2 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [pauliMatrices]
+
+private theorem map_star_conjTranspose (A : QubitMatrix) :
+    (A.map star)ᴴ = A.transpose := by
+  ext i j
+  simp
 
 private theorem pauliTimeReversal_singleKraus_sandwich
     (A X : QubitMatrix) :
     pauliTimeReversal (A * pauliTimeReversal X * Aᴴ) =
       (pauliMatrices 2 * A.map star * pauliMatrices 2) * X *
         (pauliMatrices 2 * A.map star * pauliMatrices 2)ᴴ := by
-  ext i j
-  fin_cases i <;> fin_cases j <;>
-    simp [pauliTimeReversal, Matrix.reductionMap_apply, pauliMatrices,
-      Matrix.trace_fin_two, Matrix.mul_apply]
-    <;> ring
+  rw [pauliTimeReversal_eq_pauli_two_mul_transpose_mul,
+    pauliTimeReversal_eq_pauli_two_mul_transpose_mul]
+  simp only [Matrix.transpose_mul, Matrix.conjTranspose_transpose,
+    Matrix.transpose_transpose, pauli_two_transpose, Matrix.conjTranspose_mul,
+    pauli_two_conjTranspose, map_star_conjTranspose]
+  noncomm_ring
 
 private theorem pauliTimeReversal_comp_comp_isCPMap
     {T : QubitMap} (hT : IsCPMap T) :
@@ -182,6 +232,8 @@ theorem pauliBlockDiagonalTruncation_isCPMap
     (_hHerm : ∀ X : QubitMatrix, X.IsHermitian → (T X).IsHermitian)
     (hT : IsCPMap T) : IsCPMap (pauliBlockDiagonalTruncation T) := by
   rw [pauliBlockDiagonalTruncation]
-  exact (hT.add (pauliTimeReversal_comp_comp_isCPMap hT)).smul_nonneg (by norm_num)
+  simpa only [show ((1 / 2 : ℂ)) = ((1 / 2 : ℝ) : ℂ) by norm_num] using
+    (hT.add (pauliTimeReversal_comp_comp_isCPMap hT)).smul_nonneg
+      (c := (1 / 2 : ℝ)) (by norm_num)
 
 end Wolf

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -270,7 +270,7 @@ This section states the existence theorems from
         \label{eq:pauli_block_truncation_counterexample}
     \end{align}
     This map is Hermiticity preserving but not positive, since
-    $T(\Id/2)=\diag(3/4,-1/4)$.  Its Pauli-block diagonal truncation is the
+    $T(\Id/2)=\diag(3/2,-1/2)$.  Its Pauli-block diagonal truncation is the
     completely depolarizing channel
     $T'(X)=\tr(X)\Id/2$, which is completely positive.  Thus neither the
     positivity converse nor the complete-positivity converse is valid.  See

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -157,6 +157,127 @@ This section states the existence theorems from
 % QICLean/Channel/LorentzNormalForm.lean. The correctly formulated Proposition 2.11
 % has no Lean declaration yet; declaration tags are omitted for pending results.
 
+\begin{definition}[Pauli transfer matrix]\label{def:pauli_transfer_matrix}
+    \lean{Wolf.pauliMatrices, Wolf.pauliTransferEntry}
+    \leanok
+    Let $\sigma_0=\Id,\sigma_1,\sigma_2,\sigma_3$ be the Pauli matrices.  The
+    \emph{Pauli transfer matrix} of a linear map
+    $T:\MN{2}\to\MN{2}$ is $\widehat T\in M_4(\C)$ with entries
+    \begin{align}
+        \widehat T_{ij}
+        &=\frac12\tr\!\left(\sigma_iT(\sigma_j)\right),
+        \qquad 0\leq i,j\leq3.
+        \label{eq:pauli_transfer_entries}
+    \end{align}
+    We write
+    \begin{align}
+        \widehat T
+        &=
+        \begin{pmatrix}
+            \widehat T_{00} & r^{\mathsf T}\\
+            v & \Delta
+        \end{pmatrix},
+        \label{eq:pauli_transfer_blocks}
+    \end{align}
+    where $\Delta=(\widehat T_{ij})_{i,j=1}^{3}$.  Thus $r^{\mathsf T}$ and
+    $v$ are exactly the two off-diagonal Pauli blocks.  This is the
+    representation used in \cite[Section~2.4, Eq.~(2.39)]{Wolf2012Quantum}.
+\end{definition}
+
+\begin{definition}[Pauli-block diagonal truncation]
+    \label{def:pauli_block_diagonal_truncation}
+    \lean{Wolf.pauliTimeReversal, Wolf.pauliTimeReversalDiagonal,
+        Wolf.pauliBlockDiagonalTruncation}
+    \leanok
+    \uses{def:pauli_transfer_matrix}
+    Define Pauli time reversal by
+    $\Theta(X)=\tr(X)\Id-X$.  Its Pauli transfer matrix is
+    \begin{align}
+        D&=\diag(1,-1,-1,-1).
+        \label{eq:pauli_time_reversal_diagonal}
+    \end{align}
+    For a linear map $T:\MN{2}\to\MN{2}$, define its
+    \emph{Pauli-block diagonal truncation} by
+    \begin{align}
+        T'&=\frac{T+\Theta\circ T\circ\Theta}{2}.
+        \label{eq:pauli_block_truncation}
+    \end{align}
+    This is the truncation in
+    \cite[Proposition~2.10, Section~2.4]{Wolf2012Quantum}; see also the local
+    source \path{Notes/WolfNoteTexSource/ch02_representations.tex},
+    lines~984--998.
+\end{definition}
+
+\begin{theorem}[Pauli-block truncation preserves positivity and complete positivity]
+    \label{thm:pauli_block_truncation_forward}
+    \lean{Wolf.pauliTransferEntry_timeReversal_comp,
+        Wolf.pauliTransferEntry_pauliBlockDiagonalTruncation,
+        Wolf.pauliBlockDiagonalTruncation_isPositiveMap,
+        Wolf.pauliBlockDiagonalTruncation_isCPMap}
+    \leanok
+    \uses{def:pauli_block_diagonal_truncation, def:positive_map, def:cp_map}
+    Let $T:\MN{2}\to\MN{2}$ be Hermiticity preserving, and let $T'$ be its
+    Pauli-block diagonal truncation.  If $\widehat T$ is written as in
+    \eqref{eq:pauli_transfer_blocks}, then
+    \begin{align}
+        \widehat{T'}
+        &=\frac{\widehat T+D\widehat T D}{2}
+          =\begin{pmatrix}
+              \widehat T_{00}&0\\
+              0&\Delta
+            \end{pmatrix}
+          =\widehat T_{00}\oplus\Delta.
+        \label{eq:pauli_block_truncation_matrix}
+    \end{align}
+    Equivalently, entrywise,
+    \begin{align}
+        \widehat{T'}_{ij}
+        &=\begin{cases}
+            \widehat T_{ij},& i=j=0\text{ or }i,j\in\{1,2,3\},\\
+            0,&\text{otherwise}.
+          \end{cases}
+        \label{eq:pauli_block_truncation_entrywise}
+    \end{align}
+    If $T$ is positive, then $T'$ is positive.  If $T$ is completely
+    positive, then $T'$ is completely positive.  These are precisely the
+    forward implications proved in
+    \cite[Proposition~2.10, Section~2.4]{Wolf2012Quantum}, following
+    Eq.~(2.39); the local proof is at
+    \path{Notes/WolfNoteTexSource/ch02_representations.tex}, lines~992--998.
+\end{theorem}
+
+\begin{proof}\leanok
+    In the Pauli basis, pre- and postcomposition by $\Theta$ multiply the
+    transfer matrix by $D$ on the right and left, respectively.  Averaging
+    with $D\widehat T D$ therefore gives
+    \eqref{eq:pauli_block_truncation_entrywise}.  Time reversal is positive,
+    so $\Theta\circ T\circ\Theta$ is positive whenever $T$ is positive, and
+    convexity gives positivity of $T'$.  If
+    $T(X)=\sum_iK_iXK_i^\dagger$, then
+    $\Theta\circ T\circ\Theta$ has Kraus operators
+    $\sigma_2\overline{K_i}\sigma_2$.  Hence the same averaging also
+    preserves complete positivity.
+\end{proof}
+
+\begin{remark}[Source correction: the converse fails]
+    \label{rem:pauli_block_truncation_converse}
+    Proposition~2.10 of \cite{Wolf2012Quantum} prints both preservation
+    statements as equivalences, but its proof establishes only the forward
+    implications in Theorem~\ref{thm:pauli_block_truncation_forward}.  Indeed,
+    consider
+    \begin{align}
+        T(X)&=\tr(X)\diag(3/2,-1/2).
+        \label{eq:pauli_block_truncation_counterexample}
+    \end{align}
+    This map is Hermiticity preserving but not positive, since
+    $T(\Id/2)=\diag(3/4,-1/4)$.  Its Pauli-block diagonal truncation is the
+    completely depolarizing channel
+    $T'(X)=\tr(X)\Id/2$, which is completely positive.  Thus neither the
+    positivity converse nor the complete-positivity converse is valid.  See
+    \path{docs/paper-gaps/wolf_prop2_10_block_truncation_converse.tex} for the
+    focused source-correction record.
+\end{remark}
+
 \begin{definition}[SL-filtering operation]\label{def:sl_filtering}
     \lean{Wolf.SLFiltering}\leanok
     An \emph{SL-filtering} for $D \times D$ matrices is a completely

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -9,7 +9,7 @@
 
 \title{Formalization-Derived Corrections to Wolf's \emph{Quantum Channels \& Operations}}
 \author{}
-\date{2026-07-13}
+\date{2026-08-23}
 
 \begin{document}
 \sloppy
@@ -94,6 +94,69 @@ that bound. Squaring is justified only after fixing the sign of the trace.
 This is a genuine source error. The unrestricted printed converse should not
 be claimed as formalized; the formal theorem proves the corrected,
 trace-nonnegative statement.
+
+\section{The false converse for Pauli-block truncation}
+\label{sec:pauli-block-truncation}
+
+\paragraph{Formalization trigger.}
+The forward preservation properties of Pauli-block truncation are formalized as
+\leanid{Wolf.pauliBlockDiagonalTruncation_isPositiveMap} and
+\leanid{Wolf.pauliBlockDiagonalTruncation_isCPMap} in
+\doclink{QICLean/Channel/LorentzNormalForm/PauliBlockTruncation}. The source
+error is documented in
+\path{docs/paper-gaps/wolf_prop2_10_block_truncation_converse.tex}.
+
+\paragraph{Printed source and its role.}
+In Section~2.4, after the Bloch-ball representation in Eq.~(2.39), Wolf's
+Proposition~2.10 considers the Pauli transfer matrix
+\begin{equation}
+  \widehat T=
+  \begin{pmatrix}
+    \widehat T_{00}&r^{\mathsf T}\\
+    v&\Delta
+  \end{pmatrix}
+\end{equation}
+of a Hermiticity-preserving map and prints the assertion that the block
+truncation
+\begin{equation}
+  \widehat T'=\widehat T_{00}\oplus\Delta
+\end{equation}
+is positive, respectively completely positive, if and only if $\widehat T$ is.
+The local source is
+\path{Notes/WolfNoteTexSource/ch02_representations.tex}, lines~984--990.
+
+\paragraph{Correction.}
+With $\Theta(X)=\operatorname{tr}(X)\Id-X$ and
+$D=\operatorname{diag}(1,-1,-1,-1)$, the truncation is
+\begin{equation}
+  T'=\frac{T+\Theta\circ T\circ\Theta}{2},
+  \qquad
+  \widehat T'=\frac{\widehat T+D\widehat T D}{2}
+  =\widehat T_{00}\oplus\Delta.
+\end{equation}
+The valid statements are the forward implications
+\begin{equation}
+  T\text{ positive}\Longrightarrow T'\text{ positive},
+  \qquad
+  T\text{ completely positive}\Longrightarrow
+  T'\text{ completely positive}.
+\end{equation}
+These are exactly the directions proved in the source at lines~992--998 and
+formalized by the declarations above.
+
+\paragraph{Why the correction is necessary.}
+Let
+\begin{equation}
+  T(X)=\operatorname{tr}(X)\operatorname{diag}(3/2,-1/2).
+\end{equation}
+Then $T$ is Hermiticity preserving but not positive, since
+$T(\Id/2)=\operatorname{diag}(3/4,-1/4)$. Its Pauli-block truncation is the
+completely depolarizing channel $T'(X)=\operatorname{tr}(X)\Id/2$, which is
+completely positive. Thus both printed converses fail.
+
+\paragraph{Classification.}
+This is a genuine source error. The proof of Proposition~2.10 supports the two
+forward implications, not the printed equivalences.
 
 \section{The nonempty-family boundary in the Radon--Nikodym theorem}
 \label{sec:radon-nikodym}
@@ -200,8 +263,9 @@ errata entries:
 
 \section{Conclusion}
 
-At present the formalization-derived record contains one genuine mathematical
-source error (Section~\ref{sec:lorentz}), one explicit boundary convention
+At present the formalization-derived record contains two genuine mathematical
+source errors (Sections~\ref{sec:lorentz} and
+\ref{sec:pauli-block-truncation}), one explicit boundary convention
 (Section~\ref{sec:radon-nikodym}), and one local correction to a spectrum
 shorthand (Section~\ref{sec:two-pure-state-spectrum}). These are the corrections
 asserted by the Lean documentation itself.

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -150,7 +150,7 @@ Let
   T(X)=\operatorname{tr}(X)\operatorname{diag}(3/2,-1/2).
 \end{equation}
 Then $T$ is Hermiticity preserving but not positive, since
-$T(\Id/2)=\operatorname{diag}(3/4,-1/4)$. Its Pauli-block truncation is the
+$T(\Id/2)=\operatorname{diag}(3/2,-1/2)$. Its Pauli-block truncation is the
 completely depolarizing channel $T'(X)=\operatorname{tr}(X)\Id/2$, which is
 completely positive. Thus both printed converses fail.
 

--- a/docs/paper-gaps/wolf_prop2_10_block_truncation_converse.tex
+++ b/docs/paper-gaps/wolf_prop2_10_block_truncation_converse.tex
@@ -1,0 +1,133 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The False Converse in Wolf's Pauli-Block Truncation Proposition}
+\author{}
+\date{2026-08-23}
+
+\begin{document}
+\maketitle
+\gapnote{false-source}{resolved}
+
+\section{The printed equivalence}
+
+In Section~2.4, after the Bloch-ball affine representation
+$x\mapsto v+\Delta x$ in Eq.~(2.39), Wolf considers a Hermiticity-preserving
+linear map $T:\MN{2}\to\MN{2}$. In the Pauli basis, write
+\begin{align}
+  \widehat T
+  &=\begin{pmatrix}
+      \widehat T_{00}&r^{\mathsf T}\\
+      v&\Delta
+    \end{pmatrix},
+  &
+  \widehat T_{ij}
+  &=\frac12\tr\!\left(\sigma_iT(\sigma_j)\right).
+\end{align}
+Here $\Delta=(\widehat T_{ij})_{i,j=1}^{3}$ is the lower-right Pauli block,
+and the row $r^{\mathsf T}$ and column $v$ are the two off-diagonal blocks.
+Proposition~2.10 prints the claim that
+\begin{align}
+  \widehat T'
+  :=\widehat T_{00}\oplus\Delta
+  =\begin{pmatrix}
+      \widehat T_{00}&0\\
+      0&\Delta
+    \end{pmatrix}
+\end{align}
+represents a positive, respectively completely positive, map if and only if
+$\widehat T$ does.
+\footnote{\cite[Section~2.4, Proposition~2.10, Eq.~(2.39)]{Wolf2012Quantum};
+local source \path{Notes/WolfNoteTexSource/ch02_representations.tex},
+lines~984--990.}
+
+\section{What the proof establishes}
+
+Let
+\begin{align}
+  \Theta(X)&=\tr(X)\Id-X,
+  &D&=\mathrm{diag}(1,-1,-1,-1).
+\end{align}
+The Pauli transfer matrix of $\Theta$ is $D$, and
+\begin{align}
+  T'&=\frac{T+\Theta\circ T\circ\Theta}{2},
+  &
+  \widehat T'
+  &=\frac{\widehat T+D\widehat T D}{2}
+    =\widehat T_{00}\oplus\Delta.
+  \label{eq:truncation}
+\end{align}
+Wolf's proof shows the two forward implications
+\begin{align}
+  T\text{ positive}
+  &\Longrightarrow T'\text{ positive},
+  \label{eq:positive-forward}\\
+  T\text{ completely positive}
+  &\Longrightarrow T'\text{ completely positive}.
+  \label{eq:cp-forward}
+\end{align}
+It does not prove either converse. The proof route is exactly the averaging
+in \eqref{eq:truncation}: double time reversal preserves positivity and
+complete positivity in this setting, and these cones are convex.
+\footnote{\cite[Proposition~2.10]{Wolf2012Quantum}; local source
+\path{Notes/WolfNoteTexSource/ch02_representations.tex}, lines~992--998.}
+
+The formalization follows this proof and states only the forward directions.
+Pauli time reversal, its diagonal transfer coefficients, and the truncation are
+\leanid{Wolf.pauliTimeReversal},
+\leanid{Wolf.pauliTimeReversalDiagonal}, and
+\leanid{Wolf.pauliBlockDiagonalTruncation}. The transfer-matrix identities are
+\leanid{Wolf.pauliTransferEntry_timeReversal_comp} and
+\leanid{Wolf.pauliTransferEntry_pauliBlockDiagonalTruncation}. The two
+preservation theorems are
+\leanid{Wolf.pauliBlockDiagonalTruncation_isPositiveMap} and
+\leanid{Wolf.pauliBlockDiagonalTruncation_isCPMap}.
+\footnote{All declarations are in
+\doclink{QICLean/Channel/LorentzNormalForm/PauliBlockTruncation}.}
+
+\section{Counterexample to both converses}
+
+Define
+\begin{align}
+  T(X)&=\tr(X)\begin{pmatrix}3/2&0\\0&-1/2\end{pmatrix}.
+  \label{eq:counterexample}
+\end{align}
+The map is Hermiticity preserving. It is not positive, because
+\begin{align}
+  T(\Id/2)
+  &=\begin{pmatrix}3/4&0\\0&-1/4\end{pmatrix}
+  \not\geq0.
+\end{align}
+Its Pauli transfer matrix has $\widehat T_{00}=1$, zero lower-right block
+$\Delta=0$, and a nonzero entry only in the off-diagonal column $v$.
+Consequently its truncation is
+\begin{align}
+  \widehat T'
+  &=\mathrm{diag}(1,0,0,0),
+  &
+  T'(X)&=\frac{\tr(X)}2\Id.
+\end{align}
+This is the completely depolarizing channel and is completely positive.
+Therefore $T'$ can be completely positive while $T$ is not even positive.
+The reverse implication fails for positivity and, a fortiori, the reverse
+implication fails for complete positivity.
+
+\section{Conclusion}
+
+The ``if and only if'' in Wolf's Proposition~2.10 is false as printed. The
+proof in the source establishes the valid forward implications
+\eqref{eq:positive-forward} and \eqref{eq:cp-forward}, and those are the
+statements formalized in Lean. The explicit map \eqref{eq:counterexample}
+shows that no converse can be inferred from Pauli-block truncation. The source
+statement should therefore replace both equivalences by forward implications.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_prop2_10_block_truncation_converse.tex
+++ b/docs/paper-gaps/wolf_prop2_10_block_truncation_converse.tex
@@ -101,7 +101,7 @@ Define
 The map is Hermiticity preserving. It is not positive, because
 \begin{align}
   T(\Id/2)
-  &=\begin{pmatrix}3/4&0\\0&-1/4\end{pmatrix}
+  &=\begin{pmatrix}3/2&0\\0&-1/2\end{pmatrix}
   \not\geq0.
 \end{align}
 Its Pauli transfer matrix has $\widehat T_{00}=1$, zero lower-right block


### PR DESCRIPTION
## Summary
- define Wolf's qubit Pauli time reversal and block-diagonal Pauli-transfer truncation
- prove the entrywise identity `T̂' = (T̂ + D T̂ D)/2 = T̂₀₀ ⊕ Δ`
- prove only the valid forward positivity and complete-positivity implications of Wolf Proposition 2.10
- follow Wolf's time-reversal/Kraus averaging proof, without treating time reversal itself as CP
- add the source-facing Blueprint nodes and a formalization-derived erratum for the printed false converses

The counterexample `T(X) = tr(X) diag(3/2,-1/2)` is Hermiticity preserving and not positive, while its truncation is the completely depolarizing channel. This is why the printed “if and only if” is not formalized.

## Source

- Wolf, Section 2.4, Proposition 2.10, following Eq. (2.39)
- `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 984–998

## Verification
- fresh restarted-server diagnostics: zero errors/warnings for the new module and both aggregators
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --diff-base HEAD --changed-files QICLean/Channel/LorentzNormalForm/PauliBlockTruncation.lean`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- paper-gap and Blueprint PDF/web checks (no new warnings; unrelated pre-existing warnings remain elsewhere)
- `git diff --check`
- forbidden-placeholder scan clean

No local Lake rebuild, clean, cache deletion, or dependency fetch was run.

Closes #9.