### PR TITLE
feat(channel): formalize detailed-balance matrix steps

### DIFF
--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -20,6 +20,7 @@ import QICLean.Channel.ComplementaryWeylTwirl
 import QICLean.Channel.CompletelyPositiveBridge
 import QICLean.Channel.DecomposablePPT
 import QICLean.Channel.DensityRetract
+import QICLean.Channel.DetailedBalance
 import QICLean.Channel.Determinant
 import QICLean.Channel.Determinant.Basic
 import QICLean.Channel.Determinant.Bound

--- a/QICLean/Channel/DetailedBalance.lean
+++ b/QICLean/Channel/DetailedBalance.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Analysis.MatrixSqrt
+import QICLean.Channel.SelfDual
+
+/-!
+# Detailed balance and transfer matrices
+
+This file records the matrix identities at the start of Wolf's proof that
+detailed balance controls the Jordan condition number.
+
+## Main results
+
+* `transferMatrix_detailedBalance`: Eq. (8.110) becomes
+  `Σ̂ T̂ᴴ = T̂ Σ̂` in the transfer-matrix representation.
+* `transferMatrix_sigmaSandwich_eq_kronecker_and_posDef`: the matrix
+  representation of `X ↦ sqrt(sigma) X sqrt(sigma)` is the positive-definite
+  Kronecker product used by Wolf.
+* `Matrix.PosDef.inv_sqrt_mul_mul_sqrt_isHermitian_of_detailedBalance`: conjugating
+  by the positive square root in the detailed-balance identity gives a
+  Hermitian matrix.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8,
+  Proposition “Jordan condition number and detailed balance”][Wolf2012Quantum]
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder Kronecker
+
+variable {D : ℕ}
+
+/-- Wolf Eq. (8.110) in the transfer-matrix representation:
+`Σ ∘ T* = T ∘ Σ` implies `Σ̂ T̂† = T̂ Σ̂`.
+
+The Hermiticity-preserving hypothesis is exactly the hypothesis used to
+identify the transfer matrix of `T*` with `T̂†`.
+
+Source: Wolf (2012), Chapter 8, Eq. (8.110) and lines 1288--1290 of
+`Notes/WolfNoteTexSource/ch08_distance_measures.tex`. -/
+theorem transferMatrix_detailedBalance
+    (T Sigma : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hT : ∀ X, T Xᴴ = (T X)ᴴ)
+    (hdb : Sigma.comp (Matrix.traceAdjointMap T) = T.comp Sigma) :
+    transferMatrix Sigma * (transferMatrix T)ᴴ =
+      transferMatrix T * transferMatrix Sigma := by
+  rw [transferMatrix_conjTranspose_eq_traceAdjointMap T hT,
+    ← transferMatrix_comp, ← transferMatrix_comp, hdb]
+
+/-- For positive-definite `sigma`, the transfer matrix of
+`Sigma(X) = sqrt(sigma) X sqrt(sigma)` is
+`conj(sqrt(sigma)) ⊗ sqrt(sigma)` and is positive definite.
+
+This verifies the Kronecker/matrix-representation identity used in Wolf's
+specialization rather than treating it as definitional.
+
+Source: Wolf (2012), Chapter 8, proof of the proposition “Jordan condition
+number and detailed balance”, lines 1291--1292 of
+`Notes/WolfNoteTexSource/ch08_distance_measures.tex`. -/
+theorem transferMatrix_sigmaSandwich_eq_kronecker_and_posDef
+    (sigma : Matrix (Fin D) (Fin D) ℂ) (hsigma : sigma.PosDef) :
+    transferMatrix (unitaryConjLM (CFC.sqrt sigma)) =
+        (CFC.sqrt sigma).map (starRingEnd ℂ) ⊗ₖ CFC.sqrt sigma ∧
+      (transferMatrix (unitaryConjLM (CFC.sqrt sigma))).PosDef := by
+  let R := CFC.sqrt sigma
+  have hRpsd : R.PosSemidef := by
+    simpa [R] using Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg sigma)
+  have hRdet : IsUnit R.det := by
+    simpa [R] using hsigma.isUnit_det_cfc_sqrt
+  have hRpd : R.PosDef :=
+    hRpsd.posDef_iff_isUnit.mpr ((Matrix.isUnit_iff_isUnit_det R).2 hRdet)
+  have hRmap : R.map (starRingEnd ℂ) = R.transpose := by
+    ext i j
+    have hij := congr_fun (congr_fun (Matrix.conjTranspose_cfc_sqrt sigma) j) i
+    simpa [R, Matrix.conjTranspose_apply] using hij
+  have hrep := transferMatrix_unitaryConj R
+  refine ⟨by simpa [R] using hrep, ?_⟩
+  rw [hrep, hRmap]
+  exact hRpd.transpose.kronecker hRpd
+
+/-- Wolf's fixed-point observation in the `Sigma(X) = sqrt(sigma) X sqrt(sigma)`
+specialization.  Detailed balance and `T*(1) = 1` imply `T(sigma) = sigma`.
+
+Source: Wolf (2012), Chapter 8, proposition “Jordan condition number and
+detailed balance”, lines 1283--1285 of
+`Notes/WolfNoteTexSource/ch08_distance_measures.tex`. -/
+theorem fixedPoint_of_detailedBalance_sigmaSandwich
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (sigma : Matrix (Fin D) (Fin D) ℂ) (hsigma : sigma.PosDef)
+    (hTstar : Matrix.traceAdjointMap T 1 = 1)
+    (hdb :
+      (unitaryConjLM (CFC.sqrt sigma)).comp (Matrix.traceAdjointMap T) =
+        T.comp (unitaryConjLM (CFC.sqrt sigma))) :
+    T sigma = sigma := by
+  have hsqrt : CFC.sqrt sigma * CFC.sqrt sigma = sigma :=
+    CFC.sqrt_mul_sqrt_self sigma
+  calc
+    T sigma = T (CFC.sqrt sigma * CFC.sqrt sigma) := by rw [hsqrt]
+    _ = T (unitaryConjLM (CFC.sqrt sigma) 1) := by
+      rw [unitaryConjLM_apply, Matrix.mul_one, Matrix.conjTranspose_cfc_sqrt]
+    _ = unitaryConjLM (CFC.sqrt sigma) (Matrix.traceAdjointMap T 1) := by
+      exact (LinearMap.congr_fun hdb 1).symm
+    _ = unitaryConjLM (CFC.sqrt sigma) 1 := by rw [hTstar]
+    _ = CFC.sqrt sigma * CFC.sqrt sigma := by
+      rw [unitaryConjLM_apply, Matrix.mul_one, Matrix.conjTranspose_cfc_sqrt]
+    _ = sigma := hsqrt
+
+namespace Matrix
+
+/-- The square-root similarity in Wolf's detailed-balance argument is
+Hermitian.  If `S > 0` and `S A† = A S`, then
+`S⁻¹/² A S¹/²` is Hermitian.
+
+Source: Wolf (2012), Chapter 8, proof of the proposition “Jordan condition
+number and detailed balance”, lines 1288--1291 of
+`Notes/WolfNoteTexSource/ch08_distance_measures.tex`. -/
+theorem PosDef.inv_sqrt_mul_mul_sqrt_isHermitian_of_detailedBalance
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {S A : Matrix n n ℂ} (hS : S.PosDef) (hdb : S * Aᴴ = A * S) :
+    ((CFC.sqrt S)⁻¹ * A * CFC.sqrt S).IsHermitian := by
+  let R := CFC.sqrt S
+  have hRstar : Rᴴ = R := by
+    simpa [R] using Matrix.conjTranspose_cfc_sqrt S
+  have hRdet : IsUnit R.det := by
+    simpa [R] using hS.isUnit_det_cfc_sqrt
+  have hRinvstar : (R⁻¹)ᴴ = R⁻¹ := by
+    rw [Matrix.conjTranspose_nonsing_inv, hRstar]
+  have hRinv_mul : R⁻¹ * R = 1 := Matrix.nonsing_inv_mul R hRdet
+  have hRmul_inv : R * R⁻¹ = 1 := Matrix.mul_nonsing_inv R hRdet
+  have hRR : R * R = S := by
+    simpa [R] using CFC.sqrt_mul_sqrt_self S
+  have hcore : R * Aᴴ * R⁻¹ = R⁻¹ * A * R := by
+    calc
+      R * Aᴴ * R⁻¹ = R⁻¹ * (R * R) * Aᴴ * R⁻¹ := by
+        rw [← Matrix.mul_assoc, hRinv_mul, Matrix.one_mul]
+      _ = R⁻¹ * S * Aᴴ * R⁻¹ := by rw [hRR]
+      _ = R⁻¹ * (S * Aᴴ) * R⁻¹ := by simp only [Matrix.mul_assoc]
+      _ = R⁻¹ * (A * S) * R⁻¹ := by rw [hdb]
+      _ = R⁻¹ * A * S * R⁻¹ := by simp only [Matrix.mul_assoc]
+      _ = R⁻¹ * A * R := by
+        rw [← hRR]
+        simp only [Matrix.mul_assoc, hRmul_inv, Matrix.mul_one]
+  change ((R⁻¹ * A * R)ᴴ = R⁻¹ * A * R)
+  rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul, hRstar, hRinvstar]
+  simpa only [Matrix.mul_assoc] using hcore
+
+end Matrix

