### PR TITLE
feat(channel): generalize Radon-Nikodym rectangularly

### DIFF
--- a/QICLean/Channel/RadonNikodym.lean
+++ b/QICLean/Channel/RadonNikodym.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Channel.OrderedCP
 import QICLean.Channel.KrausFreedom
+import QICLean.Channel.OrderedCP
 import QICLean.Channel.PartialTrace
 
 /-!
@@ -44,8 +44,12 @@ evolution on a system-plus-environment.
   `Matrix.blockDiagBotProj_posSemidef` — both are PSD.
 * `IsCPMap.radon_nikodym_of_stinespring`
   (Wolf, *Quantum Channels & Operations*, Theorem 2.4):
-  finite-family Radon–Nikodym theorem relative to a supplied Stinespring
+  square finite-family Radon–Nikodym theorem relative to a supplied Stinespring
   representation.
+* `IsKrausCP.radon_nikodym_of_stinespring`
+  (Wolf, *Quantum Channels & Operations*, Theorem 2.4):
+  the exact rectangular Heisenberg form for maps `M_{d'}(ℂ) → M_d(ℂ)` and a
+  supplied `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r`.
 * `IsCPMap.exists_radon_nikodym`
   (Wolf, *Quantum Channels & Operations*, Theorem 2.4, binary form):
   for CP `T₁, T₂`, there exist a Stinespring matrix `V` and two PSD
@@ -121,12 +125,48 @@ theorem Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap
 
 /-! ### Weighted Stinespring compression -/
 
