### PR TITLE
feat(channel): formalize positive-definite operator normal form

### DIFF
--- a/QICLean/Channel/LorentzNormalForm/NormalForm.lean
+++ b/QICLean/Channel/LorentzNormalForm/NormalForm.lean
@@ -10,15 +10,19 @@ import QICLean.Analysis.MarginalSupport
 /-!
 # Lorentz normal form: the generic normal form for CP maps
 
-This module proves Wolf Proposition 2.9
-(`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 894–929): a
-completely positive map with full Kraus rank (positive-definite Choi matrix)
-admits SL-filterings on the input and output factors making the composition
-doubly-stochastic.  The square and rectangular forms are both given; the
-square form is the equal-dimension specialization.
+This module proves the two generic normal-form propositions of Wolf Chapter 2
+(`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 894–929).  First, a
+positive-definite operator on `ℂ^{d₂} ⊗ ℂ^{d₁}` has a trace-minimizing
+representative under determinant-one local filtering whose two partial traces
+are scalar.  The Choi--Jamiolkowski correspondence then gives the corresponding
+normal form for a completely positive map with full Kraus rank.  The square and
+rectangular CP-map forms are both given; the square form is the equal-dimension
+specialization.
 
 ## Main results
 
+* `Wolf.exists_normal_form_generic_tau` — the positive-definite operator normal
+  form, Wolf Proposition 2.8
 * `Wolf.exists_normal_form_generic` — the generic normal form for
   `T : M_D(ℂ) → M_D(ℂ)`
 * `Wolf.exists_normal_form_generic_rect` — the generic normal form for
@@ -27,7 +31,7 @@ square form is the equal-dimension specialization.
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.4,
-  Proposition 2.9][Wolf2012QChannels]
+  Propositions 2.8--2.9][Wolf2012QChannels]
 -/
 
 open scoped Matrix BigOperators ComplexOrder Kronecker
@@ -35,6 +39,110 @@ open Matrix Finset
 open ChoiJamiolkowski
 
 namespace Wolf
