### PR TITLE
fix(blueprint): restore paper-gap PDF build

### DIFF
--- a/docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex
+++ b/docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex
@@ -99,7 +99,7 @@ A source-faithful proof requires the following steps.
     nonzero dimension,
     \leanid{Wolf.InvertibleFilter.exists_scalar_slFiltering} separates the
     filtering matrix as $X=cS$, where $c\in\C$ is nonzero,
-    $c^d=\det X$, and $S\in\SL(d,\C)$, while the induced map satisfies
+    $c^d=\det X$, and $S\in\operatorname{SL}(d,\C)$, while the induced map satisfies
     $\Phi_X=|c|^2\Phi_S$ with $|c|^2>0$.  The corresponding two-filter scalar
     identity for $\Phi_2\circ T\circ\Phi_1$ is
     \leanid{Wolf.InvertibleFilter.filteredMap_eq_normSq_smul}.


### PR DESCRIPTION
## Summary

- replace the unavailable standalone `\SL` macro with standard `\operatorname{SL}` notation
- preserve the mathematical statement and Wolf terminology
- restore the paper-gap PDF build that failed after #92 merged

## Validation

- `texra-blueprint --root . paper-gaps build`
- `git diff --check`

Closes #113