### PR TITLE
feat(analysis): start Wolf asymptotic-state convergence identities

### DIFF
--- a/QICLean/Analysis.lean
+++ b/QICLean/Analysis.lean
@@ -9,6 +9,7 @@ Authors: QICLean contributors
 -- Generated aggregator module: QICLean.Analysis
 
 import QICLean.Analysis.AdjointEigenvalues
+import QICLean.Analysis.AsymptoticStateConvergence
 import QICLean.Analysis.Birkhoff
 import QICLean.Analysis.CStarCompletion
 import QICLean.Analysis.CStarMatrixKronecker

--- a/QICLean/Analysis/AsymptoticStateConvergence.lean
+++ b/QICLean/Analysis/AsymptoticStateConvergence.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 Sirui Lu and QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import QICLean.Analysis.TraceNormContractionCoefficient
+import QICLean.Channel.Peripheral.SpectralProjection
+
+/-!
+# Trace-norm convergence towards asymptotic states
+
+This file begins the formalization of Wolf's comparison between trace-norm
+convergence of states and Hilbert--Schmidt operator-norm convergence of a
+positive trace-preserving map.  It proves the exact algebraic identities used
+before the norm estimates: the peripheral projection commutes with every
+iterate, the phase-weighted peripheral map kills the non-peripheral remainder,
+and hence the numerator in Equation (8.114) has Wolf's two equivalent forms.
+
+## References
+
+Michael M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8,
+Proposition "Convergence towards asymptotic states", Equations (8.112)--(8.117);
+local source `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1319--1364.
+-/
+
+open scoped Matrix
+
+noncomputable section
+
+namespace Matrix
+
+variable {D : ℕ}
+
+/-- Wolf's `Δ_T(ρ) = ‖ρ - T_φ(ρ)‖₁`: trace-norm distance to the peripheral
+spectral projection.
+
+Source: Wolf, Equation (8.112), definition immediately before the displayed
+bound; local source lines 1323--1328. -/
+def traceNormAsymptoticDistance
+    (T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (ρ : Matrix (Fin D) (Fin D) ℂ) : ℝ :=
+  traceNorm (ρ - T.peripheralProjection ρ)
+
+/-- The peripheral projection commutes with every iterate of `T`.
+
+This is the iterated form of the first identity on Wolf line 1337. -/
+theorem peripheralProjection_comp_pow
+    (T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) (n : ℕ) :
+    T.peripheralProjection ∘ₗ (T ^ n) = (T ^ n) ∘ₗ T.peripheralProjection := by
+  simpa only [Module.End.mul_eq_comp] using
+    (T.commute_peripheralProjection.pow_right n).eq
+
+/-- The phase-weighted peripheral map annihilates Wolf's non-peripheral
+remainder `ρ - T_φ(ρ)`.
+
+This is the identity `T_φ' T_φ = T_φ'` on Wolf line 1337, applied to the
+complement of the peripheral projection. -/
+@[simp]
+theorem peripheralWeightedProjection_apply_sub_peripheralProjection
+    (T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (ρ : Matrix (Fin D) (Fin D) ℂ) :
+    T.peripheralWeightedProjection (ρ - T.peripheralProjection ρ) = 0 := by
+  rw [Module.End.peripheralWeightedProjection, LinearMap.comp_apply, map_sub,
+    T.peripheralProjection_apply_peripheralProjection, sub_self, map_zero]
+
+/-- Every positive power of the phase-weighted peripheral map annihilates
+Wolf's non-peripheral remainder. -/
+@[simp]
+theorem peripheralWeightedProjection_pow_apply_sub_peripheralProjection
+    (T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (ρ : Matrix (Fin D) (Fin D) ℂ) {n : ℕ} (hn : 0 < n) :
+    (T.peripheralWeightedProjection ^ n) (ρ - T.peripheralProjection ρ) = 0 := by
+  cases n with
+  | zero => simp at hn
+  | succ n =>
+      rw [pow_succ, Module.End.mul_apply,
+        peripheralWeightedProjection_apply_sub_peripheralProjection, map_zero]
+
+/-- Wolf's numerator identity preceding Equation (8.114): for every positive
+iterate, `Δ_T(Tⁿρ)` is the trace norm of `Tⁿ` applied to the non-peripheral
+remainder.
+
+Source: Wolf, local source lines 1336--1344. -/
+theorem traceNormAsymptoticDistance_pow_eq
+    (T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (n : ℕ) :
+    traceNormAsymptoticDistance T ((T ^ n) ρ) =
+      traceNorm ((T ^ n) (ρ - T.peripheralProjection ρ)) := by
+  have hcomm : T.peripheralProjection ((T ^ n) ρ) =
+      (T ^ n) (T.peripheralProjection ρ) := by
+    simpa only [LinearMap.comp_apply] using congrArg
+      (fun f : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ) ↦ f ρ)
+      (peripheralProjection_comp_pow T n)
+  rw [traceNormAsymptoticDistance, hcomm, map_sub]
+
+/-- Wolf's second numerator identity preceding Equation (8.114): for every
+positive iterate, subtracting the corresponding power of the asymptotic
+dynamics does not change its action on the non-peripheral remainder.
+
+Source: Wolf, local source lines 1336--1344. -/
+theorem traceNormAsymptoticDistance_pow_eq_sub_peripheralWeightedProjection_pow
+    (T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (ρ : Matrix (Fin D) (Fin D) ℂ) {n : ℕ} (hn : 0 < n) :
+    traceNormAsymptoticDistance T ((T ^ n) ρ) =
+      traceNorm (((T ^ n) - T.peripheralWeightedProjection ^ n)
+        (ρ - T.peripheralProjection ρ)) := by
+  rw [traceNormAsymptoticDistance_pow_eq, LinearMap.sub_apply,
+    peripheralWeightedProjection_pow_apply_sub_peripheralProjection T ρ hn, sub_zero]
+
+end Matrix

--- a/QICLean/Analysis/AsymptoticStateConvergence.lean
+++ b/QICLean/Analysis/AsymptoticStateConvergence.lean
@@ -53,8 +53,8 @@ theorem peripheralProjection_comp_pow
 /-- The phase-weighted peripheral map annihilates Wolf's non-peripheral
 remainder `ρ - T_φ(ρ)`.
 
-This is the identity `T_φ' T_φ = T_φ'` on Wolf line 1337, applied to the
-complement of the peripheral projection. -/
+This is Wolf's identity `T_\varphi T_φ = T_\varphi` on source line 1337,
+applied to the complement of the peripheral projection. -/
 @[simp]
 theorem peripheralWeightedProjection_apply_sub_peripheralProjection
     (T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))

--- a/blueprint/src/chapter/ch07_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch07_qpf_cesaro_fixed_points.tex
@@ -202,7 +202,7 @@
         thm:positive_trace_preserving_mean_ergodic_projection}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving, with $D>0$.
     There is a strictly increasing sequence of positive integers $n_i$ such
-    that $T^{n_i}\to T_\varphi$ pointwise and in operator norm. This is
+    that $T^{n_i}\to T_\phi$ pointwise and in operator norm. This is
     \cite[Proposition~6.3(i)]{Wolf2012Quantum}.
 \end{theorem}
 
@@ -241,9 +241,9 @@
     \uses{thm:peripheral_projection_recurrent_subsequence,
         def:peripheral_spectral_projections}
     The peripheral projection of a positive trace-preserving map is positive
-    and trace-preserving, and then the weighted projection $T_\varphi'$ is
+    and trace-preserving, and then the weighted projection $T_\varphi$ is
     positive and trace-preserving as well. If the original map is completely
-    positive, then $T_\varphi$ and $T_\varphi'$ are quantum channels. This
+    positive, then $T_\phi$ and $T_\varphi$ are quantum channels. This
     is the preservation assertion in the opening clause of
     \cite[Proposition~6.3]{Wolf2012Quantum} (item~(ii) itself states only the
     composition identity).
@@ -254,7 +254,7 @@
     Every power of $T$ preserves positivity and trace, and every power of a
     completely positive map is completely positive. These properties are
     closed under the operator-norm limit. Composition with $T$ gives the
-    assertion for $T_\varphi'$.
+    assertion for $T_\varphi$.
 \end{proof}
 
 \begin{lemma}[Pointwise limits of endomorphisms in finite dimension]
@@ -316,7 +316,7 @@
     quantum channel. Together with
     Corollary~\ref{cor:peripheral_projection_channel} this completes the
     preservation assertion of \cite[Proposition~6.3]{Wolf2012Quantum} for all
-    three maps $T_\infty$, $T_\varphi$, and $T_\varphi'$.
+    three maps $T_\infty$, $T_\phi$, and $T_\varphi$.
 \end{corollary}
 
 \begin{proof}\leanok
@@ -361,7 +361,7 @@
     If $T_\infty$ denotes the mean-ergodic projection of a positive
     trace-preserving map, then
     \begin{align}
-        T_\varphi T_\infty=T_\infty.
+        T_\phi T_\infty=T_\infty.
     \end{align}
     This is the absorption identity adjacent to
     \cite[Equation~(6.14)]{Wolf2012Quantum}.
@@ -374,7 +374,7 @@
         thm:positive_trace_preserving_mean_ergodic_projection}
     The range of $T_\infty$ consists of fixed points of~$T$, hence every power
     of $T$ fixes this range. Passing to the recurrent-subsequence limit shows
-    that $T_\varphi$ also fixes it pointwise.
+    that $T_\phi$ also fixes it pointwise.
 \end{proof}
 
 \begin{theorem}[Asymptotic image]
@@ -397,7 +397,7 @@
     \end{align}
     be the span of its peripheral eigenvectors. Then
     \begin{enumerate}
-        \item $T_\varphi(\MN{D})=\mathcal X_T$,
+        \item $T_\phi(\MN{D})=\mathcal X_T$,
         \item there are positive semidefinite matrices $\rho_i$ with
               $\mathcal X_T=\spn\{\rho_i\}$,
         \item $T(\mathcal X_T)=\mathcal X_T$.
@@ -413,12 +413,12 @@
         cor:stationary_density_span}
     Write $V_\mu=\ker(T-\mu)$ for the eigenspace of a peripheral eigenvalue
     $\mu$, so that $\mathcal X_T=\sum_{|\mu|=1}V_\mu$ by the definition of
-    $\mathcal X_T$. The image of the projection $T_\varphi$ is its set of
-    fixed points, and the fixed points of $T_\varphi$ are the linear
+    $\mathcal X_T$. The image of the projection $T_\phi$ is its set of
+    fixed points, and the fixed points of $T_\phi$ are the linear
     combinations of peripheral eigenvectors:
     \begin{align}
-        T_\varphi(\MN{D})
-         & =\{X\in\MN{D}\mid T_\varphi(X)=X\}
+        T_\phi(\MN{D})
+         & =\{X\in\MN{D}\mid T_\phi(X)=X\}
         \label{eq:channel_asymptotic_fixed_points}\\
          & =\sum_{|\mu|=1}V_\mu
         \label{eq:channel_asymptotic_eigenspace_sum}\\
@@ -426,18 +426,18 @@
         \label{eq:channel_asymptotic_definition}
     \end{align}
     The equality (\ref{eq:channel_asymptotic_fixed_points}) holds because
-    $T_\varphi$ is a projection; a matrix fixed by $T_\varphi$ lies in the
+    $T_\phi$ is a projection; a matrix fixed by $T_\phi$ lies in the
     peripheral subspace, whose Jordan blocks are trivial for a positive
     trace-preserving map (Theorem~\ref{thm:peripheral_jordan_trivial}),
     which gives (\ref{eq:channel_asymptotic_eigenspace_sum}); and
     (\ref{eq:channel_asymptotic_definition}) is the definition of
     $\mathcal X_T$. This is the first claim.
 
-    The projection $T_\varphi$ is itself positive and trace-preserving, so its
+    The projection $T_\phi$ is itself positive and trace-preserving, so its
     fixed-point space is spanned by its stationary density matrices:
     \begin{align}
-        \mathcal X_T=\{X\in\MN{D}\mid T_\varphi(X)=X\}
-        =\spn\{\rho\mid \rho\ \text{a stationary density matrix of }T_\varphi\}.
+        \mathcal X_T=\{X\in\MN{D}\mid T_\phi(X)=X\}
+        =\spn\{\rho\mid \rho\ \text{a stationary density matrix of }T_\phi\}.
     \end{align}
     Every such $\rho$ is positive semidefinite, which is the second claim.
 

--- a/blueprint/src/chapter/ch07_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch07_qpf_cesaro_fixed_points.tex
@@ -163,9 +163,9 @@
     \leanok
     \uses{def:peripheral_spectral_splitting,
         thm:peripheral_spectral_complementarity}
-    The map $T_\varphi$ is the projection onto the peripheral subspace along
-    the non-peripheral subspace. The phase-weighted peripheral map is
-    $T_\varphi'=T\circ T_\varphi$.
+    The map $T_\phi$ is the projection onto the peripheral subspace along
+    the non-peripheral subspace. The phase-weighted peripheral map is Wolf's
+    asymptotic dynamics $T_\varphi=T\circ T_\phi$.
 \end{definition}
 
 \begin{theorem}[Properties of the peripheral spectral projections]
@@ -179,13 +179,13 @@
         Module.End.peripheralWeightedProjection_apply_of_mem_eigenspace}
     \leanok
     \uses{def:peripheral_spectral_projections}
-    The range of $T_\varphi$ is the peripheral subspace, $T_\varphi$ is
+    The range of $T_\phi$ is the peripheral subspace, $T_\phi$ is
     idempotent, and
     \begin{align}
-        T_\varphi' & =T\circ T_\varphi=T_\varphi\circ T.
+        T_\varphi & =T\circ T_\phi=T_\phi\circ T.
     \end{align}
-    On a peripheral $\mu$-eigenvector, $T_\varphi$ acts as the identity and
-    $T_\varphi'$ acts as multiplication by~$\mu$. These are
+    On a peripheral $\mu$-eigenvector, $T_\phi$ acts as the identity and
+    $T_\varphi$ acts as multiplication by~$\mu$. These are
     \cite[Equations~(6.12) and~(6.13)]{Wolf2012Quantum}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch07_qpf_weighted_cesaro.tex
+++ b/blueprint/src/chapter/ch07_qpf_weighted_cesaro.tex
@@ -95,7 +95,7 @@
     Ces\`aro means tend to zero.
 \end{proof}
 
-\begin{theorem}[Phase-weighted Ces\`aro formula for $T_\varphi$]
+\begin{theorem}[Phase-weighted Ces\`aro formula for $T_\phi$]
     \label{thm:peripheral_projection_weighted_cesaro}
     \lean{IsPositiveMap.tendsto_weightedCesaroMean_peripheralProjection,
         IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_peripheralProjection,
@@ -107,7 +107,7 @@
     let $\lambda_{1},\dots,\lambda_{m}$ denote the distinct eigenvalues of
     $T$ of modulus one. Then
     \begin{align}
-        T_\varphi
+        T_\phi
          & =\lim_{N\to\infty}\frac{1}{N}\sum_{n=1}^{N}
         \sum_{k=1}^{m}(\bar\lambda_{k}T)^{n},
         \label{eq:peripheral_projection_weighted_cesaro}
@@ -132,7 +132,7 @@
         thm:positive_trace_preserving_mean_ergodic_projection,
         lem:weighted_cesaro_mean_on_splitting,
         lem:tendsto_clm_of_tendsto_apply}
-    Split $X=T_\varphi(X)+(X-T_\varphi(X))$ along the complementary spectral
+    Split $X=T_\phi(X)+(X-T_\phi(X))$ along the complementary spectral
     subspaces. Bounded forward orbits force every eigenvalue to have modulus
     at most one, so every eigenvalue outside the peripheral spectrum has
     modulus strictly below one and $T^{n}(Y)\to0$ for every $Y$ in the
@@ -142,7 +142,7 @@
     summand to zero. Triviality of the peripheral Jordan blocks identifies
     the peripheral subspace with the span of the peripheral eigenspaces, on
     which part (i) of the same lemma acts as the identity, so the first
-    summand converges to $T_\varphi(X)$. Pointwise convergence of
+    summand converges to $T_\phi(X)$. Pointwise convergence of
     endomorphisms of a finite-dimensional space is convergence in operator
     norm.
 \end{proof}

--- a/blueprint/src/chapter/ch12_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch12_entropy_trace_norm.tex
@@ -559,6 +559,55 @@ Theorem~\ref{thm:trace_norm_abs}.
     $\rho_1\neq\rho_2$ proves the equality.
 \end{proof}
 
+\begin{definition}[Trace-norm distance to the asymptotic image]
+    \label{def:trace_norm_asymptotic_distance}
+    \lean{Matrix.traceNormAsymptoticDistance}
+    \leanok
+    \uses{def:trace_norm, def:peripheral_spectral_projections}
+    For $T:\MN{D}\to\MN{D}$, let $T_\phi$ be its peripheral spectral
+    projection and define
+    \begin{align}
+        \Delta_T(\rho):=\lVert\rho-T_\phi(\rho)\rVert_{\tr}.
+    \end{align}
+    This is Wolf's notation in
+    \cite[Chapter~8, Proposition ``Convergence towards asymptotic
+    states'', Eq.~(8.112)]{Wolf2012Quantum}.
+\end{definition}
+
+\begin{lemma}[Asymptotic-distance numerator identities]
+    \label{lem:trace_norm_asymptotic_distance_numerator}
+    \lean{Matrix.peripheralProjection_comp_pow,
+        Matrix.peripheralWeightedProjection_apply_sub_peripheralProjection,
+        Matrix.peripheralWeightedProjection_pow_apply_sub_peripheralProjection,
+        Matrix.traceNormAsymptoticDistance_pow_eq,
+        Matrix.traceNormAsymptoticDistance_pow_eq_sub_peripheralWeightedProjection_pow}
+    \leanok
+    \uses{def:trace_norm_asymptotic_distance,
+        thm:peripheral_spectral_projection_properties}
+    Let $T_\varphi:=T\circ T_\phi=T_\phi\circ T$ be Wolf's asymptotic
+    dynamics. For every matrix $\rho$, every $n\geq0$, and every $n>0$ in
+    the second equality,
+    \begin{align}
+        \Delta_T(T^n(\rho))
+        &=\lVert T^n(\rho-T_\phi(\rho))\rVert_{\tr}\\
+        &=\lVert(T^n-T_\varphi^n)(\rho-T_\phi(\rho))\rVert_{\tr}.
+        \label{eq:trace_norm_asymptotic_distance_numerator}
+    \end{align}
+    These are the numerator identities used in
+    \cite[Chapter~8, Eq.~(8.114)]{Wolf2012Quantum}. They follow from
+    $T_\phi T=TT_\phi=T_\varphi=T_\varphi T_\phi$; the positive-iterate
+    condition records that the zeroth power of $T_\varphi$ is the identity.
+\end{lemma}
+
+\begin{proof}\leanok
+    The commutation $T_\phi T=TT_\phi$ iterates to
+    $T_\phi T^n=T^nT_\phi$, which proves the first equality by linearity.
+    Idempotence of $T_\phi$ gives
+    $T_\varphi(\rho-T_\phi(\rho))=0$; every positive power of
+    $T_\varphi$ therefore vanishes on the same remainder, proving the second
+    equality.
+\end{proof}
+
 \begin{lemma}[Scaled positive-part trace estimate]
     \label{lem:scaled_posPart_trace_estimate}
     \lean{Matrix.re_trace_posPart_map_le_of_scaledTrace}


### PR DESCRIPTION
## Summary

- define Wolf's `Δ_T(ρ) = ‖ρ - T_φ(ρ)‖₁`
- prove `T_φ` commutes with every iterate of `T`
- prove the asymptotic dynamics `T_\varphi := T ∘ T_φ` annihilates the non-peripheral remainder, including all positive powers
- derive both exact numerator identities used in Wolf Eq. (8.114)
- sync the compiled leaf into the Blueprint and correct the previously swapped `T_φ` / `T_\varphi` notation to match Wolf exactly

Source: Wolf, *Quantum Channels & Operations*, Chapter 8, `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1319–1364, especially lines 1336–1344.

Advances #301 without closing it.

## Remaining source-shaped work for #301

The exact constants in Eqs. (8.112)–(8.113) still require APIs that are not presently exposed along the traced route:

- the finite-dimensional comparison `‖A‖₁ ≤ √d ‖A‖₂` and the matching induced `2 → 2` map norm / transfer-matrix norm bridge;
- Wolf's Eq. (8.117) decomposition with four positive parts whose coefficients have modulus one and whose Hilbert–Schmidt norms are individually controlled. The existing four-positive-parts declarations formalize fixed-point/span decompositions, but not this norm-controlled statement.

This PR does not assume either estimate and does not strengthen Wolf's positive trace-preserving hypotheses.

## Checks

- `lake build QICLean.Analysis.AsymptoticStateConvergence -q --log-level=info`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci`
- `git diff --check`
- proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`

`leanblueprint checkdecls` could not be completed in the isolated worktree because its cache does not contain the root `QICLean.olean`; the source/Blueprint synchronizer itself is green at the exact PR head.
