### PR TITLE
feat(channel): formalize invertible rank-one filters

### DIFF
--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -51,6 +51,7 @@ import QICLean.Channel.LocalizedKrausCPTP
 import QICLean.Channel.LorentzNormalForm
 import QICLean.Channel.LorentzNormalForm.Basic
 import QICLean.Channel.LorentzNormalForm.Infimum
+import QICLean.Channel.LorentzNormalForm.InvertibleFilter
 import QICLean.Channel.LorentzNormalForm.NormalForm
 import QICLean.Channel.LorentzNormalForm.PauliBlockTruncation
 import QICLean.Channel.LorentzNormalForm.QubitNormalForm

--- a/QICLean/Channel/LorentzNormalForm.lean
+++ b/QICLean/Channel/LorentzNormalForm.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import QICLean.Channel.LorentzNormalForm.Basic
 import QICLean.Channel.LorentzNormalForm.Infimum
+import QICLean.Channel.LorentzNormalForm.InvertibleFilter
 import QICLean.Channel.LorentzNormalForm.NormalForm
 import QICLean.Channel.LorentzNormalForm.PauliBlockTruncation
 import QICLean.Channel.LorentzNormalForm.QubitNormalForm
@@ -13,7 +14,7 @@ import QICLean.Channel.LorentzNormalForm.QubitNormalForm
 # Lorentz normal form for quantum channels (Wolf Section 2.4, Propositions 2.8–2.11)
 
 Thin module assembling the normal-form development for quantum channels under
-filtering operations from five focused submodules.
+filtering operations from six focused submodules.
 
 * `QICLean.Channel.LorentzNormalForm.Basic` — SL-filtering operations, the
   doubly-stochastic predicates, and the shared Kronecker-conjugation and
@@ -21,6 +22,9 @@ filtering operations from five focused submodules.
 * `QICLean.Channel.LorentzNormalForm.Infimum` — the compactness/minimisation
   argument (Wolf Equation (2.36)): attainment of the infimum and the AM–GM
   optimality lemmas.
+* `QICLean.Channel.LorentzNormalForm.InvertibleFilter` — the general
+  invertible Kraus-rank-one filters used in Wolf Proposition 2.11, including
+  their scalar/determinant-one decomposition.
 * `QICLean.Channel.LorentzNormalForm.NormalForm` — Wolf Proposition 2.9, the
   generic normal form for CP maps with full Kraus rank, in square and
   rectangular forms.

