### PR TITLE
feat(analysis): define Wolf subperipheral modulus

### DIFF
--- a/QICLean/Analysis.lean
+++ b/QICLean/Analysis.lean
@@ -33,6 +33,7 @@ import QICLean.Analysis.IdempotentEndomorphism
 import QICLean.Analysis.InjectiveRangeProjector
 import QICLean.Analysis.IsometricCompression
 import QICLean.Analysis.JordanBlockPower
+import QICLean.Analysis.JordanSimilarity
 import QICLean.Analysis.KleinInequality
 import QICLean.Analysis.KyFanNorm
 import QICLean.Analysis.LiebConcavity
@@ -67,6 +68,7 @@ import QICLean.Analysis.SchattenNorm
 import QICLean.Analysis.SpectralQuadraticForm
 import QICLean.Analysis.SpectralRadius
 import QICLean.Analysis.SpectralRadiusPowerDecay
+import QICLean.Analysis.SubperipheralSpectrum
 import QICLean.Analysis.SuperoperatorResolvent
 import QICLean.Analysis.SupportCompressedEntropy
 import QICLean.Analysis.SupportCompression

--- a/QICLean/Analysis/JordanSimilarity.lean
+++ b/QICLean/Analysis/JordanSimilarity.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 Sirui Lu and QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import QICLean.Analysis.JordanBlockPower
+import Mathlib.Tactic.NoncommRing
+
+/-!
+# Operator-norm comparison under similarity
+
+This file formalizes the basis-level comparison used in Wolf's Equation
+(8.108).  It deliberately keeps a chosen invertible similarity `A, B`
+explicit.  Wolf defines the Jordan condition number `κ_T` as an infimum over
+all Jordan bases; replacing the displayed factor below by that infimum requires
+an attainment theorem or a separate limiting argument.
+
+Source: Wolf (2012), Chapter 8, Equation (8.108), local source
+`Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1247--1254.
+-/
+
+open scoped Matrix.Norms.L2Operator
+
+namespace Matrix
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι] [Nonempty ι]
+
+/-- Equation (8.108) for one chosen similarity `X = A J A⁻¹`, with the
+inverse supplied as `B`.
+
+No Jordan-normal-form existence or minimization of the condition factor is
+assumed here. -/
+theorem l2_opNorm_pow_similarity_bounds
+    (A B J X : Matrix ι ι ℂ)
+    (hAB : A * B = 1) (hBA : B * A = 1) (hX : X = A * J * B) (n : ℕ) :
+    (‖A‖ * ‖B‖)⁻¹ * ‖J ^ n‖ ≤ ‖X ^ n‖ ∧
+      ‖X ^ n‖ ≤ (‖A‖ * ‖B‖) * ‖J ^ n‖ := by
+  have hcond : 0 < ‖A‖ * ‖B‖ := by
+    have hone : (1 : ℝ) ≤ ‖A‖ * ‖B‖ := by
+      calc
+        1 = ‖(1 : Matrix ι ι ℂ)‖ := by simp
+        _ = ‖A * B‖ := by rw [hAB]
+        _ ≤ ‖A‖ * ‖B‖ := l2_opNorm_mul A B
+    positivity
+  have hpow : X ^ n = A * J ^ n * B := by
+    induction n with
+    | zero => simpa only [pow_zero, Matrix.mul_one] using hAB.symm
+    | succ n ih =>
+        rw [pow_succ, ih, hX, pow_succ]
+        calc
+          A * J ^ n * B * (A * J * B) = A * J ^ n * (B * A) * J * B := by
+            simp only [Matrix.mul_assoc]
+          _ = A * (J ^ n * J) * B := by
+            rw [hBA]
+            simp only [Matrix.mul_one, Matrix.mul_assoc]
+  have hpow' : J ^ n = B * X ^ n * A := by
+    rw [hpow]
+    symm
+    calc
+      B * (A * J ^ n * B) * A = (B * A) * J ^ n * (B * A) := by
+        simp only [Matrix.mul_assoc]
+      _ = J ^ n := by rw [hBA, Matrix.one_mul, Matrix.mul_one]
+  constructor
+  · have hle : ‖J ^ n‖ ≤ (‖A‖ * ‖B‖) * ‖X ^ n‖ := by
+      calc
+        ‖J ^ n‖ = ‖B * X ^ n * A‖ := by rw [hpow']
+        _ ≤ ‖B * X ^ n‖ * ‖A‖ := l2_opNorm_mul _ _
+        _ ≤ (‖B‖ * ‖X ^ n‖) * ‖A‖ := by
+          gcongr
+          exact l2_opNorm_mul _ _
+        _ = (‖A‖ * ‖B‖) * ‖X ^ n‖ := by ring
+    exact (inv_mul_le_iff₀ hcond).2 hle
+  · rw [hpow]
+    calc
+      ‖A * J ^ n * B‖ ≤ ‖A * J ^ n‖ * ‖B‖ := l2_opNorm_mul _ _
+      _ ≤ (‖A‖ * ‖J ^ n‖) * ‖B‖ := by
+        gcongr
+        exact l2_opNorm_mul _ _
+      _ = (‖A‖ * ‖B‖) * ‖J ^ n‖ := by ring
+
+end Matrix

--- a/QICLean/Analysis/SubperipheralSpectrum.lean
+++ b/QICLean/Analysis/SubperipheralSpectrum.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 Sirui Lu and QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import Mathlib.Analysis.Complex.Norm
+import Mathlib.LinearAlgebra.Eigenspace.Minpoly
+import Mathlib.Order.ConditionallyCompleteLattice.Finset
+
+/-!
+# Wolf's subperipheral spectral modulus
+
+For a finite-dimensional complex endomorphism `T`, Wolf denotes by `μ` the
+largest modulus of an eigenvalue in the open unit disc.  This file gives that
+quantity one shared definition.  It uses `Module.End.HasEigenvalue`, which is
+equivalent to membership in the spectrum in finite dimension.
+
+The empty case is totalized by `μ = 0`.  When the subperipheral spectrum is
+nonempty, finiteness shows that the supremum is attained and is strictly less
+than one.  Notice that `μ = 0` does *not* imply that this spectrum is empty:
+it may consist only of the zero eigenvalue.
+
+Source: Wolf (2012), Chapter 8, Theorem "Asymptotic convergence I",
+local source `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines
+1225--1228.
+-/
+
+noncomputable section
+
+namespace Module.End
+
+variable {V : Type*} [AddCommGroup V] [Module ℂ V]
+
+/-- Wolf's **subperipheral spectrum**: eigenvalues in the open unit disc. -/
+def subperipheralSpectrum (T : Module.End ℂ V) : Set ℂ :=
+  {z | T.HasEigenvalue z ∧ ‖z‖ < 1}
+
+/-- Wolf's `μ`: the largest modulus of a subperipheral eigenvalue.
+
+The supremum is `0` when the subperipheral spectrum is empty. -/
+def subperipheralModulus (T : Module.End ℂ V) : ℝ :=
+  sSup ((fun z : ℂ ↦ ‖z‖) '' T.subperipheralSpectrum)
+
+/-- The convention for an empty subperipheral spectrum is `μ = 0`. -/
+theorem subperipheralModulus_eq_zero_of_empty (T : Module.End ℂ V)
+    (hT : T.subperipheralSpectrum = ∅) : T.subperipheralModulus = 0 := by
+  simp [subperipheralModulus, hT]
+
+variable [FiniteDimensional ℂ V]
+
+/-- The subperipheral spectrum of a finite-dimensional endomorphism is finite. -/
+theorem subperipheralSpectrum_finite (T : Module.End ℂ V) :
+    T.subperipheralSpectrum.Finite := by
+  apply T.finite_hasEigenvalue.subset
+  intro z hz
+  exact hz.1
+
+/-- Spectral form of Wolf's definition in finite dimension. -/
+theorem mem_subperipheralSpectrum_iff_mem_spectrum (T : Module.End ℂ V) {z : ℂ} :
+    z ∈ T.subperipheralSpectrum ↔ z ∈ spectrum ℂ T ∧ ‖z‖ < 1 := by
+  simp only [subperipheralSpectrum, Set.mem_ofPred_eq,
+    Module.End.hasEigenvalue_iff_mem_spectrum]
+
+/-- When the subperipheral spectrum is nonempty, some eigenvalue realizes
+Wolf's largest modulus `μ`. -/
+theorem exists_norm_eq_subperipheralModulus (T : Module.End ℂ V)
+    (hT : T.subperipheralSpectrum.Nonempty) :
+    ∃ z ∈ T.subperipheralSpectrum, ‖z‖ = T.subperipheralModulus := by
+  have hfinite : ((fun z : ℂ ↦ ‖z‖) '' T.subperipheralSpectrum).Finite :=
+    T.subperipheralSpectrum_finite.image _
+  have hnonempty : ((fun z : ℂ ↦ ‖z‖) '' T.subperipheralSpectrum).Nonempty :=
+    hT.image _
+  have hmem := hnonempty.csSup_mem hfinite
+  rcases hmem with ⟨z, hz, hnorm⟩
+  exact ⟨z, hz, hnorm⟩
+
+/-- Every subperipheral eigenvalue has modulus at most Wolf's `μ`. -/
+theorem norm_le_subperipheralModulus (T : Module.End ℂ V) {z : ℂ}
+    (hz : z ∈ T.subperipheralSpectrum) : ‖z‖ ≤ T.subperipheralModulus := by
+  apply le_csSup
+  · exact (T.subperipheralSpectrum_finite.image _).bddAbove
+  · exact ⟨z, hz, rfl⟩
+
+/-- Wolf's `μ` is nonnegative, including under the empty-set convention. -/
+theorem subperipheralModulus_nonneg (T : Module.End ℂ V) :
+    0 ≤ T.subperipheralModulus := by
+  by_cases hT : T.subperipheralSpectrum.Nonempty
+  · obtain ⟨z, hz, hnorm⟩ := T.exists_norm_eq_subperipheralModulus hT
+    rw [← hnorm]
+    exact norm_nonneg z
+  · rw [T.subperipheralModulus_eq_zero_of_empty (Set.not_nonempty_iff_eq_empty.mp hT)]
+
+/-- If there is a subperipheral eigenvalue, Wolf's `μ` remains strictly
+inside the unit disc. -/
+theorem subperipheralModulus_lt_one (T : Module.End ℂ V)
+    (hT : T.subperipheralSpectrum.Nonempty) : T.subperipheralModulus < 1 := by
+  rw [subperipheralModulus,
+    (T.subperipheralSpectrum_finite.image _).csSup_lt_iff (hT.image _)]
+  intro r hr
+  rcases hr with ⟨z, hz, rfl⟩
+  exact hz.2
+
+/-- Exact qualification of the `μ = 0` case: the subperipheral spectrum is
+empty or contains only the zero eigenvalue. -/
+theorem subperipheralModulus_eq_zero_iff (T : Module.End ℂ V) :
+    T.subperipheralModulus = 0 ↔ ∀ z ∈ T.subperipheralSpectrum, z = 0 := by
+  constructor
+  · intro hμ z hz
+    have hle := T.norm_le_subperipheralModulus hz
+    rw [hμ] at hle
+    exact norm_eq_zero.mp (le_antisymm hle (norm_nonneg z))
+  · intro hzero
+    by_cases hT : T.subperipheralSpectrum.Nonempty
+    · obtain ⟨z, hz, hnorm⟩ := T.exists_norm_eq_subperipheralModulus hT
+      rw [← hnorm, hzero z hz, norm_zero]
+    · exact T.subperipheralModulus_eq_zero_of_empty
+        (Set.not_nonempty_iff_eq_empty.mp hT)
+
+end Module.End

