### PR TITLE
feat(channel): formalize rectangular unitary open-system representation

### DIFF
--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -65,6 +65,7 @@ import QICLean.Channel.NPositivitySpectralCriterion
 import QICLean.Channel.NoInformationWithoutDisturbance
 import QICLean.Channel.NormalForm
 import QICLean.Channel.OpenSystem
+import QICLean.Channel.OpenSystemRectangular
 import QICLean.Channel.OperatorSystem
 import QICLean.Channel.OperatorSystemExtension
 import QICLean.Channel.OperatorSystemExtensionDirectSum

--- a/QICLean/Channel/EnvironmentInducedInstrument.lean
+++ b/QICLean/Channel/EnvironmentInducedInstrument.lean
@@ -5,6 +5,7 @@ Authors: Sirui Lu
 -/
 import QICLean.Channel.ChoiRectangular
 import QICLean.Channel.KrausRectangular
+import QICLean.Channel.OpenSystemRectangular
 import QICLean.Channel.POVM
 import QICLean.Channel.QuantumSteering
 
@@ -43,40 +44,6 @@ noncomputable def choiPurificationCoeff
     (V : Matrix (Fin d' × Fin r) (Fin d) ℂ) :
     Matrix (Fin d' × Fin d) (Fin r) ℂ :=
   fun ai e => ((1 : ℂ) / ((d : ℝ).sqrt : ℂ)) * V (ai.1, e) ai.2
-
-/-- Embed an input vector `x ∈ ℂ^d` as `x ⊗ φ`, where Wolf's fixed
-initial environment vector has type `φ ∈ ℂ^{d'} ⊗ ℂ^{d'}`. The ambient input
-space therefore has exact dimension `d * (d')^2`. -/
-noncomputable def openSystemInputEmbedding
-    (φ : Fin d' × Fin d' → ℂ) :
-    Matrix (Fin d × (Fin d' × Fin d')) (Fin d) ℂ :=
-  fun p i => if p.1 = i then φ p.2 else 0
-
-/-- Wolf's fixed-state input `ρ ⊗ |φ⟩⟨φ|` from Equation (2.14), indexed as
-`ℂ^d ⊗ (ℂ^{d'} ⊗ ℂ^{d'})`. -/
-noncomputable def openSystemInput
-    (φ : Fin d' × Fin d' → ℂ) (ρ : Matrix (Fin d) (Fin d) ℂ) :
-    Matrix (Fin d × (Fin d' × Fin d')) (Fin d × (Fin d' × Fin d')) ℂ :=
-  Matrix.kroneckerMap (· * ·) ρ (Matrix.vecMulVec φ (star φ))
-
-/-- The fixed-state input is the compression through
-`openSystemInputEmbedding`: `(𝟙_d ⊗ |φ⟩) ρ (𝟙_d ⊗ ⟨φ|)`. -/
-theorem openSystemInput_eq_embedding
-    (φ : Fin d' × Fin d' → ℂ) (ρ : Matrix (Fin d) (Fin d) ℂ) :
-    openSystemInput φ ρ =
-      openSystemInputEmbedding φ * ρ * (openSystemInputEmbedding φ)ᴴ := by
-  classical
-  ext ⟨i, s⟩ ⟨j, t⟩
-  simp only [openSystemInput, Matrix.kroneckerMap_apply, Matrix.vecMulVec_apply,
-    Pi.star_apply, RCLike.star_def, Matrix.mul_apply, openSystemInputEmbedding, ite_mul,
-    zero_mul, Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte, Matrix.conjTranspose_apply]
-  rw [Finset.sum_eq_single j]
-  · simp
-    ring
-  · intro x _ hx
-    have hjx : j ≠ x := fun h => hx h.symm
-    simp [hjx]
-  · simp
 
 /-- Reindex the output of Wolf's supplied open-system operator from
 `environment ⊗ output` to the output-first convention `output ⊗ environment`

--- a/QICLean/Channel/OpenSystemRectangular.lean
+++ b/QICLean/Channel/OpenSystemRectangular.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 Sirui Lu and QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import QICLean.Algebra.MatrixGramUnitary
+import QICLean.Channel.StinespringRectangular
+
+/-!
+# Rectangular unitary open-system representation
+
+This file formalizes Wolf, Chapter 2, Theorem 2.5, “Open-system
+representation,” and Equation (2.14)
+(`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 409–429), for a channel
+`T : M_d(ℂ) → M_{d'}(ℂ)`. The proof follows Wolf's construction: choose a
+Stinespring dilation space of dimension `d * d'`, reindex the Stinespring
+isometry into the square space `ℂ^d ⊗ ℂ^{d'} ⊗ ℂ^{d'}`, and extend it to a
+unitary after fixing a normalized vector in `ℂ^{d'} ⊗ ℂ^{d'}`.
+-/
+
+open scoped Matrix BigOperators
+open Matrix Finset
+
+namespace Channel
+
+variable {d d' : ℕ}
+
+/-- Embed an input vector `x ∈ ℂ^d` as `x ⊗ φ`, where Wolf's fixed initial
+environment vector has type `φ ∈ ℂ^{d'} ⊗ ℂ^{d'}`. -/
+noncomputable def openSystemInputEmbedding
+    (φ : Fin d' × Fin d' → ℂ) :
+    Matrix (Fin d × (Fin d' × Fin d')) (Fin d) ℂ :=
+  fun p i => if p.1 = i then φ p.2 else 0
+
+/-- Wolf's fixed-state input `ρ ⊗ |φ⟩⟨φ|` from Equation (2.14), indexed as
+`ℂ^d ⊗ (ℂ^{d'} ⊗ ℂ^{d'})`. -/
+noncomputable def openSystemInput
+    (φ : Fin d' × Fin d' → ℂ) (ρ : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix (Fin d × (Fin d' × Fin d')) (Fin d × (Fin d' × Fin d')) ℂ :=
+  Matrix.kroneckerMap (· * ·) ρ (Matrix.vecMulVec φ (star φ))
+
+/-- The fixed-state input is compression through `openSystemInputEmbedding`:
+`(𝟙_d ⊗ |φ⟩) ρ (𝟙_d ⊗ ⟨φ|)`. -/
+theorem openSystemInput_eq_embedding
+    (φ : Fin d' × Fin d' → ℂ) (ρ : Matrix (Fin d) (Fin d) ℂ) :
+    openSystemInput φ ρ =
+      openSystemInputEmbedding φ * ρ * (openSystemInputEmbedding φ)ᴴ := by
+  classical
+  ext ⟨i, s⟩ ⟨j, t⟩
+  simp only [openSystemInput, Matrix.kroneckerMap_apply, Matrix.vecMulVec_apply,
+    Pi.star_apply, RCLike.star_def, Matrix.mul_apply, openSystemInputEmbedding, ite_mul,
+    zero_mul, Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte, Matrix.conjTranspose_apply]
+  rw [Finset.sum_eq_single j]
+  · simp
+    ring
+  · intro x _ hx
+    have hjx : j ≠ x := fun h => hx h.symm
+    simp [hjx]
+  · simp
+
+/-- The environment embedding is an isometry when `φ` is normalized. -/
+private theorem openSystemInputEmbedding_conjTranspose_mul_self
+    (φ : Fin d' × Fin d' → ℂ)
+    (hφ : ∑ x, star (φ x) * φ x = 1) :
+    (openSystemInputEmbedding (d := d) φ)ᴴ *
+      openSystemInputEmbedding (d := d) φ = 1 := by
+  classical
+  ext i j
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, openSystemInputEmbedding,
+    Matrix.one_apply]
+  rw [Fintype.sum_prod_type]
+  by_cases hij : i = j
+  · subst j
+    simpa using hφ
+  · have hji : j ≠ i := Ne.symm hij
+    simp [hij, hji]
+
+/-- Reindex `ℂ^{d'} ⊗ ℂ^{d d'}` as
+`ℂ^d ⊗ ℂ^{d'} ⊗ ℂ^{d'}`, identifying Wolf's `d d'`-dimensional dilation
+space with the first two factors and placing the retained `d'`-dimensional
+output last. -/
+private def stinespringToOpenSystemEquiv (d d' : ℕ) :
+    (Fin d' × Fin (d * d')) ≃ Fin d × (Fin d' × Fin d') where
+  toFun p :=
+    let q := finProdFinEquiv.symm p.2
+    (q.1, (q.2, p.1))
+  invFun p := (p.2.2, finProdFinEquiv (p.1, p.2.1))
+  left_inv p := by
+    rcases p with ⟨a, e⟩
+    change (a, finProdFinEquiv (finProdFinEquiv.symm e)) = (a, e)
+    rw [Equiv.apply_symm_apply]
+  right_inv p := by
+    rcases p with ⟨i, j, a⟩
+    change ((finProdFinEquiv.symm (finProdFinEquiv (i, j))).1,
+      ((finProdFinEquiv.symm (finProdFinEquiv (i, j))).2, a)) = (i, (j, a))
+    rw [Equiv.symm_apply_apply]
+
+/-- A rectangular Stinespring isometry, with its output reindexed into Wolf's
+square three-factor open-system space. -/
+private noncomputable def openSystemReindexStinespring
+    (V : Matrix (Fin d' × Fin (d * d')) (Fin d) ℂ) :
+    Matrix (Fin d × (Fin d' × Fin d')) (Fin d) ℂ :=
+  Matrix.reindex (stinespringToOpenSystemEquiv d d') (Equiv.refl _) V
+
+/-- Partial trace over Wolf's environment, namely the first two factors
+`ℂ^d ⊗ ℂ^{d'}`, retaining the final output factor `ℂ^{d'}`. -/
+noncomputable def openSystemPartialTrace
+    (X : Matrix (Fin d × (Fin d' × Fin d'))
+      (Fin d × (Fin d' × Fin d')) ℂ) :
+    Matrix (Fin d') (Fin d') ℂ :=
+  fun a b => ∑ i : Fin d, ∑ j : Fin d', X (i, (j, a)) (i, (j, b))
+
+@[simp]
+private theorem openSystemReindexStinespring_apply
+    (V : Matrix (Fin d' × Fin (d * d')) (Fin d) ℂ)
+    (p : Fin d × (Fin d' × Fin d')) (k : Fin d) :
+    openSystemReindexStinespring V p k =
+      V ((stinespringToOpenSystemEquiv d d').symm p) k := rfl
+
+@[simp]
+private theorem stinespringToOpenSystemEquiv_symm_apply
+    (i : Fin d) (j a : Fin d') :
+    (stinespringToOpenSystemEquiv d d').symm (i, (j, a)) =
+      (a, finProdFinEquiv (i, j)) := rfl
+
+/-- Reindexing a matrix on the Stinespring output space turns its trace over
+`Fin (d * d')` into the trace over the first two open-system factors. -/
+private theorem openSystemPartialTrace_reindex
+    (Y : Matrix (Fin d' × Fin (d * d')) (Fin d' × Fin (d * d')) ℂ) :
+    openSystemPartialTrace
+        (Matrix.reindex (stinespringToOpenSystemEquiv d d')
+          (stinespringToOpenSystemEquiv d d') Y) =
+      Matrix.traceRight Y := by
+  classical
+  ext a b
+  simp only [openSystemPartialTrace, Matrix.traceRight_apply, Matrix.reindex_apply,
+    Matrix.submatrix_apply, stinespringToOpenSystemEquiv_symm_apply]
+  simpa only [Fintype.sum_prod_type] using
+    (Equiv.sum_comp finProdFinEquiv
+      (fun k : Fin (d * d') => Y (a, k) (b, k)))
+
+/-- Reindexing the Stinespring codomain turns its right partial trace into the
+partial trace over the first two factors of Wolf's open-system space. -/
+private theorem openSystemPartialTrace_reindexStinespring
+    (V : Matrix (Fin d' × Fin (d * d')) (Fin d) ℂ)
+    (X : Matrix (Fin d) (Fin d) ℂ) :
+    openSystemPartialTrace
+        (openSystemReindexStinespring V * X * (openSystemReindexStinespring V)ᴴ) =
+      Matrix.traceRight (V * X * Vᴴ) := by
+  classical
+  rw [show openSystemReindexStinespring V * X * (openSystemReindexStinespring V)ᴴ =
+      Matrix.reindex (stinespringToOpenSystemEquiv d d')
+        (stinespringToOpenSystemEquiv d d') (V * X * Vᴴ) by
+    ext p q
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      openSystemReindexStinespring_apply, Matrix.reindex_apply, Matrix.submatrix_apply]]
+  exact openSystemPartialTrace_reindex (V * X * Vᴴ)
+
+/-- The normalized vector used in Wolf's unitary extension: the first standard
+basis vector of `ℂ^{d'} ⊗ ℂ^{d'}`. -/
+private noncomputable def openSystemAncillaVector (d' : ℕ) (hd' : 0 < d') :
+    Fin d' × Fin d' → ℂ :=
+  fun p => if p = (⟨0, hd'⟩, ⟨0, hd'⟩) then 1 else 0
+
+/-- `openSystemAncillaVector` is normalized. -/
+private theorem openSystemAncillaVector_normalized (d' : ℕ) (hd' : 0 < d') :
+    ∑ x, star (openSystemAncillaVector d' hd' x) *
+      openSystemAncillaVector d' hd' x = 1 := by
+  classical
+  simp [openSystemAncillaVector]
+
+/-- A rectangular CPTP map with nonzero input dimension has nonzero output
+dimension. -/
+theorem output_dimension_pos_of_isKrausCPTP [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsKrausCPTP T) : 0 < d' := by
+  by_contra hd'
+  have hd'0 : d' = 0 := Nat.eq_zero_of_not_pos hd'
+  have htrace := hT.trace_map (1 : Matrix (Fin d) (Fin d) ℂ)
+  have hzero : T (1 : Matrix (Fin d) (Fin d) ℂ) = 0 := by
+    ext i j
+    exact (Nat.not_lt_zero i.val (by simpa [hd'0] using i.isLt)).elim
+  rw [hzero] at htrace
+  have hdcast : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+  exact hdcast (by simpa [Matrix.trace] using htrace.symm)
+
+/-- **Wolf, Chapter 2, Theorem 2.5, “Open-system representation,” Equation
+(2.14): rectangular unitary form.**
+
+See `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 409–429.
+
+For every CPTP map `T : M_d(ℂ) → M_{d'}(ℂ)` with nonzero input dimension, there
+are a unitary `U ∈ M_{d(d')^2}(ℂ)`, acting on
+`ℂ^d ⊗ ℂ^{d'} ⊗ ℂ^{d'}`, and a normalized
+`φ ∈ ℂ^{d'} ⊗ ℂ^{d'}` such that
+
+`T(ρ) = tr_E[U (ρ ⊗ |φ⟩⟨φ|) Uᴴ]`,
+
+where `tr_E` traces the first two factors, of total dimension `d * d'`, and
+retains the final `d'`-dimensional output factor. -/
+theorem IsKrausCPTP.exists_openSystem_unitary [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsKrausCPTP T) :
+    ∃ (U : Matrix.unitaryGroup (Fin d × (Fin d' × Fin d')) ℂ)
+      (φ : Fin d' × Fin d' → ℂ),
+      (∑ x, star (φ x) * φ x = 1) ∧
+      ∀ ρ : Matrix (Fin d) (Fin d) ℂ,
+        T ρ = openSystemPartialTrace
+          ((U : Matrix (Fin d × (Fin d' × Fin d'))
+            (Fin d × (Fin d' × Fin d')) ℂ) *
+            openSystemInput φ ρ * Uᴴ) := by
+  classical
+  have hd' : 0 < d' := output_dimension_pos_of_isKrausCPTP hT
+  obtain ⟨V, hViso, hV⟩ :=
+    ChoiRectangular.exists_stinespringV_schrodinger_of_isKrausCPTP hT
+      (ChoiRectangular.choiRank_le_mul T)
+  let V' := openSystemReindexStinespring V
+  have hV'iso : V'ᴴ * V' = 1 := by
+    ext i j
+    have hentry := congr_fun (congr_fun hViso i) j
+    simp only [V', Matrix.mul_apply, Matrix.conjTranspose_apply,
+      openSystemReindexStinespring_apply] at hentry ⊢
+    exact (Equiv.sum_comp (stinespringToOpenSystemEquiv d d').symm
+      (fun q => star (V q i) * V q j)).trans hentry
+  let φ := openSystemAncillaVector d' hd'
+  have hφ : ∑ x, star (φ x) * φ x = 1 :=
+    openSystemAncillaVector_normalized d' hd'
+  let W := openSystemInputEmbedding (d := d) φ
+  have hWiso : Wᴴ * W = 1 :=
+    openSystemInputEmbedding_conjTranspose_mul_self φ hφ
+  obtain ⟨U, hUW⟩ := Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq
+    (B := V') (A := W) (by rw [hV'iso, hWiso])
+  refine ⟨U, φ, hφ, ?_⟩
+  intro ρ
+  rw [hV ρ, ← openSystemPartialTrace_reindexStinespring V ρ]
+  congr 1
+  rw [openSystemInput_eq_embedding]
+  simp only [W, V', Matrix.conjTranspose_mul, Matrix.mul_assoc, hUW]
+
+end Channel

--- a/QICLean/Channel/Stinespring.lean
+++ b/QICLean/Channel/Stinespring.lean
@@ -201,10 +201,11 @@ theorem Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap_gen
   `T(ρ)_{ij} = ∑_k (V ρ V†)_{(i,k),(j,k)} = tr_r(V ρ V†)`
 
 where `tr_r` denotes partial trace over the dilation space `ℂ^r`. -/
-theorem stinespring_schrodinger_representation {r : ℕ}
-    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
-    (X : Matrix (Fin D) (Fin D) ℂ)
-    (i j : Fin D) :
+theorem stinespring_schrodinger_representation {r : ℕ} {α β : Type*}
+    [Fintype α]
+    (K : Fin r → Matrix β α ℂ)
+    (X : Matrix α α ℂ)
+    (i j : β) :
     (∑ l : Fin r, K l * X * (K l)ᴴ) i j =
     ∑ k : Fin r,
       (stinespringV K * X * (stinespringV K)ᴴ) (i, k) (j, k) := by

--- a/QICLean/Channel/StinespringRectangular.lean
+++ b/QICLean/Channel/StinespringRectangular.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import QICLean.Channel.KrausCPTP
 import QICLean.Channel.KrausRectangular
 import QICLean.Channel.Stinespring
 
@@ -116,6 +117,40 @@ theorem exists_stinespringV_of_isKrausCP
   · -- `V†V = ∑ⱼ Kⱼ†Kⱼ`, which is `𝟙` exactly for trace-preserving `T`.
     rw [stinespringV_conjTranspose_mul]
     exact (kraus_tp_iff_sum_conjTranspose_mul K T hK).symm
+
+/-- **Rectangular Stinespring representation, Schrödinger picture** (Wolf,
+Chapter 2, Theorem 2.2). Whenever the dimension of the dilation space is at
+least the Choi rank, a completely positive map has a Stinespring matrix whose
+right partial trace is the map itself. The matrix is an isometry exactly when
+the map preserves trace. -/
+theorem exists_stinespringV_schrodinger_of_isKrausCP
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsKrausCP T) {r : ℕ} (hr : Channel.choiRank T ≤ r) :
+    ∃ V : Matrix (Fin d' × Fin r) (Fin d) ℂ,
+      (∀ X : Matrix (Fin d) (Fin d) ℂ,
+        T X = Matrix.traceRight (V * X * Vᴴ)) ∧
+      (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) := by
+  obtain ⟨K, hK⟩ :=
+    Channel.hasKrausCard_mono (Channel.hasKrausCard_choiRank_of_cp hT) hr
+  refine ⟨stinespringV K, ?_, ?_⟩
+  · intro X
+    rw [hK X]
+    ext i j
+    exact stinespring_schrodinger_representation K X i j
+  · rw [stinespringV_conjTranspose_mul]
+    exact (kraus_tp_iff_sum_conjTranspose_mul K T hK).symm
+
+/-- **Rectangular isometric Stinespring representation for CPTP maps.** -/
+theorem exists_stinespringV_schrodinger_of_isKrausCPTP
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsKrausCPTP T) {r : ℕ} (hr : Channel.choiRank T ≤ r) :
+    ∃ V : Matrix (Fin d' × Fin r) (Fin d) ℂ,
+      Vᴴ * V = 1 ∧
+      ∀ X : Matrix (Fin d) (Fin d) ℂ,
+        T X = Matrix.traceRight (V * X * Vᴴ) := by
+  obtain ⟨V, hschrodinger, hV⟩ :=
+    exists_stinespringV_schrodinger_of_isKrausCP hT.isKrausCP hr
+  exact ⟨V, hV.mpr hT.trace_map, hschrodinger⟩
 
 /-- **Stinespring dilation at the Choi-rank ancilla dimension** (Wolf,
 Chapter 2, Theorem 2.2): the case \(r = \operatorname{rank}(\tau)\) of

--- a/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
@@ -197,6 +197,8 @@ channel.
 \begin{theorem}[Stinespring representation, rectangular form]
     \label{thm:stinespring_rectangular}
     \lean{ChoiRectangular.exists_stinespringV_of_isKrausCP,
+        ChoiRectangular.exists_stinespringV_schrodinger_of_isKrausCP,
+        ChoiRectangular.exists_stinespringV_schrodinger_of_isKrausCPTP,
         ChoiRectangular.exists_stinespringV_choiRank_of_isKrausCP,
         ChoiRectangular.exists_stinespringV_pairing_of_isKrausCP,
         ChoiRectangular.exists_stinespringV_pairing_choiRank_of_isKrausCP}
@@ -210,8 +212,15 @@ channel.
         \label{eq:stinespring_rectangular}
     \end{align}
     and $V$ is an isometry, $V^\dagger V=\Id_d$, if and only if $T$ is trace
-    preserving. In particular $r=\rank(\tau)$ is an admissible ancilla
-    dimension; by Lemma~\ref{lem:stinespring_rectangular_least_dim} no smaller
+    preserving. In the Schr\"odinger picture one may choose the same type of
+    dilation so that
+    \begin{align}
+        T(\rho)&=\tr_{\C^r}(V\rho V^\dagger)
+        \label{eq:stinespring_rectangular_schrodinger}
+    \end{align}
+    for every $\rho\in\MN{d}$. In particular $r=\rank(\tau)$ is an admissible
+    ancilla dimension; by
+    Lemma~\ref{lem:stinespring_rectangular_least_dim} no smaller
     ancilla dimension is admissible, and a dilation with $r=\rank(\tau)$ is
     called minimal. This is \cite[Theorem~2.2]{Wolf2012Quantum}.
 \end{theorem}
@@ -613,6 +622,54 @@ a common dilation space.
     Lemma~\ref{lem:exists_unitary_mul_eq_of_gram_eq}
     gives a unitary $U$ with $V=UW_0$. Substituting this identity into the
     partial trace formula gives (\ref{eq:representations_open_unitary}).
+\end{proof}
+
+\begin{theorem}[Open-system representation]
+    \label{thm:channel_exists_open_system_unitary_rectangular}
+    \lean{Channel.openSystemInputEmbedding,
+        Channel.openSystemInput,
+        Channel.openSystemInput_eq_embedding,
+        Channel.openSystemPartialTrace,
+        Channel.output_dimension_pos_of_isKrausCPTP,
+        Channel.IsKrausCPTP.exists_openSystem_unitary}
+    \leanok
+    \uses{def:is_kraus_cptp, def:partial_trace, thm:stinespring_rectangular,
+        thm:kraus_rect_rank_minimal, lem:exists_unitary_mul_eq_of_gram_eq}
+    Let $d\geq1$ and let $T:\MN{d}\to\MN{d'}$ be completely positive and
+    trace-preserving. Then $d'\geq1$, and there are a normalized vector
+    $\varphi\in\C^{d'}\otimes\C^{d'}$ and a unitary $U$ on
+    $\C^d\otimes\C^{d'}\otimes\C^{d'}$, a space of total dimension
+    $d(d')^2$, such that, for every $\rho\in\MN{d}$,
+    \begin{align}
+        T(\rho)
+        &=\tr_{\C^d\otimes\C^{d'}}\!\left[
+          U\bigl(\rho\otimes\ketbra{\varphi}{\varphi}\bigr)U^\dagger
+          \right].
+        \label{eq:representations_open_system_rectangular_unitary}
+    \end{align}
+    Here the partial trace is over the first two tensor factors
+    $\C^d\otimes\C^{d'}$ and retains the final factor $\C^{d'}$. This is
+    \cite[Theorem~2.5, Equation~(2.14)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:stinespring_rectangular, thm:kraus_rect_rank_minimal,
+        lem:exists_unitary_mul_eq_of_gram_eq}
+    Choose the Stinespring dilation space to have dimension $r=dd'$. The
+    bound $\rank(\tau_T)\leq dd'$ and the Schr\"odinger form of
+    Theorem~\ref{thm:stinespring_rectangular} give an isometry
+    $V:\C^d\to\C^{d'}\otimes\C^{dd'}$ satisfying
+    $T(\rho)=\tr_{\C^{dd'}}(V\rho V^\dagger)$. Reorder the codomain as
+    $\C^d\otimes\C^{d'}\otimes\C^{d'}$, with the retained output factor
+    last. Choose a normalized $\varphi\in\C^{d'}\otimes\C^{d'}$ and let
+    $W_\varphi x=x\otimes\varphi$. Since the reordered Stinespring map and
+    $W_\varphi$ are isometries, their Gram matrices agree. By
+    Lemma~\ref{lem:exists_unitary_mul_eq_of_gram_eq}, a unitary $U$ on the
+    common $d(d')^2$-dimensional space satisfies $V=UW_\varphi$. Substitution,
+    together with
+    $W_\varphi\rho W_\varphi^\dagger
+      =\rho\otimes\ketbra{\varphi}{\varphi}$,
+    gives (\ref{eq:representations_open_system_rectangular_unitary}).
 \end{proof}
 
 %% =========================================================

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -118,6 +118,10 @@ project import.
     — for a completely positive `T : M_d → M_{d'}` and every `r ≥ rank(τ)`
     there is a `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` with `T*(A) = V†(A ⊗ 𝟙_r)V`, an
     isometry exactly when `T` is trace preserving ✓
+    `exists_stinespringV_schrodinger_of_isKrausCP` /
+    `exists_stinespringV_schrodinger_of_isKrausCPTP`
+    — the corresponding rectangular Schrödinger-picture realization
+    `T(ρ) = tr_{ℂ^r}(VρV†)`, with an isometric witness for CPTP maps ✓
     `exists_stinespringV_choiRank_of_isKrausCP` /
     `exists_stinespringV_pairing_choiRank_of_isKrausCP`
     — the dilation at the Choi-rank ancilla dimension `r = rank(τ)` ✓
@@ -148,14 +152,32 @@ project import.
     for CP `T₁, T₂`, a constructed Stinespring matrix for `T₁ + T₂` yields
     PSD `P₁ + P₂ = 𝟙` with `Tᵢ(A) = V†(A ⊗ Pᵢ)V` ✓
 
-* **Theorem 2.5** (open-system representation, reduced form):
-  - `IsChannel.exists_stinespring_open_system` — every CPTP map is
+* **Theorem 2.5, Equation (2.14)** (open-system representation):
+  - `Channel.IsKrausCPTP.exists_openSystem_unitary` — the source-facing
+    rectangular theorem for every CPTP map `T : M_d(ℂ) → M_{d'}(ℂ)` with
+    `d ≥ 1`: take a Stinespring dilation space of dimension `r = dd'`, a
+    normalized `φ ∈ ℂ^{d'} ⊗ ℂ^{d'}`, and a unitary on
+    `ℂ^d ⊗ ℂ^{d'} ⊗ ℂ^{d'}` of total dimension `d(d')²`; tracing the first
+    two tensor factors `ℂ^d ⊗ ℂ^{d'}` retains the final `d'`-dimensional
+    factor and gives
+    `T(ρ) = tr_E[U(ρ ⊗ |φ⟩⟨φ|)U†]` ✓
+  - `IsChannel.exists_stinespring_open_system` — the older square-algebra
+    specialization gives
     `T(ρ)_{ij} = ∑ₖ (V ρ V†)_{(i,k),(j,k)}` for an isometric `V` ✓
   - `IsChannel.exists_stinespring_open_system_traceRight` — equivalent
-    form via `Matrix.traceRight`: `T(ρ) = tr_E[V ρ V†]` ✓
-  - `IsChannel.exists_stinespring_open_system_unitary` — unitary form
+    square form via `Matrix.traceRight`: `T(ρ) = tr_E[V ρ V†]` ✓
+  - `IsChannel.exists_stinespring_open_system_unitary` — square unitary form
     `T(ρ) = tr_E[U W₀ ρ W₀† U†]`, where `W₀` inserts the system into the
     first environment coordinate ✓
+
+* **Proposition “Environment induced instruments,” Equation (2.15)**:
+  - `Channel.exists_environment_povm_of_sum_eq_stinespring` — the
+    source-faithful finite-family statement relative to a supplied
+    rectangular Stinespring representation ✓
+  - `Channel.exists_environment_povm_of_sum_eq_openSystem` — the downstream
+    system-plus-environment form relative to Equation (2.14), with a POVM on
+    the `dd'`-dimensional environment and the bound
+    `krausRank(Tᵢ) ≤ rank(Pᵢ)` ✓
 
 * **Theorem 2.6** (Naimark / Neumark dilation for POVMs):
   - `POVM` — positive operator-valued measure structure ✓


### PR DESCRIPTION
## Summary

- Formalize Wolf, Chapter 2, Theorem 2.5, “Open-system representation,” and Equation (2.14) for rectangular CPTP maps `T : M_d(ℂ) → M_{d'}(ℂ)`.
- Add the rectangular Schrödinger-picture Stinespring statement needed for a dilation space of dimension `r = dd'`.
- Move the Equation (2.14) input embedding, fixed-state input, and compression identity from `EnvironmentInducedInstrument.lean` into the focused `OpenSystemRectangular.lean` module; the downstream instrument construction now imports that module.
- Synchronize the source-facing Blueprint node and the Wolf numbering coverage. The existing square open-system theorem remains unchanged as the square-algebra specialization.

## Source-following proof path

The proof follows `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 409–429.

1. The Choi-rank bound supplies a Stinespring dilation with `r = dd'` and an isometry
   `V : ℂ^d → ℂ^{d'} ⊗ ℂ^{dd'}` satisfying `T(ρ) = tr_{ℂ^{dd'}}(VρV†)`.
2. The codomain is reindexed as `ℂ^d ⊗ ℂ^{d'} ⊗ ℂ^{d'}`. In this ordering the first two tensor factors form the `dd'`-dimensional environment, while the final `d'`-dimensional factor is retained as the output.
3. A normalized `φ ∈ ℂ^{d'} ⊗ ℂ^{d'}` is fixed and `Wφ x = x ⊗ φ` is formed. The reordered Stinespring map and `Wφ` have the same Gram matrix.
4. The existing Gram-unitary extension theorem yields a unitary `U` on the common space, of total dimension `d(d')²`, with `V = U Wφ`.
5. The identity `Wφ ρ Wφ† = ρ ⊗ |φ⟩⟨φ|` and the reindexed partial trace give the literal Equation (2.14), tracing the first two tensor factors and retaining the third.

The Lean hypothesis `[NeZero d]` makes the source convention `d ≥ 1` explicit; trace preservation then proves `d' ≥ 1`, so the normalized ancillary vector exists.

## Refactoring

- `stinespring_schrodinger_representation` is generalized from square matrices to `Matrix β α ℂ`.
- The public Equation (2.14) interface is recorded in the Blueprint. Reindexing and concrete-witness machinery used only by the proof is private.
- `QICLean.Channel` imports the new module, while the pre-existing square theorem and API are preserved.

## Verification

- `lake env lean QICLean/Channel/OpenSystemRectangular.lean`
- `lake build QICLean`
- `lake exe lint_style --github`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- reverse Blueprint coverage check: no changed public declaration is missing
- reader-facing prose, numbered-module, oversized-module, and policy test suites
- `chktex` and `latexindent` on the changed Blueprint chapter
- forbidden-token scan for `sorry`, `admit`, `axiom`, and `native_decide`
- `#print axioms` for the new public theorems: only `propext`, `Classical.choice`, and `Quot.sound`

Closes #6
