### PR TITLE
fix(breuer-hall): formalize contraction counterexample

### DIFF
--- a/QICLean/Channel/BreuerHallIndecomposable.lean
+++ b/QICLean/Channel/BreuerHallIndecomposable.lean
@@ -51,6 +51,13 @@ so `(T_BH ⊗ id)(ρ)` is not positive semidefinite (its quadratic form at `Ψ` 
 By `not_isDecomposablePositiveMap_of_isPPT_not_tensorMapId_posSemidef`, `T_BH` is not
 decomposable.
 
+## Boundary for antisymmetric contractions
+
+Unitarity cannot be weakened to contractivity in the indecomposability statement. The zero
+matrix is antisymmetric and contractive, but `breuerHallMap 0 = reductionMap d 1`; the
+reduction map is completely copositive and therefore decomposable. Thus even when `d > 2`,
+not every antisymmetric contraction gives an indecomposable Breuer-Hall map.
+
 The restriction `d > 2` is necessary, not an artifact of this proof: for `d = 2` every
 antisymmetric unitary is a phase times `J = [[0, 1], [-1, 0]]`, and
 `J Xᵀ Jᴴ = Tr(X) 1 - X` for all `2 × 2` matrices `X`, so `T_BH` reduces to the zero map,
@@ -69,6 +76,8 @@ which is trivially decomposable. See
 * `Matrix.breuerHallMap_isIndecomposablePositiveMap` -- **Wolf Chapter 3, Example 3.1.**
   For antisymmetric unitary `U` in dimension `d > 2`, `breuerHallMap U` is an
   indecomposable positive map.
+* `Matrix.breuerHallMap_contraction_not_universally_indecomposable` -- the zero
+  antisymmetric contraction refutes the corresponding universal contraction claim.
 
 ## References
 
@@ -700,5 +709,17 @@ theorem breuerHallMap_isIndecomposablePositiveMap (hd : 2 < d)
     IsIndecomposablePositiveMap (Matrix.breuerHallMap U) :=
   ⟨Matrix.breuerHallMap_isPositiveMap U hUanti (le_of_eq hUunit),
     breuerHallMap_not_isDecomposablePositiveMap hd hUanti hUunit⟩
+
+/-- The Breuer-Hall indecomposability theorem does not extend from antisymmetric unitaries
+to all antisymmetric contractions, even in dimension `d > 2`: the zero contraction gives
+the decomposable reduction map \(T_1\). -/
+theorem breuerHallMap_contraction_not_universally_indecomposable (hd : 2 < d) :
+    ¬ ∀ U : Matrix (Fin d) (Fin d) ℂ,
+      Uᵀ = -U → Uᴴ * U ≤ 1 → IsIndecomposablePositiveMap (breuerHallMap U) := by
+  let _ : NeZero d := ⟨Nat.ne_of_gt (lt_trans (by omega) hd)⟩
+  intro h
+  have hzero := h (0 : Matrix (Fin d) (Fin d) ℂ) (by simp) (by simp)
+  rw [breuerHallMap_zero] at hzero
+  exact hzero.2 reductionMap_one_isDecomposablePositiveMap
 
 end Matrix

--- a/QICLean/Channel/BreuerHallMap.lean
+++ b/QICLean/Channel/BreuerHallMap.lean
@@ -5,8 +5,8 @@ Authors: TNLean contributors
 -/
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import QICLean.Algebra.MatrixAux
-import QICLean.Channel.Basic
 import QICLean.Algebra.MatrixSpectralDecomp
+import QICLean.Channel.PositiveExamples
 
 /-!
 # Positivity of the Breuer-Hall map
@@ -34,6 +34,7 @@ dimension `d > 2` is `Matrix.breuerHallMap_isIndecomposablePositiveMap`.
 ## Main declarations
 
 * `Matrix.breuerHallMap` -- the Breuer-Hall map `T_BH`.
+* `Matrix.breuerHallMap_zero` -- at `U = 0`, `T_BH` is the reduction map `T₁`.
 * `Matrix.breuerHallMap_isPositiveMap` -- `T_BH` is a positive map.
 
 ## References
@@ -133,6 +134,14 @@ theorem breuerHallMap_apply (U : Matrix (Fin d) (Fin d) ℂ) (X : Matrix (Fin d)
     breuerHallMap U X =
       Matrix.trace X • (1 : Matrix (Fin d) (Fin d) ℂ) - X - U * Xᵀ * Uᴴ :=
   rfl
+
+/-- At the zero contraction, the Breuer-Hall map is exactly the reduction map
+\(T_1(X)=\operatorname{tr}(X)I-X\). -/
+@[simp]
+theorem breuerHallMap_zero (d : ℕ) :
+    breuerHallMap (0 : Matrix (Fin d) (Fin d) ℂ) = reductionMap d 1 := by
+  ext X i j
+  simp [breuerHallMap_apply, reductionMap_apply]
 
 /-! ## Positivity on rank-one outer products -/
 

--- a/QICLean/Channel/MaximallyEntangled.lean
+++ b/QICLean/Channel/MaximallyEntangled.lean
@@ -3,12 +3,13 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Channel.TensorMap
+import Mathlib.Algebra.Ring.Idempotent
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.Analysis.Real.Sqrt
+import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.LinearAlgebra.Matrix.Trace
-import Mathlib.Data.Complex.Basic
-import Mathlib.Analysis.Real.Sqrt
-import Mathlib.Algebra.Ring.Idempotent
+import QICLean.Channel.TensorMap
 
 /-!
 # Maximally entangled state and SWAP operator
@@ -32,6 +33,7 @@ as needed for the Choi–Jamiolkowski isomorphism (Wolf Chapter 2).
 * `Matrix.swapMatrix_apply`: elementwise formula for `swapMatrix`
 * `Matrix.swapMatrix_mul_self`: `F² = 1`
 * `Matrix.swapMatrix_conjTranspose`: `F† = F`
+* `Matrix.one_sub_swapMatrix_posSemidef`: `1 - F` is positive semidefinite
 * `Matrix.trace_omegaProj`: `tr(|Ω⟩⟨Ω|) = 1` when `d > 0`
 
 ## References
@@ -39,7 +41,7 @@ as needed for the Choi–Jamiolkowski isomorphism (Wolf Chapter 2).
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2, Example 1.2][Wolf2012QChannels]
 -/
 
-open scoped Matrix
+open scoped Matrix ComplexOrder
 open Matrix Finset BigOperators
 
 namespace Matrix
@@ -174,6 +176,24 @@ theorem swapMatrix_conjTranspose :
     (propext ⟨fun ⟨a, b⟩ => ⟨b.symm, a.symm⟩,
              fun ⟨a, b⟩ => ⟨b.symm, a.symm⟩⟩)
     (fun _ => rfl) (fun _ => rfl)
+
+/-- `1 - F` is positive semidefinite, where `F` is the SWAP operator: it is twice the
+orthogonal projector onto the antisymmetric subspace. -/
+theorem one_sub_swapMatrix_posSemidef (d : ℕ) :
+    ((1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - swapMatrix d).PosSemidef := by
+  let A : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ := 1 - swapMatrix d
+  have hAstar : Aᴴ = A := by
+    simp [A, swapMatrix_conjTranspose]
+  have hAsq : Aᴴ * A = 2 • A := by
+    rw [hAstar]
+    simp only [A, sub_mul, mul_sub, one_mul, mul_one, swapMatrix_mul_self]
+    module
+  have hpsd : (Aᴴ * A).PosSemidef := Matrix.posSemidef_conjTranspose_mul_self A
+  rw [hAsq] at hpsd
+  have hhalf : ((2 : ℂ)⁻¹) • (2 • A) = A := by module
+  change A.PosSemidef
+  rw [← hhalf]
+  exact hpsd.smul (by positivity)
 
 /-- `tr(|Ω⟩⟨Ω|) = 1` when `d > 0`. -/
 theorem trace_omegaProj (hd : 0 < d) :

--- a/QICLean/Channel/PositiveExamples.lean
+++ b/QICLean/Channel/PositiveExamples.lean
@@ -18,6 +18,8 @@ This file records elementary positive maps from Wolf Chapter 3.
 * `Matrix.reductionMap`: the reduction map
   \(X \mapsto \operatorname{tr}(X) I - k^{-1}X\).
 * `Matrix.reductionMap_one_isPositiveMap`: the case \(k=1\) is positive.
+* `Matrix.reductionMap_one_isCompletelyCopositiveMap`: the case \(k=1\) is completely
+  copositive, hence decomposable.
 * `Matrix.traceAdjointMap_reductionMap`: the reduction map is self-dual for
   the trace pairing.
 * `ChoiJamiolkowski.choiMatrix_reductionMap`: Choi matrix of the reduction map.
@@ -61,6 +63,14 @@ theorem reductionMap_one_isPositiveMap {D : ℕ} [NeZero D] :
   intro X hX
   simpa [reductionMap] using
     (Matrix.PosSemidef.trace_smul_one_sub_self_posSemidef hX)
+
+/-- Composing the reduction map \(T_1\) with transposition gives
+\(X \mapsto \operatorname{tr}(X)I-X^{\mathsf T}\). -/
+@[simp]
+theorem reductionMap_one_comp_transpose_apply (D : ℕ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    ((reductionMap D 1).comp (transposeLinearMapComplex (Fin D))) X =
+      Matrix.trace X • (1 : Matrix (Fin D) (Fin D) ℂ) - Xᵀ := by
+  simp [reductionMap_apply, transposeLinearMapComplex, LinearMap.comp_apply]
 
 /-- **Wolf Chapter 3, Example 3.1, equation (3.18).** The reduction map is
 self-dual for the bilinear trace pairing:
@@ -118,4 +128,58 @@ theorem choiMatrix_reductionMap [NeZero D] (k : ℕ) :
       simp_all [choiMatrix_apply, Matrix.reductionMap, omegaSlice_eq_single,
         Matrix.omegaProj_apply, Matrix.omegaVec_apply, eq_comm]
 
+/-- The Choi matrix of \(T_1 \circ \mathrm{transpose}\) is the normalized
+antisymmetric-subspace operator \(D^{-1}(1-F)\). -/
+theorem choiMatrix_reductionMap_one_comp_transpose [NeZero D] :
+    choiMatrix ((Matrix.reductionMap D 1).comp
+      (Matrix.transposeLinearMapComplex (Fin D))) =
+      ((D : ℂ)⁻¹) • ((1 : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) -
+        Matrix.swapMatrix D) := by
+  have hDpos : (0 : ℝ) < D := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hcoeff :
+      (D : ℂ)⁻¹ = (((D : ℝ).sqrt : ℂ)⁻¹ * (((D : ℝ).sqrt : ℂ)⁻¹)) := by
+    rw [← _root_.mul_inv_rev]
+    congr
+    have hsqrt : (D : ℝ) = (D : ℝ).sqrt * (D : ℝ).sqrt := by
+      nth_rw 1 [← Real.sq_sqrt hDpos.le]
+      ring
+    exact_mod_cast hsqrt
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  rw [hcoeff]
+  by_cases h₂ : i₂ = j₂
+  · subst j₂
+    simp [choiMatrix_apply, Matrix.reductionMap_one_comp_transpose_apply,
+      omegaSlice_eq_single, Matrix.swapMatrix_apply, Matrix.trace_single_eq_same,
+      Matrix.one_apply, Matrix.single_apply]
+    split_ifs <;> grind
+  · simp [choiMatrix_apply, Matrix.reductionMap_one_comp_transpose_apply,
+      omegaSlice_eq_single, Matrix.swapMatrix_apply,
+      Matrix.trace_single_eq_of_ne i₂ j₂ _ h₂, Matrix.one_apply, Matrix.single_apply]
+    split_ifs <;> grind
+
 end ChoiJamiolkowski
+
+namespace Matrix
+
+variable {D : ℕ}
+
+/-- The reduction map \(T_1(X)=\operatorname{tr}(X)I-X\) is completely copositive. Its
+composition with transposition has Choi matrix \(D^{-1}(1-F)\), which is positive
+semidefinite. -/
+theorem reductionMap_one_isCompletelyCopositiveMap [NeZero D] :
+    IsCompletelyCopositiveMap (reductionMap D 1) := by
+  rw [IsCompletelyCopositiveMap, ChoiJamiolkowski.cp_iff_choi_posSemidef,
+    ChoiJamiolkowski.choiMatrix_reductionMap_one_comp_transpose]
+  exact (one_sub_swapMatrix_posSemidef D).smul (by positivity)
+
+/-- The reduction map \(T_1\) is decomposable (indeed, completely copositive). -/
+theorem reductionMap_one_isDecomposablePositiveMap [NeZero D] :
+    IsDecomposablePositiveMap (reductionMap D 1) := by
+  refine ⟨0, reductionMap D 1, ?_, reductionMap_one_isCompletelyCopositiveMap, ?_⟩
+  · refine ⟨0, Fin.elim0, ?_⟩
+    intro X
+    simp
+  · simp
+
+end Matrix

--- a/blueprint/src/chapter/ch04_positive_not_cp_positivity_reduction_and_breuer_hall.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_positivity_reduction_and_breuer_hall.tex
@@ -74,6 +74,33 @@ cone and map it onto itself.
     $k^{-1}\ket{\Omega}\bra{\Omega}$.
 \end{proof}
 
+\begin{theorem}[Complete copositivity of the first reduction map]
+    \label{thm:reduction_map_one_completely_copositive}
+    \lean{ChoiJamiolkowski.choiMatrix_reductionMap_one_comp_transpose,
+        Matrix.one_sub_swapMatrix_posSemidef,
+        Matrix.reductionMap_one_isCompletelyCopositiveMap,
+        Matrix.reductionMap_one_isDecomposablePositiveMap}
+    \leanok
+    \uses{def:reduction_map, def:decomposable_positive_map,
+        thm:cp_iff_choi_posSemidef}
+    For $D\ge1$, the map $T_1(X)=\tr(X)\Id-X$ is completely copositive and
+    hence decomposable. More precisely, the Choi matrix of
+    $T_1\circ\theta$, where $\theta$ is transposition, is
+    \begin{align}
+        \tau(T_1\circ\theta) & =D^{-1}(\Id-F)\ge0,
+        \notag
+    \end{align}
+    with $F$ the swap operator on $\C^D\otimes\C^D$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The operator $\Id-F$ is twice the orthogonal projector onto the
+    antisymmetric subspace, so it is positive semidefinite. The Choi criterion
+    therefore shows that $T_1\circ\theta$ is completely positive, which means
+    that $T_1$ is completely copositive. Taking the completely positive
+    summand to be zero gives a decomposable representation of $T_1$.
+\end{proof}
+
 \subsection{Automorphisms of the positive semidefinite cone}
 
 Invertible conjugations, with or without transposition, do more than preserve
@@ -433,20 +460,30 @@ of a bipartite state whose Schmidt number is at most $n$.
 
 \section{The Breuer--Hall map}
 
-A second concrete positive map of \cite[Chapter~3, Example~3.1]{Wolf2012Quantum}
-is built from an antisymmetric contraction $U$ on $\C^{D}$, a matrix with
-$U^{\mathsf T}=-U$ and $U^{\dagger}U\le\Id$. The associated Breuer--Hall map
-\cite[Equation~(3.19)]{Wolf2012Quantum} is
-$T_{\mathrm{BH}}(X)=\tr(X) \Id-X-U\,X^{\mathsf T}U^{\dagger}$.
-It is positive, and for an antisymmetric unitary in dimension $D>2$ it is
-indecomposable (Theorem~\ref{thm:breuer_hall_indecomposable}); the threshold
-beyond which it fails to be completely positive is not treated here. The
-source states indecomposability for every antisymmetric unitary without a
-dimension hypothesis, but the restriction $D>2$ is necessary: at $D=2$ every
-antisymmetric unitary is a phase multiple of
+Wolf defines the Breuer--Hall map in
+\cite[Chapter~3, Example~3.1]{Wolf2012Quantum} for an antisymmetric contraction
+$U$ on $\C^{D}$, namely $U^{\mathsf T}=-U$ and
+$U^{\dagger}U\le\Id$:
+\begin{align}
+    T_{\mathrm{BH}}(X)=\tr(X)\Id-X-U X^{\mathsf T}U^{\dagger}.
+    \notag
+\end{align}
+The contraction hypotheses are used for positivity. Wolf's subsequent
+indecomposability assertion is stated only for antisymmetric unitaries. The
+formalization preserves this distinction: positivity holds for antisymmetric
+contractions, while indecomposability is proved for antisymmetric unitaries in
+dimension $D>2$.
+
+Neither restriction may be discarded. At $D=2$, every antisymmetric unitary is
+a phase multiple of
 $J=\bigl(\begin{smallmatrix}0&1\\-1&0\end{smallmatrix}\bigr)$, and
-$JX^{\mathsf T}J^{\dagger}=\tr(X)\Id-X$ for every $2\times2$ matrix $X$, so
-$T_{\mathrm{BH}}$ is the zero map, which is decomposable.
+$JX^{\mathsf T}J^{\dagger}=\tr(X)\Id-X$, so $T_{\mathrm{BH}}$ is the zero map.
+Moreover, the unitary hypothesis cannot be replaced by contractivity in the
+indecomposability conclusion: $U=0$ is an antisymmetric contraction and gives
+$T_{\mathrm{BH}}=T_1$, which is completely copositive and decomposable by
+Theorem~\ref{thm:reduction_map_one_completely_copositive}. This counterexample
+only refutes the unrestricted contraction generalization; no sharper
+classification of antisymmetric contractions is asserted here.
 
 \begin{definition}[Breuer--Hall map]
     \label{def:breuer_hall_map}
@@ -520,6 +557,28 @@ $T_{\mathrm{BH}}$ is the zero map, which is decomposable.
     sends each such operator to a positive semidefinite matrix, and a sum of
     positive semidefinite matrices is positive semidefinite, so $T_{\mathrm{BH}}$
     is positive.
+\end{proof}
+
+\begin{theorem}[The contraction generalization of indecomposability is false]
+    \label{thm:breuer_hall_contraction_counterexample}
+    \lean{Matrix.breuerHallMap_zero,
+        Matrix.breuerHallMap_contraction_not_universally_indecomposable}
+    \leanok
+    \uses{def:breuer_hall_map, thm:reduction_map_one_completely_copositive}
+    Suppose $D>2$. It is false that the Breuer--Hall map is indecomposable for
+    every antisymmetric contraction $U$. Indeed, $U=0$ satisfies
+    $U^{\mathsf T}=-U$ and $U^{\dagger}U\le\Id$, but its Breuer--Hall map is
+    \begin{align}
+        T_{\mathrm{BH}}(X) & =\tr(X)\Id-X=T_1(X),
+        \notag
+    \end{align}
+    which is completely copositive and decomposable.
+\end{theorem}
+
+\begin{proof}\leanok
+    Substitute $U=0$ into the defining formula. The twisted-transpose term
+    vanishes, leaving the first reduction map. Apply
+    Theorem~\ref{thm:reduction_map_one_completely_copositive}.
 \end{proof}
 
 \begin{theorem}[The Breuer--Hall map is indecomposable]

--- a/docs/paper-gaps/wolf_breuer_hall_even_dim_restriction.tex
+++ b/docs/paper-gaps/wolf_breuer_hall_even_dim_restriction.tex
@@ -7,10 +7,10 @@
 
 \input{command}
 
-\title{The Even-Dimension Restriction in the Indecomposability\\
+\title{Hypothesis Boundaries for the Indecomposability\\
 of the Breuer--Hall Map (Wolf Example~3.1)}
 \author{}
-\date{2026-08-06}
+\date{2026-08-23}
 
 \begin{document}
 \maketitle
@@ -22,7 +22,7 @@ Wolf's Chapter~3, Example~3.1 introduces the Breuer--Hall
 map\footnote{\cite[Chapter~3, Example~3.1]{Wolf2012Quantum}; local source:
 \path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex}, lines
 344--355. Formalization issue:
-\href{https://github.com/LionSR/TNLean/issues/5471}{issue \#5471}.}
+\href{https://github.com/LionSR/QICLean/issues/16}{issue \#16}.}
 \begin{align}
   T_{\mathrm{BH}}(X)=\operatorname{tr}[X]\,\mathbb 1-X-UX^{T}U^{\dagger}.
   \tag{3.19}
@@ -32,12 +32,13 @@ $U^{\dagger}U\le\mathbb 1$.  The source then states: ``For $d$ even there are
 anti-symmetric unitaries
 $U^{\dagger}=U^{-1}=-\overline{U}$ \dots\ If $U$ is an anti-symmetric unitary
 $T_{\mathrm{BH}}$ is not decomposable.''  The final sentence has no dimension
-hypothesis.  Thus the source uses two distinct hypothesis regimes: the map is
-defined and proved positive for antisymmetric contractions
-$U^{\dagger}U\le\mathbb 1$, whereas its indecomposability assertion concerns
-antisymmetric unitaries $U^{\dagger}U=\mathbb 1$.  The formalization proves
-indecomposability only in the unitary case; extending that conclusion to general
-antisymmetric contractions remains open.
+hypothesis.  Thus the source uses two distinct hypothesis regimes: positivity is
+asserted for antisymmetric contractions $U^{\dagger}U\le\mathbb 1$, whereas
+indecomposability is asserted only for antisymmetric unitaries
+$U^{\dagger}U=\mathbb 1$.  The formalization preserves this distinction. It proves
+positivity in the contraction regime and indecomposability in the unitary regime,
+with the necessary dimension hypothesis $d>2$. The unrestricted contraction
+generalization of indecomposability is false.
 
 \section{The point at issue}
 
@@ -59,6 +60,39 @@ completely positive, hence decomposable. The hypothesis $d>2$ is therefore
 necessary, and the source's sentence must be read with the restriction
 $d\ge4$ (recall that antisymmetric unitaries exist only for even $d$: taking
 determinants in $U^{T}=-U$ gives $\det U=(-1)^{d}\det U$, and $\det U\ne0$).
+
+\section{Why contractivity does not suffice for indecomposability}
+
+The zero matrix is an antisymmetric contraction in every dimension:
+$0^{T}=-0$ and $0^{\dagger}0\le\mathbb 1$. At this parameter the
+Breuer--Hall map is exactly the first reduction map,
+\begin{align}
+  T_{\mathrm{BH},0}(X)
+  =\operatorname{tr}[X] \,\mathbb 1-X
+  =T_1(X).
+\end{align}
+The map $T_1$ is completely copositive. Indeed, if $\theta$ denotes
+transposition and $F$ denotes the swap operator, then the Choi matrix of
+$T_1\circ\theta$ is
+\begin{align}
+  \tau(T_1\circ\theta)=d^{-1}(\mathbb 1-F)\ge0.
+\end{align}
+The last inequality holds because $\mathbb 1-F$ is twice the orthogonal
+projector onto the antisymmetric subspace. The Choi criterion therefore shows
+that $T_1\circ\theta$ is completely positive, so $T_1$ is completely
+copositive and hence decomposable. Consequently, even for $d>2$, the
+Breuer--Hall map need not be indecomposable when $U$ ranges over all
+antisymmetric contractions. This counterexample does not give, and the
+formalization does not claim, a classification of the nonunitary contractions
+for which the map is indecomposable.\footnote{Formal declarations:
+\leanid{Matrix.breuerHallMap\_zero} in
+\doclink{QICLean/Channel/BreuerHallMap};
+\leanid{ChoiJamiolkowski.choiMatrix\_reductionMap\_one\_comp\_transpose},
+\leanid{Matrix.reductionMap\_one\_isCompletelyCopositiveMap}, and
+\leanid{Matrix.reductionMap\_one\_isDecomposablePositiveMap} in
+\doclink{QICLean/Channel/PositiveExamples}; and
+\leanid{Matrix.breuerHallMap\_contraction\_not\_universally\_indecomposable}
+in \doclink{QICLean/Channel/BreuerHallIndecomposable}.}
 
 \section{The corrected statement}
 
@@ -109,11 +143,15 @@ $T_{\mathrm{BH}}$ is not decomposable.
 
 \section{Conclusion}
 
-The source's indecomposability claim for the Breuer--Hall map is correct
-exactly in the dimensions where antisymmetric unitaries exist and $d>2$,
-i.e.\ for even $d\ge4$; at $d=2$ the map vanishes. The formalization proves
-the corrected statement with the explicit hypothesis $d>2$, and the
-blueprint entry records the restriction in its statement.
+Wolf's positivity statement applies to antisymmetric contractions, whereas the
+source's indecomposability sentence applies only to antisymmetric unitaries.
+For unitaries the dimension correction is necessary: the formalized theorem
+assumes $d>2$, equivalently even $d\ge4$ whenever an antisymmetric unitary
+exists, and at $d=2$ the map vanishes. The unitary hypothesis is also a genuine
+boundary for the stated conclusion: the antisymmetric contraction $U=0$ gives
+the completely copositive, decomposable reduction map $T_1$. The blueprint
+records both the corrected unitary theorem and this counterexample, without
+asserting a sharper classification for general contractions.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Closes #16.

Formalizes the exact failure boundary for extending Wolf Example 3.1 from antisymmetric unitaries to arbitrary antisymmetric contractions. The zero contraction gives the reduction map, whose transposed composition has Choi matrix `D⁻¹ • (1 - F)` and is completely positive; hence the reduction map is completely copositive and decomposable. The existing unitary `d > 2` indecomposability theorem remains unchanged.

Also synchronizes the Blueprint and the Breuer–Hall paper-gap note.

Verification: fresh targeted `lake env lean` on all four changed Lean modules; non-Lake module/import/prose policy checks; Blueprint and paper-gap LaTeX builds. No local Lake build, clean, fetch, update, or cache operation was run.