-/-- Compressing a `Fin`-indexed Stinespring matrix by `P = CᴴC` gives the
-Kraus sum for the corresponding linear combinations of its blocks. -/
+/-- Stinespring dual representation for a rectangular Kraus family indexed by
+an arbitrary finite type. -/
+private theorem stinespring_dual_representation_rectangular_gen
+    {η : Type*} [Fintype η] [DecidableEq η] {d d' : ℕ}
+    (K : η → Matrix (Fin d') (Fin d) ℂ) (A : Matrix (Fin d') (Fin d') ℂ) :
+    (stinespringVGen K)ᴴ *
+        Matrix.kroneckerMap (· * ·) A (1 : Matrix η η ℂ) * stinespringVGen K =
+      ∑ j : η, (K j)ᴴ * A * K j := by
+  ext a b
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    stinespringVGen_apply, Matrix.kroneckerMap_apply, Matrix.one_apply,
+    Matrix.sum_apply, Fintype.sum_prod_type, mul_ite, mul_one, mul_zero,
+    Finset.sum_ite_eq', Finset.mem_univ, ite_true]
+  exact Finset.sum_comm
+
+/-- A linear combination of rectangular Kraus blocks is obtained by
+left-multiplying the Stinespring matrix by `1 ⊗ C`. -/
+private theorem stinespringVGen_rectangular_linear_combination
+    {η : Type*} {d d' : ℕ}
+    (K : Fin r → Matrix (Fin d') (Fin d) ℂ) (C : Matrix η (Fin r) ℂ) :
+    stinespringVGen (fun α : η => ∑ j : Fin r, C α j • K j) =
+      Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C *
+        stinespringV K := by
+  ext x b
+  rcases x with ⟨a, α⟩
+  simp only [stinespringVGen_apply, stinespringV_apply, Matrix.sum_apply,
+    Matrix.smul_apply, smul_eq_mul, Matrix.mul_apply, Matrix.kroneckerMap_apply,
+    Matrix.one_apply, Fintype.sum_prod_type]
+  rw [Finset.sum_eq_single a]
+  · simp
+  · intro a' _ ha'
+    have haa' : a ≠ a' := fun h => ha' h.symm
+    simp [haa']
+  · intro h
+    exact absurd (Finset.mem_univ a) h
+
+/-- Compressing a `Fin`-indexed rectangular Stinespring matrix by `P = CᴴC`
+gives the Kraus sum for the corresponding linear combinations of its blocks. -/
 theorem weighted_stinespring_eq_kraus_sum_gen
-    {η : Type*} [Fintype η]
-    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
-    (C : Matrix η (Fin r) ℂ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    {η : Type*} [Fintype η] {d d' : ℕ}
+    (K : Fin r → Matrix (Fin d') (Fin d) ℂ)
+    (C : Matrix η (Fin r) ℂ) (X : Matrix (Fin d') (Fin d') ℂ) :
     (stinespringV K)ᴴ * Matrix.kroneckerMap (· * ·) X (Cᴴ * C) * stinespringV K =
       ∑ α : η,
         (∑ j : Fin r, C α j • K j)ᴴ * X * (∑ j : Fin r, C α j • K j) := by
@@ -134,36 +174,49 @@ theorem weighted_stinespring_eq_kraus_sum_gen
   rw [← Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap_gen X C]
   have h_reassoc :
       (stinespringV K)ᴴ *
-        ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C)ᴴ *
+        ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C)ᴴ *
           Matrix.kroneckerMap (· * ·) X (1 : Matrix η η ℂ) *
-          Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C) *
+          Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C) *
         stinespringV K =
-      ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C) *
+      ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C) *
           stinespringV K)ᴴ *
         Matrix.kroneckerMap (· * ·) X (1 : Matrix η η ℂ) *
-        ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C) *
+        ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C) *
           stinespringV K) := by
     rw [Matrix.conjTranspose_mul]
     simp only [Matrix.mul_assoc]
   rw [h_reassoc]
-  rw [← stinespringVGen_linear_combination (K := K) C]
-  exact stinespring_dual_representation_gen
-    (K := fun α : η => ∑ j : Fin r, C α j • K j) X
+  rw [← stinespring_dual_representation_rectangular_gen
+    (K := fun α : η => ∑ j : Fin r, C α j • K j) X]
+  rw [stinespringVGen_rectangular_linear_combination K C]
 
-/-- The `j`-th ancilla block of a supplied Stinespring matrix. -/
-noncomputable def stinespringBlock
-    (V : Matrix (Fin D × Fin r) (Fin D) ℂ) (j : Fin r) :
-    Matrix (Fin D) (Fin D) ℂ :=
+/-- The `j`-th ancilla block of a supplied rectangular Stinespring matrix. -/
+def stinespringBlockRectangular {d d' : ℕ}
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ) (j : Fin r) :
+    Matrix (Fin d') (Fin d) ℂ :=
   fun a b => V (a, j) b
 
-/-- Reassembling the ancilla blocks of a supplied Stinespring matrix recovers
-the original matrix. -/
-theorem stinespringV_stinespringBlock
-    (V : Matrix (Fin D × Fin r) (Fin D) ℂ) :
-    stinespringV (stinespringBlock (D := D) (r := r) V) = V := by
+/-- Reassembling the ancilla blocks of a supplied rectangular Stinespring matrix
+recovers the original matrix. -/
+theorem stinespringV_stinespringBlockRectangular {d d' : ℕ}
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ) :
+    stinespringV (stinespringBlockRectangular (r := r) V) = V := by
   ext x b
   rcases x with ⟨a, j⟩
   rfl
+
+/-- The `j`-th ancilla block of a supplied square Stinespring matrix. -/
+noncomputable def stinespringBlock
+    (V : Matrix (Fin D × Fin r) (Fin D) ℂ) (j : Fin r) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  stinespringBlockRectangular V j
+
+/-- Reassembling the ancilla blocks of a supplied square Stinespring matrix
+recovers the original matrix. -/
+theorem stinespringV_stinespringBlock
+    (V : Matrix (Fin D × Fin r) (Fin D) ℂ) :
+    stinespringV (stinespringBlock (D := D) (r := r) V) = V := by
+  exact stinespringV_stinespringBlockRectangular V
 
 /-- Radon--Nikodym theorem relative to a supplied Stinespring matrix, with an
 explicit Kraus row family for the components.
@@ -174,12 +227,12 @@ represent `T`.  If the supplied Stinespring dilation has at most as many
 ancilla rows as this family, then the fibre Gram matrices of the Kraus-freedom
 isometry give the Radon--Nikodym operators on the supplied dilation space. -/
 theorem radon_nikodym_of_stinespring_of_kraus_family
-    {ι η : Type*} [Fintype ι] [DecidableEq ι] [Fintype η]
-    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (Tᵢ : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (V : Matrix (Fin D × Fin r) (Fin D) ℂ)
+    {ι η : Type*} [Fintype ι] [DecidableEq ι] [Fintype η] {d d' : ℕ}
+    {T : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
+    (Tᵢ : ι → Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ)
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
     (label : η → ι)
-    (B : η → Matrix (Fin D) (Fin D) ℂ)
+    (B : η → Matrix (Fin d) (Fin d') ℂ)
     (hV : ∀ X, T X =
       Vᴴ * Matrix.kroneckerMap (· * ·) X (1 : Matrix (Fin r) (Fin r) ℂ) * V)
     (hComponent : ∀ i X,
@@ -192,10 +245,11 @@ theorem radon_nikodym_of_stinespring_of_kraus_family
       ∀ i X,
         Tᵢ i X = Vᴴ * Matrix.kroneckerMap (· * ·) X (P i) * V := by
   classical
-  let K : Fin r → Matrix (Fin D) (Fin D) ℂ := stinespringBlock V
-  let A : Fin r → Matrix (Fin D) (Fin D) ℂ := fun j => (K j)ᴴ
-  have hVeq : stinespringV K = V := stinespringV_stinespringBlock (D := D) (r := r) V
-  have hsame : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+  let K : Fin r → Matrix (Fin d') (Fin d) ℂ := stinespringBlockRectangular V
+  let A : Fin r → Matrix (Fin d) (Fin d') ℂ := fun j => (K j)ᴴ
+  have hVeq : stinespringV K = V :=
+    stinespringV_stinespringBlockRectangular (r := r) V
+  have hsame : ∀ X : Matrix (Fin d') (Fin d') ℂ,
       ∑ α : η, B α * X * (B α)ᴴ = ∑ j : Fin r, A j * X * (A j)ᴴ := by
     intro X
     calc
@@ -343,6 +397,78 @@ theorem IsCPMap.radon_nikodym_of_stinespring
   exact radon_nikodym_of_stinespring_of_kraus_family Tᵢ V label B hV
     hComponent hTotalKraus hCard
 
+/-- **Wolf Theorem 2.4 (rectangular Radon--Nikodym for quantum instruments).**
+
+Let a finite nonempty family of rectangular Kraus-completely-positive
+Heisenberg maps `Tᵢ : M_{d'}(ℂ) → M_d(ℂ)` sum to `T`, and let
+`V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` supply the Stinespring representation
+`T(A) = Vᴴ (A ⊗ 𝟙_r) V`. Then there are positive semidefinite operators `Pᵢ`
+on `ℂ^r`, summing to `𝟙_r`, such that
+`Tᵢ(A) = Vᴴ (A ⊗ Pᵢ) V`.
+
+No minimality of the supplied Stinespring representation is assumed. The
+nonempty-family hypothesis is necessary because the empty sum of operators
+cannot equal the identity on a nonzero supplied dilation space. -/
+theorem IsKrausCP.radon_nikodym_of_stinespring
+    {ι : Type*} [Fintype ι] [Nonempty ι] {d d' : ℕ}
+    {T : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
+    (Tᵢ : ι → Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ)
+    (hTᵢ : ∀ i, IsKrausCP (Tᵢ i))
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
+    (hV : ∀ A, T A =
+      Vᴴ * Matrix.kroneckerMap (· * ·) A (1 : Matrix (Fin r) (Fin r) ℂ) * V)
+    (hsum : (∑ i, Tᵢ i) = T) :
+    ∃ P : ι → Matrix (Fin r) (Fin r) ℂ,
+      (∀ i, (P i).PosSemidef) ∧
+      (∑ i, P i = 1) ∧
+      ∀ i A,
+        Tᵢ i A = Vᴴ * Matrix.kroneckerMap (· * ·) A (P i) * V := by
+  classical
+  let s : ι → ℕ := fun i => Classical.choose (hTᵢ i)
+  let B₀ : (i : ι) → Fin (s i) → Matrix (Fin d) (Fin d') ℂ :=
+    fun i => Classical.choose (Classical.choose_spec (hTᵢ i))
+  have hB₀ : ∀ i A, Tᵢ i A = ∑ a : Fin (s i), B₀ i a * A * (B₀ i a)ᴴ := by
+    intro i
+    exact Classical.choose_spec (Classical.choose_spec (hTᵢ i))
+  let i₀ : ι := Classical.choice ‹Nonempty ι›
+  let Row := Sum (Sigma fun i : ι => Fin (s i)) (Fin r)
+  let label : Row → ι := fun α => match α with
+    | Sum.inl x => x.1
+    | Sum.inr _ => i₀
+  let B : Row → Matrix (Fin d) (Fin d') ℂ := fun α => match α with
+    | Sum.inl x => B₀ x.1 x.2
+    | Sum.inr _ => 0
+  have hComponent : ∀ i A,
+      Tᵢ i A = ∑ α : Row, if label α = i then B α * A * (B α)ᴴ else 0 := by
+    intro i A
+    rw [hB₀ i A]
+    simp only [Row, Fintype.sum_sum_type]
+    rw [Fintype.sum_sigma]
+    simp [label, B]
+  have hTotalKraus : ∀ A, ∑ α : Row, B α * A * (B α)ᴴ = T A := by
+    intro A
+    simp only [Row, Fintype.sum_sum_type]
+    rw [Fintype.sum_sigma]
+    simp only [B, Matrix.zero_mul, Matrix.conjTranspose_zero, Matrix.mul_zero,
+      Finset.sum_const_zero, add_zero]
+    calc
+      ∑ x : ι, ∑ y : Fin (s x), B₀ x y * A * (B₀ x y)ᴴ = ∑ x : ι, Tᵢ x A := by
+        refine Finset.sum_congr rfl ?_
+        intro i _
+        exact (hB₀ i A).symm
+      _ = T A := by
+        have happ := congrArg
+          (fun F : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ => F A)
+          hsum
+        simpa [Finset.sum_apply] using happ
+  have hCard : Fintype.card (Fin r) ≤ Fintype.card Row := by
+    let emb : Fin r ↪ Row := ⟨Sum.inr, by
+      intro a b h
+      exact Sum.inr.inj h⟩
+    exact Fintype.card_le_of_embedding emb
+  exact radon_nikodym_of_stinespring_of_kraus_family Tᵢ V label B hV
+    hComponent hTotalKraus hCard
+
 /-! ### Wolf Theorem 2.4 (Radon–Nikodym, binary form) -/
 
 /-- **Wolf Theorem 2.4 (Radon–Nikodym for CP maps, binary form)**.
@@ -391,7 +517,8 @@ theorem IsCPMap.exists_radon_nikodym
     rw [Matrix.blockDiagTopProj,
         ← Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap A
           (Matrix.blockTopRows r₁ s)]
-    -- Reassociate: Vᴴ * ((𝟙⊗C)ᴴ * (A⊗𝟙) * (𝟙⊗C)) * V = ((𝟙⊗C)V)ᴴ * (A⊗𝟙) * ((𝟙⊗C)V).
+    -- Reassociate the product so that the outer factors combine into
+    -- `((𝟙 ⊗ C) V)ᴴ` and `(𝟙 ⊗ C) V`.
     rw [show (stinespringV K)ᴴ *
         ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ)
             (Matrix.blockTopRows r₁ s))ᴴ *

--- a/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
@@ -587,45 +587,47 @@ a common dilation space.
     and $P_{\mathrm{top}}+P_{\mathrm{bot}}=\Id$.
 \end{definition}
 
-\begin{theorem}[Radon--Nikodym theorem for finite quantum instruments]
+\begin{theorem}[Radon--Nikodym theorem for quantum instruments]
     \label{thm:cp_radon_nikodym_of_stinespring}
-    \lean{IsCPMap.radon_nikodym_of_stinespring}
+    \lean{IsKrausCP.radon_nikodym_of_stinespring}
     \leanok
-    \uses{def:cp_map, def:stinespring_v}
-    Let $\{T_i\}_{i\in I}$ be a nonempty finite family of completely positive
-    maps, let $T:\MN{D}\to\MN{D}$ satisfy $\sum_{i\in I}T_i=T$, and
-    suppose that $T$ has a supplied Stinespring representation
+    \uses{def:is_kraus_cp, def:stinespring_v}
+    Let $I$ be a nonempty finite set, and let
+    $T_i,T:\MN{d'}\to\MN{d}$ be completely positive linear maps such that
+    $\sum_{i\in I}T_i=T$. Suppose that a Stinespring representation of $T$ is
+    supplied by a linear map
+    $V:\C^d\to\C^{d'}\otimes\C^r$ satisfying
     \begin{align}
         T(A)
-        &=V^\dagger(A\otimes\Id_r)V.
+        &=V^\dagger(A\otimes\Id_r)V
+        \qquad (A\in\MN{d'}).
         \label{eq:representations_radon_dilation}
     \end{align}
-    Then there are positive semidefinite operators $P_i\in\MN{r}$ with
+    Then there are positive semidefinite operators $P_i\in\MN{r}$ such that
     \begin{align}
         \sum_{i\in I}P_i
-        &=\Id_r.
-        \label{eq:representations_radon_resolution}
-    \end{align}
-    For every $i\in I$ and $A\in\MN{D}$,
-    \begin{align}
+        &=\Id_r,
+        \label{eq:representations_radon_resolution}\\
         T_i(A)
-        &=V^\dagger(A\otimes P_i)V.
+        &=V^\dagger(A\otimes P_i)V
+        \qquad (i\in I,\ A\in\MN{d'}).
         \label{eq:representations_radon_components}
     \end{align}
-    This is \cite[Theorem~2.4]{Wolf2012Quantum}, with the nonempty-family condition
-    made explicit; see
-    \cite{gap:wolf_radon_nikodym_nonempty_family}.
+    This is the rectangular Heisenberg-picture statement of
+    \cite[Theorem~2.4]{Wolf2012Quantum}. The nonempty-family condition is made
+    explicit; see \cite{gap:wolf_radon_nikodym_nonempty_family}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:kraus_rectangular_freedom'}
-    Choose Kraus families for the component maps $T_i$ and group all their
-    Kraus operators into one finite family. Add zero Kraus operators to one
-    component so that this grouped family has at least as many rows as the
-    supplied Stinespring dilation. Write the grouped Kraus operators as
-    $B_\alpha$, with a label map $\ell(\alpha)\in I$, and write the Kraus
-    operators obtained from the blocks of $V$ as $A_j$. Rectangular Kraus
-    freedom gives a matrix $W$ with
+    Choose rectangular Kraus families for the component maps $T_i$ and group
+    all their Kraus operators into one finite family. Add zero Kraus operators
+    to one component so that this grouped family has at least as many rows as
+    the supplied Stinespring dilation. Write the grouped Kraus operators as
+    $B_\alpha:\C^{d'}\to\C^d$, with a label map $\ell(\alpha)\in I$, and write
+    the ancilla blocks of $V$ as $K_j:\C^d\to\C^{d'}$, and take their
+    adjoints $A_j=K_j^\dagger:\C^{d'}\to\C^d$ as Kraus operators.
+    Rectangular Kraus freedom gives a matrix $W$ with
     \begin{align}
         W^\dagger W
         &=\Id_r, \notag\\
@@ -657,6 +659,28 @@ a common dilation space.
     which proves the claim.
 \end{proof}
 
+\begin{corollary}[Square-algebra Radon--Nikodym theorem]
+    \label{cor:cp_radon_nikodym_of_stinespring_square}
+    \lean{IsCPMap.radon_nikodym_of_stinespring}
+    \leanok
+    \uses{thm:cp_radon_nikodym_of_stinespring}
+    Let $I$ be a nonempty finite set, and let
+    $T_i,T:\MN{D}\to\MN{D}$ be completely positive linear maps such that
+    $\sum_{i\in I}T_i=T$. If
+    $V:\C^D\to\C^D\otimes\C^r$ satisfies
+    $T(A)=V^\dagger(A\otimes\Id_r)V$, then there are positive semidefinite
+    operators $P_i\in\MN{r}$ satisfying
+    $\sum_{i\in I}P_i=\Id_r$ and
+    $T_i(A)=V^\dagger(A\otimes P_i)V$ for every $i\in I$ and $A\in\MN{D}$.
+\end{corollary}
+
+\begin{proof}\leanok
+    This is the specialization of
+    Theorem~\ref{thm:cp_radon_nikodym_of_stinespring} to $d'=d=D$. The legacy
+    square-algebra declaration is retained for compatibility; its formal proof
+    follows the same Kraus-family and rectangular Kraus-freedom argument.
+\end{proof}
+
 \begin{theorem}[Binary Radon--Nikodym theorem for CP maps]
     \label{thm:cp_exists_radon_nikodym}
     \lean{IsCPMap.exists_radon_nikodym}
@@ -678,8 +702,10 @@ a common dilation space.
     \label{rem:cp_radon_nikodym_scope}
     % Source-faithful scope note: Wolf's statement is the finite-family
     % theorem relative to a supplied Stinespring dilation.
-    Theorem~\ref{thm:cp_radon_nikodym_of_stinespring} treats a finite family
-    relative to a supplied Stinespring dilation. The binary case in
+    Theorem~\ref{thm:cp_radon_nikodym_of_stinespring} is Wolf's rectangular
+    finite-family theorem relative to a supplied Stinespring dilation.
+    Corollary~\ref{cor:cp_radon_nikodym_of_stinespring_square} records the
+    retained square-algebra API. The binary case in
     Theorem~\ref{thm:cp_exists_radon_nikodym} instead constructs a common
     dilation from the Kraus families of $T_1$ and $T_2$.
 \end{remark}

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -205,9 +205,12 @@ statement or proof route of Theorem~2.3.
 \label{sec:radon-nikodym}
 
 \paragraph{Formalization trigger.}
-The Lean theorem
-\leanid{IsCPMap.radon_nikodym_of_stinespring} makes the finite index type
-nonempty. The boundary is documented in
+The source-facing Lean theorem
+\leanid{IsKrausCP.radon_nikodym_of_stinespring} makes the finite index type
+nonempty. It has Wolf's rectangular Heisenberg dimensions
+$T_i,T:\mathcal M_{d'}\to\mathcal M_d$ and
+$V:\mathbb C^d\to\mathbb C^{d'}\otimes\mathbb C^r$. The boundary is
+documented in
 \path{docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex}.
 
 \paragraph{Printed source and its role.}
@@ -224,13 +227,29 @@ $T_i(A)=V^\dagger(A\otimes P_i)V$.''
 \end{quote}
 
 \paragraph{Formal statement.}
-The formal theorem uses a \emph{nonempty finite family}
-$\{T_i\}_{i\in\iota}$ and concludes
+The formal theorem uses a \emph{nonempty finite family} of completely positive
+linear maps
+$T_i,T:\mathcal M_{d'}\to\mathcal M_d$ with
+$\sum_{i\in\iota}T_i=T$, together with a supplied map
+$V:\mathbb C^d\to\mathbb C^{d'}\otimes\mathbb C^r$ satisfying
+$T(A)=V^\dagger(A\otimes I_r)V$. It concludes that there are positive
+semidefinite operators $P_i\in\mathcal M_r$ such that
 \begin{equation}
   \sum_{i\in\iota}P_i=I_r,
   \qquad
   T_i(A)=V^\dagger(A\otimes P_i)V.
 \end{equation}
+The declaration \leanid{IsCPMap.radon_nikodym_of_stinespring} is retained as
+the square-algebra specialization.
+
+\paragraph{Formal proof path.}
+The proof chooses rectangular Kraus families for the component maps, combines
+them into one labelled family, and pads one component with zero Kraus operators.
+It then compares this family with the adjoints of the ancilla blocks of the
+supplied Stinespring matrix. Rectangular Kraus freedom produces an isometry,
+and the Gram matrices of its
+labelled fibres give the operators $P_i$. This is the compiled Kraus-freedom
+proof route; it does not use Douglas factorization.
 
 \paragraph{Why the boundary is needed.}
 If the index type is empty, then $\sum_iT_i=T$ forces $T=0$. Taking the zero

--- a/docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex
+++ b/docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex
@@ -10,7 +10,7 @@
 
 \title{The nonempty-family condition in Wolf's Radon--Nikodym theorem}
 \author{}
-\date{2026-06-16}
+\date{2026-08-23}
 
 \begin{document}
 \maketitle
@@ -19,9 +19,15 @@
 \section{Source statement}
 
 Wolf's Radon--Nikodym theorem for quantum instruments states that, if
-\(\{T_i\}\) is a family of completely positive maps satisfying
-\(\sum_i T_i=T\) and
+\(\{T_i\}\) is a family of completely positive linear maps
 \[
+  T_i,T:\mathcal M_{d'}\longrightarrow\mathcal M_d
+\]
+satisfying \(\sum_i T_i=T\), and if a Stinespring representation of the total
+map is supplied by
+\[
+  V:\mathbb C^d\longrightarrow\mathbb C^{d'}\otimes\mathbb C^r,
+  \qquad
   T(A)=V^\dagger(A\otimes \mathbf 1_r)V,
 \]
 then there are positive operators \(P_i\in\mathcal M_r\) such that
@@ -37,9 +43,10 @@ The local source is
 
 \section{Local boundary}
 
-The Lean theorem \leanid{IsCPMap.radon_nikodym_of_stinespring} makes the index
-type nonempty.  This is not a strengthening of a mathematical hypothesis in the
-substantive case; it is the finite-type boundary needed for the identity
+The source-facing Lean theorem
+\leanid{IsKrausCP.radon_nikodym_of_stinespring} makes the finite index type
+nonempty. This is not a strengthening of a mathematical hypothesis in the
+substantive case; it is the finite-family boundary needed for the identity
 \[
   \sum_i P_i=\mathbf 1_r
 \]
@@ -53,8 +60,16 @@ the index type were empty, then the hypotheses \(\sum_i T_i=T\) force
 in \(\mathcal M_r\), which is false for a nonzero dilation dimension.
 
 Thus the formal theorem states the source theorem in the nonempty instrument
-case.  The blueprint entry records the same boundary explicitly by saying
-``nonempty finite family.''
+case, with its rectangular Heisenberg dimensions made explicit. The older
+\leanid{IsCPMap.radon_nikodym_of_stinespring} theorem is retained as the
+square-algebra specialization.
+
+The formal proof follows the Kraus-freedom route. Choose rectangular Kraus
+families for the component maps, combine them into one labelled family, pad one
+component by zero Kraus operators, and compare that family with the adjoints
+of the ancilla blocks of the supplied Stinespring matrix. Rectangular Kraus
+freedom gives an isometry whose fibre Gram matrices are the
+operators \(P_i\). No Douglas-factorization argument is used.
 
 \section{Elimination plan}
 

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -159,17 +159,24 @@ project import.
     corollary that constructs compatible dilations by appending Kraus
     families; it is no longer identified with the supplied source theorem ✓
 
-* **Theorem 2.4** (Radon–Nikodym for CP maps):
+* **Theorem 2.4** (Radon–Nikodym for quantum instruments):
   - `Matrix.blockDiagTopProj` / `Matrix.blockDiagBotProj` — orthogonal
     block projectors on the dilation space, PSD and summing to `𝟙` ✓
   - `Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap` — Kronecker
     identity `A ⊗ (CᴴC) = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙) (𝟙 ⊗ C)` ✓
-  - `IsCPMap.radon_nikodym_of_stinespring` — Wolf, *Quantum Channels &
-    Operations*, Theorem 2.4, source-faithful finite-family form relative to a
-    supplied Stinespring representation ✓
+  - `IsKrausCP.radon_nikodym_of_stinespring` — the source-facing rectangular
+    Heisenberg theorem: for a nonempty finite family of CP maps
+    `Tᵢ, T : M_{d'}(ℂ) → M_d(ℂ)` with `∑ᵢ Tᵢ = T` and a supplied
+    `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` satisfying `T(A) = V†(A ⊗ 𝟙_r)V`, there are
+    PSD `Pᵢ ∈ M_r(ℂ)` with `∑ᵢ Pᵢ = 𝟙_r` and
+    `Tᵢ(A) = V†(A ⊗ Pᵢ)V` ✓
+  - `IsCPMap.radon_nikodym_of_stinespring` — the retained square-algebra
+    specialization `d' = d`, provided as a legacy API and proved by the same
+    Kraus-family/Kraus-freedom route ✓
   - `IsCPMap.exists_radon_nikodym` — binary block-diagonal corollary:
-    for CP `T₁, T₂`, a constructed Stinespring matrix for `T₁ + T₂` yields
-    PSD `P₁ + P₂ = 𝟙` with `Tᵢ(A) = V†(A ⊗ Pᵢ)V` ✓
+    for square CP maps `T₁, T₂`, a constructed Stinespring matrix for
+    `T₁ + T₂` yields PSD `P₁ + P₂ = 𝟙` with
+    `Tᵢ(A) = V†(A ⊗ Pᵢ)V` ✓
 
 * **Theorem 2.5, Equation (2.14)** (open-system representation):
   - `Channel.IsKrausCPTP.exists_openSystem_unitary` — the source-facing


### PR DESCRIPTION
Closes #7.

Formalizes Wolf Chapter 2 finite-family Radon–Nikodym theorem in the exact rectangular Heisenberg dimensions. For a nonempty finite family `Tᵢ : M_{d′}(ℂ) → M_d(ℂ)` summing to `T` and a supplied Stinespring matrix `V : ℂ^d → ℂ^{d′} ⊗ ℂ^r`, the theorem produces positive semidefinite `Pᵢ` summing to the identity with `Tᵢ(A) = Vᴴ (A ⊗ Pᵢ) V`.

The proof ports the existing finite-family Kraus-freedom route; it assumes no minimality and preserves the square API. The Blueprint and Wolf errata/coverage documentation are synchronized.

Verification: fresh targeted `lake env lean QICLean/Channel/RadonNikodym.lean`, import/policy/prose checks, and Blueprint/paper-gap builds. No local Lake build, clean, fetch, update, or cache deletion was performed.