### PR TITLE
feat(channel): formalize environment-induced instruments

### DIFF
--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -30,6 +30,7 @@ import QICLean.Channel.Determinant.UnitaryCharacterization
 import QICLean.Channel.DirectSumConditionalExpectation
 import QICLean.Channel.EnsembleEquivalence
 import QICLean.Channel.EntanglementWitness
+import QICLean.Channel.EnvironmentInducedInstrument
 import QICLean.Channel.FaithfulMarginalWhitenedChoi
 import QICLean.Channel.FixedPoint
 import QICLean.Channel.GaugeConjugation

--- a/QICLean/Channel/EnvironmentInducedInstrument.lean
+++ b/QICLean/Channel/EnvironmentInducedInstrument.lean
@@ -35,7 +35,7 @@ variable {d d' r n : ℕ}
 
 /-- The coefficient matrix of the Choi purification obtained from a rectangular
 Stinespring matrix `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r`:
-`C_(a,i),e = d⁻¹ᐟ² V_(a,e),i`.
+`C_(a,i),e = d^(-1/2) V_(a,e),i`.
 
 This is Wolf's vector `(𝟙_d ⊗ V)|Ω⟩`, with factors reindexed so that the Choi
 system `ℂ^{d'} ⊗ ℂ^d` comes first and the environment `ℂ^r` comes last. -/

--- a/QICLean/Channel/EnvironmentInducedInstrument.lean
+++ b/QICLean/Channel/EnvironmentInducedInstrument.lean
@@ -1,0 +1,490 @@
+/-
+Copyright (c) 2026 Sirui Lu and QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import QICLean.Channel.ChoiRectangular
+import QICLean.Channel.KrausRectangular
+import QICLean.Channel.POVM
+import QICLean.Channel.QuantumSteering
+
+/-!
+# Environment-induced instruments
+
+This file formalizes Wolf's proposition "Environment induced instruments"
+(`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 447--475).
+
+For a rectangular channel `T : M_d(ℂ) → M_d'(ℂ)` with a supplied
+Stinespring/open-system matrix `V`, every finite decomposition `T = ∑ᵢ Tᵢ`
+into completely positive maps is realized by inserting a POVM effect on the
+same environment before taking the partial trace. Moreover, the Choi (Kraus)
+rank of each summand is at most the rank of its effect.
+
+The proof follows Wolf's route: the supplied dilation purifies the rectangular
+Choi operator, and unnormalized quantum steering produces the POVM. The direct
+Choi identity for effect insertion then transports the steering identities
+back to maps.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix Finset
+
+namespace Channel
+
+variable {d d' r n : ℕ}
+
+/-- The coefficient matrix of the Choi purification obtained from a rectangular
+Stinespring matrix `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r`:
+`C_(a,i),e = d⁻¹ᐟ² V_(a,e),i`.
+
+This is Wolf's vector `(𝟙_d ⊗ V)|Ω⟩`, with factors reindexed so that the Choi
+system `ℂ^{d'} ⊗ ℂ^d` comes first and the environment `ℂ^r` comes last. -/
+noncomputable def choiPurificationCoeff
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ) :
+    Matrix (Fin d' × Fin d) (Fin r) ℂ :=
+  fun ai e => ((1 : ℂ) / ((d : ℝ).sqrt : ℂ)) * V (ai.1, e) ai.2
+
+/-- Embed an input vector `x ∈ ℂ^d` as `x ⊗ φ`, where Wolf's fixed
+initial environment vector has type `φ ∈ ℂ^{d'} ⊗ ℂ^{d'}`. The ambient input
+space therefore has exact dimension `d * (d')^2`. -/
+noncomputable def openSystemInputEmbedding
+    (φ : Fin d' × Fin d' → ℂ) :
+    Matrix (Fin d × (Fin d' × Fin d')) (Fin d) ℂ :=
+  fun p i => if p.1 = i then φ p.2 else 0
+
+/-- Wolf's fixed-state input `ρ ⊗ |φ⟩⟨φ|` from Equation (2.14), indexed as
+`ℂ^d ⊗ (ℂ^{d'} ⊗ ℂ^{d'})`. -/
+noncomputable def openSystemInput
+    (φ : Fin d' × Fin d' → ℂ) (ρ : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix (Fin d × (Fin d' × Fin d')) (Fin d × (Fin d' × Fin d')) ℂ :=
+  Matrix.kroneckerMap (· * ·) ρ (Matrix.vecMulVec φ (star φ))
+
+/-- The fixed-state input is the compression through
+`openSystemInputEmbedding`: `(𝟙_d ⊗ |φ⟩) ρ (𝟙_d ⊗ ⟨φ|)`. -/
+theorem openSystemInput_eq_embedding
+    (φ : Fin d' × Fin d' → ℂ) (ρ : Matrix (Fin d) (Fin d) ℂ) :
+    openSystemInput φ ρ =
+      openSystemInputEmbedding φ * ρ * (openSystemInputEmbedding φ)ᴴ := by
+  classical
+  ext ⟨i, s⟩ ⟨j, t⟩
+  simp only [openSystemInput, Matrix.kroneckerMap_apply, Matrix.vecMulVec_apply,
+    Pi.star_apply, RCLike.star_def, Matrix.mul_apply, openSystemInputEmbedding, ite_mul,
+    zero_mul, Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte, Matrix.conjTranspose_apply]
+  rw [Finset.sum_eq_single j]
+  · simp
+    ring
+  · intro x _ hx
+    have hjx : j ≠ x := fun h => hx h.symm
+    simp [hjx]
+  · simp
+
+/-- Reindex the output of Wolf's supplied open-system operator from
+`environment ⊗ output` to the output-first convention `output ⊗ environment`
+used by `stinespringV` and `environmentEffectMap`. -/
+noncomputable def openSystemStinespringV
+    (U : Matrix (Fin (d * d') × Fin d')
+      (Fin d × (Fin d' × Fin d')) ℂ)
+    (φ : Fin d' × Fin d' → ℂ) :
+    Matrix (Fin d' × Fin (d * d')) (Fin d) ℂ :=
+  fun ae i => ∑ p : Fin d × (Fin d' × Fin d'),
+    U (ae.2, ae.1) p * openSystemInputEmbedding φ p i
+
+/-- The rectangular map obtained by inserting an environment effect `P` into
+`V X Vᴴ` and then tracing out the environment. This is the reduced supplied-
+Stinespring form of Wolf Equation (2.15). -/
+noncomputable def environmentEffectMap
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
+    (P : Matrix (Fin r) (Fin r) ℂ) :
+    Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ where
+  toFun X a b := ∑ e : Fin r, ∑ f : Fin r, P e f *
+    ∑ i : Fin d, ∑ j : Fin d, V (a, f) i * X i j * star (V (b, e) j)
+  map_add' X Y := by
+    ext a b
+    change (∑ e : Fin r, ∑ f : Fin r, P e f *
+        ∑ i : Fin d, ∑ j : Fin d,
+          V (a, f) i * (X + Y) i j * star (V (b, e) j)) =
+      (∑ e : Fin r, ∑ f : Fin r, P e f *
+        ∑ i : Fin d, ∑ j : Fin d,
+          V (a, f) i * X i j * star (V (b, e) j)) +
+      ∑ e : Fin r, ∑ f : Fin r, P e f *
+        ∑ i : Fin d, ∑ j : Fin d,
+          V (a, f) i * Y i j * star (V (b, e) j)
+    simp only [Matrix.add_apply, mul_add, add_mul, Finset.sum_add_distrib]
+  map_smul' c X := by
+    ext a b
+    change (∑ e : Fin r, ∑ f : Fin r, P e f *
+        ∑ i : Fin d, ∑ j : Fin d,
+          V (a, f) i * (c • X) i j * star (V (b, e) j)) =
+      c * ∑ e : Fin r, ∑ f : Fin r, P e f *
+        ∑ i : Fin d, ∑ j : Fin d,
+          V (a, f) i * X i j * star (V (b, e) j)
+    simp only [Matrix.smul_apply, smul_eq_mul, Finset.mul_sum]
+    refine Finset.sum_congr rfl fun e _ => Finset.sum_congr rfl fun f _ =>
+      Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+    ring
+
+@[simp]
+theorem environmentEffectMap_apply
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
+    (P : Matrix (Fin r) (Fin r) ℂ) (X : Matrix (Fin d) (Fin d) ℂ)
+    (a b : Fin d') :
+    environmentEffectMap V P X a b = ∑ e : Fin r, ∑ f : Fin r, P e f *
+      ∑ i : Fin d, ∑ j : Fin d, V (a, f) i * X i j * star (V (b, e) j) :=
+  rfl
+
+/-- `environmentEffectMap` is literally environment-effect insertion followed
+by the partial trace, in the output-first tensor ordering used by the local
+rectangular Stinespring API. -/
+theorem environmentEffectMap_eq_traceRight
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
+    (P : Matrix (Fin r) (Fin r) ℂ) (X : Matrix (Fin d) (Fin d) ℂ) :
+    environmentEffectMap V P X =
+      Matrix.traceRight
+        (Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) P *
+          (V * X * Vᴴ)) := by
+  classical
+  ext a b
+  simp only [environmentEffectMap_apply, Matrix.traceRight_apply, Matrix.mul_apply,
+    Matrix.kroneckerMap_apply, Matrix.one_apply, Matrix.conjTranspose_apply]
+  simp_rw [Fintype.sum_prod_type]
+  simp only [ite_mul, one_mul, zero_mul]
+  change (∑ e : Fin r, ∑ f : Fin r, P e f *
+      ∑ i : Fin d, ∑ j : Fin d, V (a, f) i * X i j * star (V (b, e) j)) =
+    ∑ e : Fin r, ∑ y : Fin d', ∑ f : Fin r,
+      if a = y then P e f *
+        ∑ j : Fin d, (∑ i : Fin d, V (y, f) i * X i j) * star (V (b, e) j)
+      else 0
+  have hcollapse (e f : Fin r) :
+      (∑ y : Fin d', if a = y then P e f *
+        ∑ j : Fin d, (∑ i : Fin d, V (y, f) i * X i j) * star (V (b, e) j)
+      else 0) =
+        P e f * ∑ j : Fin d,
+          (∑ i : Fin d, V (a, f) i * X i j) * star (V (b, e) j) := by
+    rw [Finset.sum_eq_single a]
+    · simp
+    · intro y _ hya
+      have hay : a ≠ y := fun h => hya h.symm
+      simp [hay]
+    · simp
+  refine Finset.sum_congr rfl fun e _ => ?_
+  rw [Finset.sum_comm]
+  calc
+    ∑ f : Fin r, P e f *
+        ∑ i : Fin d, ∑ j : Fin d, V (a, f) i * X i j * star (V (b, e) j) =
+      ∑ f : Fin r, P e f * ∑ j : Fin d,
+        (∑ i : Fin d, V (a, f) i * X i j) * star (V (b, e) j) := by
+          refine Finset.sum_congr rfl fun f _ => congrArg (P e f * ·) ?_
+          rw [Finset.sum_comm]
+          exact Finset.sum_congr rfl fun j _ => (Finset.sum_mul _ _ _).symm
+    _ = ∑ f : Fin r, ∑ y : Fin d', if a = y then P e f *
+        ∑ j : Fin d, (∑ i : Fin d, V (y, f) i * X i j) * star (V (b, e) j)
+      else 0 := Finset.sum_congr rfl fun f _ => (hcollapse e f).symm
+
+/-- The Choi operator of environment-effect insertion is the corresponding
+sandwich of the Choi-purification coefficient matrix. -/
+theorem choiMatrix_environmentEffectMap [NeZero d]
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
+    (P : Matrix (Fin r) (Fin r) ℂ) :
+    ChoiRectangular.choiMatrix (environmentEffectMap V P) =
+      choiPurificationCoeff V * Pᵀ * (choiPurificationCoeff V)ᴴ := by
+  classical
+  have hd : 0 < d := NeZero.pos d
+  let c : ℂ := (1 : ℂ) / ((d : ℝ).sqrt : ℂ)
+  have hcc : c * star c = 1 / (d : ℂ) := by
+    simpa [c] using ChoiJamiolkowski.omegaCoeff_eq_inv (D := d) hd
+  ext ⟨a, i⟩ ⟨b, j⟩
+  rw [ChoiRectangular.choiMatrix_apply,
+    MaximallyEntangled.omegaSlice_eq_single (d := d) i j]
+  simp only [MaximallyEntangled.omegaCoeff_eq_inv hd, environmentEffectMap_apply,
+    Matrix.mul_apply, Matrix.transpose_apply, Matrix.conjTranspose_apply,
+    choiPurificationCoeff]
+  change (∑ e : Fin r, ∑ f : Fin r, P e f *
+      ∑ x : Fin d, ∑ y : Fin d,
+        V (a, f) x * Matrix.single i j (1 / (d : ℂ)) x y * star (V (b, e) y)) =
+    ∑ f : Fin r, (∑ e : Fin r, (c * V (a, e) i) * P f e) *
+      star (c * V (b, f) j)
+  have hsingle : ∀ e f : Fin r,
+      (∑ x : Fin d, ∑ y : Fin d,
+        V (a, f) x * Matrix.single i j (1 / (d : ℂ)) x y * star (V (b, e) y)) =
+      V (a, f) i * (1 / (d : ℂ)) * star (V (b, e) j) := by
+    intro e f
+    simp only [Matrix.single, Matrix.of_apply]
+    rw [Finset.sum_eq_single i]
+    · rw [Finset.sum_eq_single j]
+      · simp
+      · intro y _ hy
+        have hjy : j ≠ y := fun h => hy h.symm
+        simp [hjy]
+      · simp
+    · intro x _ hx
+      have hix : i ≠ x := fun h => hx h.symm
+      simp [hix]
+    · simp
+  simp_rw [hsingle]
+  have hterm (e f : Fin r) :
+      P e f * (V (a, f) i * (1 / (d : ℂ)) * star (V (b, e) j)) =
+        (c * V (a, f) i) * P e f * star (c * V (b, e) j) := by
+    rw [star_mul, ← hcc]
+    ring
+  calc
+    (∑ e : Fin r, ∑ f : Fin r,
+        P e f * (V (a, f) i * (1 / (d : ℂ)) * star (V (b, e) j))) =
+      ∑ e : Fin r, ∑ f : Fin r,
+        (c * V (a, f) i) * P e f * star (c * V (b, e) j) := by
+          exact Finset.sum_congr rfl fun e _ =>
+            Finset.sum_congr rfl fun f _ => hterm e f
+    _ = ∑ f : Fin r, ∑ e : Fin r,
+        (c * V (a, e) i) * P f e * star (c * V (b, f) j) := by
+          rw [Finset.sum_comm]
+    _ = ∑ f : Fin r, (∑ e : Fin r, (c * V (a, e) i) * P f e) *
+        star (c * V (b, f) j) := by
+          exact Finset.sum_congr rfl fun f _ => (Finset.sum_mul _ _ _).symm
+
+/-- Inserting the identity effect recovers the ordinary reduced Stinespring
+map. -/
+theorem environmentEffectMap_one
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ) (X : Matrix (Fin d) (Fin d) ℂ) :
+    environmentEffectMap V (1 : Matrix (Fin r) (Fin r) ℂ) X =
+      Matrix.traceRight (V * X * Vᴴ) := by
+  rw [environmentEffectMap_eq_traceRight]
+  ext a b
+  simp [Matrix.traceRight_apply, Matrix.mul_apply]
+
+/-- Swap the row factors of a joint matrix from `environment ⊗ output`
+to `output ⊗ environment`. -/
+noncomputable def swapOutputEnvironment
+    (W : Matrix (Fin r × Fin d') (Fin d) ℂ) :
+    Matrix (Fin d' × Fin r) (Fin d) ℂ :=
+  fun ae i => W (ae.2, ae.1) i
+
+@[simp]
+theorem swapOutputEnvironment_apply
+    (W : Matrix (Fin r × Fin d') (Fin d) ℂ) (a : Fin d') (e : Fin r) (i : Fin d) :
+    swapOutputEnvironment W (a, e) i = W (e, a) i :=
+  rfl
+
+/-- Swapping an `environment ⊗ output` joint matrix to the local
+`output ⊗ environment` convention transports left partial trace with
+`P ⊗ 𝟙` to `environmentEffectMap`. -/
+theorem environmentEffectMap_swap
+    (W : Matrix (Fin r × Fin d') (Fin d) ℂ)
+    (P : Matrix (Fin r) (Fin r) ℂ) (X : Matrix (Fin d) (Fin d) ℂ) :
+    environmentEffectMap (swapOutputEnvironment W) P X =
+      Matrix.partialTraceLeft
+        (Matrix.kroneckerMap (· * ·) P
+          (1 : Matrix (Fin d') (Fin d') ℂ) * (W * X * Wᴴ)) := by
+  classical
+  ext a b
+  simp only [environmentEffectMap_apply, swapOutputEnvironment_apply,
+    Matrix.partialTraceLeft_apply,
+    Matrix.mul_apply, Matrix.kroneckerMap_apply, Matrix.one_apply,
+    Matrix.conjTranspose_apply]
+  let F : Fin r → (Fin r × Fin d') → ℂ := fun e p =>
+    (P e p.1 * if a = p.2 then 1 else 0) *
+      ∑ j : Fin d, (∑ i : Fin d, W p i * X i j) * star (W (e, b) j)
+  change (∑ e : Fin r, ∑ f : Fin r, P e f *
+      ∑ i : Fin d, ∑ j : Fin d, W (f, a) i * X i j * star (W (e, b) j)) =
+    ∑ e : Fin r, ∑ p : Fin r × Fin d', F e p
+  rw [show (∑ e : Fin r, ∑ p : Fin r × Fin d', F e p) =
+      ∑ e : Fin r, ∑ f : Fin r, ∑ y : Fin d', F e (f, y) by
+    exact Finset.sum_congr rfl fun e _ => Fintype.sum_prod_type _]
+  dsimp only [F]
+  simp only [mul_ite, mul_one, mul_zero]
+  simp only [ite_mul, zero_mul]
+  change (∑ e : Fin r, ∑ f : Fin r, P e f *
+      ∑ i : Fin d, ∑ j : Fin d, W (f, a) i * X i j * star (W (e, b) j)) =
+    ∑ e : Fin r, ∑ f : Fin r, ∑ y : Fin d',
+      if a = y then P e f *
+        ∑ j : Fin d, (∑ i : Fin d, W (f, y) i * X i j) * star (W (e, b) j)
+      else 0
+  have hcollapse (e f : Fin r) :
+      (∑ y : Fin d', if a = y then P e f *
+        ∑ j : Fin d, (∑ i : Fin d, W (f, y) i * X i j) * star (W (e, b) j)
+      else 0) =
+        P e f * ∑ j : Fin d,
+          (∑ i : Fin d, W (f, a) i * X i j) * star (W (e, b) j) := by
+    rw [Finset.sum_eq_single a]
+    · simp
+    · intro y _ hya
+      have hay : a ≠ y := fun h => hya h.symm
+      simp [hay]
+    · simp
+  refine Finset.sum_congr rfl fun e _ => ?_
+  calc
+    ∑ f : Fin r, P e f *
+        ∑ i : Fin d, ∑ j : Fin d, W (f, a) i * X i j * star (W (e, b) j) =
+      ∑ f : Fin r, P e f * ∑ j : Fin d,
+        (∑ i : Fin d, W (f, a) i * X i j) * star (W (e, b) j) := by
+          refine Finset.sum_congr rfl fun f _ => congrArg (P e f * ·) ?_
+          rw [Finset.sum_comm]
+          exact Finset.sum_congr rfl fun j _ => (Finset.sum_mul _ _ _).symm
+    _ = ∑ f : Fin r, ∑ y : Fin d', if a = y then P e f *
+        ∑ j : Fin d, (∑ i : Fin d, W (f, y) i * X i j) * star (W (e, b) j)
+      else 0 := Finset.sum_congr rfl fun f _ => (hcollapse e f).symm
+
+/-- Effect insertion for the reindexed Stinespring matrix is exactly Wolf's
+system-plus-environment expression. The left partial trace discards the
+`d * d'`-dimensional environment and retains the `d'`-dimensional output. -/
+theorem environmentEffectMap_openSystem
+    (U : Matrix (Fin (d * d') × Fin d')
+      (Fin d × (Fin d' × Fin d')) ℂ)
+    (φ : Fin d' × Fin d' → ℂ)
+    (P : Matrix (Fin (d * d')) (Fin (d * d')) ℂ)
+    (X : Matrix (Fin d) (Fin d) ℂ) :
+    environmentEffectMap (openSystemStinespringV U φ) P X =
+      Matrix.partialTraceLeft
+        ((Matrix.kroneckerMap (· * ·) P
+            (1 : Matrix (Fin d') (Fin d') ℂ) * U) *
+          openSystemInput φ X * Uᴴ) := by
+  classical
+  let W : Matrix (Fin (d * d') × Fin d') (Fin d) ℂ :=
+    U * openSystemInputEmbedding φ
+  have hV : openSystemStinespringV U φ = swapOutputEnvironment W := by
+    ext ae i
+    rcases ae with ⟨a, e⟩
+    simp only [openSystemStinespringV, swapOutputEnvironment_apply, W,
+      Matrix.mul_apply]
+  rw [hV, environmentEffectMap_swap W]
+  congr 1
+  rw [openSystemInput_eq_embedding]
+  simp only [W, Matrix.conjTranspose_mul, Matrix.mul_assoc]
+
+/-- **Environment induced instruments** (Wolf, Chapter 2, Proposition and
+Equation (2.15), `Notes/WolfNoteTexSource/ch02_representations.tex`, lines
+447--475), in reduced supplied-Stinespring form.
+
+Let `T : M_d(ℂ) → M_d'(ℂ)` be completely positive and trace preserving, and
+suppose the supplied rectangular matrix `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` realizes
+`T(X) = tr_r(V X Vᴴ)`. For every nonempty finite decomposition `T = ∑ᵢ Tᵢ`
+into completely positive maps, there is a POVM `P` on that same environment
+such that
+
+`Tᵢ(X) = tr_r[(𝟙_{d'} ⊗ Pᵢ) V X Vᴴ]`
+
+for every `i` and `X`, and
+`Channel.choiRank (Tᵢ i) ≤ (P.ops i).rank`.
+
+The explicit trace-preservation hypothesis records Wolf's channel assumption;
+the steering argument itself only uses complete positivity, the decomposition,
+and the supplied representation. -/
+theorem exists_environment_povm_of_sum_eq_stinespring [NeZero d]
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (Tᵢ : Fin n →
+      Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (hT : IsKrausCP T)
+    (_hTP : ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace)
+    (hTᵢ : ∀ i, IsKrausCP (Tᵢ i))
+    (hsum : ∑ i, Tᵢ i = T)
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
+    (hV : ∀ X, T X = Matrix.traceRight (V * X * Vᴴ)) :
+    ∃ P : POVM r n,
+      (∀ i X, Tᵢ i X = environmentEffectMap V (P.ops i) X) ∧
+      (∀ i, Channel.choiRank (Tᵢ i) ≤ (P.ops i).rank) := by
+  classical
+  let _ : NeZero n := ⟨by
+    intro hn
+    subst n
+    have hTzero : T = 0 := by simpa using hsum.symm
+    have htrace := _hTP (1 : Matrix (Fin d) (Fin d) ℂ)
+    rw [hTzero] at htrace
+    have hd : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+    exact hd (by simpa using htrace.symm)⟩
+  let C := choiPurificationCoeff V
+  have hTchoi : (ChoiRectangular.choiMatrix T).PosSemidef :=
+    (ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef T).mp hT
+  have hTᵢchoi : ∀ i, (ChoiRectangular.choiMatrix (Tᵢ i)).PosSemidef := fun i =>
+    (ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef (Tᵢ i)).mp (hTᵢ i)
+  have hC : C * Cᴴ = ChoiRectangular.choiMatrix T := by
+    calc
+      C * Cᴴ = C * (1 : Matrix (Fin r) (Fin r) ℂ)ᵀ * Cᴴ := by simp
+      _ = ChoiRectangular.choiMatrix
+          (environmentEffectMap V (1 : Matrix (Fin r) (Fin r) ℂ)) := by
+            simpa [C] using
+              (choiMatrix_environmentEffectMap V
+                (1 : Matrix (Fin r) (Fin r) ℂ)).symm
+      _ = ChoiRectangular.choiMatrix T := by
+            congr 1
+            ext X
+            rw [environmentEffectMap_one, ← hV X]
+  have hchoiSum : ∑ i, ChoiRectangular.choiMatrix (Tᵢ i) =
+      ChoiRectangular.choiMatrix T := by
+    rw [← ChoiRectangular.choiMatrix_sum Finset.univ Tᵢ]
+    simpa using congrArg ChoiRectangular.choiMatrix hsum
+  obtain ⟨P, hP⟩ := Matrix.exists_povm_of_sum_posSemidef
+    (ρ := ChoiRectangular.choiMatrix T) hTchoi (C := C) hC
+    (fun i => ChoiRectangular.choiMatrix (Tᵢ i)) hTᵢchoi hchoiSum
+  refine ⟨P, ?_, ?_⟩
+  · intro i X
+    have hmaps : Tᵢ i = environmentEffectMap V (P.ops i) :=
+      ChoiRectangular.choiMatrix_injective <| by
+        rw [choiMatrix_environmentEffectMap]
+        exact hP i
+    exact LinearMap.congr_fun hmaps X
+  · intro i
+    rw [Channel.choiRank, hP i]
+    simpa only [Matrix.mul_assoc] using
+      (Matrix.rank_mul_le_right C ((P.ops i)ᵀ * Cᴴ)).trans
+        ((Matrix.rank_mul_le_left (P.ops i)ᵀ Cᴴ).trans_eq
+          (Matrix.rank_transpose (P.ops i)))
+
+/-- **Wolf Proposition (Environment induced instruments), literal
+system-plus-environment form** (Chapter 2, Equation (2.15),
+`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 447--475).
+
+The supplied operator `U` has Wolf's exact dimensions. Its input is
+`ℂ^d ⊗ ℂ^{d'} ⊗ ℂ^{d'}`, of total dimension `d * (d')^2`; its output is
+`ℂ^{d d'} ⊗ ℂ^{d'}`, with environment dimension `d d'` and retained system
+dimension `d'`. The fixed normalized vector is
+`φ ∈ ℂ^{d'} ⊗ ℂ^{d'}`. For every CP decomposition `T = ∑ᵢ Tᵢ`, the returned
+POVM on `ℂ^{d d'}` realizes the literal insertion formula
+
+`Tᵢ(ρ) = tr_E[(Pᵢ ⊗ 𝟙_{d'}) U (ρ ⊗ |φ⟩⟨φ|) Uᴴ]`
+
+and satisfies `choiRank (Tᵢ i) ≤ rank(Pᵢ)`.
+
+The two Gram identities state that the supplied heterogeneous matrix `U` is
+unitary after identifying its equal-cardinality input and output index types.
+They and the normalization hypothesis record all data of Wolf Equation (2.14);
+the proof uses the supplied representation itself to pass to the reduced
+Stinespring theorem above. -/
+theorem exists_environment_povm_of_sum_eq_openSystem [NeZero d]
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (Tᵢ : Fin n →
+      Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (hT : IsKrausCP T)
+    (hTP : ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace)
+    (hTᵢ : ∀ i, IsKrausCP (Tᵢ i))
+    (hsum : ∑ i, Tᵢ i = T)
+    (U : Matrix (Fin (d * d') × Fin d')
+      (Fin d × (Fin d' × Fin d')) ℂ)
+    (_hU : Uᴴ * U = 1 ∧ U * Uᴴ = 1)
+    (φ : Fin d' × Fin d' → ℂ)
+    (_hφ : ∑ x, star (φ x) * φ x = 1)
+    (hopen : ∀ ρ : Matrix (Fin d) (Fin d) ℂ,
+      T ρ = Matrix.partialTraceLeft (U * openSystemInput φ ρ * Uᴴ)) :
+    ∃ P : POVM (d * d') n,
+      (∀ i ρ, Tᵢ i ρ =
+        Matrix.partialTraceLeft
+          ((Matrix.kroneckerMap (· * ·) (P.ops i)
+              (1 : Matrix (Fin d') (Fin d') ℂ) * U) *
+            openSystemInput φ ρ * Uᴴ)) ∧
+      (∀ i, Channel.choiRank (Tᵢ i) ≤ (P.ops i).rank) := by
+  classical
+  let V := openSystemStinespringV U φ
+  have hV : ∀ ρ : Matrix (Fin d) (Fin d) ℂ,
+      T ρ = Matrix.traceRight (V * ρ * Vᴴ) := by
+    intro ρ
+    calc
+      T ρ = Matrix.partialTraceLeft (U * openSystemInput φ ρ * Uᴴ) := hopen ρ
+      _ = environmentEffectMap V (1 : Matrix (Fin (d * d')) (Fin (d * d')) ℂ) ρ := by
+        rw [environmentEffectMap_openSystem]
+        simp
+      _ = Matrix.traceRight (V * ρ * Vᴴ) := environmentEffectMap_one V ρ
+  obtain ⟨P, hrealize, hrank⟩ :=
+    exists_environment_povm_of_sum_eq_stinespring T Tᵢ hT hTP hTᵢ hsum V hV
+  refine ⟨P, ?_, hrank⟩
+  intro i ρ
+  rw [hrealize i ρ]
+  exact environmentEffectMap_openSystem U φ (P.ops i) ρ
+
+end Channel

--- a/QICLean/Channel/QuantumSteering.lean
+++ b/QICLean/Channel/QuantumSteering.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Algebra.MatrixAux
-import QICLean.Algebra.OrthogonalProjection
 import QICLean.Algebra.MatrixTracePairing
+import QICLean.Algebra.OrthogonalProjection
 import QICLean.Analysis.MatrixSqrt
 import QICLean.Channel.KrausCPTP
 import QICLean.Channel.MaximalOverlap
@@ -112,8 +112,9 @@ theorem partialTraceRight_idTensorMap_vecMulVec {dB' : ℕ} (ψ : Fin dA × Fin 
   set C := Matrix.schmidtCoeffMatrix ψ with hC
   set M := Matrix.traceAdjointMap T (1 : Matrix (Fin dB') (Fin dB') ℂ) with hM
   ext i₁ j₁
-  have hstep : Matrix.partialTraceRight (Matrix.idTensorMap T (Matrix.vecMulVec ψ (star ψ)))
-      i₁ j₁ = Matrix.trace (T (Matrix.bipartiteBlock (Matrix.vecMulVec ψ (star ψ)) i₁ j₁)) := by
+  have hstep :
+      Matrix.partialTraceRight (Matrix.idTensorMap T (Matrix.vecMulVec ψ (star ψ))) i₁ j₁ =
+        Matrix.trace (T (Matrix.bipartiteBlock (Matrix.vecMulVec ψ (star ψ)) i₁ j₁)) := by
     simp only [Matrix.partialTraceRight_apply, Matrix.idTensorMap_apply, Matrix.trace]
     rfl
   rw [hstep, bipartiteBlock_vecMulVec_eq]
@@ -134,20 +135,21 @@ theorem partialTraceRight_idTensorMap_vecMulVec {dB' : ℕ} (ψ : Fin dA × Fin 
 variable {n : ℕ} {ρ : Matrix (Fin dA) (Fin dA) ℂ}
 
 /-- A real scalar multiple of a positive-semidefinite matrix is Hermitian. -/
-private theorem isHermitian_smul_of_posSemidef {A : Matrix (Fin dA) (Fin dA) ℂ}
-    (hA : A.PosSemidef) (c : ℝ) : (c • A).IsHermitian := by
+private theorem isHermitian_smul_of_posSemidef {α : Type*}
+    {A : Matrix α α ℂ} (hA : A.PosSemidef) (c : ℝ) : (c • A).IsHermitian := by
   rw [RCLike.real_smul_eq_coe_smul (K := ℂ)]
   exact hA.isHermitian.smul (isSelfAdjoint_iff.mpr (by simp))
 
 /-- The support projection of `ρ` absorbs each weighted summand of a convex
 decomposition of `ρ`, on both sides. -/
-private theorem supportProj_mul_smul_mul_supportProj (hρ : ρ.PosSemidef) {n : ℕ}
-    {lam : Fin n → ℝ} {rho' : Fin n → Matrix (Fin dA) (Fin dA) ℂ}
+private theorem supportProj_mul_smul_mul_supportProj {α : Type*} [Fintype α] [DecidableEq α]
+    {ρ : Matrix α α ℂ} (hρ : ρ.PosSemidef) {n : ℕ}
+    {lam : Fin n → ℝ} {rho' : Fin n → Matrix α α ℂ}
     (hlam0 : ∀ i, 0 ≤ lam i) (hrho' : ∀ i, (rho' i).PosSemidef)
     (hsum : ∑ i, lam i • rho' i = ρ) (i : Fin n) :
     hρ.supportProj * (lam i • rho' i) * hρ.supportProj = lam i • rho' i := by
   have hB : ∀ j, (lam j • rho' j).PosSemidef := fun j => (hrho' j).smul (hlam0 j)
-  have hker : ∀ v : Fin dA → ℂ, ρ *ᵥ v = 0 → (lam i • rho' i) *ᵥ v = 0 := fun v hv =>
+  have hker : ∀ v : α → ℂ, ρ *ᵥ v = 0 → (lam i • rho' i) *ᵥ v = 0 := fun v hv =>
     Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero hB (by rwa [hsum]) i
   have hright : (lam i • rho' i) * hρ.isHermitian.supportProj = lam i • rho' i :=
     hρ.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le hker
@@ -163,27 +165,32 @@ private theorem supportProj_mul_smul_mul_supportProj (hρ : ρ.PosSemidef) {n : 
 `ρ`, built from the generalized inverse of `ρ` on its support:
 `C⁺ := Cᴴ ρ⁺`. It satisfies `C C⁺ = ` the support projection of `ρ`
 (`mul_purificationPinv`). -/
-private noncomputable def purificationPinv (hρ : ρ.PosSemidef)
-    (C : Matrix (Fin dA) (Fin dB) ℂ) : Matrix (Fin dB) (Fin dA) ℂ :=
+private noncomputable def purificationPinv {α : Type*} [Fintype α] [DecidableEq α]
+    {ρ : Matrix α α ℂ} (hρ : ρ.PosSemidef)
+    (C : Matrix α (Fin dB) ℂ) : Matrix (Fin dB) α ℂ :=
   Cᴴ * hρ.supportInv
 
-private theorem mul_purificationPinv (hρ : ρ.PosSemidef) {C : Matrix (Fin dA) (Fin dB) ℂ}
+private theorem mul_purificationPinv {α : Type*} [Fintype α] [DecidableEq α]
+    {ρ : Matrix α α ℂ} (hρ : ρ.PosSemidef) {C : Matrix α (Fin dB) ℂ}
     (hCC : C * Cᴴ = ρ) :
     C * purificationPinv hρ C = hρ.supportProj := by
   change C * (Cᴴ * hρ.supportInv) = hρ.supportProj
   rw [← Matrix.mul_assoc, hCC]
   exact hρ.self_mul_supportInv
 
-private theorem purificationPinv_conjTranspose (hρ : ρ.PosSemidef)
-    (C : Matrix (Fin dA) (Fin dB) ℂ) :
+private theorem purificationPinv_conjTranspose {α : Type*} [Fintype α] [DecidableEq α]
+    {ρ : Matrix α α ℂ} (hρ : ρ.PosSemidef)
+    (C : Matrix α (Fin dB) ℂ) :
     (purificationPinv hρ C)ᴴ = hρ.supportInv * C := by
   change (Cᴴ * hρ.supportInv)ᴴ = hρ.supportInv * C
   rw [Matrix.conjTranspose_mul, hρ.supportInv_isHermitian.eq, Matrix.conjTranspose_conjTranspose]
 
 /-- `C⁺ C` is an orthogonal projection on Bob's system: the "leftover"
 subspace of `H_B` not needed to purify `ρ` is its orthogonal complement. -/
-private theorem isOrthogonalProjection_purificationPinv_mul (hρ : ρ.PosSemidef)
-    {C : Matrix (Fin dA) (Fin dB) ℂ} (hCC : C * Cᴴ = ρ) :
+private theorem isOrthogonalProjection_purificationPinv_mul
+    {α : Type*} [Fintype α] [DecidableEq α]
+    {ρ : Matrix α α ℂ} (hρ : ρ.PosSemidef)
+    {C : Matrix α (Fin dB) ℂ} (hCC : C * Cᴴ = ρ) :
     IsOrthogonalProjection (purificationPinv hρ C * C) := by
   have hCinvC : purificationPinv hρ C * hρ.supportProj = purificationPinv hρ C := by
     change (Cᴴ * hρ.supportInv) * hρ.supportProj = Cᴴ * hρ.supportInv
@@ -201,31 +208,138 @@ private theorem isOrthogonalProjection_purificationPinv_mul (hρ : ρ.PosSemidef
 /-- The "leftover" completion term: the transpose of the orthogonal
 complement of `C⁺ C`, absorbed by `Cᴴ` on the right and `C` on the left with
 zero contribution (`mul_purificationPinvComplement_mul`). -/
-private noncomputable def purificationPinvComplement (hρ : ρ.PosSemidef)
-    (C : Matrix (Fin dA) (Fin dB) ℂ) : Matrix (Fin dB) (Fin dB) ℂ :=
+private noncomputable def purificationPinvComplement
+    {α : Type*} [Fintype α] [DecidableEq α]
+    {ρ : Matrix α α ℂ} (hρ : ρ.PosSemidef)
+    (C : Matrix α (Fin dB) ℂ) : Matrix (Fin dB) (Fin dB) ℂ :=
   (1 - purificationPinv hρ C * C)ᵀ
 
-private theorem purificationPinvComplement_posSemidef (hρ : ρ.PosSemidef)
-    {C : Matrix (Fin dA) (Fin dB) ℂ} (hCC : C * Cᴴ = ρ) :
+private theorem purificationPinvComplement_posSemidef
+    {α : Type*} [Fintype α] [DecidableEq α]
+    {ρ : Matrix α α ℂ} (hρ : ρ.PosSemidef)
+    {C : Matrix α (Fin dB) ℂ} (hCC : C * Cᴴ = ρ) :
     (purificationPinvComplement hρ C).PosSemidef :=
   (isOrthogonalProjection_posSemidef
     (isOrthogonalProjection_purificationPinv_mul hρ hCC).one_sub).transpose
 
 /-- `C` sandwiches `C⁺ C` back to `ρ`. -/
-private theorem mul_purificationPinv_mul_mul (hρ : ρ.PosSemidef)
-    {C : Matrix (Fin dA) (Fin dB) ℂ} (hCC : C * Cᴴ = ρ) :
+private theorem mul_purificationPinv_mul_mul
+    {α : Type*} [Fintype α] [DecidableEq α]
+    {ρ : Matrix α α ℂ} (hρ : ρ.PosSemidef)
+    {C : Matrix α (Fin dB) ℂ} (hCC : C * Cᴴ = ρ) :
     C * (purificationPinv hρ C * C) * Cᴴ = ρ := by
   calc C * (purificationPinv hρ C * C) * Cᴴ
       = (C * purificationPinv hρ C) * (C * Cᴴ) := by simp only [Matrix.mul_assoc]
     _ = hρ.supportProj * ρ := by rw [mul_purificationPinv hρ hCC, hCC]
     _ = ρ := hρ.supportProj_mul_self
 
-private theorem mul_purificationPinvComplement_mul (hρ : ρ.PosSemidef)
-    {C : Matrix (Fin dA) (Fin dB) ℂ} (hCC : C * Cᴴ = ρ) :
+private theorem mul_purificationPinvComplement_mul
+    {α : Type*} [Fintype α] [DecidableEq α]
+    {ρ : Matrix α α ℂ} (hρ : ρ.PosSemidef)
+    {C : Matrix α (Fin dB) ℂ} (hCC : C * Cᴴ = ρ) :
     C * (purificationPinvComplement hρ C)ᵀ * Cᴴ = 0 := by
   change C * (1 - purificationPinv hρ C * C) * Cᴴ = 0
   rw [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_one, hCC,
     mul_purificationPinv_mul_mul hρ hCC, sub_self]
+
+/-- **Unnormalized POVM steering.** Let `C` purify a positive matrix
+`ρ = C Cᴴ`, and let `ρ = ∑ᵢ σᵢ` be a finite nonempty decomposition into
+positive matrices. Then a POVM on the purifying space realizes every summand
+by the steering sandwich `σᵢ = C (Pᵢ)ᵀ Cᴴ`.
+
+This is the unnormalized form of the construction in Wolf Proposition 1.3
+(lines 348--370). It is useful for decompositions of Choi operators, whose
+summands need not have unit trace. -/
+theorem exists_povm_of_sum_posSemidef
+    {α : Type*} [Finite α] {n : ℕ} [NeZero n]
+    {ρ : Matrix α α ℂ} (hρ : ρ.PosSemidef) {C : Matrix α (Fin dB) ℂ}
+    (hCC : C * Cᴴ = ρ)
+    (sigma : Fin n → Matrix α α ℂ)
+    (hsigma : ∀ i, (sigma i).PosSemidef)
+    (hsum : ∑ i, sigma i = ρ) :
+    ∃ P : POVM dB n, ∀ i, sigma i = C * (P.ops i)ᵀ * Cᴴ := by
+  classical
+  let _ := Fintype.ofFinite α
+  let i0 : Fin n := ⟨0, NeZero.pos n⟩
+  let Cinv := purificationPinv hρ C
+  let X : Fin n → Matrix (Fin dB) (Fin dB) ℂ :=
+    fun i => Cinv * sigma i * Cinvᴴ
+  have hXpsd : ∀ i, (X i).PosSemidef := fun i =>
+    (hsigma i).mul_mul_conjTranspose_same Cinv
+  have hCinvHCH : Cinvᴴ * Cᴴ = hρ.supportProj := by
+    dsimp [Cinv]
+    rw [purificationPinv_conjTranspose, Matrix.mul_assoc, hCC]
+    exact hρ.supportInv_mul_self
+  have hsigma_support : ∀ i,
+      hρ.supportProj * sigma i * hρ.supportProj = sigma i := by
+    intro i
+    have hker : ∀ v : α → ℂ, ρ *ᵥ v = 0 → sigma i *ᵥ v = 0 := fun v hv =>
+      Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero hsigma (by rwa [hsum]) i
+    have hright : sigma i * hρ.isHermitian.supportProj = sigma i :=
+      hρ.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le hker
+    have hleft : hρ.isHermitian.supportProj * sigma i = sigma i := by
+      have h := congrArg Matrix.conjTranspose hright
+      simpa only [Matrix.conjTranspose_mul, hρ.isHermitian.supportProj_isHermitian.eq,
+        (hsigma i).isHermitian.eq] using h
+    change hρ.isHermitian.supportProj * sigma i * hρ.isHermitian.supportProj = sigma i
+    rw [hleft, hright]
+  have hCX : ∀ i, C * X i * Cᴴ = sigma i := by
+    intro i
+    have hstep : C * X i * Cᴴ = (C * Cinv) * sigma i * (Cinvᴴ * Cᴴ) := by
+      simp only [X, Matrix.mul_assoc]
+    rw [hstep, mul_purificationPinv hρ hCC, hCinvHCH]
+    exact hsigma_support i
+  have hCHCinvH : Cᴴ * Cinvᴴ = Cinv * C := by
+    change Cᴴ * (purificationPinv hρ C)ᴴ = purificationPinv hρ C * C
+    rw [purificationPinv_conjTranspose, purificationPinv, ← Matrix.mul_assoc]
+  have hXsum : ∑ i, X i = Cinv * C := by
+    have hpull : ∑ i, X i = Cinv * (∑ i, sigma i) * Cinvᴴ := by
+      simp only [X, ← Matrix.mul_sum, ← Matrix.sum_mul]
+    rw [hpull, hsum, ← hCC]
+    calc Cinv * (C * Cᴴ) * Cinvᴴ = Cinv * (C * (Cᴴ * Cinvᴴ)) := by
+          simp only [Matrix.mul_assoc]
+      _ = Cinv * (C * (Cinv * C)) := by rw [hCHCinvH]
+      _ = Cinv * C * (Cinv * C) := by simp only [Matrix.mul_assoc]
+      _ = Cinv * C := (isOrthogonalProjection_purificationPinv_mul hρ hCC).2
+  let L := purificationPinvComplement hρ C
+  have hLpsd : L.PosSemidef := purificationPinvComplement_posSemidef hρ hCC
+  have hLtranspose : Lᵀ = 1 - Cinv * C := rfl
+  let E : Fin n → Matrix (Fin dB) (Fin dB) ℂ :=
+    fun i => (X i)ᵀ + if i = i0 then L else 0
+  have hEpsd : ∀ i, (E i).PosSemidef := by
+    intro i
+    refine Matrix.PosSemidef.add (hXpsd i).transpose ?_
+    split
+    · exact hLpsd
+    · exact Matrix.PosSemidef.zero
+  have hEsum : ∑ i, E i = 1 := by
+    have hsum1 : ∑ i, E i = (∑ i, X i)ᵀ + L := by
+      simp only [E]
+      rw [Finset.sum_add_distrib, Matrix.transpose_sum]
+      congr 1
+      rw [Finset.sum_ite_eq' Finset.univ i0 (fun _ => L)]
+      simp
+    rw [hsum1, hXsum]
+    change (Cinv * C)ᵀ + (1 - Cinv * C)ᵀ = 1
+    rw [← Matrix.transpose_add]
+    have : Cinv * C + (1 - Cinv * C) = (1 : Matrix (Fin dB) (Fin dB) ℂ) := by
+      abel
+    rw [this, Matrix.transpose_one]
+  let P : POVM dB n := ⟨E, hEpsd, hEsum⟩
+  refine ⟨P, fun i => ?_⟩
+  change sigma i = C * (E i)ᵀ * Cᴴ
+  by_cases hi : i = i0
+  · subst hi
+    have hEi0 : E i0 = (X i0)ᵀ + L := by simp [E]
+    have hEi : (E i0)ᵀ = X i0 + (1 - Cinv * C) := by
+      rw [hEi0, Matrix.transpose_add, Matrix.transpose_transpose, hLtranspose]
+    have hzero : C * (1 - Cinv * C) * Cᴴ = 0 :=
+      mul_purificationPinvComplement_mul hρ hCC
+    rw [hEi, Matrix.mul_add, Matrix.add_mul, hCX i0, hzero, add_zero]
+  · have hEi : (E i)ᵀ = X i := by
+      simp only [E, ite_eq_right hi]
+      rw [Matrix.transpose_add, Matrix.transpose_transpose, Matrix.transpose_zero, add_zero]
+    rw [hEi, hCX i]
 
 /-- **Wolf Proposition (Quantum steering)**, Chapter 1, lines 348--357;
 proof sketch lines 359--370. For a density operator `ρ` with purification
@@ -274,7 +388,9 @@ theorem exists_instrument_of_isConvexDecomposition (hρ : ρ.PosSemidef) (_hρtr
     have hpull : ∑ i, X i = Cinv * (∑ i, lam i • rho' i) * Cinvᴴ := by
       simp only [hXdef, ← Matrix.mul_sum, ← Matrix.sum_mul]
     rw [hpull, hsum, ← hCC]
-    calc Cinv * (C * Cᴴ) * Cinvᴴ = Cinv * (C * (Cᴴ * Cinvᴴ)) := by simp only [Matrix.mul_assoc]
+    calc
+      Cinv * (C * Cᴴ) * Cinvᴴ = Cinv * (C * (Cᴴ * Cinvᴴ)) := by
+        simp only [Matrix.mul_assoc]
       _ = Cinv * (C * (Cinv * C)) := by rw [hCHCinvH]
       _ = Cinv * C * (Cinv * C) := by simp only [Matrix.mul_assoc]
       _ = Cinv * C := (isOrthogonalProjection_purificationPinv_mul hρ hCC).2

--- a/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
@@ -633,6 +633,133 @@ a common dilation space.
     \end{align}
 \end{definition}
 
+\begin{lemma}[Unnormalized POVM steering]
+    \label{lem:unnormalized_povm_steering}
+    \lean{Matrix.exists_povm_of_sum_posSemidef}
+    \leanok
+    \uses{def:povm, thm:quantum_steering}
+    Let $\rho\geq0$ act on a finite-dimensional Hilbert space, and let
+    $C:\C^r\to\mathcal H$ satisfy $CC^\dagger=\rho$. If
+    $\rho=\sum_{i=0}^{n-1}\sigma_i$, where $n\geq1$ and every
+    $\sigma_i\geq0$, then there is a POVM $\{P_i\}_{i=0}^{n-1}$ on
+    $\C^r$ such that
+    \begin{align}
+        \sigma_i
+        &=C P_i^{\mathsf T}C^\dagger
+        \label{eq:representations_unnormalized_steering}
+    \end{align}
+    for every $i$.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:quantum_steering}
+    Apply the generalized-inverse construction from quantum steering to the
+    positive summands $\sigma_i$. Their supports lie in the support of
+    $\rho$. The resulting effects sum to the projection onto the part of
+    $\C^r$ seen by $C$; add the complementary projection to one effect.
+    This preserves (\ref{eq:representations_unnormalized_steering}) and makes
+    the effects sum to the identity.
+\end{proof}
+
+\begin{theorem}[Environment-induced instruments, supplied Stinespring form]
+    \label{thm:environment_induced_instruments_stinespring}
+    \lean{Channel.exists_environment_povm_of_sum_eq_stinespring}
+    \leanok
+    \uses{def:povm, def:kraus_rank_rect, thm:choi_rect_cp,
+        lem:unnormalized_povm_steering}
+    Let $d\geq1$, let $T:\MN{d}\to\MN{d'}$ be a quantum channel, and let
+    $V:\C^d\to\C^{d'}\otimes\C^r$ be a supplied Stinespring matrix such
+    that
+    \begin{align}
+        T(\rho)&=\tr_{\C^r}(V\rho V^\dagger).
+        \label{eq:representations_environment_instruments_stinespring}
+    \end{align}
+    Suppose $n\geq1$ and
+    $T=\sum_{i=0}^{n-1}T_i$, where every
+    $T_i:\MN{d}\to\MN{d'}$ is completely positive. Then there is a POVM
+    $\{P_i\}_{i=0}^{n-1}$ on $\C^r$ such that, for every $i$ and $\rho$,
+    \begin{align}
+        T_i(\rho)
+        &=\tr_{\C^r}\!\left[(\Id_{d'}\otimes P_i)
+          V\rho V^\dagger\right].
+        \label{eq:representations_environment_instruments_reduced}
+    \end{align}
+    If $k_i$ is the Kraus rank, equivalently the Choi rank, of $T_i$, then
+    $k_i\leq\rank(P_i)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:unnormalized_povm_steering, thm:choi_rect_cp,
+        def:kraus_rank_rect}
+    The supplied Stinespring matrix gives a purification $C$ of the Choi
+    matrix $\tau_T$. Complete positivity and
+    $T=\sum_iT_i$ give a positive decomposition
+    $\tau_T=\sum_i\tau_{T_i}$. Lemma~\ref{lem:unnormalized_povm_steering}
+    yields a POVM satisfying
+    $\tau_{T_i}=CP_i^{\mathsf T}C^\dagger$. The Choi identity for inserting
+    an environment effect gives
+    (\ref{eq:representations_environment_instruments_reduced}). Finally,
+    \begin{align}
+        k_i=\rank(\tau_{T_i})
+        =\rank(CP_i^{\mathsf T}C^\dagger)
+        \leq\rank(P_i).
+        \notag
+    \end{align}
+\end{proof}
+
+\begin{proposition}[Environment-induced instruments]
+    \label{prop:environment_induced_instruments}
+    \lean{Channel.exists_environment_povm_of_sum_eq_openSystem}
+    \leanok
+    \uses{def:povm, def:kraus_rank_rect,
+        thm:environment_induced_instruments_stinespring}
+    Let $d\geq1$ and let $T:\MN{d}\to\MN{d'}$ be a quantum channel.
+    Suppose a normalized vector $\varphi\in\C^{d'}\otimes\C^{d'}$ and a
+    unitary identification
+    \begin{align}
+        U:\C^d\otimes(\C^{d'}\otimes\C^{d'})
+        &\longrightarrow \C^{dd'}\otimes\C^{d'}
+        \notag
+    \end{align}
+    are supplied, so both sides have dimension $d(d')^2$, and suppose that
+    the system-plus-environment representation from Equation~(2.14) holds:
+    \begin{align}
+        T(\rho)
+        &=\tr_{\C^{dd'}}\!\left[
+          U\bigl(\rho\otimes\ketbra{\varphi}{\varphi}\bigr)U^\dagger
+          \right].
+        \label{eq:representations_environment_instruments_open_system}
+    \end{align}
+    If $n\geq1$ and $T=\sum_{i=0}^{n-1}T_i$ is a decomposition into
+    completely positive maps $T_i:\MN{d}\to\MN{d'}$, then there is a POVM
+    $\{P_i\}_{i=0}^{n-1}\subset\MN{dd'}$ such that
+    \begin{align}
+        T_i(\rho)
+        &=\tr_{\C^{dd'}}\!\left[
+          (P_i\otimes\Id_{d'})
+          U\bigl(\rho\otimes\ketbra{\varphi}{\varphi}\bigr)U^\dagger
+          \right]
+        \label{eq:representations_environment_induced_instruments}
+    \end{align}
+    for every $i$ and $\rho$. Moreover, the Kraus rank $k_i$ of $T_i$
+    satisfies $k_i\leq\rank(P_i)$. This is
+    \cite[Proposition~(Environment induced instruments), Equation~(2.15)]
+    {Wolf2012Quantum}.
+\end{proposition}
+
+\begin{proof}\leanok
+    \uses{thm:environment_induced_instruments_stinespring}
+    Restrict $U$ to inputs of the form $x\otimes\varphi$ and reorder the
+    output factors. This gives a supplied Stinespring matrix
+    $V:\C^d\to\C^{d'}\otimes\C^{dd'}$ satisfying
+    (\ref{eq:representations_environment_instruments_stinespring}). Apply
+    Theorem~\ref{thm:environment_induced_instruments_stinespring} and rewrite
+    its effect-insertion formula in the original environment-first tensor
+    order. The result is
+    (\ref{eq:representations_environment_induced_instruments}), with the same
+    rank bound.
+\end{proof}
+
 \begin{definition}[Naimark Kraus square roots]\label{def:naimark_kraus}
     \lean{POVM.naimarkKraus, POVM.naimarkKraus_spec}
     \leanok


### PR DESCRIPTION
## Summary
- formalize Wolf's environment-induced instruments proposition for rectangular channels
- prove an unnormalized POVM-steering theorem and apply it to the supplied rectangular Choi purification
- prove the reduced supplied-Stinespring realization and the literal system-plus-environment Eq. (2.15) wrapper
- retain Wolf's exact dimensions, normalized environment vector, supplied Eq. (2.14) representation, and Kraus/Choi-rank bound
- synchronize the Chapter 2 Blueprint

## Main result

```lean
Channel.exists_environment_povm_of_sum_eq_openSystem
```

For a supplied rectangular open-system representation and any finite decomposition `T = ∑ i, Tᵢ i` into CP maps, it returns `P : POVM (d * d') n` with

```text
Tᵢ i ρ = tr_E[(Pᵢ ⊗ I) U (ρ ⊗ |φ><φ|) U†]
```

and

```text
Channel.choiRank (Tᵢ i) ≤ (P.ops i).rank.
```

## Source
- Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2, Proposition “Environment induced instruments”
- `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 447–475, especially Eq. (2.15)

## Verification
- fresh targeted `lake env lean` checks for `QuantumSteering.lean`, `EnvironmentInducedInstrument.lean`, and `QICLean/Channel.lean`
- import aggregators current: 29 aggregators covering 486 production modules
- Blueprint ↔ Lean sync: 1764/1764 theorem-like entries synchronized; changed declarations fully covered
- Blueprint PDF/web compilation completed
- scoped Mathlib-style review completed
- `git diff --check` and forbidden-placeholder/suppression scans clean

No local `lake build`, clean, dependency fetch/update, or cache deletion was run.

Closes #11.