+
+/-! ### Positive-definite operator normal form (Wolf Proposition 2.8) -/
+
+section PositiveDefiniteOperatorNormalForm
+
+variable {d₁ d₂ : ℕ}
+
+-- Source: Notes/WolfNoteTexSource/ch02_representations.tex lines 894–919 (Wolf Proposition 2.8).
+/-- **Wolf Proposition 2.8: normal form for a generic positive-definite operator.**
+
+Let `τ` be a positive-definite operator on `ℂ^{d₂} ⊗ ℂ^{d₁}`.  There are
+matrices `Sᵢ ∈ SL(dᵢ, ℂ)` attaining the infimum in Wolf Equation (2.36) such
+that, for
+`τ' = (S₂ ⊗ₖ S₁) * τ * (S₂ ⊗ₖ S₁)ᴴ`, both partial traces of `τ'` are
+proportional to the identity.
+
+The proof follows Wolf's order at source lines 901--919.  First choose a global
+minimizer using `infimum_is_attained`.  Holding either local filtering fixed,
+the other partial trace minimizes `tr(S M Sᴴ)` over `det S = 1`; the
+trace--determinant AM--GM equality criterion `posDef_orbit_min_isScalar` then
+forces that marginal to be scalar. -/
+theorem exists_normal_form_generic_tau [NeZero d₁] [NeZero d₂]
+    {τ : Matrix (Fin d₂ × Fin d₁) (Fin d₂ × Fin d₁) ℂ}
+    (hτ : τ.PosDef) :
+    ∃ (S₁ : Matrix (Fin d₁) (Fin d₁) ℂ) (S₂ : Matrix (Fin d₂) (Fin d₂) ℂ),
+      S₁.det = 1 ∧ S₂.det = 1 ∧
+      (∀ (T₁ : Matrix (Fin d₁) (Fin d₁) ℂ)
+          (T₂ : Matrix (Fin d₂) (Fin d₂) ℂ),
+        T₁.det = 1 → T₂.det = 1 →
+        (Matrix.trace ((T₂ ⊗ₖ T₁) * τ * (T₂ ⊗ₖ T₁)ᴴ)).re ≥
+          (Matrix.trace ((S₂ ⊗ₖ S₁) * τ * (S₂ ⊗ₖ S₁)ᴴ)).re) ∧
+      (∃ κ₁ : ℂ,
+        Matrix.traceLeft ((S₂ ⊗ₖ S₁) * τ * (S₂ ⊗ₖ S₁)ᴴ) = κ₁ • 1) ∧
+      (∃ κ₂ : ℂ,
+        Matrix.traceRight ((S₂ ⊗ₖ S₁) * τ * (S₂ ⊗ₖ S₁)ᴴ) = κ₂ • 1) := by
+  classical
+  obtain ⟨S₁, S₂, hS₁det, hS₂det, hmin⟩ := infimum_is_attained hτ
+  have hU2 : IsUnit (S₂ ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ)) := by
+    simp [Matrix.isUnit_iff_isUnit_det, Matrix.det_kronecker, hS₂det]
+  have hU1 : IsUnit ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ S₁) := by
+    simp [Matrix.isUnit_iff_isUnit_det, Matrix.det_kronecker, hS₁det]
+  set ρ₂ := (S₂ ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ)) * τ *
+    (S₂ ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ))ᴴ with hρ₂
+  set ρ₁ := ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ S₁) * τ *
+    ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ S₁)ᴴ with hρ₁
+  have hρ₂pd : ρ₂.PosDef :=
+    hτ.mul_mul_conjTranspose_same (Matrix.vecMul_injective_iff_isUnit.mpr hU2)
+  have hρ₁pd : ρ₁.PosDef :=
+    hτ.mul_mul_conjTranspose_same (Matrix.vecMul_injective_iff_isUnit.mpr hU1)
+  have hX : ∀ X : Matrix (Fin d₁) (Fin d₁) ℂ,
+      Matrix.traceLeft ((S₂ ⊗ₖ X) * τ * (S₂ ⊗ₖ X)ᴴ)
+        = X * Matrix.traceLeft ρ₂ * Xᴴ := by
+    intro X
+    have hfactor : (S₂ ⊗ₖ X) =
+        ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ X) *
+          (S₂ ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ)) := by
+      rw [← Matrix.mul_kronecker_mul, Matrix.one_mul, Matrix.mul_one]
+    have hsplit : (S₂ ⊗ₖ X) * τ * (S₂ ⊗ₖ X)ᴴ
+        = ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ X) * ρ₂ *
+            ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ X)ᴴ := by
+      rw [hρ₂, hfactor, Matrix.conjTranspose_mul]
+      simp only [Matrix.mul_assoc]
+    rw [hsplit, traceLeft_one_kron_conj]
+  have hY : ∀ X : Matrix (Fin d₂) (Fin d₂) ℂ,
+      Matrix.traceRight ((X ⊗ₖ S₁) * τ * (X ⊗ₖ S₁)ᴴ)
+        = X * Matrix.traceRight ρ₁ * Xᴴ := by
+    intro X
+    have hfactor : (X ⊗ₖ S₁) =
+        (X ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ)) *
+          ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ S₁) := by
+      rw [← Matrix.mul_kronecker_mul, Matrix.mul_one, Matrix.one_mul]
+    have hsplit : (X ⊗ₖ S₁) * τ * (X ⊗ₖ S₁)ᴴ
+        = (X ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ)) * ρ₁ *
+            (X ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ))ᴴ := by
+      rw [hρ₁, hfactor, Matrix.conjTranspose_mul]
+      simp only [Matrix.mul_assoc]
+    rw [hsplit, traceRight_kron_one_conj]
+  have hM₁pd : (Matrix.traceLeft ρ₂).PosDef := hρ₂pd.partialTraceLeft
+  have hM₂pd : (Matrix.traceRight ρ₁).PosDef := hρ₁pd.partialTraceRight
+  have hN₂ : ∃ κ₂ : ℂ,
+      Matrix.traceRight ((S₂ ⊗ₖ S₁) * τ * (S₂ ⊗ₖ S₁)ᴴ) = κ₂ • 1 := by
+    exact posDef_orbit_min_isScalar hM₂pd
+      (by
+        simpa only [hY S₂] using hM₂pd.posSemidef.mul_mul_conjTranspose_same S₂)
+      (by
+        simp [hY S₂, Matrix.det_mul, hS₂det])
+      (by
+        intro S hS
+        simpa only [← trace_eq_trace_traceRight, ← hY S] using
+          hmin S₁ S hS₁det hS)
+  have hN₁ : ∃ κ₁ : ℂ,
+      Matrix.traceLeft ((S₂ ⊗ₖ S₁) * τ * (S₂ ⊗ₖ S₁)ᴴ) = κ₁ • 1 := by
+    exact posDef_orbit_min_isScalar hM₁pd
+      (by
+        simpa only [hX S₁] using hM₁pd.posSemidef.mul_mul_conjTranspose_same S₁)
+      (by
+        simp [hX S₁, Matrix.det_mul, hS₁det])
+      (by
+        intro S hS
+        simpa only [← Matrix.trace_eq_trace_traceLeft, ← hX S] using
+          hmin S S₂ hS hS₂det)
+  exact ⟨S₁, S₂, hS₁det, hS₂det, hmin, hN₁, hN₂⟩
+
+end PositiveDefiniteOperatorNormalForm
 
 /-! ### Generic normal form (Wolf Proposition 2.9) -/
 
