### PR TITLE
feat(channel/ordered-cp): relate supplied Stinespring dilations

### DIFF
--- a/QICLean/Channel/OrderedCP.lean
+++ b/QICLean/Channel/OrderedCP.lean
@@ -80,12 +80,12 @@ This is the finite-dimensional Douglas lemma in the orientation of Wolf
 Equation (2.13). The row types of `A` and `B` may be different. -/
 theorem Matrix.exists_contraction_mul_of_conjTranspose_mul_le
     {n r₁ r₂ : Type*}
-    [Fintype n] [DecidableEq n] [Fintype r₁] [DecidableEq r₁]
-    [Fintype r₂] [DecidableEq r₂]
+    [Finite n] [Fintype r₁] [Fintype r₂] [DecidableEq r₂]
     (A : Matrix r₁ n ℂ) (B : Matrix r₂ n ℂ)
     (hAB : Aᴴ * A ≤ Bᴴ * B) :
     ∃ C : Matrix r₁ r₂ ℂ, Cᴴ * C ≤ 1 ∧ A = C * B := by
   classical
+  let _ : Fintype n := Fintype.ofFinite n
   let P : Matrix n n ℂ := Bᴴ * B - Aᴴ * A
   have hP : P.PosSemidef := hAB
   let S : Matrix n n ℂ := hP.isHermitian.cfc Real.sqrt
@@ -185,12 +185,12 @@ theorem Matrix.sqNorm_mulVec_le_of_conjTranspose_mul_le
 (Equation (2.13), in squared form). -/
 theorem Matrix.exists_contraction_mul_of_sqNorm_le
     {n r₁ r₂ : Type*}
-    [Fintype n] [DecidableEq n] [Fintype r₁] [DecidableEq r₁]
-    [Fintype r₂] [DecidableEq r₂]
+    [Fintype n] [Fintype r₁] [Fintype r₂] [DecidableEq r₂]
     (A : Matrix r₁ n ℂ) (B : Matrix r₂ n ℂ)
     (hAB : ∀ x : n → ℂ,
       star (A.mulVec x) ⬝ᵥ A.mulVec x ≤ star (B.mulVec x) ⬝ᵥ B.mulVec x) :
     ∃ C : Matrix r₁ r₂ ℂ, Cᴴ * C ≤ 1 ∧ A = C * B := by
+  classical
   have hGram : Aᴴ * A ≤ Bᴴ * B := by
     rw [Matrix.le_iff]
     refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
@@ -336,10 +336,11 @@ theorem stinespringW_conjTranspose_mul_self
 
 /-- A matrix with surjective right factor may be cancelled on the right. -/
 theorem Matrix.eq_of_mul_eq_mul_of_mulVec_surjective
-    {m n p : Type*} [Fintype n] [DecidableEq n] [Fintype p]
+    {m n p : Type*} [Fintype n] [Fintype p]
     (A B : Matrix m n ℂ) (W : Matrix n p ℂ)
     (hW : Function.Surjective W.mulVec)
     (h : A * W = B * W) : A = B := by
+  classical
   have hall : ∀ y : n → ℂ, A.mulVec y = B.mulVec y := by
     intro y
     obtain ⟨x, rfl⟩ := hW y

--- a/QICLean/Channel/OrderedCP.lean
+++ b/QICLean/Channel/OrderedCP.lean
@@ -223,8 +223,8 @@ theorem Matrix.exists_contraction_mul_of_sqNorm_le
 /-- Wolf's auxiliary matrix
 `W = (1ᵣ ⊗ ⟨Ω|)(V ⊗ 1)` from the proof of Theorem 2.3.
 