--- a/blueprint/src/chapter/ch09_channel_asymptotics.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics.tex
@@ -16,6 +16,7 @@ dynamics into cyclic decompositions.
 
 \input{chapter/ch09_channel_asymptotics_jordan_block_power}
 \input{chapter/ch09_channel_asymptotics_upper_triangular_power}
+\input{chapter/ch09_channel_asymptotics_detailed_balance}
 \input{chapter/ch09_channel_asymptotics_mean_ergodic}
 \input{chapter/ch09_channel_asymptotics_fixed_point_algebras}
 \input{chapter/ch09_channel_asymptotics_fixed_points_and_wedderburn_i}

--- a/blueprint/src/chapter/ch09_channel_asymptotics_detailed_balance.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_detailed_balance.tex
@@ -1,0 +1,83 @@
+% Source: Wolf (2012), Chapter 8, Equation (8.110), lines 1274--1293
+
+\begin{theorem}[Detailed balance in the matrix representation]
+    \label{thm:detailed_balance_transfer_matrix}
+    \lean{transferMatrix_detailedBalance}
+    \leanok
+    This is the matrix-representation step in the proof of
+    \cite[Chapter~8, Equation~(8.110)]{Wolf2012Quantum}.
+    Let $T:M_d(\mathbb C)\to M_d(\mathbb C)$ be Hermiticity preserving and
+    let $\Sigma:M_d(\mathbb C)\to M_d(\mathbb C)$ be linear.  If
+    $\Sigma T^*=T\Sigma$, then
+    \begin{align}
+        \widehat\Sigma\,\widehat T^\dagger
+          =\widehat T\,\widehat\Sigma.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Composition becomes matrix multiplication under the transfer-matrix
+    representation.  Hermiticity preservation identifies the transfer matrix
+    of $T^*$ with $\widehat T^\dagger$, so applying the representation to both
+    sides of $\Sigma T^*=T\Sigma$ gives the displayed identity.
+\end{proof}
+
+\begin{theorem}[Matrix representation of the square-root sandwich]
+    \label{thm:sigma_sandwich_transfer_matrix}
+    \lean{transferMatrix_sigmaSandwich_eq_kronecker_and_posDef}
+    \leanok
+    This is the Kronecker identity used in the specialization of
+    \cite[Chapter~8, Proposition ``Jordan condition number and detailed balance'']{Wolf2012Quantum}.
+    If $\sigma>0$ and
+    $\Sigma(X)=\sqrt\sigma\,X\sqrt\sigma$, then
+    \begin{align}
+        \widehat\Sigma
+          =\overline{\sqrt\sigma}\otimes\sqrt\sigma>0.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Vectorizing conjugation by $\sqrt\sigma$ gives the displayed Kronecker
+    product.  The square root is positive definite, and its entrywise
+    conjugate is its transpose because it is Hermitian.  Transposition and
+    Kronecker products preserve positive definiteness.
+\end{proof}
+
+\begin{theorem}[Hermitian representative from detailed balance]
+    \label{thm:detailed_balance_hermitian_representative}
+    \lean{Matrix.PosDef.inv_sqrt_mul_mul_sqrt_isHermitian_of_detailedBalance}
+    \leanok
+    This is the square-root conjugation in the proof of
+    \cite[Chapter~8, Proposition ``Jordan condition number and detailed balance'']{Wolf2012Quantum}.
+    Let $S,A\in M_n(\mathbb C)$, with $S>0$.  If
+    $SA^\dagger=AS$, then
+    $S^{-1/2}AS^{1/2}$ is Hermitian.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Put $R=S^{1/2}$.  Positive definiteness makes $R$ invertible and
+    Hermitian.  Multiplying $R^2A^\dagger=AR^2$ on the left and right by
+    $R^{-1}$ gives
+    $RA^\dagger R^{-1}=R^{-1}AR$, which says exactly that
+    $R^{-1}AR$ is Hermitian.
+\end{proof}
+
+\begin{theorem}[Fixed point from the detailed-balance sandwich]
+    \label{thm:detailed_balance_sigma_fixed_point}
+    \lean{fixedPoint_of_detailedBalance_sigmaSandwich}
+    \leanok
+    This is the fixed-point observation in
+    \cite[Chapter~8, Proposition ``Jordan condition number and detailed balance'']{Wolf2012Quantum}.
+    Let $\sigma>0$ and set
+    $\Sigma(X)=\sqrt\sigma\,X\sqrt\sigma$.  If
+    $\Sigma T^*=T\Sigma$ and $T^*(\Id)=\Id$, then $T(\sigma)=\sigma$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Evaluate detailed balance at the identity:
+    $T(\sigma)=T(\Sigma(\Id))=\Sigma(T^*(\Id))=\Sigma(\Id)=\sigma$.
+\end{proof}