@@ -201,11 +309,11 @@ SL-filterings Φ₁ on `M_{d₁}(ℂ)` and Φ₂ on `M_{d₂}(ℂ)` — invertib
 Kraus rank one — such that `Φ₂ ∘ T ∘ Φ₁` is doubly-stochastic: both
 `(Φ₂TΦ₁)(𝟙)` and `(Φ₂TΦ₁)*(𝟙)` are proportional to the identity matrix.
 
-The proof follows the source: the infimum of
-`tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]` over `SL(d₁) × SL(d₂)` is attained
-(`infimum_is_attained`), and at the minimiser each partial trace saturates the
-trace–determinant AM–GM bound, so both reduced operators are scalar
-(`posDef_orbit_min_isScalar`).  The square case `d₁ = d₂` is
+The proof applies `exists_normal_form_generic_tau`, Wolf's preceding operator
+normal form, to the rectangular Choi matrix of `T`.  The Choi transformation
+rule identifies its minimizing local filters with `Φ₂ ∘ T ∘ Φ₁`, and the two
+scalar partial-trace identities are exactly the two clauses of
+`DoublyStochasticRect`.  The square case `d₁ = d₂` is
 `exists_normal_form_generic` above. -/
 theorem exists_normal_form_generic_rect [NeZero d₁] [NeZero d₂]
     (T : Matrix (Fin d₁) (Fin d₁) ℂ →ₗ[ℂ] Matrix (Fin d₂) (Fin d₂) ℂ)
@@ -214,8 +322,8 @@ theorem exists_normal_form_generic_rect [NeZero d₁] [NeZero d₂]
     ∃ (Φ₁ : SLFiltering d₁) (Φ₂ : SLFiltering d₂),
       DoublyStochasticRect (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map) := by
   classical
-  obtain ⟨S₁, S₂, hS₁det, hS₂det, hmin⟩ :=
-    infimum_is_attained (τ := ChoiRectangular.choiMatrix T) _hFullRank
+  obtain ⟨S₁, S₂, hS₁det, hS₂det, _, hτN₁, hτN₂⟩ :=
+    exists_normal_form_generic_tau _hFullRank
   let Φ₁ : SLFiltering d₁ :=
     { S := S₁ᵀ
       det_eq_one := by rw [Matrix.det_transpose, hS₁det]
@@ -240,74 +348,11 @@ theorem exists_normal_form_generic_rect [NeZero d₁] [NeZero d₂]
         rw [← Matrix.mul_kronecker_mul, Matrix.mul_one, Matrix.one_mul],
       Matrix.conjTranspose_mul]
     simp only [Matrix.mul_assoc]
