### PR TITLE
doc(channel): match Wolf peripheral-map notation

### DIFF
--- a/QICLean/Channel/Peripheral/CesaroRecurrence.lean
+++ b/QICLean/Channel/Peripheral/CesaroRecurrence.lean
@@ -52,7 +52,7 @@ finite dimension).
   `IsPositiveMap.peripheralProjection_isCPMap`: `T_φ` inherits positivity,
   trace preservation, and complete positivity.
 * `IsChannel.peripheralProjection`, `IsChannel.peripheralWeightedProjection`:
-  the channel properties of `T_φ` and `T_φ' = T T_φ` (Wolf Equation 6.13).
+  the channel properties of `T_φ` and `T_ϕ = T T_φ` (Wolf Equation 6.13).
 * `IsPositiveMap.peripheralProjection_comp_meanErgodicProjection`:
   the absorption identity `T_φ T_∞ = T_∞` (Wolf Equation 6.14 area).
 
@@ -446,8 +446,8 @@ theorem exists_strictMono_tendsto_pow_peripheralProjection_clm
     fun X ↦ hPos.tendsto_pow_apply_peripheralProjection hTP hnmono hn X,
     hPos.tendsto_endEquiv_pow_peripheralProjection hTP hnmono hn⟩
 
-/-- The phase-weighted peripheral projection `T_φ' = T ∘ T_φ` of a positive
-trace-preserving map is positive: the positive-only case for `T_φ'` of the
+/-- Wolf's phase-weighted peripheral map `T_ϕ = T ∘ T_φ` for a positive
+trace-preserving map is positive: the positive-only case for `T_ϕ` of the
 preservation assertion in the opening of Wolf, Proposition 6.3
 (`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--229; item
 (ii) itself states only the composition identity). Positive maps are closed
@@ -459,9 +459,9 @@ theorem peripheralWeightedProjection_isPositiveMap
   rw [Module.End.peripheralWeightedProjection, LinearMap.comp_apply]
   exact hPos _ ((hPos.peripheralProjection_isPositiveMap hTP) _ hX)
 
-/-- The phase-weighted peripheral projection `T_φ' = T ∘ T_φ` of a positive
+/-- Wolf's phase-weighted peripheral map `T_ϕ = T ∘ T_φ` for a positive
 trace-preserving map is trace-preserving: both factors preserve the trace.
-This is the positive-only case for `T_φ'` of the preservation assertion in
+This is the positive-only case for `T_ϕ` of the preservation assertion in
 Wolf, Proposition 6.3
 (`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--229). -/
 theorem peripheralWeightedProjection_isTracePreservingMap
@@ -497,8 +497,8 @@ theorem peripheralProjection (hT : IsChannel T) :
   cp := IsPositiveMap.peripheralProjection_isCPMap hT.cp hT.tp
   tp := IsPositiveMap.peripheralProjection_isTracePreservingMap hT.cp.isPositiveMap hT.tp
 
-/-- The phase-weighted peripheral projection `T_φ' = T ∘ T_φ` of a channel is
-again a channel.  This packages Wolf Equation (6.13). -/
+/-- Wolf's phase-weighted peripheral map `T_ϕ = T ∘ T_φ` for a channel is
+again a channel. This packages Wolf Equation (6.13). -/
 theorem peripheralWeightedProjection (hT : IsChannel T) :
     IsChannel T.peripheralWeightedProjection := by
   have hP := peripheralProjection hT

--- a/QICLean/Channel/Peripheral/SpectralProjection.lean
+++ b/QICLean/Channel/Peripheral/SpectralProjection.lean
@@ -18,8 +18,8 @@ remaining eigenvalues.  The two subspaces are complementary, so there is a
 linear projection onto the peripheral part: the **peripheral spectral
 projection** `T_φ` of Wolf Equation (6.12), i.e. `Σ_{k:|λₖ|=1} Pₖ` in the
 spectral decomposition of Wolf Equation (6.5).  Composing with `f` gives the
-phase-weighted map `T_φ' = f ∘ T_φ` of Wolf Equation (6.13),
-`Σ_{k:|λₖ|=1} λₖ Pₖ`; the identity `T_φ' = T T_φ` of Wolf Proposition 6.3(ii)
+phase-weighted map `T_ϕ = f ∘ T_φ` of Wolf Equation (6.13),
+`Σ_{k:|λₖ|=1} λₖ Pₖ`; the identity `T_ϕ = T T_φ` of Wolf Proposition 6.3(ii)
 holds by construction.
 
 For a positive trace-preserving map on matrices, Wolf Proposition 6.2 (trivial
@@ -37,14 +37,14 @@ Equation (6.65).
   complementarity of the two subspaces.
 * `Module.End.peripheralProjection`: the projection `T_φ` onto the peripheral
   subspace along the non-peripheral subspace (Wolf (6.12)).
-* `Module.End.peripheralWeightedProjection`: the map `T_φ' = T ∘ T_φ`
+* `Module.End.peripheralWeightedProjection`: the map `T_ϕ = T ∘ T_φ`
   (Wolf (6.13)).
 
 ## Main statements
 
 * `Module.End.peripheralProjection_comp`: `T_φ` commutes with `T`.
 * `Module.End.peripheralWeightedProjection_apply_of_mem_eigenspace`:
-  `T_φ'` acts as `μ • id` on the peripheral `μ`-eigenspace (Wolf (6.13)).
+  `T_ϕ` acts as `μ • id` on the peripheral `μ`-eigenspace (Wolf (6.13)).
 * `IsPositiveMap.maxGenEigenspace_eq_eigenspace_of_norm_eq_one`: Wolf
   Proposition 6.2, subspace form.
 * `IsPositiveMap.peripheralSubspace_eq_iSup_eigenspace`: Wolf Equation (6.65).
@@ -243,25 +243,25 @@ theorem commute_peripheralProjection (f : Module.End ℂ V) :
   simpa only [Commute, SemiconjBy, Module.End.mul_eq_comp]
     using f.peripheralProjection_comp
 
-/-! ### The phase-weighted peripheral spectral map `T_φ'` -/
+/-! ### The phase-weighted peripheral spectral map `T_ϕ` -/
 
-/-- The **phase-weighted peripheral spectral map** `T_φ' := T ∘ T_φ` of Wolf
+/-- The **phase-weighted peripheral spectral map** `T_ϕ := T ∘ T_φ` of Wolf
 Equation (6.13).  Since `T_φ` projects onto the peripheral spectral subspace,
 on each peripheral eigenspace of eigenvalue `λ` this map acts as `λ • id`,
 while it vanishes on the non-peripheral subspace; it is therefore
 `Σ_{k:|λₖ|=1} λₖ Pₖ` of the spectral decomposition.  The identity
-`T_φ' = T T_φ` of Wolf Proposition 6.3(ii) holds by construction.
+`T_ϕ = T T_φ` of Wolf Proposition 6.3(ii) holds by construction.
 
 Source: Wolf, Equation (6.13) and Proposition 6.3(ii); local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 213--256. -/
 noncomputable def peripheralWeightedProjection (f : Module.End ℂ V) : Module.End ℂ V :=
   f ∘ₗ f.peripheralProjection
 
-/-- **Wolf Proposition 6.3(ii)**: `T_φ' = T T_φ`. -/
+/-- **Wolf Proposition 6.3(ii)**: `T_ϕ = T T_φ`. -/
 theorem peripheralWeightedProjection_eq_comp (f : Module.End ℂ V) :
     f.peripheralWeightedProjection = f ∘ₗ f.peripheralProjection := rfl
 
-/-- The commuted form of Wolf Proposition 6.3(ii): `T_φ' = T_φ T`. -/
+/-- The commuted form of Wolf Proposition 6.3(ii): `T_ϕ = T_φ T`. -/
 theorem peripheralWeightedProjection_eq_peripheralProjection_comp (f : Module.End ℂ V) :
     f.peripheralWeightedProjection = f.peripheralProjection ∘ₗ f := by
   rw [peripheralWeightedProjection, ← f.peripheralProjection_comp]
@@ -282,7 +282,7 @@ theorem peripheralProjection_apply_of_mem_eigenspace (f : Module.End ℂ V) {μ 
     (Module.End.eigenspace_le_maxGenEigenspace hx)
 
 /-- **Wolf Equation (6.13)**: on the peripheral `μ`-eigenspace, the
-phase-weighted map `T_φ'` acts as `μ • id`. -/
+phase-weighted map `T_ϕ` acts as `μ • id`. -/
 theorem peripheralWeightedProjection_apply_of_mem_eigenspace (f : Module.End ℂ V) {μ : ℂ}
     (heig : f.HasEigenvalue μ) (hμ : ‖μ‖ = 1) {x : V} (hx : x ∈ f.eigenspace μ) :
     f.peripheralWeightedProjection x = μ • x := by

--- a/blueprint/src/chapter/ch07_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch07_qpf_cesaro_fixed_points.tex
@@ -241,7 +241,7 @@
     \uses{thm:peripheral_projection_recurrent_subsequence,
         def:peripheral_spectral_projections}
     The peripheral projection of a positive trace-preserving map is positive
-    and trace-preserving, and then the weighted projection $T_\varphi$ is
+    and trace-preserving, and then the phase-weighted map $T_\varphi$ is
     positive and trace-preserving as well. If the original map is completely
     positive, then $T_\phi$ and $T_\varphi$ are quantum channels. This
     is the preservation assertion in the opening clause of


### PR DESCRIPTION
Refs #301.

Follow-up to #362. The Blueprint now uses Wolf’s exact notation, but the underlying peripheral Lean API documentation still called the phase-weighted map T_φ prime and sometimes called it a projection. This documentation-only cleanup consistently uses T_φ for the peripheral projection and T_ϕ = T T_φ for Wolf’s phase-weighted asymptotic dynamics from Eqs. (6.12)–(6.13). Declaration names remain unchanged.

Validated with focused builds of the peripheral recurrence and asymptotic-state modules, the Lean module-policy tests, Blueprint/Lean synchronization, terminology scans, and git diff checks. This does not close #301.