### PR TITLE
feat(analysis): formalize conic weak duality

### DIFF
--- a/QICLean/Analysis.lean
+++ b/QICLean/Analysis.lean
@@ -16,6 +16,7 @@ import QICLean.Analysis.CfcConjugation
 import QICLean.Analysis.CfcKronecker
 import QICLean.Analysis.CfcLogAdditive
 import QICLean.Analysis.CoisometricCompression
+import QICLean.Analysis.ConicProgram
 import QICLean.Analysis.ConvexHullCompact
 import QICLean.Analysis.DeterminantTraceBound
 import QICLean.Analysis.Dirichlet

--- a/QICLean/Analysis/ConicProgram.lean
+++ b/QICLean/Analysis/ConicProgram.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import Mathlib.Analysis.Convex.Cone.InnerDual
+import Mathlib.Data.EReal.Basic
+
+/-!
+# Conic programs and weak duality
+
+This file defines the primal and dual conic programs in Wolf's convention and proves weak
+duality. The source is Wolf, *Quantum Channels & Operations*, Chapter 4,
+`Notes/WolfNoteTexSource/ch04_convex_structure.tex`, lines 39--71, especially equations
+`conic-primal` and `conic-dual`.
+
+The optimization values lie in `EReal`. Thus an infeasible primal problem has value `+∞`, an
+infeasible dual problem has value `-∞`, a primal problem unbounded below has value `-∞`, and a
+dual problem unbounded above has value `+∞`.
+
+No strong-duality or attainment assertion is made here.
+-/
+
+noncomputable section
+
+open Set
+
+namespace ConicProgram
+
+variable {V V' : Type*}
+variable [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
+variable [NormedAddCommGroup V'] [InnerProductSpace ℝ V'] [FiniteDimensional ℝ V']
+
+local instance : CompleteSpace V := FiniteDimensional.complete ℝ V
+local instance : CompleteSpace V' := FiniteDimensional.complete ℝ V'
+
+/-- The feasible set of Wolf's primal problem
+`inf {<c, x> | x ∈ K, T x = b}`.
+
+Source: Wolf, Chapter 4, equation `conic-primal`, lines 39--48. -/
+def primalFeasible (K : ProperCone ℝ V) (T : V →ₗ[ℝ] V') (b : V') : Set V :=
+  {x | x ∈ K ∧ T x = b}
+
+/-- The feasible set of Wolf's dual problem
+`sup {<b, y> | c - T† y ∈ K*}`, where `K*` is the inner dual cone.
+
+The adjoint is the continuous-linear adjoint of the automatically continuous map `T`.
+Source: Wolf, Chapter 4, equation `conic-dual` and the definition of `K*`, lines 61--70. -/
+def dualFeasible (K : ProperCone ℝ V) (T : V →ₗ[ℝ] V') (c : V) : Set V' :=
+  {y | c - T.toContinuousLinearMap.adjoint y ∈ ProperCone.innerDual (K : Set V)}
+
+/-- The extended-real value `C_p` of Wolf's primal problem.
+
+The infimum over an empty feasible set is `+∞`; an objective unbounded below has infimum `-∞`.
+Source: Wolf, Chapter 4, equation `conic-primal`, lines 39--48. -/
+def primalValue (K : ProperCone ℝ V) (T : V →ₗ[ℝ] V') (c : V) (b : V') : EReal :=
+  ⨅ x : primalFeasible K T b, ((inner ℝ c (x : V) : ℝ) : EReal)
+
+/-- The extended-real value `C_d` of Wolf's dual problem.
+
+The supremum over an empty feasible set is `-∞`; an objective unbounded above has supremum `+∞`.
+Source: Wolf, Chapter 4, equation `conic-dual`, lines 61--65. -/
+def dualValue (K : ProperCone ℝ V) (T : V →ₗ[ℝ] V') (c : V) (b : V') : EReal :=
+  ⨆ y : dualFeasible K T c, ((inner ℝ b (y : V') : ℝ) : EReal)
+
+/-- **Pointwise weak duality.** Every dual-feasible objective value is at most every
+primal-feasible objective value.
+
+Source: Wolf, Chapter 4, weak-duality sentence after equation `conic-dual`, line 71. -/
+theorem weak_duality_pointwise {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V} {b : V'}
+    {x : V} {y : V'} (hx : x ∈ primalFeasible K T b) (hy : y ∈ dualFeasible K T c) :
+    inner ℝ b y ≤ inner ℝ c x := by
+  change x ∈ K ∧ T x = b at hx
+  change c - T.toContinuousLinearMap.adjoint y ∈ ProperCone.innerDual (K : Set V) at hy
+  have hdual : 0 ≤ inner ℝ x (c - T.toContinuousLinearMap.adjoint y) :=
+    (ProperCone.mem_innerDual.mp hy) hx.1
+  have hbound : inner ℝ x (T.toContinuousLinearMap.adjoint y) ≤ inner ℝ x c :=
+    sub_nonneg.mp (by simpa only [inner_sub_right] using hdual)
+  rw [← hx.2]
+  change inner ℝ (T.toContinuousLinearMap x) y ≤ inner ℝ c x
+  rw [← T.toContinuousLinearMap.adjoint_inner_right]
+  exact hbound.trans_eq (real_inner_comm x c).symm
+
+/-- **Weak duality for optimal values:** Wolf's extended-real dual value is at most the
+extended-real primal value, `C_d ≤ C_p`.
+
+Because the values use complete-lattice infima and suprema in `EReal`, this statement also covers
+infeasible and unbounded problems with the documented conventions.
+Source: Wolf, Chapter 4, weak-duality sentence after equation `conic-dual`, line 71. -/
+theorem weak_duality {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V} {b : V'} :
+    dualValue K T c b ≤ primalValue K T c b := by
+  refine iSup_le fun y => ?_
+  refine le_iInf fun x => ?_
+  exact EReal.coe_le_coe (weak_duality_pointwise x.property y.property)
+
+end ConicProgram

--- a/blueprint/src/chapter/ch04_convex_structure.tex
+++ b/blueprint/src/chapter/ch04_convex_structure.tex
@@ -1,0 +1,62 @@
+\chapter{Convex Structure}\label{ch:convex_structure}
+
+This chapter follows the convex-optimization framework of
+\cite[Chapter~4]{Wolf2012Quantum}.
+
+\begin{definition}[Primal and dual conic programs]
+    \label{def:conic_programs}
+    \lean{ConicProgram.primalFeasible, ConicProgram.dualFeasible,
+        ConicProgram.primalValue, ConicProgram.dualValue}
+    \leanok
+    Let $V$ and $V'$ be finite-dimensional real Hilbert spaces, let
+    $K\subseteq V$ be a closed pointed convex cone with nonempty interior, let
+    $T:V\to V'$ be linear, and fix $c\in V$ and $b\in V'$.  As in
+    \cite[Chapter~4, equations~(4.1)--(4.2)]{Wolf2012Quantum}, define the dual
+    cone, the primal and dual feasible sets, and their values by
+    \begin{align}
+        K^*
+         & :=\{u\in V:\forall z\in K,\ \langle z|u\rangle\geq0\},
+        \label{eq:conic_dual_cone}                                                                               \\
+        \mathcal F_p
+         & :=\{x\in K:T(x)=b\},
+         & C_p                                                    & :=\inf_{x\in\mathcal F_p}\langle c|x\rangle,
+        \label{eq:conic_primal}                                                                                  \\
+        \mathcal F_d
+         & :=\{y\in V':c-T^*(y)\in K^*\},
+         & C_d                                                    & :=\sup_{y\in\mathcal F_d}\langle b|y\rangle.
+        \label{eq:conic_dual}
+    \end{align}
+    The values belong to the extended real line.  The conventions are
+    $\inf\varnothing=+\infty$ and $\sup\varnothing=-\infty$; an objective
+    unbounded below has infimum $-\infty$, and one unbounded above has
+    supremum $+\infty$.  The nonempty-interior assumption is Wolf's
+    convention for a conic program; the definitions and weak duality do not
+    require it.
+\end{definition}
+
+\begin{theorem}[Weak duality]
+    \label{thm:conic_weak_duality}
+    \lean{ConicProgram.weak_duality_pointwise, ConicProgram.weak_duality}
+    \leanok
+    \uses{def:conic_programs}
+    For every $x\in\mathcal F_p$ and $y\in\mathcal F_d$,
+    $\langle b|y\rangle\leq\langle c|x\rangle$.  Consequently,
+    $C_d\leq C_p$ with the extended-real conventions of
+    Definition~\ref{def:conic_programs}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:conic_programs}
+    Dual feasibility and $x\in K$ give
+    \begin{align}
+        0
+         & \leq\langle x|c-T^*(y)\rangle
+        =\langle c|x\rangle-\langle T(x)|y\rangle
+        =\langle c|x\rangle-\langle b|y\rangle.
+        \label{eq:conic_pointwise_weak_duality}
+    \end{align}
+    This is the pointwise inequality.  Taking the supremum over
+    $y\in\mathcal F_d$ and then the infimum over $x\in\mathcal F_p$ proves
+    $C_d\leq C_p$.
+\end{proof}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -34,6 +34,7 @@
 %   Ch.3  Positive, but not completely -> ch04_positive_not_cp_* (except
 %                                          kramers_degeneracy, which stays
 %                                          in TNLean)
+%   Ch.4  Convex Structure             -> ch04_convex_structure
 %   Ch.5  Operator Inequalities        -> ch05_schwarz_* (including the
 %                                          former auxiliary chapter's
 %                                          abstract-domains-and-order
@@ -55,10 +56,10 @@
 %                                          {jordan_block_power,
 %                                          upper_triangular_power}
 %
-% No Wolf Ch.4 (Convex Structure) or Ch.9-11 (Symmetries, Special channels,
-% Quantum spin chains) content moved: none of TNLean's blueprint chapters
-% attached to those source chapters cleared the >=0.5 qic-item-count
-% threshold used for this extraction.
+% No Wolf Ch.9-11 (Symmetries, Special channels, Quantum spin chains) content
+% moved: none of TNLean's blueprint chapters attached to those source chapters
+% cleared the >=0.5 qic-item-count threshold used for this extraction. Wolf
+% Ch.4 was added directly in QICLean after extraction.
 %
 % TNLean's catch-all "Auxiliary Quantum-Channel Theory" chapter did not
 % survive the move to a volume-native numbering: its four sections were
@@ -76,6 +77,7 @@
 
 \input{chapter/ch04_positive_not_cp}
 \input{chapter/ch04_positive_not_cp_supporting_results}
+\input{chapter/ch04_convex_structure}
 
 \input{chapter/ch05_schwarz}
 \input{chapter/ch05_schwarz_supporting_results}


### PR DESCRIPTION
## Summary

- define Wolf's primal and dual conic feasible sets using Mathlib's `ProperCone` and inner dual
- define `C_p` and `C_d` in `EReal`, so empty and unbounded cases have literal extended-real semantics
- prove pointwise weak duality and derive `C_d ≤ C_p`
- add the Chapter 4 Blueprint definition/theorem pair and generated Analysis import

## Source and scope

This follows `Notes/WolfNoteTexSource/ch04_convex_structure.tex`, lines 39--71, including the signs and adjoint orientation in the displayed primal and dual problems. The proof is Wolf's inner-product calculation. The Lean theorem is harmlessly more general in that weak duality does not use nonempty interior; the Blueprint retains Wolf's conic-program convention.

No strong-duality or attainment assertion is included.

## Validation

- `lake build QICLean.Analysis.ConicProgram -q --log-level=info`
- `lake exe lint_style`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --ci`
- Blueprint PDF and web builds, chktex, latexindent, paper-gap reference check
- forbidden-bypass scan and `#print axioms` audit: standard axioms only

The standalone local `checkdecls` command requires the broad root `QICLean.olean` in this fresh worktree; focused declaration sync and reverse coverage pass, and CI will run the repository-wide check.

Closes #109