--- a/QICLean/Channel/LorentzNormalForm/InvertibleFilter.lean
+++ b/QICLean/Channel/LorentzNormalForm/InvertibleFilter.lean
@@ -1,0 +1,300 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Channel.KrausRank
+import QICLean.Channel.LorentzNormalForm.Basic
+import QICLean.Channel.SingleKraus
+import Mathlib.FieldTheory.IsAlgClosed.Basic
+import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Basic
+
+/-!
+# Invertible Kraus-rank-one filtering operations
+
+Wolf Section 2.4 studies completely positive maps up to pre- and
+postcomposition by invertible maps of Kraus rank one.  Such a *filtering
+operation* has the form
+
+`Phi_X(A) = X * A * X^H`, with `X` invertible.
+
+This module records these general filters using `GL (Fin D) C`.  It also
+separates each filtering matrix into a nonzero complex scalar and a
+determinant-one matrix.  The complex scalar itself need not be real or
+positive; only its contribution `Complex.normSq c` to the induced completely
+positive map is a positive real number.
+
+## Main declarations
+
+* `Wolf.InvertibleFilter` -- an invertible single-Kraus filter.
+* `Wolf.InvertibleFilter.comp` and `Wolf.InvertibleFilter.inv` -- composition
+  and inverse filterings, with the same order as composition of their maps.
+* `Wolf.InvertibleFilter.choiRank_eq_one` -- the Kraus rank is exactly one in
+  nonzero dimension.
+* `Wolf.InvertibleFilter.exists_scalar_slFiltering` -- decomposition into a
+  nonzero complex scalar and an existing `Wolf.SLFiltering`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.4,
+  Equation (2.35) and Proposition 2.11][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace Wolf
+
+/-- An invertible Kraus-rank-one filtering operation on `D x D` matrices.
+The filtering matrix is bundled as an element of `GL (Fin D) C`; its map is
+defined separately below. -/
+structure InvertibleFilter (D : ℕ) where
+  /-- The invertible filtering matrix `X`. -/
+  X : GL (Fin D) ℂ
+
+namespace InvertibleFilter
+
+/-- The filtering operation `Phi_X(A) = X A X^H`. -/
+noncomputable def map {D : ℕ} (Phi : InvertibleFilter D) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+  singleKrausMap (Phi.X : Matrix (Fin D) (Fin D) ℂ)
+
+@[simp]
+theorem map_apply {D : ℕ} (Phi : InvertibleFilter D)
+    (A : Matrix (Fin D) (Fin D) ℂ) :
+    Phi.map A = (Phi.X : Matrix (Fin D) (Fin D) ℂ) * A *
+      (Phi.X : Matrix (Fin D) (Fin D) ℂ)ᴴ :=
+  rfl
+
+/-- The general filtering map agrees with the conjugation map used by the
+existing determinant-one filtering API. -/
+theorem map_eq_unitaryConjLM {D : ℕ} (Phi : InvertibleFilter D) :
+    Phi.map = unitaryConjLM (Phi.X : Matrix (Fin D) (Fin D) ℂ) := by
+  ext A
+  rfl
+
+/-- Every invertible filtering operation is completely positive. -/
+theorem cp {D : ℕ} (Phi : InvertibleFilter D) : IsCPMap Phi.map := by
+  exact isKrausCP_iff_isCPMap.mp
+    (singleKrausMap_isKrausCP (Phi.X : Matrix (Fin D) (Fin D) ℂ))
+
+/-- The identity filtering operation. -/
+def id (D : ℕ) : InvertibleFilter D where
+  X := 1
+
+@[simp]
+theorem map_id (D : ℕ) : (id D).map = LinearMap.id := by
+  apply LinearMap.ext
+  intro A
+  simp [map_apply, id]
+
+/-- Composition of filtering operations.  The order matches map
+composition: `(Phi.comp Psi).map = Phi.map.comp Psi.map`. -/
+def comp {D : ℕ} (Phi Psi : InvertibleFilter D) : InvertibleFilter D where
+  X := Phi.X * Psi.X
+
+@[simp]
+theorem comp_X {D : ℕ} (Phi Psi : InvertibleFilter D) :
+    (Phi.comp Psi).X = Phi.X * Psi.X :=
+  rfl
+
+/-- Matrix multiplication gives the source composition order for filtering
+operations. -/
+theorem map_comp {D : ℕ} (Phi Psi : InvertibleFilter D) :
+    (Phi.comp Psi).map = Phi.map.comp Psi.map := by
+  exact (singleKrausMap_comp
+    (Phi.X : Matrix (Fin D) (Fin D) ℂ)
+    (Psi.X : Matrix (Fin D) (Fin D) ℂ)).symm
+
+/-- The inverse filtering operation, represented by `X^{-1}`. -/
+def inv {D : ℕ} (Phi : InvertibleFilter D) : InvertibleFilter D where
+  X := Phi.X⁻¹
+
+@[simp]
+theorem inv_X {D : ℕ} (Phi : InvertibleFilter D) : Phi.inv.X = Phi.X⁻¹ :=
+  rfl
+
+@[simp]
+theorem inv_comp {D : ℕ} (Phi : InvertibleFilter D) : Phi.inv.comp Phi = id D := by
+  cases Phi with
+  | mk X =>
+    change InvertibleFilter.mk (X⁻¹ * X) = InvertibleFilter.mk 1
+    rw [inv_mul_cancel X]
+
+@[simp]
+theorem comp_inv {D : ℕ} (Phi : InvertibleFilter D) : Phi.comp Phi.inv = id D := by
+  cases Phi with
+  | mk X =>
+    change InvertibleFilter.mk (X * X⁻¹) = InvertibleFilter.mk 1
+    rw [mul_inv_cancel X]
+
+/-- The inverse filtering map is a left inverse. -/
+theorem inv_map_comp {D : ℕ} (Phi : InvertibleFilter D) :
+    Phi.inv.map.comp Phi.map = LinearMap.id := by
+  rw [← map_comp Phi.inv Phi, inv_comp, map_id]
+
+/-- The inverse filtering map is a right inverse. -/
+theorem map_comp_inv {D : ℕ} (Phi : InvertibleFilter D) :
+    Phi.map.comp Phi.inv.map = LinearMap.id := by
+  rw [← map_comp Phi Phi.inv, comp_inv, map_id]
+
+/-- The displayed filtering matrix is a one-operator Kraus representation. -/
+theorem hasKrausCard_one {D : ℕ} (Phi : InvertibleFilter D) :
+    Channel.HasKrausCard Phi.map 1 := by
+  refine ⟨fun _ ↦ (Phi.X : Matrix (Fin D) (Fin D) ℂ), ?_⟩
+  intro A
+  simp [map_apply]
+
+/-- In nonzero dimension an invertible filtering operation is not the zero
+linear map. -/
+theorem map_ne_zero {D : ℕ} [NeZero D] (Phi : InvertibleFilter D) :
+    Phi.map ≠ 0 := by
+  intro hzero
+  have hcomp := Phi.inv_map_comp
+  rw [hzero] at hcomp
+  simp only [LinearMap.comp_zero] at hcomp
+  have hone := LinearMap.congr_fun hcomp (1 : Matrix (Fin D) (Fin D) ℂ)
+  simp only [LinearMap.zero_apply, LinearMap.id_apply] at hone
+  exact one_ne_zero hone.symm
+
+/-- In nonzero dimension an invertible single-Kraus filtering operation has
+Kraus rank (equivalently, Choi rank) exactly one. -/
+theorem choiRank_eq_one {D : ℕ} [NeZero D] (Phi : InvertibleFilter D) :
+    Channel.choiRank Phi.map = 1 := by
+  have hle : Channel.choiRank Phi.map ≤ 1 :=
+    Channel.choiRank_le_of_hasKrausCard Phi.hasKrausCard_one
+  have hne : Channel.choiRank Phi.map ≠ 0 := by
+    intro hzero
+    have hcard := Channel.hasKrausCard_choiRank_of_cp
+      (isKrausCP_iff_isCPMap.mpr Phi.cp)
+    rw [hzero] at hcard
+    rcases hcard with ⟨K, hK⟩
+    have heqzero : Phi.map = 0 := by
+      ext A
+      simp [hK A]
+    exact Phi.map_ne_zero heqzero
+  omega
+
+/-- Scaling a single Kraus matrix by `c` scales its completely positive map
+by the nonnegative real number `Complex.normSq c = |c|^2`. -/
+theorem singleKrausMap_smul {D : ℕ} (c : ℂ)
+    (S : Matrix (Fin D) (Fin D) ℂ) :
+    singleKrausMap (c • S) =
+      ((Complex.normSq c : ℝ) : ℂ) • singleKrausMap S := by
+  apply LinearMap.ext
+  intro A
+  simp only [singleKrausMap_apply, LinearMap.smul_apply, Matrix.conjTranspose_smul]
+  simp [smul_smul, Complex.normSq_eq_conj_mul_self, mul_comm]
+
+/-! ### Pre- and postfiltering in Wolf's order -/
+
+/-- Pre- and postfilter a possibly rectangular map in the order of Wolf
+Equation (2.35): `Phi₂ ∘ T ∘ Phi₁`. -/
+noncomputable def filteredMap {d₁ d₂ : ℕ}
+    (Phi₂ : InvertibleFilter d₂)
+    (T : Matrix (Fin d₁) (Fin d₁) ℂ →ₗ[ℂ] Matrix (Fin d₂) (Fin d₂) ℂ)
+    (Phi₁ : InvertibleFilter d₁) :
+    Matrix (Fin d₁) (Fin d₁) ℂ →ₗ[ℂ] Matrix (Fin d₂) (Fin d₂) ℂ :=
+  Phi₂.map.comp (T.comp Phi₁.map)
+
+@[simp]
+theorem filteredMap_apply {d₁ d₂ : ℕ}
+    (Phi₂ : InvertibleFilter d₂)
+    (T : Matrix (Fin d₁) (Fin d₁) ℂ →ₗ[ℂ] Matrix (Fin d₂) (Fin d₂) ℂ)
+    (Phi₁ : InvertibleFilter d₁) (A : Matrix (Fin d₁) (Fin d₁) ℂ) :
+    filteredMap Phi₂ T Phi₁ A =
+      (Phi₂.X : Matrix (Fin d₂) (Fin d₂) ℂ) *
+        T ((Phi₁.X : Matrix (Fin d₁) (Fin d₁) ℂ) * A *
+          (Phi₁.X : Matrix (Fin d₁) (Fin d₁) ℂ)ᴴ) *
+        (Phi₂.X : Matrix (Fin d₂) (Fin d₂) ℂ)ᴴ :=
+  rfl
+
+/-- The two scalar factors in `Phi₂ ∘ T ∘ Phi₁` combine to the positive
+map scalar `Complex.normSq (c₁ * c₂)`.  This is the rectangular-map identity
+used in the scalar-normalization discussion following Wolf Equation (2.35). -/
+theorem filteredMap_eq_normSq_smul {d₁ d₂ : ℕ}
+    (Phi₂ : InvertibleFilter d₂)
+    (T : Matrix (Fin d₁) (Fin d₁) ℂ →ₗ[ℂ] Matrix (Fin d₂) (Fin d₂) ℂ)
+    (Phi₁ : InvertibleFilter d₁)
+    (c₁ c₂ : ℂ) (Psi₁ : SLFiltering d₁) (Psi₂ : SLFiltering d₂)
+    (h₁ : Phi₁.map = ((Complex.normSq c₁ : ℝ) : ℂ) • Psi₁.map)
+    (h₂ : Phi₂.map = ((Complex.normSq c₂ : ℝ) : ℂ) • Psi₂.map) :
+    filteredMap Phi₂ T Phi₁ =
+      ((Complex.normSq (c₁ * c₂) : ℝ) : ℂ) •
+        (Psi₂.map.comp (T.comp Psi₁.map)) := by
+  ext A
+  simp only [filteredMap, LinearMap.comp_apply, LinearMap.smul_apply]
+  rw [h₁, h₂]
+  simp only [LinearMap.smul_apply, map_smul]
+  rw [smul_smul, Complex.normSq_mul]
+  norm_cast
+
+/-- Every invertible filtering matrix in nonzero dimension is a nonzero
+complex scalar multiple of a determinant-one filtering matrix.  At map level
+the corresponding scalar is the positive real number `Complex.normSq c`.
+
+This is the scalar freedom required by Wolf Proposition 2.11; it is not a
+claim that the matrix scalar `c` itself is positive real. -/
+theorem exists_scalar_slFiltering {D : ℕ} [NeZero D]
+    (Phi : InvertibleFilter D) :
+    ∃ (c : ℂ), c ≠ 0 ∧
+      c ^ D = (Phi.X : Matrix (Fin D) (Fin D) ℂ).det ∧
+      0 < Complex.normSq c ∧
+      ∃ Psi : SLFiltering D,
+        (Phi.X : Matrix (Fin D) (Fin D) ℂ) = c • Psi.S ∧
+          Phi.map = ((Complex.normSq c : ℝ) : ℂ) • Psi.map := by
+  obtain ⟨c, hcD⟩ := IsAlgClosed.exists_pow_nat_eq
+    (Phi.X : Matrix (Fin D) (Fin D) ℂ).det (NeZero.pos D)
+  have hc : c ≠ 0 := by
+    intro hc0
+    rw [hc0, zero_pow (NeZero.ne D)] at hcD
+    exact Phi.X.det_ne_zero hcD.symm
+  let S : Matrix (Fin D) (Fin D) ℂ := c⁻¹ • (Phi.X : Matrix (Fin D) (Fin D) ℂ)
+  have hSdet : S.det = 1 := by
+    dsimp only [S]
+    rw [Matrix.det_smul, Fintype.card_fin, inv_pow, hcD]
+    exact inv_mul_cancel₀ Phi.X.det_ne_zero
+  let Psi : SLFiltering D :=
+    { S := S
+      det_eq_one := hSdet
+      map := unitaryConjLM S
+      map_eq := rfl
+      cp := unitaryConjLM_isCPMap S }
+  have hX : (Phi.X : Matrix (Fin D) (Fin D) ℂ) = c • S := by
+    dsimp only [S]
+    rw [smul_smul, mul_inv_cancel₀ hc]
+    exact (one_smul ℂ (Phi.X : Matrix (Fin D) (Fin D) ℂ)).symm
+  have hmap : Phi.map = ((Complex.normSq c : ℝ) : ℂ) • Psi.map := by
+    rw [show Phi.map = singleKrausMap (Phi.X : Matrix (Fin D) (Fin D) ℂ) from rfl,
+      hX, singleKrausMap_smul]
+    congr 1
+  refine ⟨c, hc, hcD, Complex.normSq_pos.mpr hc, Psi, ?_, hmap⟩
+  exact hX
+
+end InvertibleFilter
+
+namespace SLFiltering
+
+/-- Regard an existing determinant-one filtering as a general invertible
+filtering operation.  This preserves the established `SLFiltering` API as the
+determinant-one specialization. -/
+noncomputable def toInvertibleFilter {D : ℕ} (Phi : SLFiltering D) :
+    InvertibleFilter D where
+  X := Matrix.GeneralLinearGroup.mkOfDetNeZero Phi.S (by
+    rw [Phi.det_eq_one]
+    exact one_ne_zero)
+
+@[simp]
+theorem toInvertibleFilter_X {D : ℕ} (Phi : SLFiltering D) :
+    (Phi.toInvertibleFilter.X : Matrix (Fin D) (Fin D) ℂ) = Phi.S :=
+  rfl
+
+/-- Passing an `SLFiltering` to the general filter type does not change its
+associated completely positive map. -/
+theorem toInvertibleFilter_map {D : ℕ} (Phi : SLFiltering D) :
+    Phi.toInvertibleFilter.map = Phi.map := by
+  rw [Phi.map_eq, Phi.toInvertibleFilter.map_eq_unitaryConjLM,
+    toInvertibleFilter_X]
+
+end SLFiltering
+
+end Wolf

--- a/QICLean/Channel/LorentzNormalForm/QubitNormalForm.lean
+++ b/QICLean/Channel/LorentzNormalForm/QubitNormalForm.lean
@@ -143,10 +143,13 @@ A former declaration in this file incorrectly restricted both filters to
 channel. That statement is false: determinant-one filters cannot supply the
 scalar normalization required for all channels, so the declaration was removed.
 The correctly formulated theorem remains to be formalized. Its proof will need:
-- A type for general invertible Kraus-rank-one CP filters, including scalar freedom;
 - The compactness and minimization results above, with the required normalization;
 - The Lorentz group classification of the filtering orbits;
 - The complete-positivity condition `λ₁ + λ₂ ≤ 1 + λ₃`.
+
+The general filtering type, its exact Kraus-rank-one property, and its
+scalar/determinant-one decomposition are provided by
+`Wolf.InvertibleFilter` in `LorentzNormalForm.InvertibleFilter`.
 
 See Wolf Section 2.4 for the complete proof. -/
 

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -286,6 +286,92 @@ This section states the existence theorems from
     invertible and have Kraus rank~1.
 \end{definition}
 
+\begin{definition}[Invertible filtering operation]
+\label{def:invertible_filtering}
+    \lean{Wolf.InvertibleFilter,
+        Wolf.InvertibleFilter.map,
+        Wolf.InvertibleFilter.map_apply,
+        Wolf.InvertibleFilter.map_eq_unitaryConjLM,
+        Wolf.InvertibleFilter.cp,
+        Wolf.InvertibleFilter.id,
+        Wolf.InvertibleFilter.map_id,
+        Wolf.InvertibleFilter.comp,
+        Wolf.InvertibleFilter.comp_X,
+        Wolf.InvertibleFilter.map_comp,
+        Wolf.InvertibleFilter.inv,
+        Wolf.InvertibleFilter.inv_X,
+        Wolf.InvertibleFilter.inv_comp,
+        Wolf.InvertibleFilter.comp_inv,
+        Wolf.InvertibleFilter.inv_map_comp,
+        Wolf.InvertibleFilter.map_comp_inv,
+        Wolf.InvertibleFilter.filteredMap,
+        Wolf.InvertibleFilter.filteredMap_apply,
+        Wolf.SLFiltering.toInvertibleFilter,
+        Wolf.SLFiltering.toInvertibleFilter_X,
+        Wolf.SLFiltering.toInvertibleFilter_map}\leanok
+    An \emph{invertible filtering operation} on $\MN{D}$ is a completely
+    positive map
+    \begin{align}
+        \Phi_X(A)=XAX^\dagger,
+        \qquad X\in\GL(D,\C).
+        \label{eq:representations_invertible_filter}
+    \end{align}
+    If $T:\MN{d_1}\to\MN{d_2}$, pre- and postfiltering are written in
+    Wolf's order as $\Phi_2\circ T\circ\Phi_1$.  The matrices $X$ are
+    retained as part of the data; in particular, matrices which differ by a
+    phase are not identified.
+\end{definition}
+
+\begin{lemma}[Scalar and determinant-one decomposition]
+\label{lem:invertible_filter_scalar_sl}
+    \lean{Wolf.InvertibleFilter.hasKrausCard_one,
+        Wolf.InvertibleFilter.map_ne_zero,
+        Wolf.InvertibleFilter.choiRank_eq_one,
+        Wolf.InvertibleFilter.singleKrausMap_smul,
+        Wolf.InvertibleFilter.exists_scalar_slFiltering}\leanok
+    Let $D\geq1$ and let $X\in\GL(D,\C)$.  There are a nonzero
+    $c\in\C$ and $S\in\SL(D,\C)$ such that
+    \begin{align}
+        c^D&=\det X, & X&=cS,
+        \label{eq:representations_filter_scalar_matrix}\\
+        \Phi_X&=|c|^2\Phi_S, & |c|^2&>0.
+        \label{eq:representations_filter_scalar_map}
+    \end{align}
+    Moreover, $\Phi_X$ has Kraus rank exactly one.  The matrix scalar $c$
+    is complex and need not be positive real; positivity applies only to the
+    map scalar $|c|^2$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Choose a $D$th root $c$ of $\det X$.  Since $X$ is invertible, both
+    $\det X$ and $c$ are nonzero.  Put $S=c^{-1}X$.  Multiplicativity of the
+    determinant gives $\det S=1$, while direct expansion of
+    $(cS)A(cS)^\dagger$ gives
+    $\Phi_X=|c|^2\Phi_S$.  The displayed nonzero Kraus operator gives Kraus
+    rank at most one, and invertibility excludes Kraus rank zero.
+\end{proof}
+
+\begin{lemma}[Scalar factors under pre- and postfiltering]
+\label{lem:invertible_filter_two_scalar}
+    \lean{Wolf.InvertibleFilter.filteredMap_eq_normSq_smul}\leanok
+    \uses{def:invertible_filtering, lem:invertible_filter_scalar_sl}
+    Suppose $X_i=c_iS_i$, where $c_i\neq0$ and
+    $S_i\in\SL(d_i,\C)$.  For every linear map
+    $T:\MN{d_1}\to\MN{d_2}$,
+    \begin{align}
+        \Phi_{X_2}\circ T\circ\Phi_{X_1}
+        =|c_1c_2|^2
+          \bigl(\Phi_{S_2}\circ T\circ\Phi_{S_1}\bigr).
+        \label{eq:representations_filter_two_scalar}
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Substitute $\Phi_{X_i}=|c_i|^2\Phi_{S_i}$ and use linearity of $T$ and
+    of the outer filtering operation.  The two real scalars combine as
+    $|c_1|^2|c_2|^2=|c_1c_2|^2$.
+\end{proof}
+
 \begin{definition}[Doubly-stochastic map]\label{def:doubly_stochastic}
     \lean{Wolf.DoublyStochastic}\leanok
     A linear map $T : \MN{D} \to \MN{D}$ is \emph{doubly-stochastic}

--- a/docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex
+++ b/docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex
@@ -94,8 +94,15 @@ a canonical representative for every qubit channel remains open.
 
 A source-faithful proof requires the following steps.
 \begin{enumerate}
-  \item Define general invertible Kraus-rank-one completely positive filters and
-    separate each filter into a determinant-one factor and a nonzero scalar.
+  \item[\(\checkmark\)] General invertible Kraus-rank-one completely positive
+    filters are now formalized as \leanid{Wolf.InvertibleFilter}.  For every
+    nonzero dimension,
+    \leanid{Wolf.InvertibleFilter.exists_scalar_slFiltering} separates the
+    filtering matrix as $X=cS$, where $c\in\C$ is nonzero,
+    $c^d=\det X$, and $S\in\SL(d,\C)$, while the induced map satisfies
+    $\Phi_X=|c|^2\Phi_S$ with $|c|^2>0$.  The corresponding two-filter scalar
+    identity for $\Phi_2\circ T\circ\Phi_1$ is
+    \leanid{Wolf.InvertibleFilter.filteredMap_eq_normSq_smul}.
   \item Use the minimisation argument of Propositions~2.8 and~2.9 for the
     full-Kraus-rank case, retaining the proportionality constants of the two
     marginals.

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -332,6 +332,20 @@ project import.
   Φ(X) = S X S† with det(S) = 1 ✓ (definitional)
 * `Wolf.SLFiltering.comp` — composition of SL-filterings ✓
 * `Wolf.SLFiltering.S_isUnit` — `S` invertible follows from det=1 ✓
+* `Wolf.InvertibleFilter` / `Wolf.InvertibleFilter.map` — **general
+  invertible Kraus-rank-one filtering operation**
+  `Φ_X(A) = X A X†` for `X ∈ GL(d, ℂ)` ✓ (definitional)
+* `Wolf.InvertibleFilter.comp` / `Wolf.InvertibleFilter.inv` — composition
+  and inverse filterings, with map composition in the source order ✓
+* `Wolf.InvertibleFilter.choiRank_eq_one` — an invertible filter has Kraus
+  rank exactly one when `d ≥ 1` ✓
+* `Wolf.InvertibleFilter.exists_scalar_slFiltering` — every invertible
+  filtering matrix has a decomposition `X = cS`, with `c ≠ 0`,
+  `c^d = det X`, `S ∈ SL(d, ℂ)`, and
+  `Φ_X = |c|² Φ_S`, where `|c|² > 0` ✓
+* `Wolf.InvertibleFilter.filteredMap_eq_normSq_smul` — for a rectangular
+  `T : M_{d₁} → M_{d₂}`, the source-ordered filtering
+  `Φ₂ ∘ T ∘ Φ₁` has scalar factor `|c₁c₂|²` after decomposing both filters ✓
 * `Wolf.DoublyStochastic` — doubly-stochastic condition: T(1) ∝ 1 and
   tr₁[τ] ∝ 1 ✓ (definitional)
 * `pauliMatrices` — the four Pauli matrices (qubit basis) ✓ (definitional)
@@ -363,9 +377,10 @@ project import.
   doubly-stochastic ✓ (derived from `Wolf.exists_normal_form_generic_tau` by
   the rectangular Choi transformation and partial-trace identities)
 * **Wolf Proposition 2.11 (Lorentz normal form for qubit channels)** remains
-  pending. Wolf requires general invertible Kraus-rank-one CP filters, including
-  scalar freedom. The former determinant-one `SLFiltering` formulation was false
-  and has been removed; there is currently no Lean declaration for the theorem.
+  pending. The required general invertible Kraus-rank-one CP filters and their
+  scalar freedom are now formalized, but the Lorentz-orbit classification and
+  the final trace-preserving normalization have no Lean declaration yet. The
+  former determinant-one `SLFiltering` formulation was false and was removed.
 
 #### Formalization
 
@@ -391,6 +406,12 @@ project import.
 | Vectorization | `Mathlib.LinearAlgebra.Matrix.Vec` | `Matrix.vec` |
 | SL-filtering | `LorentzNormalForm.lean` | `Wolf.SLFiltering` |
 | SL-filtering composition | `LorentzNormalForm.lean` | `Wolf.SLFiltering.comp` |
+| Invertible filtering | `LorentzNormalForm/InvertibleFilter.lean` |
+  `Wolf.InvertibleFilter` |
+| Exact invertible-filter Kraus rank | `LorentzNormalForm/InvertibleFilter.lean` |
+  `Wolf.InvertibleFilter.choiRank_eq_one` |
+| Scalar/SL filtering decomposition | `LorentzNormalForm/InvertibleFilter.lean` |
+  `Wolf.InvertibleFilter.exists_scalar_slFiltering` |
 | Doubly-stochastic | `LorentzNormalForm.lean` | `Wolf.DoublyStochastic` |
 | Rectangular doubly-stochastic | `LorentzNormalForm.lean` | `Wolf.DoublyStochasticRect` |
 | Rectangular generic normal form | `LorentzNormalForm.lean` |
@@ -406,9 +427,10 @@ project import.
 | Result | Notes |
 |--------|-------|
 | Section 2.4 Lorentz normal form (Proposition 2.11) | Correctly formulated
-  statement and proof remain pending. Wolf uses general invertible Kraus-rank-one
-  CP filters with scalar freedom; the former determinant-one formulation was
-  false and was removed. The proof also needs the Lorentz-orbit classification. |
+  statement and proof remain pending. The general invertible Kraus-rank-one
+  filters and their scalar/SL decomposition are available. The proof still
+  needs the Lorentz-orbit classification and the final trace-preserving
+  normalization. |
 | Section 2.4 Sorted singular values | Current SVD is unsorted; later uses want sorted values |
 
 ### References


### PR DESCRIPTION
Closes #4.

## Summary

- Define `Wolf.InvertibleFilter D` from `GL (Fin D) ℂ` and the existing single-Kraus map, with complete positivity, identity, composition, and inverse laws.
- Prove exact Choi/Kraus rank one under `[NeZero D]`.
- Decompose every filtering matrix as `X = c • S`, with `c ≠ 0`, `c ^ D = det X`, and `S ∈ SL(D, ℂ)`; only the induced map scalar `Complex.normSq c` is asserted to be positive.
- Record the distinct-dimension identity for `Φ₂ ∘ T ∘ Φ₁` in Equation (2.35) order, with scalar `|c₁c₂|²`, while preserving the existing `Wolf.SLFiltering` API.
- Synchronize the Blueprint, Wolf numbering coverage, and only the first elimination-plan item in the Proposition 2.11 gap note.

## Source and scope

The statements follow Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2, lines 865–887 and 1021–1065. Proposition 2.11 itself remains pending: this pull request does not claim trace preservation, the spinor action, or the Lorentz-orbit classification.

## Verification

- `lake build QICLean.Channel.LorentzNormalForm.InvertibleFilter QICLean.Channel.LorentzNormalForm -q --log-level=info`
- `lake exe checkdecls blueprint/lean_decls`
- Blueprint synchronization and reverse declaration coverage against `origin/main`
- import-aggregator, reader-facing prose, numbered-module, paper-gap reference, `chktex`, and Lean style checks
- `#print axioms` for the headline declarations (only `propext`, `Classical.choice`, and `Quot.sound`)
- no `sorry`, `admit`, `axiom`, or `native_decide`