-  -- Invertibility of the Kronecker factors.
-  have hU2 : IsUnit (S₂ ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ)) := by
-    rw [Matrix.isUnit_iff_isUnit_det, Matrix.det_kronecker, hS₂det, Matrix.det_one]; simp
-  have hU1 : IsUnit ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ S₁) := by
-    rw [Matrix.isUnit_iff_isUnit_det, Matrix.det_kronecker, hS₁det, Matrix.det_one]; simp
-  -- The two partially filtered operators and their positivity.
-  set ρ₂ := (S₂ ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ)) * ChoiRectangular.choiMatrix T *
-    (S₂ ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ))ᴴ with hρ₂
-  set ρ₁ := ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ S₁) * ChoiRectangular.choiMatrix T *
-    ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ S₁)ᴴ with hρ₁
-  have hρ₂pd : ρ₂.PosDef :=
-    _hFullRank.mul_mul_conjTranspose_same (Matrix.vecMul_injective_iff_isUnit.mpr hU2)
-  have hρ₁pd : ρ₁.PosDef :=
-    _hFullRank.mul_mul_conjTranspose_same (Matrix.vecMul_injective_iff_isUnit.mpr hU1)
-  -- Conjugation/partial-trace reductions.
-  have hX : ∀ X : Matrix (Fin d₁) (Fin d₁) ℂ,
-      Matrix.traceLeft ((S₂ ⊗ₖ X) * ChoiRectangular.choiMatrix T * (S₂ ⊗ₖ X)ᴴ)
-        = X * Matrix.traceLeft ρ₂ * Xᴴ := by
-    intro X
-    have hsplit : (S₂ ⊗ₖ X) * ChoiRectangular.choiMatrix T * (S₂ ⊗ₖ X)ᴴ
-        = ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ X) * ρ₂ *
-            ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ X)ᴴ := by
-      rw [hρ₂, show (S₂ ⊗ₖ X) = ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ X) *
-          (S₂ ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ)) by
-            rw [← Matrix.mul_kronecker_mul, Matrix.one_mul, Matrix.mul_one],
-        Matrix.conjTranspose_mul]
-      simp only [Matrix.mul_assoc]
-    rw [hsplit, traceLeft_one_kron_conj]
-  have hY : ∀ X : Matrix (Fin d₂) (Fin d₂) ℂ,
-      Matrix.traceRight ((X ⊗ₖ S₁) * ChoiRectangular.choiMatrix T * (X ⊗ₖ S₁)ᴴ)
-        = X * Matrix.traceRight ρ₁ * Xᴴ := by
-    intro X
-    have hsplit : (X ⊗ₖ S₁) * ChoiRectangular.choiMatrix T * (X ⊗ₖ S₁)ᴴ
-        = (X ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ)) * ρ₁ *
-            (X ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ))ᴴ := by
-      rw [hρ₁, show (X ⊗ₖ S₁) = (X ⊗ₖ (1 : Matrix (Fin d₁) (Fin d₁) ℂ)) *
-          ((1 : Matrix (Fin d₂) (Fin d₂) ℂ) ⊗ₖ S₁) by
-            rw [← Matrix.mul_kronecker_mul, Matrix.mul_one, Matrix.one_mul],
-        Matrix.conjTranspose_mul]
-      simp only [Matrix.mul_assoc]
-    rw [hsplit, traceRight_kron_one_conj]
-  have hM₁pd : (Matrix.traceLeft ρ₂).PosDef := hρ₂pd.partialTraceLeft
-  have hM₂pd : (Matrix.traceRight ρ₁).PosDef := hρ₁pd.partialTraceRight
   have hd₁ : (d₁ : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d₁)
   refine ⟨Φ₁, Φ₂, ?_, ?_⟩
   · -- Clause 1: `(Φ₂ ∘ T ∘ Φ₁)(𝟙) ∝ 𝟙`, from the input-side minimisation.
-    have hN₂ : ∃ κ : ℂ,
-        Matrix.traceRight (ChoiRectangular.choiMatrix (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map)) =
-          κ • 1 := by
-      apply posDef_orbit_min_isScalar hM₂pd
-      · rw [hC]
-        exact (_hFullRank.posSemidef.mul_mul_conjTranspose_same _).partialTraceRight
-      · rw [hC, hY S₂, Matrix.det_mul, Matrix.det_mul, hS₂det, Matrix.det_conjTranspose,
-          hS₂det]; simp
-      · intro S hS
-        have e1 : (Matrix.trace (Matrix.traceRight (ChoiRectangular.choiMatrix
-            (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map)))).re
-            = (Matrix.trace ((S₂ ⊗ₖ S₁) * ChoiRectangular.choiMatrix T *
-                (S₂ ⊗ₖ S₁)ᴴ)).re := by
-          rw [hC, ← trace_eq_trace_traceRight]
-        have e2 : (Matrix.trace (S * Matrix.traceRight ρ₁ * Sᴴ)).re
-            = (Matrix.trace ((S ⊗ₖ S₁) * ChoiRectangular.choiMatrix T *
-                (S ⊗ₖ S₁)ᴴ)).re := by
-          rw [← hY S, ← trace_eq_trace_traceRight]
-        rw [e1, e2]
-        exact hmin S₁ S hS₁det hS
-    obtain ⟨κ, hκ⟩ := hN₂
-    rw [ChoiRectangular.traceRight_choiMatrix] at hκ
+    obtain ⟨κ, hκ⟩ := hτN₂
+    rw [← hC, ChoiRectangular.traceRight_choiMatrix] at hκ
     refine ⟨(d₁ : ℂ) * κ, ?_⟩
     calc (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map) 1
         = (1 : ℂ) • ((Φ₂.map ∘ₗ T ∘ₗ Φ₁.map) 1) := by rw [one_smul]