--- a/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
@@ -1,5 +1,58 @@
 % Source: Wolf (2012), Chapter 8, upper-triangular power lemma
 
+\begin{definition}[Largest subperipheral modulus]
+    \label{def:wolf_subperipheral_modulus}
+    \lean{Module.End.subperipheralSpectrum,
+      Module.End.subperipheralModulus}
+    \leanok
+    For a finite-dimensional complex endomorphism $T$, let
+    \begin{align}
+      \operatorname{spec}_{<1}(T)
+        &=\{\lambda:\lambda\text{ is an eigenvalue of }T,
+             \ |\lambda|<1\},\\
+      \mu(T)&=\sup\{|\lambda|:\lambda\in
+             \operatorname{spec}_{<1}(T)\}.
+    \end{align}
+    We use the explicit convention $\mu(T)=0$ when the displayed spectrum is
+    empty.  If it is nonempty, the spectrum is finite, so the supremum is an
+    attained maximum and $\mu(T)<1$.
+\end{definition}
+
+\begin{proof}
+    \leanok
+    Finite dimensionality makes the eigenvalue set finite.  Its subset in the
+    open unit disc is finite as well, so a nonempty image under the modulus has
+    a greatest element.  If the set is empty, the real supremum convention is
+    zero.  See the separate qualification for the case where zero is the only
+    subperipheral eigenvalue.
+\end{proof}
+
+\begin{lemma}[Similarity comparison for powers]
+    \label{lem:wolf_jordan_similarity_comparison}
+    \lean{Matrix.l2_opNorm_pow_similarity_bounds}
+    \leanok
+    If $AB=BA=I$ and $X=AJB$, then for every $n\in\mathbb N$,
+    \begin{align}
+      (\lVert A\rVert_\infty\lVert B\rVert_\infty)^{-1}
+        \lVert J^n\rVert_\infty
+      \le \lVert X^n\rVert_\infty
+      \le \lVert A\rVert_\infty\lVert B\rVert_\infty
+        \lVert J^n\rVert_\infty.
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    First prove $X^n=AJ^nB$ and $J^n=BX^nA$ from the two inverse identities.
+    Apply submultiplicativity to both equalities.  The factor
+    $\lVert A\rVert_\infty\lVert B\rVert_\infty$ is positive because it is at
+    least the norm of $AB=I$.
+
+% This is Equation (8.108) for a chosen basis.  Replacing the condition factor
+% by Wolf's infimum \kappa_T requires attainment or a compatible limiting
+% argument; the full Jordan-scaling theorem is therefore not marked \leanok.
+\end{proof}
+
 \begin{theorem}[Noncommutative upper-triangular word bound]
     \label{thm:wolf_upper_triangular_word_bound}
     \lean{Matrix.wolf_eq_105_seminorm}

