### PR TITLE
refactor(channel): follow Wolf's Radon-Nikodym proof

### DIFF
--- a/QICLean/Channel/RadonNikodym.lean
+++ b/QICLean/Channel/RadonNikodym.lean
@@ -125,42 +125,6 @@ theorem Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap
 
 /-! ### Weighted Stinespring compression -/
 
-/-- Stinespring dual representation for a rectangular Kraus family indexed by
-an arbitrary finite type. -/
-private theorem stinespring_dual_representation_rectangular_gen
-    {η : Type*} [Fintype η] [DecidableEq η] {d d' : ℕ}
-    (K : η → Matrix (Fin d') (Fin d) ℂ) (A : Matrix (Fin d') (Fin d') ℂ) :
-    (stinespringVGen K)ᴴ *
-        Matrix.kroneckerMap (· * ·) A (1 : Matrix η η ℂ) * stinespringVGen K =
-      ∑ j : η, (K j)ᴴ * A * K j := by
-  ext a b
-  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
-    stinespringVGen_apply, Matrix.kroneckerMap_apply, Matrix.one_apply,
-    Matrix.sum_apply, Fintype.sum_prod_type, mul_ite, mul_one, mul_zero,
-    Finset.sum_ite_eq', Finset.mem_univ, ite_true]
-  exact Finset.sum_comm
-
-/-- A linear combination of rectangular Kraus blocks is obtained by
-left-multiplying the Stinespring matrix by `1 ⊗ C`. -/
-private theorem stinespringVGen_rectangular_linear_combination
-    {η : Type*} {d d' : ℕ}
-    (K : Fin r → Matrix (Fin d') (Fin d) ℂ) (C : Matrix η (Fin r) ℂ) :
-    stinespringVGen (fun α : η => ∑ j : Fin r, C α j • K j) =
-      Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C *
-        stinespringV K := by
-  ext x b
-  rcases x with ⟨a, α⟩
-  simp only [stinespringVGen_apply, stinespringV_apply, Matrix.sum_apply,
-    Matrix.smul_apply, smul_eq_mul, Matrix.mul_apply, Matrix.kroneckerMap_apply,
-    Matrix.one_apply, Fintype.sum_prod_type]
-  rw [Finset.sum_eq_single a]
-  · simp
-  · intro a' _ ha'
-    have haa' : a ≠ a' := fun h => ha' h.symm
-    simp [haa']
-  · intro h
-    exact absurd (Finset.mem_univ a) h
-
 /-- Compressing a `Fin`-indexed rectangular Stinespring matrix by `P = CᴴC`
 gives the Kraus sum for the corresponding linear combinations of its blocks. -/
 theorem weighted_stinespring_eq_kraus_sum_gen
@@ -186,9 +150,14 @@ theorem weighted_stinespring_eq_kraus_sum_gen
     rw [Matrix.conjTranspose_mul]
     simp only [Matrix.mul_assoc]
   rw [h_reassoc]
-  rw [← stinespring_dual_representation_rectangular_gen
-    (K := fun α : η => ∑ j : Fin r, C α j • K j) X]
-  rw [stinespringVGen_rectangular_linear_combination K C]
+  let L : η → Matrix (Fin d') (Fin d) ℂ :=
+    fun α => ∑ j : Fin r, C α j • K j
+  have hlinear : stinespringVGen L =
+      Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C *
+        stinespringV K := by
+    exact stinespringVGen_linear_combination K C
+  rw [← hlinear]
+  exact stinespring_dual_representation_gen L X
 
 /-- The `j`-th ancilla block of a supplied rectangular Stinespring matrix. -/
 def stinespringBlockRectangular {d d' : ℕ}

--- a/QICLean/Channel/RadonNikodym.lean
+++ b/QICLean/Channel/RadonNikodym.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Channel.KrausFreedom
 import QICLean.Channel.OrderedCP
 import QICLean.Channel.PartialTrace
 
@@ -187,189 +186,11 @@ theorem stinespringV_stinespringBlock
     stinespringV (stinespringBlock (D := D) (r := r) V) = V := by
   exact stinespringV_stinespringBlockRectangular V
 
-/-- Radon--Nikodym theorem relative to a supplied Stinespring matrix, with an
-explicit Kraus row family for the components.
-
-The finite row type `η` is partitioned by `label : η → ι`.  The Kraus rows in
-the fibre over `i` represent the component map `Tᵢ i`, and all rows together
-represent `T`.  If the supplied Stinespring dilation has at most as many
-ancilla rows as this family, then the fibre Gram matrices of the Kraus-freedom
-isometry give the Radon--Nikodym operators on the supplied dilation space. -/
-theorem radon_nikodym_of_stinespring_of_kraus_family
-    {ι η : Type*} [Fintype ι] [DecidableEq ι] [Fintype η] {d d' : ℕ}
-    {T : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
-    (Tᵢ : ι → Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ)
-    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
-    (label : η → ι)
-    (B : η → Matrix (Fin d) (Fin d') ℂ)
-    (hV : ∀ X, T X =
-      Vᴴ * Matrix.kroneckerMap (· * ·) X (1 : Matrix (Fin r) (Fin r) ℂ) * V)
-    (hComponent : ∀ i X,
-      Tᵢ i X = ∑ α : η, if label α = i then B α * X * (B α)ᴴ else 0)
-    (hTotalKraus : ∀ X, ∑ α : η, B α * X * (B α)ᴴ = T X)
-    (hCard : Fintype.card (Fin r) ≤ Fintype.card η) :
-    ∃ P : ι → Matrix (Fin r) (Fin r) ℂ,
-      (∀ i, (P i).PosSemidef) ∧
-      (∑ i, P i = 1) ∧
-      ∀ i X,
-        Tᵢ i X = Vᴴ * Matrix.kroneckerMap (· * ·) X (P i) * V := by
-  classical
-  let K : Fin r → Matrix (Fin d') (Fin d) ℂ := stinespringBlockRectangular V
-  let A : Fin r → Matrix (Fin d) (Fin d') ℂ := fun j => (K j)ᴴ
-  have hVeq : stinespringV K = V :=
-    stinespringV_stinespringBlockRectangular (r := r) V
-  have hsame : ∀ X : Matrix (Fin d') (Fin d') ℂ,
-      ∑ α : η, B α * X * (B α)ᴴ = ∑ j : Fin r, A j * X * (A j)ᴴ := by
-    intro X
-    calc
-      ∑ α : η, B α * X * (B α)ᴴ = T X := hTotalKraus X
-      _ = Vᴴ * Matrix.kroneckerMap (· * ·) X
-            (1 : Matrix (Fin r) (Fin r) ℂ) * V := hV X
-      _ = (stinespringV K)ᴴ * Matrix.kroneckerMap (· * ·) X
-            (1 : Matrix (Fin r) (Fin r) ℂ) * stinespringV K := by rw [hVeq]
-      _ = ∑ j : Fin r, A j * X * (A j)ᴴ := by
-            rw [stinespring_dual_representation (K := K) (A := X)]
-            simp [A]
-  obtain ⟨W, hW, hB⟩ := kraus_rectangular_freedom' B A hsame hCard
-  let C : ι → Matrix η (Fin r) ℂ := fun i α j =>
-    if label α = i then star (W α j) else 0
-  refine ⟨fun i => (C i)ᴴ * C i, ?_, ?_, ?_⟩
-  · intro i
-    exact Matrix.posSemidef_conjTranspose_mul_self (C i)
-  · ext j k
-    have hexpand : ((∑ c : ι, (C c)ᴴ * C c) : Matrix (Fin r) (Fin r) ℂ) j k =
-        ∑ c : ι, ∑ α : η, star (C c α j) * C c α k := by
-      rw [Matrix.sum_apply]
-      exact Finset.sum_congr rfl fun c _ => rfl
-    rw [hexpand, Finset.sum_comm]
-    have hcollapse : ∀ α : η,
-        (∑ i : ι,
-          star (if label α = i then star (W α j) else 0) *
-            (if label α = i then star (W α k) else 0)) =
-          W α j * star (W α k) := by
-      intro α
-      rw [Finset.sum_eq_single (label α)]
-      · simp
-      · intro i _ hi
-        have hne : label α ≠ i := fun h => hi h.symm
-        simp [hne]
-      · intro h
-        exact absurd (Finset.mem_univ (label α)) h
-    change (∑ α : η, ∑ i : ι,
-      star (if label α = i then star (W α j) else 0) *
-        (if label α = i then star (W α k) else 0)) =
-      (1 : Matrix (Fin r) (Fin r) ℂ) j k
-    simp_rw [hcollapse]
-    have hentry := congr_fun (congr_fun hW k) j
-    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply] at hentry
-    simpa [Matrix.one_apply, eq_comm, mul_comm] using hentry
-  · intro i X
-    calc
-      Tᵢ i X = ∑ α : η, if label α = i then B α * X * (B α)ᴴ else 0 :=
-        hComponent i X
-      _ = ∑ α : η, (∑ j : Fin r, C i α j • K j)ᴴ * X *
-            (∑ j : Fin r, C i α j • K j) := by
-          refine Finset.sum_congr rfl ?_
-          intro α _
-          by_cases hα : label α = i
-          · have hlin : (∑ j : Fin r, C i α j • K j)ᴴ = B α := by
-              rw [hB α]
-              rw [Matrix.conjTranspose_sum]
-              simp [C, hα, A, Matrix.conjTranspose_smul]
-            rw [ite_eq_left hα, ← hlin]
-            simp [Matrix.conjTranspose_conjTranspose]
-          · have hzero : (∑ j : Fin r, C i α j • K j) = 0 := by
-              simp [C, hα]
-            rw [ite_eq_right hα, hzero]
-            simp
-      _ = (stinespringV K)ᴴ * Matrix.kroneckerMap (· * ·) X ((C i)ᴴ * C i) *
-            stinespringV K := by
-          rw [weighted_stinespring_eq_kraus_sum_gen (K := K) (C := C i) (X := X)]
-      _ = Vᴴ * Matrix.kroneckerMap (· * ·) X ((C i)ᴴ * C i) * V := by rw [hVeq]
-
-/-! ### Wolf Theorem 2.4 (finite-family supplied Stinespring form) -/
-
-/-- **Wolf Theorem 2.4 (Radon--Nikodym for quantum instruments).**
-
-Let a finite nonempty family of completely positive maps `Tᵢ` sum to a map `T`
-with a supplied Stinespring representation `T(X) = Vᴴ (X ⊗ 𝟙_r) V`.  Then
-there are positive operators `Pᵢ` on the same dilation space, summing to the
-identity, such that
-`Tᵢ(X) = Vᴴ (X ⊗ Pᵢ) V`.
-
-This is the source-faithful finite-family statement of
-Wolf, *Quantum Channels & Operations*, Theorem 2.4.  No minimality of the
-Stinespring representation is assumed.
-
-**Local fix (nonempty family):** The source theorem states a set of component
-maps.  The Lean statement makes the index type nonempty, since for an empty
-family the conclusion `∑ i, P i = 1` is false for a nonzero supplied dilation.
-This boundary is recorded in
-`docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex`. -/
-theorem IsCPMap.radon_nikodym_of_stinespring
-    {ι : Type*} [Fintype ι] [Nonempty ι]
-    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (Tᵢ : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (hTᵢ : ∀ i, IsCPMap (Tᵢ i))
-    (V : Matrix (Fin D × Fin r) (Fin D) ℂ)
-    (hV : ∀ X, T X =
-      Vᴴ * Matrix.kroneckerMap (· * ·) X (1 : Matrix (Fin r) (Fin r) ℂ) * V)
-    (hsum : (∑ i, Tᵢ i) = T) :
-    ∃ P : ι → Matrix (Fin r) (Fin r) ℂ,
-      (∀ i, (P i).PosSemidef) ∧
-      (∑ i, P i = 1) ∧
-      ∀ i X,
-        Tᵢ i X = Vᴴ * Matrix.kroneckerMap (· * ·) X (P i) * V := by
-  classical
-  let s : ι → ℕ := fun i => Classical.choose (hTᵢ i)
-  let B₀ : (i : ι) → Fin (s i) → Matrix (Fin D) (Fin D) ℂ :=
-    fun i => Classical.choose (Classical.choose_spec (hTᵢ i))
-  have hB₀ : ∀ i X, Tᵢ i X = ∑ a : Fin (s i), B₀ i a * X * (B₀ i a)ᴴ := by
-    intro i
-    exact Classical.choose_spec (Classical.choose_spec (hTᵢ i))
-  let i₀ : ι := Classical.choice ‹Nonempty ι›
-  let Row := Sum (Sigma fun i : ι => Fin (s i)) (Fin r)
-  let label : Row → ι := fun α => match α with
-    | Sum.inl x => x.1
-    | Sum.inr _ => i₀
-  let B : Row → Matrix (Fin D) (Fin D) ℂ := fun α => match α with
-    | Sum.inl x => B₀ x.1 x.2
-    | Sum.inr _ => 0
-  have hComponent : ∀ i X,
-      Tᵢ i X = ∑ α : Row, if label α = i then B α * X * (B α)ᴴ else 0 := by
-    intro i X
-    rw [hB₀ i X]
-    simp only [Row, Fintype.sum_sum_type]
-    rw [Fintype.sum_sigma]
-    simp [label, B]
-  have hTotalKraus : ∀ X, ∑ α : Row, B α * X * (B α)ᴴ = T X := by
-    intro X
-    simp only [Row, Fintype.sum_sum_type]
-    rw [Fintype.sum_sigma]
-    simp only [B, Matrix.zero_mul, Matrix.conjTranspose_zero, Matrix.mul_zero,
-      Finset.sum_const_zero, add_zero]
-    calc
-      ∑ x : ι, ∑ y : Fin (s x), B₀ x y * X * (B₀ x y)ᴴ = ∑ x : ι, Tᵢ x X := by
-        refine Finset.sum_congr rfl ?_
-        intro i _
-        exact (hB₀ i X).symm
-      _ = T X := by
-        have happ := congrArg
-          (fun F : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ => F X)
-          hsum
-        simpa [Finset.sum_apply] using happ
-  have hCard : Fintype.card (Fin r) ≤ Fintype.card Row := by
-    let emb : Fin r ↪ Row := ⟨Sum.inr, by
-      intro a b h
-      exact Sum.inr.inj h⟩
-    exact Fintype.card_le_of_embedding emb
-  exact radon_nikodym_of_stinespring_of_kraus_family Tᵢ V label B hV
-    hComponent hTotalKraus hCard
 
 /-- **Wolf Theorem 2.4 (rectangular Radon--Nikodym for quantum instruments).**
 
-Let a finite nonempty family of rectangular Kraus-completely-positive
-Heisenberg maps `Tᵢ : M_{d'}(ℂ) → M_d(ℂ)` sum to `T`, and let
+Let a finite nonempty family of completely positive linear maps
+`Tᵢ : M_{d'}(ℂ) → M_d(ℂ)` sum to `T`, and let
 `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` supply the Stinespring representation
 `T(A) = Vᴴ (A ⊗ 𝟙_r) V`. Then there are positive semidefinite operators `Pᵢ`
 on `ℂ^r`, summing to `𝟙_r`, such that
@@ -590,6 +411,29 @@ theorem IsKrausCP.radon_nikodym_of_stinespring
         rw [Matrix.kroneckerMap_add_right (· * ·) (fun a b c => mul_add a b c)]
         rw [Matrix.mul_add, Matrix.add_mul, ← hEcomponent i A, hResidual A, add_zero]
       · simpa [P, hi] using hEcomponent i A
+
+/-- **Wolf Theorem 2.4 (square Radon--Nikodym theorem).**
+
+This is the square specialization of
+`IsKrausCP.radon_nikodym_of_stinespring`. A finite nonempty family of
+completely positive maps summing to `T` is represented by positive operators
+on any supplied Stinespring dilation of `T`, and these operators sum to the
+identity. -/
+theorem IsCPMap.radon_nikodym_of_stinespring
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (Tᵢ : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hTᵢ : ∀ i, IsCPMap (Tᵢ i))
+    (V : Matrix (Fin D × Fin r) (Fin D) ℂ)
+    (hV : ∀ X, T X =
+      Vᴴ * Matrix.kroneckerMap (· * ·) X (1 : Matrix (Fin r) (Fin r) ℂ) * V)
+    (hsum : (∑ i, Tᵢ i) = T) :
+    ∃ P : ι → Matrix (Fin r) (Fin r) ℂ,
+      (∀ i, (P i).PosSemidef) ∧
+      (∑ i, P i = 1) ∧
+      ∀ i X,
+        Tᵢ i X = Vᴴ * Matrix.kroneckerMap (· * ·) X (P i) * V := by
+  exact IsKrausCP.radon_nikodym_of_stinespring Tᵢ hTᵢ V hV hsum
 
 /-! ### Wolf Theorem 2.4 (Radon–Nikodym, binary form) -/
 

--- a/QICLean/Channel/RadonNikodym.lean
+++ b/QICLean/Channel/RadonNikodym.lean
@@ -19,6 +19,10 @@ Wolf's Radon–Nikodym theorem says: if a finite family of CP maps `Tᵢ` sums
 to a map `T` with a supplied Stinespring representation
 `T(A) = V†(A ⊗ 𝟙_r)V`, then there are PSD operators `Pᵢ` on that same
 dilation space, summing to `𝟙_r`, such that `Tᵢ(A) = V†(A ⊗ Pᵢ)V`.
+Wolf presents this as a simple corollary of the preceding comparison theorem
+for ordered completely positive maps. The proof below follows that route: an
+aggregate outcome-labelled dilation factors through the supplied dilation by
+a contraction, and the residual `𝟙_r - CᴴC` is assigned to one outcome.
 
 The file also keeps the earlier binary block-diagonal corollary: for CP maps
 `T₁, T₂`, one may construct a Stinespring matrix for `T₁ + T₂` by
@@ -41,14 +45,13 @@ evolution on a system-plus-environment.
   the identity: resolution of identity on the dilation space.
 * `Matrix.blockDiagTopProj_posSemidef`,
   `Matrix.blockDiagBotProj_posSemidef` — both are PSD.
-* `IsCPMap.radon_nikodym_of_stinespring`
-  (Wolf, *Quantum Channels & Operations*, Theorem 2.4):
-  square finite-family Radon–Nikodym theorem relative to a supplied Stinespring
-  representation.
 * `IsKrausCP.radon_nikodym_of_stinespring`
   (Wolf, *Quantum Channels & Operations*, Theorem 2.4):
   the exact rectangular Heisenberg form for maps `M_{d'}(ℂ) → M_d(ℂ)` and a
   supplied `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r`.
+* `IsCPMap.radon_nikodym_of_stinespring`
+  (Wolf, *Quantum Channels & Operations*, Theorem 2.4):
+  the direct square specialization of the rectangular finite-family theorem.
 * `IsCPMap.exists_radon_nikodym`
   (Wolf, *Quantum Channels & Operations*, Theorem 2.4, binary form):
   for CP `T₁, T₂`, there exist a Stinespring matrix `V` and two PSD
@@ -186,6 +189,7 @@ theorem stinespringV_stinespringBlock
     stinespringV (stinespringBlock (D := D) (r := r) V) = V := by
   exact stinespringV_stinespringBlockRectangular V
 
+/-! ### Wolf Theorem 2.4 (finite-family supplied Stinespring form) -/
 
 /-- **Wolf Theorem 2.4 (rectangular Radon--Nikodym for quantum instruments).**
 
@@ -196,9 +200,11 @@ Let a finite nonempty family of completely positive linear maps
 on `ℂ^r`, summing to `𝟙_r`, such that
 `Tᵢ(A) = Vᴴ (A ⊗ Pᵢ) V`.
 
-No minimality of the supplied Stinespring representation is assumed. The
-nonempty-family hypothesis is necessary because the empty sum of operators
-cannot equal the identity on a nonzero supplied dilation space. -/
+No minimality of the supplied Stinespring representation is assumed. The proof
+uses Wolf's preceding ordered-map comparison theorem and completes the
+preliminary effects by its positive contraction residual. The nonempty-family
+hypothesis is necessary uniformly in the supplied dilation dimension, because
+an empty sum cannot equal the identity when the dilation space is nonzero. -/
 theorem IsKrausCP.radon_nikodym_of_stinespring
     {ι : Type*} [Fintype ι] [Nonempty ι] {d d' : ℕ}
     {T : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}

--- a/QICLean/Channel/RadonNikodym.lean
+++ b/QICLean/Channel/RadonNikodym.lean
@@ -393,50 +393,203 @@ theorem IsKrausCP.radon_nikodym_of_stinespring
       ∀ i A,
         Tᵢ i A = Vᴴ * Matrix.kroneckerMap (· * ·) A (P i) * V := by
   classical
-  let s : ι → ℕ := fun i => Classical.choose (hTᵢ i)
-  let B₀ : (i : ι) → Fin (s i) → Matrix (Fin d) (Fin d') ℂ :=
-    fun i => Classical.choose (Classical.choose_spec (hTᵢ i))
-  have hB₀ : ∀ i A, Tᵢ i A = ∑ a : Fin (s i), B₀ i a * A * (B₀ i a)ᴴ := by
-    intro i
-    exact Classical.choose_spec (Classical.choose_spec (hTᵢ i))
-  let i₀ : ι := Classical.choice ‹Nonempty ι›
-  let Row := Sum (Sigma fun i : ι => Fin (s i)) (Fin r)
-  let label : Row → ι := fun α => match α with
-    | Sum.inl x => x.1
-    | Sum.inr _ => i₀
-  let B : Row → Matrix (Fin d) (Fin d') ℂ := fun α => match α with
-    | Sum.inl x => B₀ x.1 x.2
-    | Sum.inr _ => 0
-  have hComponent : ∀ i A,
-      Tᵢ i A = ∑ α : Row, if label α = i then B α * A * (B α)ᴴ else 0 := by
-    intro i A
-    rw [hB₀ i A]
-    simp only [Row, Fintype.sum_sum_type]
-    rw [Fintype.sum_sigma]
-    simp [label, B]
-  have hTotalKraus : ∀ A, ∑ α : Row, B α * A * (B α)ᴴ = T A := by
-    intro A
-    simp only [Row, Fintype.sum_sum_type]
-    rw [Fintype.sum_sigma]
-    simp only [B, Matrix.zero_mul, Matrix.conjTranspose_zero, Matrix.mul_zero,
-      Finset.sum_const_zero, add_zero]
-    calc
-      ∑ x : ι, ∑ y : Fin (s x), B₀ x y * A * (B₀ x y)ᴴ = ∑ x : ι, Tᵢ x A := by
-        refine Finset.sum_congr rfl ?_
-        intro i _
-        exact (hB₀ i A).symm
-      _ = T A := by
-        have happ := congrArg
-          (fun F : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ => F A)
-          hsum
-        simpa [Finset.sum_apply] using happ
-  have hCard : Fintype.card (Fin r) ≤ Fintype.card Row := by
-    let emb : Fin r ↪ Row := ⟨Sum.inr, by
-      intro a b h
-      exact Sum.inr.inj h⟩
-    exact Fintype.card_le_of_embedding emb
-  exact radon_nikodym_of_stinespring_of_kraus_family Tᵢ V label B hV
-    hComponent hTotalKraus hCard
+  by_cases hd' : d' = 0
+  · subst d'
+    let i₀ : ι := Classical.choice ‹Nonempty ι›
+    refine ⟨fun i => if i = i₀ then 1 else 0, ?_, ?_, ?_⟩
+    · intro i
+      by_cases hi : i = i₀
+      · simp [hi, Matrix.PosSemidef.one]
+      · simp [hi, Matrix.PosSemidef.zero]
+    · simp [i₀]
+    · intro i A
+      have hA : A = 0 := Subsingleton.elim _ _
+      subst A
+      simp
+  · let _ : NeZero d' := ⟨hd'⟩
+    let s : ι → ℕ := fun i => Classical.choose (hTᵢ i)
+    let B₀ : (i : ι) → Fin (s i) → Matrix (Fin d) (Fin d') ℂ :=
+      fun i => Classical.choose (Classical.choose_spec (hTᵢ i))
+    have hB₀ : ∀ i A, Tᵢ i A = ∑ a : Fin (s i), B₀ i a * A * (B₀ i a)ᴴ := by
+      intro i
+      exact Classical.choose_spec (Classical.choose_spec (hTᵢ i))
+    let Row := Sigma fun i : ι => Fin (s i)
+    let m := Fintype.card Row
+    let e : Row ≃ Fin m := Fintype.equivFin Row
+    let label : Fin m → ι := fun α => (e.symm α).1
+    let B : Fin m → Matrix (Fin d) (Fin d') ℂ := fun α =>
+      B₀ (e.symm α).1 (e.symm α).2
+    have hComponent : ∀ i A,
+        Tᵢ i A = ∑ α : Fin m, if label α = i then B α * A * (B α)ᴴ else 0 := by
+      intro i A
+      rw [hB₀ i A]
+      calc
+        ∑ a : Fin (s i), B₀ i a * A * (B₀ i a)ᴴ =
+            ∑ x : Row,
+              if x.1 = i then B₀ x.1 x.2 * A * (B₀ x.1 x.2)ᴴ else 0 := by
+          rw [Fintype.sum_sigma]
+          simp
+        _ = ∑ α : Fin m,
+              if (e.symm α).1 = i then
+                B₀ (e.symm α).1 (e.symm α).2 * A *
+                  (B₀ (e.symm α).1 (e.symm α).2)ᴴ
+              else 0 := by
+          exact (e.symm.sum_comp fun x : Row =>
+            if x.1 = i then B₀ x.1 x.2 * A * (B₀ x.1 x.2)ᴴ else 0).symm
+    have hTotalKraus : ∀ A, ∑ α : Fin m, B α * A * (B α)ᴴ = T A := by
+      intro A
+      change (∑ α : Fin m,
+        B₀ (e.symm α).1 (e.symm α).2 * A *
+          (B₀ (e.symm α).1 (e.symm α).2)ᴴ) = T A
+      calc
+        ∑ α : Fin m,
+            B₀ (e.symm α).1 (e.symm α).2 * A *
+              (B₀ (e.symm α).1 (e.symm α).2)ᴴ =
+            ∑ x : Row, B₀ x.1 x.2 * A * (B₀ x.1 x.2)ᴴ := by
+          exact e.symm.sum_comp fun x : Row => B₀ x.1 x.2 * A * (B₀ x.1 x.2)ᴴ
+        _ = ∑ i : ι, ∑ a : Fin (s i), B₀ i a * A * (B₀ i a)ᴴ := by
+          rw [Fintype.sum_sigma]
+        _ = ∑ i : ι, Tᵢ i A := by
+          refine Finset.sum_congr rfl ?_
+          intro i _
+          exact (hB₀ i A).symm
+        _ = T A := by
+          have happ := congrArg
+            (fun S : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ =>
+              S A) hsum
+          simpa [Finset.sum_apply] using happ
+    let Khat : Fin m → Matrix (Fin d') (Fin d) ℂ := fun α => (B α)ᴴ
+    let Vhat : Matrix (Fin d' × Fin m) (Fin d) ℂ := stinespringV Khat
+    have hTCP : IsKrausCP T :=
+      ⟨m, B, fun A => (hTotalKraus A).symm⟩
+    have hVhat : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+        T A = Vhatᴴ * stinespringPi (r := m) A * Vhat := by
+      intro A
+      calc
+        T A = ∑ α : Fin m, B α * A * (B α)ᴴ := (hTotalKraus A).symm
+        _ = Vhatᴴ * stinespringPi (r := m) A * Vhat := by
+          rw [stinespringPi, stinespring_dual_representation]
+          simp [Khat]
+    have hV' : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+        T A = Vᴴ * stinespringPi (r := r) A * V := by
+      simpa [stinespringPi] using hV
+    obtain ⟨C, hC, hVfactor, _⟩ :=
+      CPDominates.exists_supplied_stinespring_contraction hTCP hTCP
+        (CPDominates.refl T) Vhat V hVhat hV'
+    let K : Fin r → Matrix (Fin d') (Fin d) ℂ := stinespringBlockRectangular V
+    have hVeq : stinespringV K = V :=
+      stinespringV_stinespringBlockRectangular (r := r) V
+    have hKhat : ∀ α, Khat α = ∑ j : Fin r, C α j • K j := by
+      have hlinear :
+          stinespringVGen (fun α : Fin m => ∑ j : Fin r, C α j • K j) = Vhat := by
+        calc
+          stinespringVGen (fun α : Fin m => ∑ j : Fin r, C α j • K j) =
+              Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C *
+                stinespringV K := stinespringVGen_linear_combination K C
+          _ = Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C *
+                V := by rw [hVeq]
+          _ = Vhat := hVfactor.symm
+      intro α
+      ext a b
+      have hentry := congr_fun (congr_fun hlinear (a, α)) b
+      simpa only [stinespringVGen_apply, Vhat, stinespringV_apply] using hentry.symm
+    have hBlinear : ∀ α, (∑ j : Fin r, C α j • K j)ᴴ = B α := by
+      intro α
+      rw [← hKhat α]
+      simp [Khat]
+    let F : ι → Matrix (Fin m) (Fin r) ℂ := fun i α j =>
+      if label α = i then C α j else 0
+    let E : ι → Matrix (Fin r) (Fin r) ℂ := fun i => (F i)ᴴ * F i
+    let R : Matrix (Fin r) (Fin r) ℂ := 1 - Cᴴ * C
+    have hEpos : ∀ i, (E i).PosSemidef := fun i =>
+      Matrix.posSemidef_conjTranspose_mul_self (F i)
+    have hRpos : R.PosSemidef := by
+      change (1 - Cᴴ * C).PosSemidef
+      exact Matrix.le_iff.mp hC
+    have hEcomponent : ∀ i A,
+        Tᵢ i A = Vᴴ * Matrix.kroneckerMap (· * ·) A (E i) * V := by
+      intro i A
+      calc
+        Tᵢ i A = ∑ α : Fin m,
+            if label α = i then B α * A * (B α)ᴴ else 0 := hComponent i A
+        _ = ∑ α : Fin m, (∑ j : Fin r, F i α j • K j)ᴴ * A *
+              (∑ j : Fin r, F i α j • K j) := by
+            refine Finset.sum_congr rfl ?_
+            intro α _
+            by_cases hα : label α = i
+            · have hlin : (∑ j : Fin r, F i α j • K j)ᴴ = B α := by
+                simpa only [F, hα, ite_true] using hBlinear α
+              rw [ite_eq_left hα, ← hlin]
+              simp only [Matrix.conjTranspose_conjTranspose]
+            · have hzero : ∑ j : Fin r, F i α j • K j = 0 := by
+                simp [F, hα]
+              rw [ite_eq_right hα, hzero]
+              simp
+        _ = (stinespringV K)ᴴ * Matrix.kroneckerMap (· * ·) A (E i) *
+              stinespringV K := by
+            change (∑ α : Fin m, (∑ j : Fin r, F i α j • K j)ᴴ * A *
+                (∑ j : Fin r, F i α j • K j)) =
+              (stinespringV K)ᴴ *
+                Matrix.kroneckerMap (· * ·) A ((F i)ᴴ * F i) * stinespringV K
+            rw [weighted_stinespring_eq_kraus_sum_gen]
+        _ = Vᴴ * Matrix.kroneckerMap (· * ·) A (E i) * V := by rw [hVeq]
+    have hsumE : ∑ i, E i = Cᴴ * C := by
+      ext j k
+      simp only [E, Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+      rw [Finset.sum_comm]
+      refine Finset.sum_congr rfl ?_
+      intro α _
+      rw [Finset.sum_eq_single (label α)]
+      · simp [F]
+      · intro i _ hi
+        have hne : label α ≠ i := fun h => hi h.symm
+        simp [F, hne]
+      · intro h
+        exact absurd (Finset.mem_univ (label α)) h
+    have htotalC : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+        Vᴴ * Matrix.kroneckerMap (· * ·) A (Cᴴ * C) * V = T A := by
+      intro A
+      rw [← Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap_gen A C]
+      rw [show Vᴴ *
+          ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C)ᴴ *
+            Matrix.kroneckerMap (· * ·) A (1 : Matrix (Fin m) (Fin m) ℂ) *
+            Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C) * V =
+          (Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C * V)ᴴ *
+            Matrix.kroneckerMap (· * ·) A (1 : Matrix (Fin m) (Fin m) ℂ) *
+            (Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin d') (Fin d') ℂ) C * V) by
+        rw [Matrix.conjTranspose_mul]
+        simp only [Matrix.mul_assoc]]
+      rw [← hVfactor]
+      exact (hVhat A).symm
+    have hResidual : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+        Vᴴ * Matrix.kroneckerMap (· * ·) A R * V = 0 := by
+      intro A
+      have hkron : Matrix.kroneckerMap (· * ·) A R =
+          Matrix.kroneckerMap (· * ·) A (1 : Matrix (Fin r) (Fin r) ℂ) -
+            Matrix.kroneckerMap (· * ·) A (Cᴴ * C) := by
+        ext ⟨a, j⟩ ⟨b, k⟩
+        simp [R, Matrix.kroneckerMap_apply]
+        ring
+      rw [hkron, Matrix.mul_sub, Matrix.sub_mul, ← hV A, htotalC A, sub_self]
+    let i₀ : ι := Classical.choice ‹Nonempty ι›
+    let P : ι → Matrix (Fin r) (Fin r) ℂ := fun i =>
+      E i + if i = i₀ then R else 0
+    refine ⟨P, ?_, ?_, ?_⟩
+    · intro i
+      by_cases hi : i = i₀
+      · simpa [P, hi] using (hEpos i).add hRpos
+      · simpa [P, hi] using hEpos i
+    · calc
+        ∑ i, P i = (∑ i, E i) + R := by
+          simp [P, Finset.sum_add_distrib, i₀]
+        _ = Cᴴ * C + (1 - Cᴴ * C) := by rw [hsumE]
+        _ = 1 := by simp
+    · intro i A
+      by_cases hi : i = i₀
+      · rw [show P i = E i + R by simp [P, hi]]
+        rw [Matrix.kroneckerMap_add_right (· * ·) (fun a b c => mul_add a b c)]
+        rw [Matrix.mul_add, Matrix.add_mul, ← hEcomponent i A, hResidual A, add_zero]
+      · simpa [P, hi] using hEcomponent i A
 
 /-! ### Wolf Theorem 2.4 (Radon–Nikodym, binary form) -/
 

--- a/QICLean/Channel/Stinespring.lean
+++ b/QICLean/Channel/Stinespring.lean
@@ -144,8 +144,9 @@ theorem stinespringVGen_apply {η α β : Type*}
 
 /-- Stinespring dual representation for a Kraus family indexed by an arbitrary
 finite type. -/
-theorem stinespring_dual_representation_gen {η : Type*} [Fintype η] [DecidableEq η]
-    (K : η → Matrix (Fin D) (Fin D) ℂ) (A : Matrix (Fin D) (Fin D) ℂ) :
+theorem stinespring_dual_representation_gen
+    {η α β : Type*} [Fintype η] [DecidableEq η] [Fintype β]
+    (K : η → Matrix β α ℂ) (A : Matrix β β ℂ) :
     (stinespringVGen K)ᴴ *
       (kroneckerMap (· * ·) A (1 : Matrix η η ℂ)) *
       stinespringVGen K =
@@ -160,11 +161,11 @@ theorem stinespring_dual_representation_gen {η : Type*} [Fintype η] [Decidable
 /-- A linear combination of Kraus blocks is obtained by left-multiplying the
 Stinespring matrix by `1 ⊗ C`. -/
 theorem stinespringVGen_linear_combination
-    {η : Type*}
-    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    {η α β : Type*} [Fintype β] [DecidableEq β]
+    (K : Fin r → Matrix β α ℂ)
     (C : Matrix η (Fin r) ℂ) :
     stinespringVGen (fun α : η => ∑ j : Fin r, C α j • K j) =
-      Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C *
+      Matrix.kroneckerMap (· * ·) (1 : Matrix β β ℂ) C *
         stinespringV K := by
   ext x b
   rcases x with ⟨a, α⟩
@@ -182,18 +183,18 @@ theorem stinespringVGen_linear_combination
 /-- The Kronecker identity
 `A ⊗ (CᴴC) = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙)(𝟙 ⊗ C)` for an arbitrary finite row type. -/
 theorem Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap_gen
-    {η : Type*} [Fintype η] [DecidableEq η]
-    (A : Matrix (Fin D) (Fin D) ℂ) (C : Matrix η (Fin r) ℂ) :
-    (Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C)ᴴ *
+    {η β : Type*} [Fintype η] [DecidableEq η] [Fintype β] [DecidableEq β]
+    (A : Matrix β β ℂ) (C : Matrix η (Fin r) ℂ) :
+    (Matrix.kroneckerMap (· * ·) (1 : Matrix β β ℂ) C)ᴴ *
         Matrix.kroneckerMap (· * ·) A (1 : Matrix η η ℂ) *
-        Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C =
+        Matrix.kroneckerMap (· * ·) (1 : Matrix β β ℂ) C =
       Matrix.kroneckerMap (· * ·) A (Cᴴ * C) := by
   rw [Matrix.conjTranspose_kronecker]
-  rw [show (1 : Matrix (Fin D) (Fin D) ℂ)ᴴ = 1 from Matrix.conjTranspose_one]
-  rw [← Matrix.mul_kronecker_mul (A := (1 : Matrix (Fin D) (Fin D) ℂ)) (B := A)
+  rw [show (1 : Matrix β β ℂ)ᴴ = 1 from Matrix.conjTranspose_one]
+  rw [← Matrix.mul_kronecker_mul (A := (1 : Matrix β β ℂ)) (B := A)
       (A' := Cᴴ) (B' := (1 : Matrix η η ℂ))]
-  rw [← Matrix.mul_kronecker_mul (A := (1 * A : Matrix (Fin D) (Fin D) ℂ))
-      (B := (1 : Matrix (Fin D) (Fin D) ℂ)) (A' := Cᴴ * 1) (B' := C)]
+  rw [← Matrix.mul_kronecker_mul (A := (1 * A : Matrix β β ℂ))
+      (B := (1 : Matrix β β ℂ)) (A' := Cᴴ * 1) (B' := C)]
   simp
 
 /-- **Stinespring representation, Schrödinger picture** (Wolf Theorem 2.2):

--- a/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_dilations_and_ordered_cp.tex
@@ -591,7 +591,8 @@ a common dilation space.
     \label{thm:cp_radon_nikodym_of_stinespring}
     \lean{IsKrausCP.radon_nikodym_of_stinespring}
     \leanok
-    \uses{def:is_kraus_cp, def:stinespring_v}
+    \uses{def:is_kraus_cp, def:stinespring_v,
+        thm:cp_dominates_stinespring_contraction}
     Let $I$ be a nonempty finite set, and let
     $T_i,T:\MN{d'}\to\MN{d}$ be completely positive linear maps such that
     $\sum_{i\in I}T_i=T$. Suppose that a Stinespring representation of $T$ is
@@ -619,44 +620,58 @@ a common dilation space.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:kraus_rectangular_freedom'}
-    Choose rectangular Kraus families for the component maps $T_i$ and group
-    all their Kraus operators into one finite family. Add zero Kraus operators
-    to one component so that this grouped family has at least as many rows as
-    the supplied Stinespring dilation. Write the grouped Kraus operators as
-    $B_\alpha:\C^{d'}\to\C^d$, with a label map $\ell(\alpha)\in I$, and write
-    the ancilla blocks of $V$ as $K_j:\C^d\to\C^{d'}$, and take their
-    adjoints $A_j=K_j^\dagger:\C^{d'}\to\C^d$ as Kraus operators.
-    Rectangular Kraus freedom gives a matrix $W$ with
+    \uses{def:stinespring_v_gen,
+        thm:cp_dominates_stinespring_contraction}
+    First suppose that $d'>0$. Choose Kraus families for the maps $T_i$, and
+    enumerate their disjoint union as
+    $B_\alpha:\C^{d'}\to\C^d$, with outcome label $\ell(\alpha)\in I$.
+    The aggregate Stinespring matrix $\widehat V$, whose $\alpha$-th ancilla
+    block is $B_\alpha^\dagger$, represents the total map $T$.
+
+    Apply Theorem~\ref{thm:cp_dominates_stinespring_contraction} to the
+    reflexive order relation $T\le T$, using $\widehat V$ for the first
+    supplied representation and $V$ for the second. It gives a contraction
+    $C:\C^r\to\C^m$ such that
     \begin{align}
-        W^\dagger W
-        &=\Id_r, \notag\\
-        B_\alpha
-        &=\sum_{j=0}^{r-1}W_{\alpha j}A_j.
+        \widehat V
+        &=(\Id_{d'}\otimes C)V,
+        & C^\dagger C&\leq\Id_r.
         \notag
     \end{align}
-    For the fibre over $i$, set
+    Let $C_i$ be the matrix obtained from $C$ by retaining the rows labelled
+    by $i$ and setting all other rows to zero, and define the preliminary
+    effect
     \begin{align}
-        (C_i)_{\alpha j}
-        &=
-        \begin{cases}
-            \overline{W_{\alpha j}}, & \ell(\alpha)=i,\\
-            0, & \ell(\alpha)\ne i,
-        \end{cases}
-        \notag\\
-        P_i
+        E_i
         &=C_i^\dagger C_i.
         \label{eq:representations_radon_effects}
     \end{align}
-    Then $P_i\ge0$, and (\ref{eq:representations_radon_resolution}) follows
-    from $W^\dagger W=\Id_r$. Finally,
+    The labelled fibres partition the rows of $C$, so
     \begin{align}
-        V^\dagger(A\otimes P_i)V
-        &=\sum_{\ell(\alpha)=i}B_\alpha A B_\alpha^\dagger
-          =T_i(A),
-        \notag
+        E_i&\geq0,
+        & \sum_{i\in I}E_i&=C^\dagger C,
+        & T_i(A)&=V^\dagger(A\otimes E_i)V.
+        \label{eq:representations_radon_preliminary_effects}
     \end{align}
-    which proves the claim.
+    For a nonminimal supplied dilation the middle sum need not yet be the
+    identity. Set
+    $R=\Id_r-C^\dagger C\geq0$. Since $V$ and $\widehat V$ represent the
+    same total map, the contraction identity gives
+    \begin{align}
+        V^\dagger(A\otimes R)V=0
+        \qquad(A\in\MN{d'}).
+        \label{eq:representations_radon_residual_invisible}
+    \end{align}
+    Choose $i_0\in I$ and put
+    $P_{i_0}=E_{i_0}+R$ and $P_i=E_i$ for $i\ne i_0$. These operators are
+    positive, their sum is $\Id_r$, and
+    (\ref{eq:representations_radon_residual_invisible}) shows that their
+    Stinespring compressions still give the maps $T_i$.
+
+    If $d'=0$, every matrix $A\in\MN{0}$ is zero. Choose $i_0\in I$, set
+    $P_{i_0}=\Id_r$ and $P_i=0$ for $i\ne i_0$, and use linearity. This
+    separate case preserves the statement without an additional
+    positive-dimension assumption.
 \end{proof}
 
 \begin{corollary}[Square-algebra Radon--Nikodym theorem]
@@ -676,9 +691,7 @@ a common dilation space.
 
 \begin{proof}\leanok
     This is the specialization of
-    Theorem~\ref{thm:cp_radon_nikodym_of_stinespring} to $d'=d=D$. The legacy
-    square-algebra declaration is retained for compatibility; its formal proof
-    follows the same Kraus-family and rectangular Kraus-freedom argument.
+    Theorem~\ref{thm:cp_radon_nikodym_of_stinespring} to $d'=d=D$.
 \end{proof}
 
 \begin{theorem}[Binary Radon--Nikodym theorem for CP maps]
@@ -711,8 +724,8 @@ a common dilation space.
 \end{remark}
 
 \begin{proof}\leanok
-    \uses{thm:cp_dominates_stinespring_contraction, thm:exists_stinespring_dilation,
-        def:block_diag_projectors}
+    \uses{thm:exists_stinespring_dilation, def:block_diag_projectors,
+        lem:stinespring_intertwine_append}
     Take Heisenberg-form Kraus families $K_1$ for $T_1$ and
     Schr\"odinger-form $L$ for $T_2$, and form
     $K=K_1\mathbin{+\!+}L^\dagger$ on $\C^{r_1+s}$. Choose

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -218,7 +218,9 @@ This theorem is the immediate instrument-valued corollary of the preceding
 comparison theorem for ordered completely positive maps.  A supplied
 Stinespring representation of the total map is held fixed, and the theorem
 resolves each CP component by a positive effect on the same dilation space.
-Chapter~2, Theorem~2.4 (book p.~39) says:
+The exact local source is
+\path{Notes/WolfNoteTexSource/ch02_representations.tex}:399--407. Chapter~2,
+Theorem~2.4 (book p.~39) says:
 \begin{quote}
 ``Let $\{T_i\}$ be a set of completely positive linear maps such that
 $\sum_iT_i=T$ \ldots\ Then there is a set of positive operators $P_i\in M_r$
@@ -243,13 +245,26 @@ The declaration \leanid{IsCPMap.radon_nikodym_of_stinespring} is retained as
 the square-algebra specialization.
 
 \paragraph{Formal proof path.}
-The proof chooses rectangular Kraus families for the component maps, combines
-them into one labelled family, and pads one component with zero Kraus operators.
-It then compares this family with the adjoints of the ancilla blocks of the
-supplied Stinespring matrix. Rectangular Kraus freedom produces an isometry,
-and the Gram matrices of its
-labelled fibres give the operators $P_i$. This is the compiled Kraus-freedom
-proof route; it does not use Douglas factorization.
+Wolf gives no separate proof beyond calling the result a simple corollary of
+the ordered-map comparison theorem. The formal proof makes this corollary
+explicit. It combines Kraus families for the components into an
+outcome-labelled Stinespring representation $\widehat V$ of $T$, then applies
+the preceding theorem to $T\leq T$ and the two representations
+$\widehat V,V$. This gives a contraction, not in general an isometry,
+\begin{equation}
+  \widehat V=(I_{d'}\otimes C)V,
+  \qquad C^\dagger C\leq I_r.
+\end{equation}
+If $C_i$ retains the rows labelled by $i$, the preliminary effects
+$E_i=C_i^\dagger C_i$ are positive, represent $T_i$, and sum to
+$C^\dagger C$. The residual
+$R=I_r-C^\dagger C$ is positive and satisfies
+$V^\dagger(A\otimes R)V=0$. A chosen outcome $i_0$ receives this residual,
+so that $P_{i_0}=E_{i_0}+R$ and $P_i=E_i$ otherwise. This last step is needed
+for an arbitrary nonminimal supplied dilation and is exactly where
+nonemptiness is used. When $d'=0$, the formal proof separately assigns $I_r$
+to a chosen outcome and zero to all others. The square-algebra declaration is
+a direct specialization of the rectangular theorem.
 
 \paragraph{Why the boundary is needed.}
 If the index type is empty, then $\sum_iT_i=T$ forces $T=0$. Taking the zero

--- a/docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex
+++ b/docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex
@@ -37,9 +37,13 @@ then there are positive operators \(P_i\in\mathcal M_r\) such that
   T_i(A)=V^\dagger(A\otimes P_i)V.
 \]
 The local source is
-\path{Notes/WolfNoteTexSource/ch02_representations.tex}:402--407, titled
-``Radon--Nikodym for quantum instruments'' in
-\cite{Wolf2012Quantum}.
+\path{Notes/WolfNoteTexSource/ch02_representations.tex}:399--407. The two
+preceding lines describe the result as a simple corollary of the comparison
+theorem for ordered completely positive maps; the theorem itself is titled
+``Radon--Nikodym for quantum instruments'' in \cite{Wolf2012Quantum}.
+The source does not separately say that the outcome set is finite. The formal
+statement reads its unqualified sum as a finite sum, as elsewhere in this
+finite-dimensional development.
 
 \section{Local boundary}
 
@@ -58,18 +62,38 @@ the index type were empty, then the hypotheses \(\sum_i T_i=T\) force
   0=\mathbf 1_r
 \]
 in \(\mathcal M_r\), which is false for a nonzero dilation dimension.
+For the exceptional zero-dimensional ancilla \(r=0\), the two sides do agree;
+the nonempty hypothesis is the uniform condition valid for arbitrary supplied
+dilations.
 
 Thus the formal theorem states the source theorem in the nonempty instrument
 case, with its rectangular Heisenberg dimensions made explicit. The older
 \leanid{IsCPMap.radon_nikodym_of_stinespring} theorem is retained as the
 square-algebra specialization.
 
-The formal proof follows the Kraus-freedom route. Choose rectangular Kraus
-families for the component maps, combine them into one labelled family, pad one
-component by zero Kraus operators, and compare that family with the adjoints
-of the ancilla blocks of the supplied Stinespring matrix. Rectangular Kraus
-freedom gives an isometry whose fibre Gram matrices are the
-operators \(P_i\). No Douglas-factorization argument is used.
+The formal proof follows Wolf's indicated corollary route. Choose rectangular
+Kraus families for the component maps and combine them into an
+outcome-labelled Stinespring representation \(\widehat V\) of \(T\). Applying
+the preceding ordered-map theorem to the reflexive relation \(T\leq T\) and
+the two supplied representations \(\widehat V,V\) gives a contraction
+\[
+  \widehat V=(\mathbf 1_{d'}\otimes C)V,
+  \qquad C^\dagger C\leq\mathbf 1_r.
+\]
+Restricting the rows of \(C\) to outcome \(i\) gives a matrix \(C_i\) and a
+preliminary effect \(E_i=C_i^\dagger C_i\). These effects are positive,
+represent the component maps, and satisfy
+\(\sum_iE_i=C^\dagger C\). The residual operator
+\[
+  R=\mathbf 1_r-C^\dagger C
+\]
+is positive and has zero Stinespring compression under \(V\). Nonemptiness is
+used precisely to choose an outcome \(i_0\) receiving this residual:
+\(P_{i_0}=E_{i_0}+R\), with \(P_i=E_i\) otherwise. This completes the
+resolution of the identity even when the supplied dilation is nonminimal. If
+\(d'=0\), all source matrices vanish; the separate formal branch assigns
+\(\mathbf 1_r\) to one chosen outcome and zero to the others. The square
+declaration is proved directly by specializing the rectangular theorem.
 
 \section{Elimination plan}
 

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -161,7 +161,9 @@ project import.
 
 * **Theorem 2.4** (Radon–Nikodym for quantum instruments):
   - `Matrix.blockDiagTopProj` / `Matrix.blockDiagBotProj` — orthogonal
-    block projectors on the dilation space, PSD and summing to `𝟙` ✓
+    block projectors on the dilation space, PSD and summing to `𝟙`; these
+    support only the separately constructed binary corollary, not the
+    source-facing finite-family proof ✓
   - `Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap` — Kronecker
     identity `A ⊗ (CᴴC) = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙) (𝟙 ⊗ C)` ✓
   - `IsKrausCP.radon_nikodym_of_stinespring` — the source-facing rectangular
@@ -170,9 +172,14 @@ project import.
     `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` satisfying `T(A) = V†(A ⊗ 𝟙_r)V`, there are
     PSD `Pᵢ ∈ M_r(ℂ)` with `∑ᵢ Pᵢ = 𝟙_r` and
     `Tᵢ(A) = V†(A ⊗ Pᵢ)V` ✓
+    - Proof route: form the aggregate outcome-labelled dilation `V̂`, apply
+      `CPDominates.exists_supplied_stinespring_contraction` to
+      `CPDominates.refl T`, and restrict the resulting contraction `C` by
+      outcome. The preliminary effects `Eᵢ` sum to `CᴴC`. The residual
+      `𝟙 - CᴴC`, whose Stinespring compression under `V` vanishes, is assigned
+      to a chosen outcome. The `d' = 0` case is handled separately ✓
   - `IsCPMap.radon_nikodym_of_stinespring` — the retained square-algebra
-    specialization `d' = d`, provided as a legacy API and proved by the same
-    Kraus-family/Kraus-freedom route ✓
+    specialization `d' = d`, proved directly from the rectangular theorem ✓
   - `IsCPMap.exists_radon_nikodym` — binary block-diagonal corollary:
     for square CP maps `T₁, T₂`, a constructed Stinespring matrix for
     `T₁ + T₂` yields PSD `P₁ + P₂ = 𝟙` with


### PR DESCRIPTION
## Summary

- Reproves Wolf's rectangular finite-instrument Radon--Nikodym theorem as the stated corollary of the preceding ordered-CP theorem, using the supplied Stinespring dilation.
- Forms the aggregate outcome-labelled dilation, obtains its contraction `C`, constructs the preliminary effects `Eᵢ`, and assigns the positive residual `R = I - Cᴴ C` to one outcome.
- Handles `d' = 0` explicitly and preserves the finite nonempty correction needed to obtain a normalized family for arbitrary environment dimension.
- Makes the established square theorem a direct specialization of the rectangular theorem and removes the duplicated Kraus-freedom proof route.
- Generalizes the reusable finite Stinespring helpers and synchronizes the Blueprint, paper-gap notes, errata, and Wolf-numbering coverage.

## Source correspondence

Wolf, *Quantum Channels & Operations*, Chapter 2, lines 399--407, calls Theorem 2.4 a simple corollary of the ordered-CP Theorem 2.3. The proof now follows that route:

1. aggregate the component Kraus families into an outcome-labelled dilation of `T`;
2. factor this dilation through the supplied `V` by a contraction `C`;
3. partition `Cᴴ C` into the preliminary positive effects `Eᵢ`;
4. use equality of the two total representations to show that `R = I - Cᴴ C` is invisible under compression by `V`;
5. assign `R` to a chosen outcome, obtaining positive `Pᵢ` with `∑ i, Pᵢ = I` and the required component identities.

The dimensions and orientation remain those of the source: `Tᵢ : M_{d'} → M_d` and `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r`. No minimality, trace-preservation, unitality, or isometry assumption is added. The explicit `[Nonempty ι]` hypothesis is the necessary uniform correction for arbitrary `r`; finiteness agrees with Wolf's finite-outcome convention.

This is a source-fidelity follow-up to #91. The theorem signature introduced there is unchanged.

## Verification

Passed locally on the rebased head:

- `lake build QICLean.Channel.Stinespring QICLean.Channel.RadonNikodym QICLean.Channel.OpenSystem -q --log-level=info`
- `lake env lean QICLean/Channel/RadonNikodym.lean`
- `lake exe lint_style`
- explicit kernel `#print axioms` audit of both Radon--Nikodym declarations; each depends only on `propext`, `Classical.choice`, and `Quot.sound`
- independent adversarial vacuity/source-boundary audit, including the `d' = 0` and `r = 0` cases
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (1824/1824)
- `chktex -q -l blueprint/.chktexrc` on the changed TeX files
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `texra-blueprint paper-gaps check`
- `texra-blueprint --root . paper-gaps build`
- full Blueprint PDF build and targeted builds of both changed paper-gap documents
- `git diff --check`

Closes #7
