### PR TITLE
doc(blueprint): restore rectangular Wolf Schwarz theorem

### DIFF
--- a/blueprint/src/chapter/ch04_positive_not_cp_two_positive_schmidt_and_choi.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_two_positive_schmidt_and_choi.tex
@@ -12,8 +12,11 @@ rank-$k$ projection forms of the same condition.
 \begin{definition}[$k$-positive map]\label{def:k_positive_map}
     \lean{IsNPositiveMap}
     \leanok
-    A linear map $E : \MN{D} \to \MN{D}$ is $k$-positive if
-    $E \otimes \id_{k}$ is positive on $\MN{D} \otimes \MN{k}$.
+    A linear map
+    $E : \MN{D_{\rm in}} \to \MN{D_{\rm out}}$ is $k$-positive if
+    $E \otimes \id_{k}$ is positive from
+    $\MN{D_{\rm in}} \otimes \MN{k}$ to
+    $\MN{D_{\rm out}} \otimes \MN{k}$.
 \end{definition}
 
 \begin{definition}[Two-positive map]
@@ -88,11 +91,13 @@ rank-$k$ projection forms of the same condition.
 \begin{definition}[Blockwise ampliation]\label{def:blockwise_ampliation}
     \lean{nPositiveAmpliation}
     \leanok
-    For a linear map $E : \MN{D}\to\MN{D}$, its $k$-fold ampliation acts on
-    block matrices by
+    For a linear map
+    $E : \MN{D_{\rm in}}\to\MN{D_{\rm out}}$, its $k$-fold ampliation acts
+    between the corresponding block-matrix algebras by
     \begin{align}
         E^{(k)}(X)_{(i,p),(j,q)}
-         & =E((X_{(a,p),(b,q)})_{a,b})_{i,j}.
+         & =E((X_{(a,p),(b,q)})_{a,b})_{i,j},
+         \qquad i,j<D_{\rm out},\quad a,b<D_{\rm in}.
         \label{eq:schwarz_blockwise_ampliation}
     \end{align}
 \end{definition}

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order.tex
@@ -394,8 +394,9 @@ positivity.
     \lean{SchwarzTwoVariable.schwarz_two_variable}
     \leanok
     \uses{def:2positive_map}
-    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map.
-    For every $A,B\in\MN{D}$ and all vectors $v,w$ such that
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a $2$-positive
+    complex-linear map. For every $A,B\in\MN{D_{\rm in}}$ and all
+    $v,w\in\mathbb C^{D_{\rm out}}$ such that
     $E(B^\dagger B)\,w = E(B^\dagger A)\,v$, we have
     \begin{align}
         v^\dagger\,E(A^\dagger A)\,v
@@ -430,8 +431,8 @@ positivity.
     \lean{SchwarzTwoVariable.map_EBA_eq_conjTranspose_EAB}
     \leanok
     \uses{def:2positive_map}
-    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
-    $A,B\in\MN{D}$,
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a $2$-positive
+    complex-linear map. For every $A,B\in\MN{D_{\rm in}}$,
     \begin{align}
         E(B^\dagger A) & = E(A^\dagger B)^\dagger.
         \notag
@@ -449,8 +450,10 @@ positivity.
     \lean{SchwarzTwoVariable.ker_EBB_le_ker_EAB}
     \leanok
     \uses{def:2positive_map, thm:map_EBA_eq_conjTranspose_EAB}
-    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
-    $A,B\in\MN{D}$, $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$.
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a $2$-positive
+    complex-linear map. For every $A,B\in\MN{D_{\rm in}}$,
+    $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$ as subspaces of
+    $\mathbb C^{D_{\rm out}}$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -471,8 +474,8 @@ positivity.
     \lean{SchwarzTwoVariable.EBB_mul_pinv_mul_EBA_eq}
     \leanok
     \uses{def:2positive_map, def:pinv, thm:ker_EBB_le_ker_EAB}
-    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
-    $A,B\in\MN{D}$,
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a $2$-positive
+    complex-linear map. For every $A,B\in\MN{D_{\rm in}}$,
     \begin{align}
         E(B^\dagger B)\bigl(E(B^\dagger B)^{+}E(B^\dagger A)\bigr)
          & = E(B^\dagger A).
@@ -488,21 +491,20 @@ positivity.
     support projection, the displayed identity follows.
 \end{proof}
 
-\begin{theorem}[Two-variable operator Schwarz inequality]
+\begin{theorem}[Rectangular two-variable operator Schwarz inequality]
     \label{thm:two_variable_operator_schwarz}
     \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional}
     \leanok
     \uses{def:2positive_map, def:pinv}
-    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
-    $A,B\in\MN{D}$,
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a $2$-positive
+    complex-linear map. For every $A,B\in\MN{D_{\rm in}}$,
     \begin{align}
         E(A^\dagger B)\,E(B^\dagger B)^{+}\,E(B^\dagger A)
          & \le E(A^\dagger A),
         \notag
     \end{align}
     where $(\cdot)^+$ is the Moore--Penrose pseudoinverse, i.e.\ the
-    inverse taken on the range. This is \cite[Eq.~(5.4)]{Wolf2012Quantum},
-    unconditional: no vector is assumed to exist.
+    inverse taken on the range. No vector witness is assumed to exist.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -520,6 +522,32 @@ positivity.
     right-inverse witness for $E(B^\dagger A)$ on the support of
     $E(B^\dagger B)$. Applying the conditional lemma with this $w$ for
     every $v$ gives the displayed matrix inequality.
+\end{proof}
+
+\begin{theorem}[Wolf's operator Schwarz inequality]
+    \label{thm:wolf_two_variable_operator_schwarz}
+    \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional_of_traceAdjointMap}
+    \leanok
+    \uses{thm:two_variable_operator_schwarz,
+        thm:k_positive_trace_pairing_adjoint}
+    Let $E=T^*:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a positive
+    complex-linear map. If
+    $T:\MN{D_{\rm out}}\to\MN{D_{\rm in}}$ is $2$-positive, then for all
+    $A,B\in\MN{D_{\rm in}}$,
+    \begin{align}
+        E(A^\dagger B)\,E(B^\dagger B)^{+}\,E(B^\dagger A)
+         & \le E(A^\dagger A).
+        \notag
+    \end{align}
+    This is exactly \cite[Theorem~5.3 and Eq.~(5.4)]{Wolf2012Quantum}, with
+    the inverse taken on the range.
+\end{theorem}
+
+\begin{proof}\leanok
+    By trace-adjoint invariance of $2$-positivity,
+    Theorem~\ref{thm:k_positive_trace_pairing_adjoint}, the map $E=T^*$ is
+    itself $2$-positive. Apply
+    Theorem~\ref{thm:two_variable_operator_schwarz}.
 \end{proof}
 
 \begin{definition}[Per-$B$ Schwarz hypothesis]\label{def:has_schwarz_inequality_for}


### PR DESCRIPTION
## Summary
- state k-positivity and its blockwise ampliation with independent input/output dimensions
- propagate those dimensions through the conditional, adjoint, kernel, pseudoinverse, and direct Schwarz nodes
- separate the rectangular supporting theorem from Wolf Theorem 5.3 in its exact trace-adjoint form and source factor order

## Source
Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 5, Theorem 5.3 and Eq. (5.4), `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 180–190.

## Validation
- `lake build QICLean.Channel.Schwarz.TwoVariableUnconditional` (3063/3063)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `chktex` on both changed files
- `latexindent -k -s -l blueprint/latexindent.yaml` on both changed files
- `git diff --check`

Closes #358