### PR TITLE
refactor(analysis): derive Schur diagonal power bound

### DIFF
--- a/QICLean/Analysis/UpperTriangularBound.lean
+++ b/QICLean/Analysis/UpperTriangularBound.lean
@@ -840,11 +840,21 @@ open scoped Matrix.Norms.L2Operator
 
 variable {D : ℕ} {Λ N : Matrix (Fin D) (Fin D) ℂ} {n : ℕ} {μ : ℝ}
 
+/-- Powers are submultiplicative for the L2 operator norm on nonempty square
+matrices, including the zeroth power. -/
+lemma l2_opNorm_pow_le_pow [Nonempty (Fin D)]
+    (A : Matrix (Fin D) (Fin D) ℂ) (m : ℕ) : ‖A ^ m‖ ≤ ‖A‖ ^ m := by
+  cases m with
+  | zero =>
+      rw [pow_zero, pow_zero, ← Matrix.diagonal_one, Matrix.l2_opNorm_diagonal]
+      simp
+  | succ m => exact norm_pow_le' A (Nat.succ_pos m)
+
 /-- **Wolf Eq. (8.111), coarse Schur-form estimate.**
 
 This is the matrix estimate obtained after a Schur decomposition.  The spectral
-input is kept explicit: the diagonal part has operator norm `μ`, and its `n`th
-power has norm at most `μ ^ n`.  The channel-level theorem additionally has to
+input is kept explicit: the diagonal part has operator norm `μ`.  The
+channel-level theorem additionally has to
 construct this decomposition for `T - T_ϕ`, where `T_ϕ = T T_φ` is Wolf's
 phase-weighted peripheral map, and identify `μ` with the largest subperipheral
 eigenvalue modulus.
@@ -854,15 +864,16 @@ As in `wolf_eq_103`, the natural exponent requires `D - 1 ≤ n`; see
 theorem wolf_eq_111_schur_form
     (hΛ_diag : IsDiag Λ) (hN_sut : IsStrictlyUpperTriangular N)
     (hDpos : D ≠ 0) (hn_ge : D - 1 ≤ n) (hΛ_norm : ‖Λ‖ = μ)
-    (hμ_le_one : μ ≤ 1) (hΛ_pow : ‖Λ ^ n‖ ≤ μ ^ n) :
+    (hμ_le_one : μ ≤ 1) :
     ‖(Λ + N) ^ n‖ ≤ μ ^ n +
       (((D - 1 : ℕ) * n ^ (D - 1 : ℕ) : ℕ) : ℝ) * μ ^ (n - (D - 1)) *
         max ‖N‖ (‖N‖ ^ (D - 1)) := by
+  let _ : Nonempty (Fin D) := Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero hDpos)
   have h := wolf_eq_103
     (SeminormedRing.toRingSeminorm (Matrix (Fin D) (Fin D) ℂ))
     hΛ_diag hN_sut hDpos hn_ge (hΛ_norm.trans_le hμ_le_one)
   simp only [SeminormedRing.toRingSeminorm_apply, hΛ_norm] at h
-  exact h.trans (by gcongr)
+  exact h.trans (by gcongr; simpa [hΛ_norm] using l2_opNorm_pow_le_pow Λ n)
 
 /-- **Wolf Eq. (8.111), refined Schur-form estimate.**
 
@@ -872,15 +883,16 @@ Wolf's refined estimate. -/
 theorem wolf_eq_111_schur_form_refined
     (hΛ_diag : IsDiag Λ) (hN_sut : IsStrictlyUpperTriangular N)
     (hDpos : D ≠ 0) (hn_ge : 2 * (D - 1) ≤ n) (hΛ_norm : ‖Λ‖ = μ)
-    (hμ_le_one : μ ≤ 1) (hΛ_pow : ‖Λ ^ n‖ ≤ μ ^ n) :
+    (hμ_le_one : μ ≤ 1) :
     ‖(Λ + N) ^ n‖ ≤ μ ^ n +
       (((D - 1 : ℕ) * Nat.choose n (D - 1) : ℕ) : ℝ) * μ ^ (n - (D - 1)) *
         max ‖N‖ (‖N‖ ^ (D - 1)) := by
