### PR TITLE
doc(channel): correct Proposition 3.6 citation

### DIFF
--- a/QICLean/Channel/TransferMatrix.lean
+++ b/QICLean/Channel/TransferMatrix.lean
@@ -729,8 +729,7 @@ For a linear map `T : M_D(ℂ) → M_D(ℂ)` the following are equivalent:
 
 1. `T` maps the cone of positive semidefinite matrices onto itself;
 2. `T` is positive and preserves the rank of Hermitian matrices;
-3. there is an invertible `Y` with `T(X) = Y X Y†` or `T(X) = Y Xᵀ Y†`
-   (eq. 3.42).
+3. there is an invertible `Y` with `T(X) = Y X Y†` or `T(X) = Y Xᵀ Y†`.
 
 The direction (3) ⇒ (1) is recorded here: both standard forms — conjugation
 `Ad_Y(X) = Y X Y†` and its transpose variant `X ↦ Y Xᵀ Y†` — map the positive


### PR DESCRIPTION
## Summary

- remove the stale Equation (3.42) attribution from the conjugation and transpose-conjugation forms
- keep Equation (3.42) reserved for Wolf's face `C(P)`, as in source lines 666-668
- split this independent citation cleanup from the proof work still tracked by #89

## Validation

- `lake exe cache get`
- `lake build QICLean.Channel.TransferMatrix -q --log-level=info`
- forbidden-token scan of the changed Lean file
- `git diff --check`

Closes #115