### PR TITLE
feat(analysis): specialize Schur power estimate

### DIFF
--- a/QICLean/Analysis/UpperTriangularBound.lean
+++ b/QICLean/Analysis/UpperTriangularBound.lean
@@ -19,6 +19,7 @@ import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Ring
 import Mathlib.Analysis.Normed.Unbundled.RingSeminorm
+import Mathlib.Analysis.CStarAlgebra.Matrix
 /-!
 # Upper-triangular power bound — Wolf Eqs. (8.103) and (8.105)
 
@@ -832,5 +833,55 @@ theorem wolf_eq_103_refined (ν : RingSeminorm (Matrix (Fin D) (Fin D) R))
   simpa [hd] using h_helper d h_total_bound
 
 end WolfEq103Refined
+
+section WolfEq111SchurForm
+
+open scoped Matrix.Norms.L2Operator
+
+variable {D : ℕ} {Λ N : Matrix (Fin D) (Fin D) ℂ} {n : ℕ} {μ : ℝ}
+
+/-- **Wolf Eq. (8.111), coarse Schur-form estimate.**
+
+This is the matrix estimate obtained after a Schur decomposition.  The spectral
+input is kept explicit: the diagonal part has operator norm `μ`, and its `n`th
+power has norm at most `μ ^ n`.  The channel-level theorem additionally has to
+construct this decomposition for `T - T_ϕ`, where `T_ϕ = T T_φ` is Wolf's
+phase-weighted peripheral map, and identify `μ` with the largest subperipheral
+eigenvalue modulus.
+
+As in `wolf_eq_103`, the natural exponent requires `D - 1 ≤ n`; see
+`docs/paper-gaps/wolf_ch8_eq_8_103_negative_exponent.tex`. -/
+theorem wolf_eq_111_schur_form
+    (hΛ_diag : IsDiag Λ) (hN_sut : IsStrictlyUpperTriangular N)
+    (hDpos : D ≠ 0) (hn_ge : D - 1 ≤ n) (hΛ_norm : ‖Λ‖ = μ)
+    (hμ_le_one : μ ≤ 1) (hΛ_pow : ‖Λ ^ n‖ ≤ μ ^ n) :
+    ‖(Λ + N) ^ n‖ ≤ μ ^ n +
+      (((D - 1 : ℕ) * n ^ (D - 1 : ℕ) : ℕ) : ℝ) * μ ^ (n - (D - 1)) *
+        max ‖N‖ (‖N‖ ^ (D - 1)) := by
+  have h := wolf_eq_103
+    (SeminormedRing.toRingSeminorm (Matrix (Fin D) (Fin D) ℂ))
+    hΛ_diag hN_sut hDpos hn_ge (hΛ_norm.trans_le hμ_le_one)
+  simp only [SeminormedRing.toRingSeminorm_apply, hΛ_norm] at h
+  exact h.trans (by gcongr)
+
+/-- **Wolf Eq. (8.111), refined Schur-form estimate.**
+
+Under `2 * (D - 1) ≤ n`, the coarse power factor in
+`wolf_eq_111_schur_form` is replaced by the binomial coefficient printed in
+Wolf's refined estimate. -/
+theorem wolf_eq_111_schur_form_refined
+    (hΛ_diag : IsDiag Λ) (hN_sut : IsStrictlyUpperTriangular N)
+    (hDpos : D ≠ 0) (hn_ge : 2 * (D - 1) ≤ n) (hΛ_norm : ‖Λ‖ = μ)
+    (hμ_le_one : μ ≤ 1) (hΛ_pow : ‖Λ ^ n‖ ≤ μ ^ n) :
+    ‖(Λ + N) ^ n‖ ≤ μ ^ n +
+      (((D - 1 : ℕ) * Nat.choose n (D - 1) : ℕ) : ℝ) * μ ^ (n - (D - 1)) *
+        max ‖N‖ (‖N‖ ^ (D - 1)) := by
+  have h := wolf_eq_103_refined
+    (SeminormedRing.toRingSeminorm (Matrix (Fin D) (Fin D) ℂ))
+    hΛ_diag hN_sut hDpos hn_ge (hΛ_norm.trans_le hμ_le_one)
+  simp only [SeminormedRing.toRingSeminorm_apply, hΛ_norm] at h
+  exact h.trans (by gcongr)
+
+end WolfEq111SchurForm
 
 end Matrix