@@ -318,28 +363,8 @@ theorem exists_normal_form_generic_rect [NeZero d₁] [NeZero d₂]
       _ = (d₁ : ℂ) • (κ • (1 : Matrix (Fin d₂) (Fin d₂) ℂ)) := by rw [← hκ]
       _ = ((d₁ : ℂ) * κ) • (1 : Matrix (Fin d₂) (Fin d₂) ℂ) := smul_smul _ _ _
   · -- Clause 2: `(Φ₂ ∘ T ∘ Φ₁)*(𝟙) ∝ 𝟙`, from the output-side minimisation.
-    have hN₁ : ∃ κ : ℂ,
-        Matrix.traceLeft (ChoiRectangular.choiMatrix (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map)) =
-          κ • 1 := by
-      apply posDef_orbit_min_isScalar hM₁pd
-      · rw [hC, hX S₁]
-        exact (hM₁pd.posSemidef.mul_mul_conjTranspose_same S₁)
-      · rw [hC, hX S₁, Matrix.det_mul, Matrix.det_mul, hS₁det, Matrix.det_conjTranspose,
-          hS₁det]; simp
-      · intro S hS
-        have e1 : (Matrix.trace (Matrix.traceLeft (ChoiRectangular.choiMatrix
-            (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map)))).re
-            = (Matrix.trace ((S₂ ⊗ₖ S₁) * ChoiRectangular.choiMatrix T *
-                (S₂ ⊗ₖ S₁)ᴴ)).re := by
-          rw [hC, ← Matrix.trace_eq_trace_traceLeft]
-        have e2 : (Matrix.trace (S * Matrix.traceLeft ρ₂ * Sᴴ)).re
-            = (Matrix.trace ((S₂ ⊗ₖ S) * ChoiRectangular.choiMatrix T *
-                (S₂ ⊗ₖ S)ᴴ)).re := by
-          rw [← hX S, ← Matrix.trace_eq_trace_traceLeft]
-        rw [e1, e2]
-        exact hmin S S₂ hS hS₂det
-    obtain ⟨κ, hκ⟩ := hN₁
-    rw [ChoiRectangular.traceLeft_choiMatrix] at hκ
+    obtain ⟨κ, hκ⟩ := hτN₁
+    rw [← hC, ChoiRectangular.traceLeft_choiMatrix] at hκ
     refine ⟨(d₁ : ℂ) * κ, ?_⟩
     have hT : (Matrix.traceAdjointMap (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map) 1).transpose =
         ((d₁ : ℂ) * κ) • (1 : Matrix (Fin d₁) (Fin d₁) ℂ) := by

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -477,6 +477,60 @@ This section states the existence theorems from
     carries the inequality to an arbitrary finite index set of $D$ elements.
 \end{proof}
 