-For `V : ℂᵈ → ℂᵈʹ ⊗ ℂʳ`, the matrix `W` maps
-`ℂᵈ ⊗ ℂᵈʹ → ℂʳ`. Its entries use Wolf's normalized maximally
+For `V : ℂᵈ → ℂᵈ' ⊗ ℂʳ`, the matrix `W` maps
+`ℂᵈ ⊗ ℂᵈ' → ℂʳ`. Its entries use Wolf's normalized maximally
 entangled vector on the `d'`-dimensional factor. -/
 noncomputable def stinespringW {d d' r : ℕ}
     (V : Matrix (Fin d' × Fin r) (Fin d) ℂ) :
@@ -382,7 +382,7 @@ theorem stinespringW_mulVec_surjective_of_minimal
 /-- **Wolf Theorem 2.3 (relation between ordered CP maps).**
 
 Let `T₁, T₂ : M_{d'}(ℂ) → M_d(ℂ)` be completely positive maps with
-`T₂ ≥ T₁`, and let `Vᵢ : ℂᵈ → ℂᵈʹ ⊗ ℂʳᵢ` be supplied Stinespring
+`T₂ ≥ T₁`, and let `Vᵢ : ℂᵈ → ℂᵈ' ⊗ ℂʳᵢ` be supplied Stinespring
 representations. Then there is a contraction from the `r₂`-dimensional
 ancilla to the `r₁`-dimensional ancilla, represented by
 `C : Matrix (Fin r₁) (Fin r₂) ℂ`, such that

--- a/QICLean/Channel/OrderedCP.lean
+++ b/QICLean/Channel/OrderedCP.lean
@@ -4,39 +4,45 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Channel.Basic
+import QICLean.Channel.KrausRank
 import QICLean.Channel.Stinespring
+import QICLean.Algebra.MatrixGramUnitary
+import QICLean.Analysis.MatrixSqrt
 import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 
 /-!
 # Ordered completely positive maps (Wolf Section 2.1, Theorem 2.3)
 
-This file relates two CP maps `T₁ ≤ T₂` through canonical Stinespring
-realizations. The central statement is Wolf's Theorem 2.3 (Eq. (2.13)): if `T₂ - T₁` is CP,
-then a Heisenberg-form Stinespring realization for `T₁` factors through one for
-`T₂` via a **contraction** on the dilation space.
+This file proves Wolf's supplied, rectangular form of Theorem 2.3. For CP maps
+`Tᵢ : M_{d'}(ℂ) → M_d(ℂ)` with `T₂ - T₁` CP, any two supplied
+Heisenberg Stinespring representations are related by a contraction on their
+possibly different dilation spaces. The contraction is unique when the
+dominating representation has ancilla dimension `rank(τ₂)`.
 
-In the canonical realization provided here, the Stinespring matrix for `T₂` is
-obtained by concatenating Kraus operators of `T₁` with Kraus operators of
-`T₂ - T₁`, and the intertwining contraction is the explicit block-top
-co-isometry `C : ℂ^{r₁+s} → ℂ^{r₁}` (taking the first `r₁` coordinates).
+The proof follows Wolf's Choi/auxiliary-matrix argument. It defines the
+normalized matrices `Wᵢ`, obtains the squared norm comparison (2.13) from
+Choi order, applies a rectangular contraction factorization, and transports
+the result back to the supplied `Vᵢ`. The earlier explicit construction by
+concatenating Kraus families is retained as a canonical square corollary.
 
 ## Main definitions
 
 * `CPDominates S T` — the CP partial order: `S - T` is completely positive.
+* `stinespringW V` — Wolf's normalized auxiliary matrix associated with a
+  supplied Stinespring matrix.
 * `Matrix.blockTopRows r s` — the rectangular `r × (r+s)` matrix whose rows
   are the first `r` rows of the identity; equivalently, the block `[𝟙_r | 0]`.
 
 ## Main results (Wolf Theorem 2.3)
 
-* `Matrix.blockTopRows_mul_conjTranspose` — `C * Cᴴ = 1_r` (co-isometry).
-* `Matrix.blockTopRows_conjTranspose_mul_le_one` — `Cᴴ * C ≤ 1` (contraction).
-* `stinespringV_eq_kronecker_blockTopRows_mul_append` — entrywise intertwining:
-  `V₁ = (𝟙_D ⊗ C) * V₂` where `V₂ = stinespringV (Fin.append K L)`.
-* `CPDominates.exists_stinespring_contraction` — existential form of Wolf
-  Theorem 2.3: if `T₁ ≤ T₂` (in the CP order), there exist Stinespring
-  realizations for both and a contraction on the dilation space that
-  intertwines them.
+* `CPDominates.exists_supplied_stinespring_contraction` — the source theorem
+  for supplied rectangular dilations, including minimal-dilation uniqueness.
+* `stinespringW_conjTranspose_mul_self` — the source identity `WᴴW = τ`.
+* `Matrix.exists_contraction_mul_of_sqNorm_le` — the rectangular
+  factorization of Wolf's norm comparison.
+* `CPDominates.exists_stinespring_contraction` — the canonical square
+  corollary obtained by appending Kraus families.
 
 ## References
 
@@ -52,17 +58,395 @@ variable {D : ℕ}
 
 /-- **CP partial order**: `S` dominates `T` iff `S - T` is completely positive.
 This is the partial order on CP maps used throughout Wolf Chapter 2. -/
-def CPDominates
-    (S T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) : Prop :=
-  IsCPMap (S - T)
+def CPDominates {d d' : ℕ}
+    (S T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) : Prop :=
+  IsKrausCP (S - T)
 
 /-- Reflexivity of the CP order: `T - T = 0` has the empty Kraus family. -/
 theorem CPDominates.refl
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
     CPDominates T T := by
   refine ⟨0, (fun i : Fin 0 => i.elim0), ?_⟩
   intro X
   simp
+
+/-! ### Rectangular contraction factorization -/
+
+/-- The rectangular contraction factorization used in Wolf's proof of
+Theorem 2.3. If `Aᴴ * A ≤ Bᴴ * B`, then `A` factors through `B` on the
+left by a contraction.
+
+This is the finite-dimensional Douglas lemma in the orientation of Wolf
+Equation (2.13). The row types of `A` and `B` may be different. -/
+theorem Matrix.exists_contraction_mul_of_conjTranspose_mul_le
+    {n r₁ r₂ : Type*}
+    [Fintype n] [DecidableEq n] [Fintype r₁] [DecidableEq r₁]
+    [Fintype r₂] [DecidableEq r₂]
+    (A : Matrix r₁ n ℂ) (B : Matrix r₂ n ℂ)
+    (hAB : Aᴴ * A ≤ Bᴴ * B) :
+    ∃ C : Matrix r₁ r₂ ℂ, Cᴴ * C ≤ 1 ∧ A = C * B := by
+  classical
+  let P : Matrix n n ℂ := Bᴴ * B - Aᴴ * A
+  have hP : P.PosSemidef := hAB
+  let S : Matrix n n ℂ := hP.isHermitian.cfc Real.sqrt
+  have hS_herm : Sᴴ = S := hP.cfc_sqrt_isHermitian.eq
+  have hSS : Sᴴ * S = P := by
+    rw [hS_herm]
+    exact hP.cfc_sqrt_mul_self
+  let Abar : Matrix (Sum r₁ (Sum n r₂)) n ℂ := fun x j =>
+    match x with
+    | Sum.inl a => A a j
+    | Sum.inr (Sum.inl i) => S i j
+    | Sum.inr (Sum.inr _) => 0
+  let Bbar : Matrix (Sum r₁ (Sum n r₂)) n ℂ := fun x j =>
+    match x with
+    | Sum.inl _ => 0
+    | Sum.inr (Sum.inl _) => 0
+    | Sum.inr (Sum.inr b) => B b j
+  have hGram : Abarᴴ * Abar = Bbarᴴ * Bbar := by
+    ext i j
+    rw [Matrix.mul_apply, Matrix.mul_apply]
+    rw [Fintype.sum_sum_type, Fintype.sum_sum_type,
+      Fintype.sum_sum_type, Fintype.sum_sum_type]
+    simp_rw [Matrix.conjTranspose_apply]
+    simp only [Abar, Bbar, star_zero, zero_mul, Finset.sum_const_zero, zero_add]
+    simp only [add_zero]
+    have hSSij := congr_fun (congr_fun hSS i) j
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply] at hSSij
+    change (∑ x : r₁, star (A x i) * A x j) +
+        ∑ x : n, star (S x i) * S x j =
+      ∑ x : r₂, star (B x i) * B x j
+    rw [hSSij]
+    simp [P, Matrix.mul_apply]
+  obtain ⟨U, hU⟩ :=
+    Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq Abar Bbar hGram
+  let C : Matrix r₁ r₂ ℂ := fun a b =>
+    (U : Matrix (Sum r₁ (Sum n r₂)) (Sum r₁ (Sum n r₂)) ℂ)
+      (Sum.inl a) (Sum.inr (Sum.inr b))
+  have hfactor : A = C * B := by
+    ext a j
+    have hentry := congr_fun (congr_fun hU (Sum.inl a)) j
+    rw [Matrix.mul_apply] at hentry
+    rw [Fintype.sum_sum_type, Fintype.sum_sum_type] at hentry
+    simp only [Abar, Bbar] at hentry
+    rw [Matrix.mul_apply]
+    simpa [C] using hentry
+  let R : Matrix (Sum n r₂) r₂ ℂ := fun x b =>
+    (U : Matrix (Sum r₁ (Sum n r₂)) (Sum r₁ (Sum n r₂)) ℂ)
+      (Sum.inr x) (Sum.inr (Sum.inr b))
+  have hU_iso :
+      (U : Matrix (Sum r₁ (Sum n r₂)) (Sum r₁ (Sum n r₂)) ℂ)ᴴ *
+          (U : Matrix (Sum r₁ (Sum n r₂)) (Sum r₁ (Sum n r₂)) ℂ) = 1 := by
+    simpa [Matrix.star_eq_conjTranspose] using Matrix.UnitaryGroup.star_mul_self U
+  have hsplit : (1 : Matrix r₂ r₂ ℂ) - Cᴴ * C = Rᴴ * R := by
+    ext b c
+    have hentry := congr_fun
+      (congr_fun hU_iso (Sum.inr (Sum.inr b))) (Sum.inr (Sum.inr c))
+    rw [Matrix.mul_apply, Fintype.sum_sum_type] at hentry
+    simp only [Matrix.conjTranspose_apply,
+      Matrix.one_apply, Sum.inr.injEq] at hentry
+    rw [Matrix.sub_apply, Matrix.mul_apply, Matrix.mul_apply, Fintype.sum_sum_type]
+    simp_rw [Matrix.conjTranspose_apply]
+    simp only [Matrix.one_apply, C, R]
+    rw [← hentry]
+    ring_nf
+    rw [Fintype.sum_sum_type]
+  refine ⟨C, ?_, hfactor⟩
+  rw [Matrix.le_iff, hsplit]
+  exact Matrix.posSemidef_conjTranspose_mul_self R
+
+/-- Quadratic Gram domination is Wolf's squared norm comparison. -/
+theorem Matrix.sqNorm_mulVec_le_of_conjTranspose_mul_le
+    {n r₁ r₂ : Type*} [Fintype n] [Fintype r₁] [Fintype r₂]
+    (A : Matrix r₁ n ℂ) (B : Matrix r₂ n ℂ)
+    (hAB : Aᴴ * A ≤ Bᴴ * B) (x : n → ℂ) :
+    star (A.mulVec x) ⬝ᵥ A.mulVec x ≤ star (B.mulVec x) ⬝ᵥ B.mulVec x := by
+  have hq := (Matrix.le_iff.mp hAB).dotProduct_mulVec_nonneg x
+  have hA : star x ⬝ᵥ ((Aᴴ * A).mulVec x) =
+      star (A.mulVec x) ⬝ᵥ A.mulVec x := by
+    calc
+      star x ⬝ᵥ ((Aᴴ * A).mulVec x) =
+          star x ⬝ᵥ (Aᴴ.mulVec (A.mulVec x)) := by
+            rw [Matrix.mulVec_mulVec]
+      _ = star (A.mulVec x) ⬝ᵥ A.mulVec x := by
+        simpa using Matrix.star_dotProduct_mulVec Aᴴ x (A.mulVec x)
+  have hB : star x ⬝ᵥ ((Bᴴ * B).mulVec x) =
+      star (B.mulVec x) ⬝ᵥ B.mulVec x := by
+    calc
+      star x ⬝ᵥ ((Bᴴ * B).mulVec x) =
+          star x ⬝ᵥ (Bᴴ.mulVec (B.mulVec x)) := by
+            rw [Matrix.mulVec_mulVec]
+      _ = star (B.mulVec x) ⬝ᵥ B.mulVec x := by
+        simpa using Matrix.star_dotProduct_mulVec Bᴴ x (B.mulVec x)
+  rw [Matrix.sub_mulVec, dotProduct_sub, hB, hA] at hq
+  exact sub_nonneg.mp hq
+
+/-- Rectangular contraction factorization stated from Wolf's norm comparison
+(Equation (2.13), in squared form). -/
+theorem Matrix.exists_contraction_mul_of_sqNorm_le
+    {n r₁ r₂ : Type*}
+    [Fintype n] [DecidableEq n] [Fintype r₁] [DecidableEq r₁]
+    [Fintype r₂] [DecidableEq r₂]
+    (A : Matrix r₁ n ℂ) (B : Matrix r₂ n ℂ)
+    (hAB : ∀ x : n → ℂ,
+      star (A.mulVec x) ⬝ᵥ A.mulVec x ≤ star (B.mulVec x) ⬝ᵥ B.mulVec x) :
+    ∃ C : Matrix r₁ r₂ ℂ, Cᴴ * C ≤ 1 ∧ A = C * B := by
+  have hGram : Aᴴ * A ≤ Bᴴ * B := by
+    rw [Matrix.le_iff]
+    refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
+    · exact (Matrix.posSemidef_conjTranspose_mul_self B).isHermitian.sub
+        (Matrix.posSemidef_conjTranspose_mul_self A).isHermitian
+    · intro x
+      have hq := sub_nonneg.mpr (hAB x)
+      have hA : star x ⬝ᵥ ((Aᴴ * A).mulVec x) =
+          star (A.mulVec x) ⬝ᵥ A.mulVec x := by
+        calc
+          star x ⬝ᵥ ((Aᴴ * A).mulVec x) =
+              star x ⬝ᵥ (Aᴴ.mulVec (A.mulVec x)) := by
+                rw [Matrix.mulVec_mulVec]
+          _ = star (A.mulVec x) ⬝ᵥ A.mulVec x := by
+            simpa using Matrix.star_dotProduct_mulVec Aᴴ x (A.mulVec x)
+      have hB : star x ⬝ᵥ ((Bᴴ * B).mulVec x) =
+          star (B.mulVec x) ⬝ᵥ B.mulVec x := by
+        calc
+          star x ⬝ᵥ ((Bᴴ * B).mulVec x) =
+              star x ⬝ᵥ (Bᴴ.mulVec (B.mulVec x)) := by
+                rw [Matrix.mulVec_mulVec]
+          _ = star (B.mulVec x) ⬝ᵥ B.mulVec x := by
+            simpa using Matrix.star_dotProduct_mulVec Bᴴ x (B.mulVec x)
+      rw [Matrix.sub_mulVec, dotProduct_sub, hB, hA]
+      exact hq
+  exact Matrix.exists_contraction_mul_of_conjTranspose_mul_le A B hGram
+
+/-! ### Wolf's auxiliary matrices `Wᵢ` -/
+
+/-- Wolf's auxiliary matrix
+`W = (1ᵣ ⊗ ⟨Ω|)(V ⊗ 1)` from the proof of Theorem 2.3.
+
+For `V : ℂᵈ → ℂᵈʹ ⊗ ℂʳ`, the matrix `W` maps
+`ℂᵈ ⊗ ℂᵈʹ → ℂʳ`. Its entries use Wolf's normalized maximally
+entangled vector on the `d'`-dimensional factor. -/
+noncomputable def stinespringW {d d' r : ℕ}
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ) :
+    Matrix (Fin r) (Fin d × Fin d') ℂ :=
+  fun j p => ((1 : ℂ) / ((d' : ℝ).sqrt : ℂ)) * V (p.2, j) p.1
+
+@[simp] theorem stinespringW_apply {d d' r : ℕ}
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
+    (j : Fin r) (i : Fin d) (a : Fin d') :
+    stinespringW V j (i, a) =
+      ((1 : ℂ) / ((d' : ℝ).sqrt : ℂ)) * V (a, j) i := rfl
+
+/-- For a nonzero physical output dimension, Wolf's assignment `V ↦ W` is
+injective. This is the elementary inversion of the displayed definition of
+`W` in the proof of Theorem 2.3. -/
+theorem stinespringW_injective {d d' r : ℕ} [NeZero d'] :
+    Function.Injective
+      (stinespringW : Matrix (Fin d' × Fin r) (Fin d) ℂ →
+        Matrix (Fin r) (Fin d × Fin d') ℂ) := by
+  intro V₁ V₂ hW
+  apply Matrix.ext
+  rintro ⟨a, j⟩ i
+  have hentry := congr_fun (congr_fun hW j) (i, a)
+  have hdpos : 0 < d' := Nat.pos_of_ne_zero (NeZero.ne d')
+  have hsqrt : (((d' : ℝ).sqrt : ℝ) : ℂ) ≠ 0 :=
+    Complex.ofReal_ne_zero.mpr (Real.sqrt_ne_zero'.mpr (by exact_mod_cast hdpos))
+  have hc : (1 : ℂ) / ((d' : ℝ).sqrt : ℂ) ≠ 0 := one_div_ne_zero hsqrt
+  exact (mul_left_cancel₀ hc hentry)
+
+/-- Left multiplication of a supplied Stinespring matrix by `1 ⊗ C`
+becomes left multiplication of Wolf's auxiliary matrix by `C`. -/
+theorem stinespringW_kronecker_mul {d d' r₁ r₂ : ℕ}
+    (C : Matrix (Fin r₁) (Fin r₂) ℂ)
+    (V : Matrix (Fin d' × Fin r₂) (Fin d) ℂ) :
+    stinespringW
+        (Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C * V) =
+      C * stinespringW V := by
+  ext j ⟨i, a⟩
+  simp only [stinespringW_apply, Matrix.mul_apply, Matrix.kroneckerMap_apply,
+    Fintype.sum_prod_type, Matrix.one_apply]
+  rw [Finset.sum_eq_single a]
+  · rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun x _ => ?_
+    simp
+    ring
+  · intro b _ hba
+    have hab : a ≠ b := Ne.symm hba
+    simp [hab]
+  · intro ha
+    exact absurd (Finset.mem_univ a) ha
+
+/-- Wolf's `V`-intertwining equation is equivalent to the corresponding
+`W`-factorization equation. -/
+theorem stinespring_eq_kronecker_mul_iff_W_eq_mul
+    {d d' r₁ r₂ : ℕ} [NeZero d']
+    (V₁ : Matrix (Fin d' × Fin r₁) (Fin d) ℂ)
+    (V₂ : Matrix (Fin d' × Fin r₂) (Fin d) ℂ)
+    (C : Matrix (Fin r₁) (Fin r₂) ℂ) :
+    V₁ = Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C * V₂ ↔
+      stinespringW V₁ = C * stinespringW V₂ := by
+  constructor
+  · rintro rfl
+    exact stinespringW_kronecker_mul C V₂
+  · intro hW
+    apply stinespringW_injective
+    rw [hW, stinespringW_kronecker_mul]
+
+/-- The Gram matrix of Wolf's auxiliary `W` is the Choi matrix of the
+Heisenberg map represented by the supplied Stinespring matrix `V`.
+
+This is the identity used immediately before Wolf Equation (2.13). -/
+theorem stinespringW_conjTranspose_mul_self
+    {d d' r : ℕ}
+    {T : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
+    (hV : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+      T A = Vᴴ * stinespringPi (r := r) A * V) :
+    (stinespringW V)ᴴ * stinespringW V = ChoiRectangular.choiMatrix T := by
+  classical
+  let K : Fin r → Matrix (Fin d') (Fin d) ℂ := fun j a i => V (a, j) i
+  have hstV : stinespringV K = V := by
+    ext ⟨a, j⟩ i
+    rfl
+  have hdual : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+      T A = ∑ j : Fin r, (K j)ᴴ * A * K j := by
+    intro A
+    rw [hV A, ← hstV]
+    exact stinespring_dual_representation K A
+  have hKraus : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+      T A = ∑ j : Fin r, (K j)ᴴ * A * ((K j)ᴴ)ᴴ := by
+    intro A
+    simpa using hdual A
+  rw [Channel.choiMatrix_eq_sum_vecMulVec_of_kraus
+    (fun j => (K j)ᴴ) T hKraus]
+  ext ⟨i, a⟩ ⟨k, b⟩
+  rw [Matrix.mul_apply, Matrix.sum_apply]
+  refine Finset.sum_congr rfl fun j _ => ?_
+  simp only [stinespringW_apply, Matrix.conjTranspose_apply,
+    Matrix.vecMulVec_apply, K]
+  change star (((1 : ℂ) / ((d' : ℝ).sqrt : ℂ)) * V (a, j) i) *
+      (((1 : ℂ) / ((d' : ℝ).sqrt : ℂ)) * V (b, j) k) =
+    ((1 : ℂ) / ((d' : ℝ).sqrt : ℂ)) * star (V (a, j) i) *
+      star (((1 : ℂ) / ((d' : ℝ).sqrt : ℂ)) * star (V (b, j) k))
+  have hcstar : star ((1 : ℂ) / ((d' : ℝ).sqrt : ℂ)) =
+      (1 : ℂ) / ((d' : ℝ).sqrt : ℂ) := by
+    simp [Complex.conj_ofReal]
+  rw [star_mul, star_mul, hcstar, star_star]
+  ring
+
+/-- A matrix with surjective right factor may be cancelled on the right. -/
+theorem Matrix.eq_of_mul_eq_mul_of_mulVec_surjective
+    {m n p : Type*} [Fintype n] [DecidableEq n] [Fintype p]
+    (A B : Matrix m n ℂ) (W : Matrix n p ℂ)
+    (hW : Function.Surjective W.mulVec)
+    (h : A * W = B * W) : A = B := by
+  have hall : ∀ y : n → ℂ, A.mulVec y = B.mulVec y := by
+    intro y
+    obtain ⟨x, rfl⟩ := hW y
+    calc
+      A.mulVec (W.mulVec x) = (A * W).mulVec x :=
+        Matrix.mulVec_mulVec x A W
+      _ = (B * W).mulVec x := congrArg (fun M => M.mulVec x) h
+      _ = B.mulVec (W.mulVec x) := (Matrix.mulVec_mulVec x B W).symm
+  ext i j
+  have hentry := congr_fun (hall (Pi.single j 1)) i
+  simpa using hentry
+
+/-- A supplied Stinespring representation at Choi-rank ancilla dimension has
+surjective Wolf matrix `W`. This is Wolf's minimality argument: the Gram
+identity `WᴴW = τ` gives `rank W = rank τ = r`. -/
+theorem stinespringW_mulVec_surjective_of_minimal
+    {d d' r : ℕ}
+    {T : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
+    (hV : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+      T A = Vᴴ * stinespringPi (r := r) A * V)
+    (hmin : r = Channel.choiRank T) :
+    Function.Surjective (stinespringW V).mulVec := by
+  have hGram := stinespringW_conjTranspose_mul_self V hV
+  have hrank : (stinespringW V).rank = r := by
+    calc
+      (stinespringW V).rank = ((stinespringW V)ᴴ * stinespringW V).rank :=
+        (Matrix.rank_conjTranspose_mul_self (stinespringW V)).symm
+      _ = (ChoiRectangular.choiMatrix T).rank := congrArg Matrix.rank hGram
+      _ = Channel.choiRank T := rfl
+      _ = r := hmin.symm
+  change Function.Surjective (stinespringW V).mulVecLin
+  apply LinearMap.range_eq_top.mp
+  apply Submodule.eq_top_of_finrank_eq
+  change (stinespringW V).rank = Module.finrank ℂ (Fin r → ℂ)
+  simpa using hrank
+
+/-! ### Wolf Theorem 2.3 for supplied rectangular dilations -/
+
+/-- **Wolf Theorem 2.3 (relation between ordered CP maps).**
+
+Let `T₁, T₂ : M_{d'}(ℂ) → M_d(ℂ)` be completely positive maps with
+`T₂ ≥ T₁`, and let `Vᵢ : ℂᵈ → ℂᵈʹ ⊗ ℂʳᵢ` be supplied Stinespring
+representations. Then there is a contraction from the `r₂`-dimensional
+ancilla to the `r₁`-dimensional ancilla, represented by
+`C : Matrix (Fin r₁) (Fin r₂) ℂ`, such that
+`V₁ = (1 ⊗ C) V₂`. If the dominating representation is minimal in
+Wolf's sense, `r₂ = rank(τ₂)`, then this `C` is unique.
+
+The proof follows Wolf's order exactly: Choi order gives
+`W₁ᴴW₁ ≤ W₂ᴴW₂` (equivalently, his norm comparison (2.13));
+the rectangular contraction factorization gives `W₁ = C W₂`; the
+`V ↔ W` identity transports this equation back to the supplied dilations;
+and minimality makes the supplied `W₂` surjective, which gives uniqueness.
+
+The complete-positivity assumptions are retained exactly as in Wolf's
+statement, although each is also forced by its supplied Stinespring identity. -/
+theorem CPDominates.exists_supplied_stinespring_contraction
+    {d d' r₁ r₂ : ℕ} [NeZero d']
+    {T₁ T₂ : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
+    (_hT₁ : IsKrausCP T₁) (_hT₂ : IsKrausCP T₂)
+    (hdom : CPDominates T₂ T₁)
+    (V₁ : Matrix (Fin d' × Fin r₁) (Fin d) ℂ)
+    (V₂ : Matrix (Fin d' × Fin r₂) (Fin d) ℂ)
+    (hV₁ : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+      T₁ A = V₁ᴴ * stinespringPi (r := r₁) A * V₁)
+    (hV₂ : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+      T₂ A = V₂ᴴ * stinespringPi (r := r₂) A * V₂) :
+    ∃ C : Matrix (Fin r₁) (Fin r₂) ℂ,
+      Cᴴ * C ≤ 1 ∧
+      V₁ = Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C * V₂ ∧
+      (r₂ = Channel.choiRank T₂ →
+        ∀ C' : Matrix (Fin r₁) (Fin r₂) ℂ,
+          V₁ = Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C' * V₂ →
+          C' = C) := by
+  have hChoiSub : ChoiRectangular.choiMatrix (T₂ - T₁) =
+      ChoiRectangular.choiMatrix T₂ - ChoiRectangular.choiMatrix T₁ := by
+    exact (ChoiRectangular.choiMatrixLinearMap (d := d') (d' := d)).map_sub T₂ T₁
+  have hChoiOrder : ChoiRectangular.choiMatrix T₁ ≤
+      ChoiRectangular.choiMatrix T₂ := by
+    rw [Matrix.le_iff, ← hChoiSub]
+    exact (ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef (T₂ - T₁)).mp hdom
+  have hW₁Gram := stinespringW_conjTranspose_mul_self V₁ hV₁
+  have hW₂Gram := stinespringW_conjTranspose_mul_self V₂ hV₂
+  have hWOrder : (stinespringW V₁)ᴴ * stinespringW V₁ ≤
+      (stinespringW V₂)ᴴ * stinespringW V₂ := by
+    rw [hW₁Gram, hW₂Gram]
+    exact hChoiOrder
+  have hWNorm : ∀ ψ : (Fin d × Fin d') → ℂ,
+      star ((stinespringW V₁).mulVec ψ) ⬝ᵥ (stinespringW V₁).mulVec ψ ≤
+        star ((stinespringW V₂).mulVec ψ) ⬝ᵥ (stinespringW V₂).mulVec ψ := by
+    intro ψ
+    exact Matrix.sqNorm_mulVec_le_of_conjTranspose_mul_le
+      (stinespringW V₁) (stinespringW V₂) hWOrder ψ
+  obtain ⟨C, hC, hWfactor⟩ :=
+    Matrix.exists_contraction_mul_of_sqNorm_le
+      (stinespringW V₁) (stinespringW V₂) hWNorm
+  have hVfactor :
+      V₁ = Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C * V₂ :=
+    (stinespring_eq_kronecker_mul_iff_W_eq_mul V₁ V₂ C).mpr hWfactor
+  refine ⟨C, hC, hVfactor, ?_⟩
+  intro hmin C' hVfactor'
+  have hWfactor' :=
+    (stinespring_eq_kronecker_mul_iff_W_eq_mul V₁ V₂ C').mp hVfactor'
+  have hsurj := stinespringW_mulVec_surjective_of_minimal V₂ hV₂ hmin
+  exact Matrix.eq_of_mul_eq_mul_of_mulVec_surjective C' C (stinespringW V₂) hsurj
+    (hWfactor'.symm.trans hWfactor)
 
 /-! ### The block-top rectangular co-isometry -/
 
@@ -231,7 +615,8 @@ theorem Matrix.blockTopRows_conjTranspose_mul_le_one (r s : ℕ) :
 
 /-! ### Intertwining identity for the canonical Stinespring matrices -/
 
-/-- **Entrywise intertwining (Wolf Theorem 2.3 canonical form)**: the block-top
+/-- **Entrywise intertwining (canonical square corollary of Wolf Theorem 2.3)**:
+the block-top
 co-isometry `C = blockTopRows r s` relates the Stinespring matrix of a Kraus
 family `K : Fin r → M` with that of its append with another family
 `L : Fin s → M`:
@@ -261,9 +646,9 @@ theorem stinespringV_eq_kronecker_blockTopRows_mul_append
     simp [this]
   · intro hi; exact absurd (Finset.mem_univ i) hi
 
-/-! ### Wolf Theorem 2.3: ordered CP-maps -/
+/-! ### Canonical square corollary -/
 
-/-- **Wolf Theorem 2.3 (ordered CP-maps, canonical form)**.
+/-- **Canonical square corollary of Wolf Theorem 2.3.**
 
 Let `T₁, T₂ : M_D(ℂ) →ₗ M_D(ℂ)` be CP maps with `T₁ ≤ T₂` in the CP partial
 order (i.e. `T₂ - T₁` is CP). Then there exist an ancilla dimension `m`,

--- a/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
@@ -302,7 +302,7 @@ a common dilation space.
 \begin{definition}[CP partial order]\label{def:cp_dominates}
     \lean{CPDominates, CPDominates.refl}
     \leanok
-    \uses{def:cp_map}
+    \uses{def:is_kraus_cp}
     For linear maps $S,T:\MN{d_{\rm in}}\to\MN{d_{\rm out}}$, write
     $T\le S$ (in the CP order) when $S-T$ is completely positive.
 \end{definition}
@@ -342,6 +342,11 @@ a common dilation space.
 \begin{proof}\leanok
     The coordinate formula
     $W_{j,(i,a)}=d'^{-1/2}V_{(a,j),i}$ is invertible because $d'>0$.
+    Equivalently, with the canonical tensor-factor identifications used in
+    the source,
+    $V=d'(W\otimes\Id_{d'})(\Id_d\otimes\ket{\Omega})$.
+    The coefficient $d'^2$ printed in the source footnote is a normalization
+    typo; see \path{docs/paper-gaps/wolf_lecture_notes_errata.tex}.
     Expanding the Kronecker product shows directly that multiplication by
     $\Id_{d'}\otimes C$ on $V$ becomes multiplication by $C$ on $W$.
 \end{proof}

--- a/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
@@ -300,12 +300,171 @@ by tracking how two CP maps related by domination or decomposition sit inside
 a common dilation space.
 
 \begin{definition}[CP partial order]\label{def:cp_dominates}
-    \lean{CPDominates}
+    \lean{CPDominates, CPDominates.refl}
     \leanok
     \uses{def:cp_map}
-    For linear maps $S,T:\MN{D}\to\MN{D}$, write $T\le S$ (in the CP
-    order) when $S-T$ is completely positive.
+    For linear maps $S,T:\MN{d_{\rm in}}\to\MN{d_{\rm out}}$, write
+    $T\le S$ (in the CP order) when $S-T$ is completely positive.
 \end{definition}
+
+\begin{definition}[Wolf auxiliary matrix]\label{def:ordered_cp_stinespring_w}
+    \lean{stinespringW, stinespringW_apply}
+    \leanok
+    \uses{def:stinespring_v}
+    Let $V:\C^d\to\C^{d'}\otimes\C^r$ be a supplied Stinespring
+    matrix, and let
+    $\ket{\Omega}=d'^{-1/2}\sum_{a=1}^{d'}\ket{a,a}$ be normalized.
+    Wolf's auxiliary operator is
+    \begin{align}
+        W
+        &:=(\Id_r\otimes\bra{\Omega})(V\otimes\Id_{d'})
+          :\C^d\otimes\C^{d'}\longrightarrow\C^r,
+        \label{eq:ordered_cp_w_definition}
+    \end{align}
+    or, in coordinates, $W_{j,(i,a)}=d'^{-1/2}V_{(a,j),i}$.
+\end{definition}
+
+\begin{lemma}[The $V$--$W$ correspondence]
+    \label{lem:ordered_cp_v_w_correspondence}
+    \lean{stinespringW_injective, stinespringW_kronecker_mul,
+        stinespring_eq_kronecker_mul_iff_W_eq_mul}
+    \leanok
+    \uses{def:ordered_cp_stinespring_w}
+    If $d'>0$, the assignment $V\mapsto W$ is one-to-one. Moreover, for
+    every $C:\C^{r_2}\to\C^{r_1}$,
+    \[
+        V_1=(\Id_{d'}\otimes C)V_2
+        \quad\Longleftrightarrow\quad
+        W_1=CW_2.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    The coordinate formula
+    $W_{j,(i,a)}=d'^{-1/2}V_{(a,j),i}$ is invertible because $d'>0$.
+    Expanding the Kronecker product shows directly that multiplication by
+    $\Id_{d'}\otimes C$ on $V$ becomes multiplication by $C$ on $W$.
+\end{proof}
+
+\begin{lemma}[The auxiliary Gram matrix is the Choi matrix]
+    \label{lem:ordered_cp_stinespring_w_gram}
+    \lean{stinespringW_conjTranspose_mul_self}
+    \leanok
+    \uses{def:ordered_cp_stinespring_w, def:choi_matrix_rect,
+        thm:stinespring_dual_representation}
+    Suppose that $T:\MN{d'}\to\MN{d}$ has the supplied representation
+    $T(A)=V^\dagger(A\otimes\Id_r)V$. If $\tau$ is the normalized Choi
+    matrix of $T$, then
+    \begin{align}
+        W^\dagger W=\tau.
+        \label{eq:ordered_cp_w_gram}
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Write $V=\sum_jK_j\otimes\ket j$. Then
+    $T(A)=\sum_jK_j^\dagger A K_j$, so $T$ has Kraus operators
+    $K_j^\dagger$. Both sides of
+    (\ref{eq:ordered_cp_w_gram}) have entries
+    \[
+        \frac1{d'}\sum_j
+        \overline{(K_j)_{a i}}(K_j)_{b k}
+    \]
+    at the pair of indices $(i,a),(k,b)$.
+\end{proof}
+
+\begin{lemma}[Rectangular contraction factorization]
+    \label{lem:ordered_cp_rectangular_contraction_factorization}
+    \lean{Matrix.exists_contraction_mul_of_conjTranspose_mul_le,
+        Matrix.sqNorm_mulVec_le_of_conjTranspose_mul_le,
+        Matrix.exists_contraction_mul_of_sqNorm_le}
+    \leanok
+    Let $W_i:H\to R_i$ be finite-dimensional complex matrices. If
+    \begin{align}
+        \lVert W_1\psi\rVert^2
+        \leq \lVert W_2\psi\rVert^2
+        \qquad(\psi\in H),
+        \label{eq:ordered_cp_norm_comparison}
+    \end{align}
+    then there is a contraction $C:R_2\to R_1$ such that
+    $W_1=CW_2$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Equivalently, (\ref{eq:ordered_cp_norm_comparison}) is
+    $W_1^\dagger W_1\leq W_2^\dagger W_2$. Take the positive square root
+    $S$ of $W_2^\dagger W_2-W_1^\dagger W_1$. After adjoining zero rows,
+    the matrices with row blocks $(W_1,S,0)$ and $(0,0,W_2)$ have the
+    same Gram matrix. A unitary carrying the second matrix to the first
+    has an $R_1\times R_2$ corner $C$ satisfying $W_1=CW_2$; orthonormality
+    of its columns gives $C^\dagger C\leq\Id_{R_2}$.
+\end{proof}
+
+\begin{lemma}[Minimality makes the auxiliary matrix surjective]
+    \label{lem:ordered_cp_minimal_w_surjective}
+    \lean{stinespringW_mulVec_surjective_of_minimal,
+        Matrix.eq_of_mul_eq_mul_of_mulVec_surjective}
+    \leanok
+    \uses{lem:ordered_cp_stinespring_w_gram,
+        lem:stinespring_rectangular_least_dim}
+    If the supplied dominating dilation is minimal,
+    $r_2=\rank(\tau_2)$, then $W_2$ is surjective. Consequently a
+    factorization $W_1=CW_2$ determines $C$ uniquely.
+\end{lemma}
+
+\begin{proof}\leanok
+    The Gram identity gives
+    $\rank(W_2)=\rank(W_2^\dagger W_2)=\rank(\tau_2)=r_2$, so $W_2$ has
+    full row rank and is surjective. A surjective right factor can be
+    cancelled.
+\end{proof}
+
+\begin{theorem}[Relation between ordered CP maps]
+    \label{thm:cp_dominates_stinespring_contraction}
+    \lean{CPDominates.exists_supplied_stinespring_contraction}
+    \leanok
+    \uses{def:cp_dominates, def:ordered_cp_stinespring_w,
+        lem:ordered_cp_stinespring_w_gram,
+        lem:ordered_cp_rectangular_contraction_factorization,
+        lem:ordered_cp_v_w_correspondence,
+        lem:ordered_cp_minimal_w_surjective}
+    Let $T_i:\MN{d'}\to\MN{d}$ be completely positive maps with
+    $T_1\leq T_2$. Suppose that, for possibly distinct ancilla dimensions
+    $r_i$, matrices $V_i:\C^d\to\C^{d'}\otimes\C^{r_i}$ are supplied and
+    satisfy
+    \[
+        T_i(A)=V_i^\dagger(A\otimes\Id_{r_i})V_i
+        \qquad(A\in\MN{d'}).
+    \]
+    Then there is a contraction $C:\C^{r_2}\to\C^{r_1}$ such that
+    \begin{align}
+        V_1=(\Id_{d'}\otimes C)V_2.
+        \label{eq:representations_ordered_intertwining}
+    \end{align}
+    If $V_2$ is minimal, in the source sense
+    $r_2=\rank(\tau_2)$, then $C$ is unique. This is
+    \cite[Theorem~2.3 and Equation~(2.13)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Complete positivity of $T_2-T_1$ and the Choi correspondence give
+    $\tau_1\leq\tau_2$. By
+    Lemma~\ref{lem:ordered_cp_stinespring_w_gram},
+    \[
+        W_1^\dagger W_1=\tau_1\leq\tau_2=W_2^\dagger W_2,
+    \]
+    which is precisely the squared norm comparison
+    (\ref{eq:ordered_cp_norm_comparison}). The rectangular factorization
+    lemma gives a contraction $C$ with $W_1=CW_2$. Inverting
+    (\ref{eq:ordered_cp_w_definition}) gives
+    (\ref{eq:representations_ordered_intertwining}) with the same supplied
+    $V_i$.
+
+    If $r_2=\rank(\tau_2)$, then
+    $\rank(W_2)=\rank(W_2^\dagger W_2)=\rank(\tau_2)=r_2$; hence $W_2$ is
+    surjective. Thus two coefficients satisfying $W_1=CW_2=C'W_2$ agree,
+    proving uniqueness.
+\end{proof}
 
 \begin{definition}[Block-top contraction]\label{def:block_top_rows}
     \lean{Matrix.blockTopRows}
@@ -365,7 +524,7 @@ a common dilation space.
     precisely $V_K$.
 \end{proof}
 
-\begin{theorem}[Ordered CP maps via Stinespring contractions]\label{thm:cp_dominates_stinespring_contraction}
+\begin{corollary}[Canonical square realization]\label{cor:cp_dominates_stinespring_contraction_canonical}
     \lean{CPDominates.exists_stinespring_contraction}
     \leanok
     \uses{def:cp_dominates, def:stinespring_v, def:block_top_rows,
@@ -380,10 +539,12 @@ a common dilation space.
     \begin{align}
         V_1
         &=(\Id_D\otimes\widetilde C)V_2.
-        \label{eq:representations_ordered_intertwining}
+        \label{eq:representations_ordered_intertwining_canonical}
     \end{align}
-    This is~\cite[Theorem~2.3]{Wolf2012Quantum}.
-\end{theorem}
+    This is the explicit square corollary obtained by constructing both
+    dilation matrices, rather than the supplied-dilation statement of
+    Theorem~\ref{thm:cp_dominates_stinespring_contraction}.
+\end{corollary}
 
 \begin{proof}\leanok
     \uses{thm:exists_stinespring_dilation, lem:block_top_rows_contraction,

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -158,6 +158,49 @@ completely positive. Thus both printed converses fail.
 This is a genuine source error. The proof of Proposition~2.10 supports the two
 forward implications, not the printed equivalences.
 
+\section{The inverse coefficient in the proof of Theorem~2.3}
+\label{sec:ordered-cp-inverse}
+
+\paragraph{Formalization trigger.}
+The formal proof defines Wolf's normalized auxiliary matrix as
+\leanid{stinespringW} and proves that the assignment from a supplied
+Stinespring matrix is injective in \leanid{stinespringW_injective}, both in
+\doclink{QICLean/Channel/OrderedCP}.
+
+\paragraph{Printed source and its role.}
+In the proof of Theorem~2.3, Wolf takes the normalized vector
+$\ket{\Omega}=d'^{-1/2}\sum_a\ket{a,a}$ and defines
+\begin{equation}
+  W_i=(\one_{r_i}\otimes\bra{\Omega})
+      (V_i\otimes\one_{d'}).
+\end{equation}
+The footnote asserting that $V_i\mapsto W_i$ is one-to-one prints the inverse
+with the coefficient $d'^2$. The same coefficient appears in the local source
+at \path{Notes/WolfNoteTexSource/ch02_representations.tex}, lines~392--393,
+and in the PDF on book p.~39.
+
+\paragraph{Correction.}
+The coordinate relation is
+\begin{equation}
+  (W_i)_{j,(k,a)}=d'^{-1/2}(V_i)_{(a,j),k},
+\end{equation}
+so its coordinate inverse multiplies by $\sqrt{d'}$. Equivalently, with the
+canonical tensor-factor identifications used in the source, the inverse is
+\begin{equation}
+  V_i=d'(W_i\otimes\one_{d'})(\one_d\otimes\ket{\Omega}).
+\end{equation}
+
+\paragraph{Why the correction is necessary.}
+The second occurrence of the normalized vector contributes another factor
+$d'^{-1/2}$. Hence the tensor expression without its leading coefficient is
+$V_i/d'$, and the leading coefficient must be $d'$, not $d'^2$. The theorem
+itself is unaffected: the formal injectivity proof uses the coordinate
+relation and only cancels the nonzero factor $d'^{-1/2}$.
+
+\paragraph{Classification.}
+This is a normalization typo in a source footnote. It does not change the
+statement or proof route of Theorem~2.3.
+
 \section{The nonempty-family boundary in the Radon--Nikodym theorem}
 \label{sec:radon-nikodym}
 
@@ -263,12 +306,13 @@ errata entries:
 
 \section{Conclusion}
 
-At present the formalization-derived record contains two genuine mathematical
-source errors (Sections~\ref{sec:lorentz} and
-\ref{sec:pauli-block-truncation}), one explicit boundary convention
+At present the formalization-derived record contains two false printed
+assertions (Sections~\ref{sec:lorentz} and
+\ref{sec:pauli-block-truncation}), one normalization typo
+(Section~\ref{sec:ordered-cp-inverse}), one explicit boundary convention
 (Section~\ref{sec:radon-nikodym}), and one local correction to a spectrum
-shorthand (Section~\ref{sec:two-pure-state-spectrum}). These are the corrections
-asserted by the Lean documentation itself.
+shorthand (Section~\ref{sec:two-pure-state-spectrum}). These are the
+corrections asserted by the Lean documentation itself.
 
 \appendix
 \section{Corrected errors in the local LaTeX transcription}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -131,14 +131,29 @@ project import.
     and dilations with it are minimal (discussion after Thm. 2.2) ✓
 
 * **Theorem 2.3** (ordered CP-maps):
-  - `CPDominates` — CP partial order: `S - T` is completely positive ✓
+  - `CPDominates` — rectangular CP partial order: `S - T` is completely
+    positive ✓
+  - `stinespringW` / `stinespringW_conjTranspose_mul_self` — Wolf's
+    normalized auxiliary operator for a supplied rectangular Stinespring
+    matrix and the source identity `WᴴW = τ` ✓
+  - `Matrix.sqNorm_mulVec_le_of_conjTranspose_mul_le` /
+    `Matrix.exists_contraction_mul_of_sqNorm_le` — Equation (2.13), in
+    squared form, and the rectangular factorization `W₁ = C W₂` by a
+    contraction `C : ℂ^{r₂} → ℂ^{r₁}` ✓
+  - `CPDominates.exists_supplied_stinespring_contraction` — **source-facing
+    Wolf Theorem 2.3**: for CP maps `Tᵢ : M_{d'} → M_d` with `T₁ ≤ T₂`
+    and supplied Stinespring matrices with potentially distinct ancilla
+    dimensions, returns `C` with `V₁ = (𝟙_{d'} ⊗ C)V₂`; if
+    `r₂ = Channel.choiRank T₂`, the supplied `W₂` is surjective and `C`
+    is unique ✓
   - `Matrix.blockTopRows` / `Matrix.blockTopRows_mul_conjTranspose` /
     `Matrix.blockTopRows_conjTranspose_mul_le_one` — explicit block-top
-    contraction on the dilation space ✓
+    contraction used in the canonical square corollary ✓
   - `stinespringV_eq_kronecker_blockTopRows_mul_append` — intertwining
     `V_{K} = (𝟙_D ⊗ C) · V_{K ++ L}` for the block-top projector ✓
-  - `CPDominates.exists_stinespring_contraction` — existential form of
-    Wolf Theorem 2.3: `T₁ ≤ T₂` gives Stinespring realizations and a contraction ✓
+  - `CPDominates.exists_stinespring_contraction` — canonical square
+    corollary that constructs compatible dilations by appending Kraus
+    families; it is no longer identified with the supplied source theorem ✓
 
 * **Theorem 2.4** (Radon–Nikodym for CP maps):
   - `Matrix.blockDiagTopProj` / `Matrix.blockDiagBotProj` — orthogonal

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -136,6 +136,10 @@ project import.
   - `stinespringW` / `stinespringW_conjTranspose_mul_self` — Wolf's
     normalized auxiliary operator for a supplied rectangular Stinespring
     matrix and the source identity `WᴴW = τ` ✓
+  - the inverse of `V ↦ W` uses the coefficient `d'` in tensor form (or
+    `√d'` in coordinates), rather than the `d'^2` printed in the source
+    footnote; the normalization typo is recorded in
+    `docs/paper-gaps/wolf_lecture_notes_errata.tex` ✓
   - `Matrix.sqNorm_mulVec_le_of_conjTranspose_mul_le` /
     `Matrix.exists_contraction_mul_of_sqNorm_le` — Equation (2.13), in
     squared form, and the rectangular factorization `W₁ = C W₂` by a


### PR DESCRIPTION
## Summary

- Generalizes `CPDominates` to rectangular matrix algebras while preserving the square API.
- Introduces Wolf's normalized auxiliary matrices `Wᵢ`, proves `Wᵢᴴ Wᵢ = τᵢ`, and exposes Equation (2.13) as a squared-norm comparison.
- Proves the required rectangular contraction factorization and obtains a contraction `C : ℂ^{r₂} → ℂ^{r₁}` with `V₁ = (𝟙_{d'} ⊗ C)V₂` for the supplied dilations.
- Proves uniqueness when the dominating dilation is minimal in Wolf's sense, `r₂ = Channel.choiRank T₂`, by showing that the supplied `W₂` is surjective.
- Retains the earlier append-Kraus theorem as an explicitly named canonical square corollary and synchronizes the Blueprint and Wolf-numbering coverage.
- Records the normalization typo in Wolf's inverse footnote: normalized `Ω` gives coefficient `√d'` in coordinates and `d'` in tensor form, rather than the printed `d'^2`.

## Source correspondence

The proof follows `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 364–397, in its stated order:

1. Choi order `τ₁ ≤ τ₂`;
2. normalized auxiliary matrices `Wᵢ`;
3. the squared-norm inequality of Equation (2.13);
4. contraction factorization `W₁ = C W₂`;
5. transport back to the same supplied `Vᵢ`;
6. uniqueness from minimality of `V₂`.

The Heisenberg dimensions and contraction orientation agree with the source: `Tᵢ : M_{d'} → M_d` and `C : ℂ^{r₂} → ℂ^{r₁}`. The statement and proof route of Theorem 2.3 are unchanged by the inverse-coefficient correction, which is recorded in `docs/paper-gaps/wolf_lecture_notes_errata.tex`.

## Verification

Passed locally:

- `lake env lean QICLean/Channel/OrderedCP.lean`
- `lake build QICLean.Channel.OrderedCP` with no declaration-linter warnings
- `lake env lean QICLean/Channel/RadonNikodym.lean`
- `lake exe lint_style --github`
- explicit `#print axioms` audit of the factorization, minimal-surjectivity lemma, and headline theorem; each depends only on `propext`, `Classical.choice`, and `Quot.sound`
- `python3 scripts/blueprint_lean_sync.py --ci` (1792/1792)
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex`
- `python3 scripts/blueprint_bibtex.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `texra-blueprint paper-gaps check`
- `texra-blueprint --root . paper-gaps build`
- Lean module-policy tests, oversized-file guard, numbered-file guard, and `git diff --check`

The repository-wide `latexindent --check` reports the chapter's existing file-wide formatting differences; this CI step is warning-only. The local `texra-blueprint web` gate could not reach project parsing because Homebrew plasTeX under Python 3.14 cannot import the Miniforge-installed `texra_blueprint` package. CI installs a matched renderer and should provide that render gate.

Closes #8