+  let _ : Nonempty (Fin D) := Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero hDpos)
   have h := wolf_eq_103_refined
     (SeminormedRing.toRingSeminorm (Matrix (Fin D) (Fin D) ℂ))
     hΛ_diag hN_sut hDpos hn_ge (hΛ_norm.trans_le hμ_le_one)
   simp only [SeminormedRing.toRingSeminorm_apply, hΛ_norm] at h
-  exact h.trans (by gcongr)
+  exact h.trans (by gcongr; simpa [hΛ_norm] using l2_opNorm_pow_le_pow Λ n)
 
 end WolfEq111SchurForm
 

--- a/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
@@ -70,16 +70,32 @@
 % natural-power derivation is meaningful.
 \end{proof}
 
+\begin{lemma}[Operator norm of matrix powers]
+    \label{lem:l2_operator_norm_matrix_power}
+    \lean{Matrix.l2_opNorm_pow_le_pow}
+    \leanok
+    For every $A\in M_D(\mathbb C)$ with $D\ge1$ and every $n\in\mathbb N$,
+    \begin{align}
+      \lVert A^n\rVert_\infty\le\lVert A\rVert_\infty^n.
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    For positive powers this is submultiplicativity.  For the zeroth power,
+    the identity matrix has operator norm one because $D\ge1$.
+\end{proof}
+
 \begin{theorem}[Schur-form spectral-radius estimate]
     \label{thm:wolf_schur_form_spectral_radius_estimate}
     \lean{Matrix.wolf_eq_111_schur_form,
       Matrix.wolf_eq_111_schur_form_refined}
     \leanok
-    \uses{thm:wolf_upper_triangular_power_estimate}
+    \uses{thm:wolf_upper_triangular_power_estimate,
+      lem:l2_operator_norm_matrix_power}
     Let $\Lambda,N\in M_D(\mathbb C)$, where $\Lambda$ is diagonal and $N$ is
     strictly upper triangular.  Suppose
-    $\lVert\Lambda\rVert_\infty=\mu\le1$ and
-    $\lVert\Lambda^n\rVert_\infty\le\mu^n$.  If $D-1\le n$, then
+    $\lVert\Lambda\rVert_\infty=\mu\le1$.  If $D-1\le n$, then
     \begin{align}
       \lVert(\Lambda+N)^n\rVert_\infty
       \le \mu^n
@@ -92,8 +108,10 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:wolf_upper_triangular_power_estimate}
+    \uses{thm:wolf_upper_triangular_power_estimate,
+      lem:l2_operator_norm_matrix_power}
     Apply Theorem~\ref{thm:wolf_upper_triangular_power_estimate} to the
-    $\ell^2$ operator norm and substitute the two bounds for the diagonal
-    part.
+    $\ell^2$ operator norm, use submultiplicativity to bound
+    $\lVert\Lambda^n\rVert_\infty\le\lVert\Lambda\rVert_\infty^n$, and
+    substitute the norm of the diagonal part.
 \end{proof}


### PR DESCRIPTION
Refs #300. Follow-up to #361.

Removes the redundant hypothesis `‖Λ^n‖∞ ≤ μ^n` from both Schur-form estimates. The bound now follows internally from submultiplicativity and `‖Λ‖∞ = μ`, including the `n = 0` case for nonempty matrices. This keeps the helper signatures closer to Wolf’s actual Schur data rather than exposing an extra proof premise.

The Blueprint is synchronized with the weaker statement and records the small operator-norm power lemma used by the proof. This remains a matrix-level cleanup and does not close #300.

Verification:
- `lake exe cache get`
- `lake build QICLean.Analysis.UpperTriangularBound -q --log-level=info`
- Blueprint sync scripts
- proof-integrity grep
- `git diff --check`