### PR DESCRIPTION
## Summary

- transport Wolf Eq. (8.110) from linear maps to the matrix identity `SigmaHat THat* = THat SigmaHat` under the exact Hermiticity-preserving hypothesis
- prove that positive-definite detailed balance makes `S^(-1/2) A S^(1/2)` Hermitian
- verify the square-root sandwich representation `SigmaHat = conjugate(sqrt(sigma)) tensor sqrt(sigma)` and its positive definiteness
- prove Wolf's fixed-point observation from detailed balance and `T*(1) = 1`
- synchronize only these proved declarations with the Chapter 8 Blueprint

## Source boundary

This follows `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1274--1293, in the source order: matrix representation, positive square-root conjugation, and the `Sigma(X) = sqrt(sigma) X sqrt(sigma)` specialization.

This is intentionally a non-closing advance toward #298. Current `main` has no source-shaped Jordan condition number `kappa_T` or API for the infimum over all similarities bringing the transfer matrix to Jordan normal form. That definition is also required by #297. This PR does not invent a parallel chosen diagonalization, add a condition-number hypothesis, or mark Wolf's final inequality as proved.

## Validation

- `lake build` (9234 targets at PR head `a3afcb6` after the requested rebase onto `cc5187a`)
- `lake build QICLean.Channel.DetailedBalance`
- `lake exe lint_style`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `texra-blueprint web`
- proof-integrity scan of the new Lean file: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`

Refs #298
Dependency for #297