+% Lean: Wolf.exists_normal_form_generic_tau
+\begin{theorem}[Normal form for generic $\tau$]
+    \label{thm:exists_normal_form_generic_tau}
+    \lean{Wolf.exists_normal_form_generic_tau}
+    \leanok
+    \uses{lem:infimum_is_attained, lem:trace_det_amgm}
+    Let $\tau\in\mathcal{B}(\C^{d_2}\otimes\C^{d_1})$ be positive-definite. Then
+    there exist $S_i\in\mathrm{SL}(d_i,\C)$ which attain the infimum
+    \begin{align}
+        p
+        &:={\inf}_{X_i\in\mathrm{SL}(d_i,\C)}
+          \tr\!\left[(X_2\otimes X_1)\tau
+          (X_2\otimes X_1)^\dagger\right].
+        \label{eq:representations_generic_tau_infimum}
+    \end{align}
+    In particular, for
+    \begin{align}
+        \tau'
+        &:=(S_2\otimes S_1)\tau(S_2\otimes S_1)^\dagger,
+        \notag
+    \end{align}
+    both partial traces are proportional to the respective identity matrices:
+    \begin{align}
+        \tr_{2}[\tau']&=\kappa_1\Id_{d_1},
+        &\tr_{1}[\tau']&=\kappa_2\Id_{d_2}
+        \label{eq:representations_generic_tau_marginals}
+    \end{align}
+    for some $\kappa_1,\kappa_2\in\C$. This is
+    \cite[Proposition~2.8, lines 894--919]{Wolf2012Quantum}, with the two
+    dimensions kept independent.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:infimum_is_attained, lem:trace_det_amgm}
+    Choose a minimizing pair $(S_1,S_2)$ by
+    Lemma~\ref{lem:infimum_is_attained}. Hold $S_2$ fixed and set
+    \begin{align}
+        \rho_2
+        &:=(S_2\otimes\Id_{d_1})\tau
+          (S_2\otimes\Id_{d_1})^\dagger,
+        &M_1&:=\tr_2[\rho_2].
+        \notag
+    \end{align}
+    Positive-definiteness of $\tau$ and invertibility of $S_2$ imply that
+    $M_1$ is positive-definite. The defining minimality of $(S_1,S_2)$ says
+    that $S_1$ minimizes $\tr(XM_1X^\dagger)$ over
+    $X\in\mathrm{SL}(d_1,\C)$. A determinant-one whitening of $M_1$ attains
+    the trace--determinant arithmetic--geometric-mean bound, while its equality
+    case in Lemma~\ref{lem:trace_det_amgm} forces
+    $S_1M_1S_1^\dagger$ to be a scalar matrix. This matrix is
+    $\tr_2[\tau']$. Holding $S_1$ fixed and interchanging the two tensor
+    factors gives $\tr_1[\tau']\propto\Id_{d_2}$ in the same way.
+\end{proof}
+
 % Lean: Wolf.exists_normal_form_generic
 \begin{theorem}[Generic normal form for CP maps]\label{thm:exists_normal_form_generic}
     \lean{Wolf.exists_normal_form_generic}
@@ -536,8 +590,7 @@ This section states the existence theorems from
     \lean{Wolf.exists_normal_form_generic_rect}
     \leanok
     \uses{def:sl_filtering, def:doubly_stochastic_rect,
-    lem:infimum_is_attained, lem:trace_det_amgm, def:choi_matrix_rect,
-    def:is_kraus_cp}
+    thm:exists_normal_form_generic_tau, def:choi_matrix_rect, def:is_kraus_cp}
     Let $T : \MN{d_1} \to \MN{d_2}$ be a completely positive map whose
     Choi matrix is positive-definite (equivalently, $T$ has full Kraus
     rank). Then there exist SL-filterings $\Phi_{1}$ on $\MN{d_1}$ and
@@ -547,18 +600,16 @@ This section states the existence theorems from
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:infimum_is_attained, lem:trace_det_amgm}
-    The argument is the one of Theorem~\ref{thm:exists_normal_form_generic}
-    with the two dimensions tracked separately: take the minimiser
-    $(S_{1},S_{2})\in\mathrm{SL}(d_1,\C)\times\mathrm{SL}(d_2,\C)$ of
-    $\tr[(S_{2}\otimes_{k}S_{1})\tau(S_{2}\otimes_{k}S_{1})^{\dagger}]$
-    from Lemma~\ref{lem:infimum_is_attained} and set $\Phi_{1},\Phi_{2}$ to
-    be the filterings with matrices $S_{1}^{\mathsf T}$ and $S_{2}$.  Each
-    partial trace of the filtered Choi matrix minimises a functional
-    $\tr(SMS^{\dagger})$ over $\det S=1$, which saturates the
-    trace--determinant AM--GM bound of Lemma~\ref{lem:trace_det_amgm}; the
-    equality case forces both partial traces to be proportional to the
-    identity, and the partial-trace identities
+    \uses{thm:exists_normal_form_generic_tau}
+    Apply Theorem~\ref{thm:exists_normal_form_generic_tau} to the rectangular
+    Choi matrix $\tau$ of $T$, and let $S_1,S_2$ be the resulting
+    determinant-one matrices. Define $\Phi_1,\Phi_2$ to be the filterings with
+    matrices $S_1^{\mathsf T}$ and $S_2$, respectively. The Choi matrix of
+    $\Phi_2\circ T\circ\Phi_1$ is then the minimizing representative
+    $(S_2\otimes S_1)\tau(S_2\otimes S_1)^\dagger$. Its two partial
+    traces are scalar by
+    Equation~\eqref{eq:representations_generic_tau_marginals}, and the
+    rectangular Choi identities
     $\tr_B(\tau)=T(\Id)/d_1$ and $\tr_A(\tau)=(T^{*}(\Id))^{\mathsf T}/d_1$
     give the doubly-stochastic condition.
 \end{proof}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -316,9 +316,15 @@ project import.
 * `Wolf.infimum_is_attained` — **key compactness lemma**: trace minimisation
   over SL(d₁, ℂ) × SL(d₂, ℂ) filterings of a positive-definite operator on
   ℂ^{d₂} ⊗ ℂ^{d₁} attains its infimum ✓ (rectangular form)
+* `Wolf.exists_normal_form_generic_tau` — **Wolf Proposition 2.8, normal form
+  for generic τ** (source lines 894–919): for every positive-definite operator
+  on ℂ^{d₂} ⊗ ℂ^{d₁}, there are determinant-one local filters attaining the
+  infimum in Equation (2.36) whose filtered operator has both partial traces
+  proportional to the respective identity matrices ✓ (distinct dimensions
+  d₁ and d₂ are preserved)
 * `Wolf.exists_normal_form_generic` — **Wolf Proposition 2.9, square case**:
   every CP map `T : M_D → M_D` with full Kraus rank admits SL-filterings
-  making it doubly-stochastic ✓ (proved via the AGM/first-order optimality
+  making it doubly-stochastic ✓ (proved via the global-minimum/AM–GM
   argument at the minimiser, using the trace-determinant AM-GM equality
   characterisation). This is the equal-dimension specialization; the general
   rectangular statement is `Wolf.exists_normal_form_generic_rect` below
@@ -328,7 +334,8 @@ project import.
   form**: every CP map `T : M_{d₁} → M_{d₂}` with full Kraus rank
   (positive-definite `ChoiRectangular.choiMatrix T`) admits SL-filterings
   `Φ₁ : SLFiltering d₁`, `Φ₂ : SLFiltering d₂` making `Φ₂ ∘ T ∘ Φ₁`
-  doubly-stochastic ✓
+  doubly-stochastic ✓ (derived from `Wolf.exists_normal_form_generic_tau` by
+  the rectangular Choi transformation and partial-trace identities)
 * **Wolf Proposition 2.11 (Lorentz normal form for qubit channels)** remains
   pending. Wolf requires general invertible Kraus-rank-one CP filters, including
   scalar freedom. The former determinant-one `SLFiltering` formulation was false


### PR DESCRIPTION
## Summary

- add `Wolf.exists_normal_form_generic_tau`, the source-facing positive-definite operator normal form of Wolf Proposition 2.8
- preserve the independent dimensions `d₁` and `d₂`, return determinant-one local filters attaining the global infimum in Equation (2.36), and return both scalar partial-trace identities
- follow Wolf's proof order: attain the infimum, hold one filter fixed, and use determinant-one marginal whitening together with the trace-determinant AM–GM equality case
- refactor `Wolf.exists_normal_form_generic_rect`, Wolf Proposition 2.9, to obtain its two scalar Choi marginals directly from the preceding τ-level proposition
- add a separate Proposition 2.8 Blueprint node and synchronize the Wolf numbering coverage record

## Source correspondence

The new theorem formalizes `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 894–919. Proposition 2.8 is the theorem for a positive-definite operator

\[
\tau'=(S_2\otimes S_1)\tau(S_2\otimes S_1)^\dagger.
\]

It produces `Sᵢ ∈ SL(dᵢ, ℂ)` attaining the filtering infimum and proves that both partial traces of `τ'` are proportional to the respective identity matrices. Proposition 2.9, at source lines 921–929, is then the immediate Choi–Jamiolkowski corollary for completely positive maps. The implementation and Blueprint now follow this source order without passing through an invented Choi hypothesis at the τ level.

## Validation

- `lake env lean QICLean/Channel/LorentzNormalForm/NormalForm.lean`
- `lake build QICLean.Channel.LorentzNormalForm.NormalForm -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `(cd blueprint && leanblueprint pdf)`
- `#print axioms` for both affected theorems reports only `propext`, `Classical.choice`, and `Quot.sound`
- no `sorry`, `admit`, `axiom`, or `native_decide` occurs in the changed Lean module

Closes #5