--- a/docs/paper-gaps/wolf_thm823_jordan_scaling_qualifications.tex
+++ b/docs/paper-gaps/wolf_thm823_jordan_scaling_qualifications.tex
@@ -1,0 +1,102 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Wolf Theorem ``Asymptotic Convergence I'' --- Jordan-Scaling Qualifications}
+\author{}
+\date{2026-08-23}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{The source statement}
+
+Wolf defines $\mu$ as the largest modulus of an eigenvalue of $T$ in the open
+unit disc and $d_\mu$ as the largest dimension of a corresponding Jordan
+block~\cite[Chapter~8, lines~1221--1272]{Wolf2012Quantum}.  Theorem
+``Asymptotic convergence I'' then compares
+\begin{equation}
+  \lVert\widehat T^n-\widehat T_\varphi^n\rVert_\infty
+  \quad\text{with}\quad
+  \mu^n n^{d_\mu-1}.
+\end{equation}
+The local source is
+\path{Notes/WolfNoteTexSource/ch08_distance_measures.tex}, lines~1221--1272,
+especially Equations~(8.106)--(8.109).
+
+\section{Empty and zero subperipheral spectrum}
+
+If there is no eigenvalue in the open unit disc, neither the printed largest
+modulus nor $d_\mu$ is defined.  The formal definition
+\leanid{Module.End.subperipheralModulus} totalizes only the first datum by
+setting $\mu=0$.  On a nonempty subperipheral spectrum, finiteness proves that
+this supremum is an attained maximum strictly below one; see
+\leanid{Module.End.exists_norm_eq_subperipheralModulus} and
+\leanid{Module.End.subperipheralModulus_lt_one} in
+\doclink{QICLean/Analysis/SubperipheralSpectrum.lean}.
+
+The equality $\mu=0$ still does not imply emptiness: it means exactly that
+every subperipheral eigenvalue is zero.  A zero-eigenvalue Jordan block of
+dimension $D>1$ is nilpotent but its positive powers need not vanish for
+$1\le n<D$.  Consequently an upper bound by
+$C_2\mu^n n^{d_\mu-1}=0$ cannot hold in that range.  A qualified zero-modulus
+statement must either start at the nilpotence index or treat the finite initial
+range separately without the printed factor.  The zeroth power also requires
+an explicit convention for $0^0$ and does not belong to the positive-power
+argument at source lines~1247--1266.
+
+\section{The block-diagonal comparison}
+
+At source line~1261 the notes print
+\begin{equation}
+  \lVert J^n\rVert_\infty\le \lVert X^n\rVert_\infty,
+\end{equation}
+where $X$ is one block of the block-diagonal matrix $J$.  In the Hilbert-space
+operator norm the inequality for an arbitrary chosen block has the opposite
+direction.  The intended eventual-dominance argument must prove that a block
+of largest subperipheral modulus and, among ties, largest dimension realizes
+the maximum of all block norms.  Only then does one obtain the required
+eventual equality $\lVert J^n\rVert_\infty=\lVert X^n\rVert_\infty$.
+
+\section{The Jordan condition infimum}
+
+For a chosen similarity $X=AJA^{-1}$, submultiplicativity gives
+\begin{equation}
+ (\lVert A\rVert_\infty\lVert A^{-1}\rVert_\infty)^{-1}
+ \lVert J^n\rVert_\infty
+ \le \lVert X^n\rVert_\infty
+ \le
+ \lVert A\rVert_\infty\lVert A^{-1}\rVert_\infty
+ \lVert J^n\rVert_\infty.
+\end{equation}
+This exact basis-level comparison is formalized as
+\leanid{Matrix.l2_opNorm_pow_similarity_bounds} in
+\doclink{QICLean/Analysis/JordanSimilarity.lean}.  Wolf instead writes the
+infimum $\kappa_T$ over all Jordan changes of basis directly in Equation
+(8.108).  That replacement needs either attainment of the infimum or a
+limiting argument compatible with the chosen normalized Jordan form.  No such
+result is currently available in the imported Lean Jordan API, so the formal
+declaration does not assume a minimizing basis.
+
+\section{Verdict}
+
+\textbf{Verdict: source qualifications and missing Jordan-form
+infrastructure.}
+
+The shared modulus and the basis-level similarity inequality are proved.
+The full two-sided theorem still requires a constructive Jordan decomposition,
+largest-block data $d_\mu$, the direct-sum norm maximum, eventual dominance,
+and a justified passage to $\kappa_T$.  Until those dependencies are supplied,
+Equations~(8.106)--(8.109) should not be marked formalized.  Tracking:
+\href{https://github.com/LionSR/QICLean/issues/297}{QICLean issue \#297}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

- define Wolf's shared subperipheral spectrum and largest modulus `μ` for finite-dimensional complex endomorphisms, with an exact bridge to `spectrum`
- prove finiteness, attainment when nonempty, the universal modulus bound, `0 ≤ μ < 1` in the nonempty case, and the exact `μ = 0` qualification
- formalize the chosen-basis operator-norm comparison underlying Equation (8.108)
- synchronize only these proved declarations with the Chapter 8/9 Blueprint and add a focused paper-gap note

## Source boundary

This follows `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1221–1272. It is intentionally a **non-closing** prerequisite for #297 and supplies the common source-shaped `μ` required by #300.

`Matrix.l2_opNorm_pow_similarity_bounds` is Equation (8.108) for one explicitly chosen inverse pair `A, B`; it does **not** assert that Wolf's Jordan condition infimum `κ_T` is attained or silently replace the chosen-basis factor by that infimum.

The full theorem remains open on these exact source/API gaps:

- no constructive Jordan-normal-form/decomposition API from which to define and obtain the largest corresponding block size `d_μ`;
- the empty subperipheral spectrum has no printed `d_μ`, while the formal convention totalizes only `μ` as zero;
- when `μ = 0`, a nontrivial zero-eigenvalue Jordan block can remain nonzero for positive powers below its nilpotence index, so the printed all-positive-`n` upper bound by `C₂ μ^n n^(d_μ-1)` is false in that initial range;
- source line 1261 has the arbitrary-block inequality in the wrong direction; the proof needs the direct-sum norm maximum plus eventual dominance of the largest-modulus/largest-dimension block;
- using `κ_T` itself in (8.108) needs attainment of its infimum or a compatible limiting argument.

No Jordan form, minimizing basis, complete positivity, normality, or diagonalizability is assumed by this slice.

## Validation

- `lake build QICLean.Analysis.SubperipheralSpectrum QICLean.Analysis.JordanSimilarity -q --log-level=info`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base cc5187a --ci`
- full Blueprint PDF build (303 pages)
- standalone paper-gap PDF build (2 pages, with repository-local `command.tex`)
- `git diff --check`
- proof-integrity scan of the new modules and landed Eq. (8.104) dependency: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`

Refs #297
Prerequisite for #300
Related dependency boundary for #298