--- a/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
@@ -69,3 +69,31 @@
 % therefore stated in the range $D-1\le n$, where the displayed
 % natural-power derivation is meaningful.
 \end{proof}
+
+\begin{theorem}[Schur-form spectral-radius estimate]
+    \label{thm:wolf_schur_form_spectral_radius_estimate}
+    \lean{Matrix.wolf_eq_111_schur_form,
+      Matrix.wolf_eq_111_schur_form_refined}
+    \leanok
+    \uses{thm:wolf_upper_triangular_power_estimate}
+    Let $\Lambda,N\in M_D(\mathbb C)$, where $\Lambda$ is diagonal and $N$ is
+    strictly upper triangular.  Suppose
+    $\lVert\Lambda\rVert_\infty=\mu\le1$ and
+    $\lVert\Lambda^n\rVert_\infty\le\mu^n$.  If $D-1\le n$, then
+    \begin{align}
+      \lVert(\Lambda+N)^n\rVert_\infty
+      \le \mu^n
+      +(D-1)n^{D-1}\mu^{n-D+1}
+        \max\{\lVert N\rVert_\infty,\lVert N\rVert_\infty^{D-1}\}.
+    \end{align}
+    If $2(D-1)\le n$, the factor $(D-1)n^{D-1}$ may be replaced by
+    $(D-1)\binom{n}{D-1}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:wolf_upper_triangular_power_estimate}
+    Apply Theorem~\ref{thm:wolf_upper_triangular_power_estimate} to the
+    $\ell^2$ operator norm and substitute the two bounds for the diagonal
+    part.
+\end{proof}

--- a/docs/paper-gaps/wolf_ch8_eq_8_103_negative_exponent.tex
+++ b/docs/paper-gaps/wolf_ch8_eq_8_103_negative_exponent.tex
@@ -67,6 +67,17 @@ declarations are:
     $2(D-1)\le n$.
 \end{itemize}
 
+Equation~(8.111) applies Equation~(8.103) to the Schur form of
+$\widehat T-\widehat T_\varphi$, with matrix dimension $D=d^2$ and
+$\lVert\Lambda\rVert_\infty=\mu$.  It therefore inherits the same restriction
+$d^2-1\le n$ in the natural-power interpretation.  The corresponding coarse
+and refined Schur-form estimates are
+\leanid{Matrix.wolf_eq_111_schur_form} and
+\leanid{Matrix.wolf_eq_111_schur_form_refined}.  These declarations establish
+the estimate once the Schur decomposition and its spectral identification are
+given; constructing that decomposition for $\widehat T-\widehat T_\varphi$
+remains part of the channel-level theorem.
+
 \section{Verdict}
 
 \textbf{Verdict: source scope restriction.}


### PR DESCRIPTION
Refs #300.

Formalizes the matrix-level Schur-form consequence used in Wolf Eq. (8.111):
- specializes the landed Eq. (8.103) bounds to the L2 operator norm;
- substitutes `‖Λ‖∞ = μ` and `‖Λ^n‖∞ ≤ μ^n`;
- includes both Wolf constants and preserves the source-qualified exponent ranges;
- synchronizes the Blueprint and the existing paper-gap note.

This intentionally does not close #300. The remaining source-shaped boundary is to reuse #297’s common subperipheral modulus `μ`, prove the power-difference identity for Wolf’s phase-weighted peripheral map `T_ϕ = T T_φ`, construct a Schur decomposition of the channel matrix of `T - T_ϕ`, and prove Wolf’s `‖N‖∞ ≤ μ + 2√d` bound from the positive trace-preserving hypotheses. No Schur-triangularization API currently exists in QICLean or the pinned Mathlib.

Verification:
- `lake exe cache get`
- `lake build QICLean.Analysis.UpperTriangularBound -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- proof-integrity grep and `git diff --check`

A broad `lake build QICLean` was started to enable local `checkdecls` but stopped after the targeted module passed because several concurrent isolated worktrees were rebuilding the same dependency graph; CI remains the full-build gate.