### PR TITLE
feat(channel): formalize Wolf Proposition 6.1

### DIFF
--- a/QICLean/Channel/Peripheral/SpectralRadius.lean
+++ b/QICLean/Channel/Peripheral/SpectralRadius.lean
@@ -7,6 +7,7 @@ import QICLean.Algebra.MatrixOperatorSpace
 import QICLean.Channel.Determinant.Bound
 import QICLean.Channel.KrausMap
 import QICLean.Channel.PerronFrobenius.Existence
+import QICLean.Channel.Schwarz.SchwarzSubnormal
 import Mathlib.Analysis.Normed.Algebra.Spectrum
 import Mathlib.Topology.Algebra.Module.FiniteDimension
 
@@ -48,6 +49,128 @@ open Matrix
 variable {D : ℕ}
 
 namespace IsPositiveMap
+
+section RussoDye
+
+open scoped MatrixOrder Matrix.Norms.L2Operator
+
+/-- A nonnegative real multiple of a positive matrix map is positive. -/
+private theorem smul_nonneg
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) {c : ℝ} (hc : 0 ≤ c) :
+    IsPositiveMap ((c : ℂ) • T) := by
+  intro X hX
+  have hcC : 0 ≤ (c : ℂ) := by exact_mod_cast hc
+  simpa only [LinearMap.smul_apply, Complex.coe_smul] using (hT X hX).smul hcC
+
+/-- The sharp matrix Russo--Dye estimate for a contraction: if `T` is positive and
+`‖A‖∞ ≤ 1`, then `‖T A‖∞ ≤ ‖T 1‖∞`.
+
+Here `‖·‖∞` is the matrix C*-algebra (spectral/operator) norm, not the
+Frobenius norm.  The proof derives the estimate from Wolf's Theorem 5.6 for a
+positive subunital map, after normalizing by `‖T 1‖∞`. -/
+theorem norm_apply_le_norm_map_one_of_norm_le_one
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) {A : Matrix (Fin D) (Fin D) ℂ}
+    (hA : ‖A‖ ≤ 1) :
+    ‖T A‖ ≤ ‖T 1‖ := by
+  let c : ℝ := ‖T 1‖
+  have hc : 0 ≤ c := norm_nonneg _
+  have hAstarA : Aᴴ * A ≤ (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    rw [← CStarAlgebra.norm_le_one_iff_of_nonneg
+      (Aᴴ * A) (Matrix.posSemidef_conjTranspose_mul_self A).nonneg,
+      Matrix.l2_opNorm_conjTranspose_mul_self]
+    nlinarith [norm_nonneg A]
+  by_cases hc0 : c = 0
+  · have hT1zero : T 1 = 0 := norm_eq_zero.mp (by simpa only [c] using hc0)
+    have hSub : T 1 ≤ (1 : Matrix (Fin D) (Fin D) ℂ) := by
+      rw [hT1zero]
+      exact Matrix.PosSemidef.one.nonneg
+    have hKS :=
+      KadisonSchwarz.schwarz_inequality_commuting_dominant_operator
+        T hT hSub A 1 Matrix.PosSemidef.one (Commute.one_left A) hAstarA
+    have hProdLe : (T A)ᴴ * T A ≤ 0 := by
+      calc
+        (T A)ᴴ * T A = T Aᴴ * T A := by rw [hT.map_conjTranspose]
+        _ ≤ T 1 := hKS.1
+        _ = 0 := hT1zero
+    have hProdEq : (T A)ᴴ * T A = 0 := by
+      apply le_antisymm hProdLe
+      exact (Matrix.posSemidef_conjTranspose_mul_self (T A)).nonneg
+    have hTAzero : T A = 0 := Matrix.conjTranspose_mul_self_eq_zero.mp hProdEq
+    simp [hTAzero, c, hc0]
+  · have hcpos : 0 < c := lt_of_le_of_ne hc (Ne.symm hc0)
+    let S : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+      ((c⁻¹ : ℝ) : ℂ) • T
+    have hSPos : IsPositiveMap S := by
+      exact smul_nonneg hT (inv_nonneg.mpr hc)
+    have hS1nonneg : 0 ≤ S 1 := by
+      exact (hSPos 1 Matrix.PosSemidef.one).nonneg
+    have hS1norm : ‖S 1‖ ≤ 1 := by
+      have hEq : ‖S 1‖ = 1 := by
+        simp [S, c, norm_smul, hc0]
+      exact hEq.le
+    have hSub : S 1 ≤ (1 : Matrix (Fin D) (Fin D) ℂ) :=
+      (CStarAlgebra.norm_le_one_iff_of_nonneg (S 1) hS1nonneg).mp hS1norm
+    have hKS :=
+      KadisonSchwarz.schwarz_inequality_commuting_dominant_operator
+        S hSPos hSub A 1 Matrix.PosSemidef.one (Commute.one_left A) hAstarA
+    have hProdLe : (S A)ᴴ * S A ≤ (1 : Matrix (Fin D) (Fin D) ℂ) := by
+      calc
+        (S A)ᴴ * S A = S Aᴴ * S A := by rw [hSPos.map_conjTranspose]
+        _ ≤ S 1 := hKS.1
+        _ ≤ 1 := hSub
+    have hProdNorm : ‖(S A)ᴴ * S A‖ ≤ 1 :=
+      (CStarAlgebra.norm_le_one_iff_of_nonneg
+        ((S A)ᴴ * S A) (Matrix.posSemidef_conjTranspose_mul_self (S A)).nonneg).mpr hProdLe
+    rw [Matrix.l2_opNorm_conjTranspose_mul_self] at hProdNorm
+    have hSAnorm : ‖S A‖ ≤ 1 := by
+      nlinarith [norm_nonneg (S A)]
+    have hScaled : c⁻¹ * ‖T A‖ ≤ 1 := by
+      simpa [S, norm_smul, abs_of_nonneg hc] using hSAnorm
+    rw [inv_mul_le_iff₀ hcpos] at hScaled
+    simpa only [mul_one, c] using hScaled
+
+/-- The sharp matrix Russo--Dye estimate used on Wolf's Proposition 6.1, source line 84:
+`‖T A‖∞ ≤ ‖T 1‖∞ ‖A‖∞`.
+
+The norm is the C*-operator norm.  This formalization obtains the estimate as
+a consequence of Wolf's Theorem 5.6 with dominant operator `Dom = 1`; it does
+not pass through the four-positive-parts bound. -/
+theorem norm_apply_le_norm_map_one_mul_norm
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (A : Matrix (Fin D) (Fin D) ℂ) :
+    ‖T A‖ ≤ ‖T 1‖ * ‖A‖ := by
+  by_cases hA0 : A = 0
+  · simp [hA0]
+  · have hAnormPos : 0 < ‖A‖ := norm_pos_iff.mpr hA0
+    let B : Matrix (Fin D) (Fin D) ℂ := (((‖A‖⁻¹ : ℝ) : ℂ) • A)
+    have hBnorm : ‖B‖ ≤ 1 := by
+      have hEq : ‖B‖ = 1 := by
+        simp [B, norm_smul, hA0]
+      exact hEq.le
+    have hContract := hT.norm_apply_le_norm_map_one_of_norm_le_one hBnorm
+    have hScaled : ‖A‖⁻¹ * ‖T A‖ ≤ ‖T 1‖ := by
+      simpa [B, norm_smul, abs_of_nonneg (norm_nonneg A)] using hContract
+    rw [inv_mul_le_iff₀ hAnormPos] at hScaled
+    simpa only [mul_comm] using hScaled
+
+/-- **Wolf Equation (6.3)**: every eigenvalue `μ` of a positive matrix map
+satisfies `|μ| ≤ ‖T 1‖∞`. -/
+theorem eigenvalue_norm_le_norm_map_one
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (μ : ℂ) (hμ : Module.End.HasEigenvalue T μ) :
+    ‖μ‖ ≤ ‖T 1‖ := by
+  obtain ⟨A, hAmem, hAne⟩ := hμ.exists_hasEigenvector
+  have hEig : T A = μ • A := Module.End.mem_eigenspace_iff.mp hAmem
+  have hBound := hT.norm_apply_le_norm_map_one_mul_norm A
+  rw [hEig, norm_smul] at hBound
+  exact le_of_mul_le_mul_right hBound (norm_pos_iff.mpr hAne)
+
+end RussoDye
 
 /-- **Wolf Proposition 6.1** (eigenvalue-1 existence): For a positive trace-preserving
 map on $M_D(\mathbb{C})$ with $D > 0$, there exists a nonzero PSD matrix $\rho$
@@ -96,6 +219,25 @@ theorem eigenvalue_one_exists_of_tracePreserving
 end IsPositiveMap
 
 /-- If every eigenvalue of a linear endomorphism of a finite-dimensional complex normed space
+has `nnnorm` at most `c`, then its spectral radius (computed after transport to the induced
+continuous linear map) is at most `c`.
+
+This is the norm-agnostic passage from an algebraic eigenvalue bound to a
+spectral-radius bound. -/
+theorem spectralRadius_le_of_forall_eigenvalue_nnnorm_le
+    {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V] [FiniteDimensional ℂ V]
+    (E : V →ₗ[ℂ] V) (c : ℝ≥0)
+    (h : ∀ μ, Module.End.HasEigenvalue E μ → ‖μ‖₊ ≤ c) :
+    spectralRadius ℂ (Module.End.toContinuousLinearMap V E) ≤ c := by
+  have hSpec : spectrum ℂ (Module.End.toContinuousLinearMap V E) = spectrum ℂ E :=
+    AlgEquiv.spectrum_eq (Module.End.toContinuousLinearMap V) E
+  rw [spectralRadius]
+  refine iSup₂_le fun μ hμ ↦ ?_
+  have hμE : μ ∈ spectrum ℂ E := hSpec ▸ hμ
+  have hEig : Module.End.HasEigenvalue E μ := Module.End.hasEigenvalue_iff_mem_spectrum.mpr hμE
+  exact_mod_cast h μ hEig
+
+/-- If every eigenvalue of a linear endomorphism of a finite-dimensional complex normed space
 has modulus at most one, then its spectral radius (computed after transport to the induced
 continuous linear map) is at most one.
 
@@ -106,14 +248,84 @@ operator norm on `V`. -/
 theorem spectralRadius_le_one_of_forall_eigenvalue_norm_le_one
     {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V] [FiniteDimensional ℂ V]
     (E : V →ₗ[ℂ] V) (h : ∀ μ, Module.End.HasEigenvalue E μ → ‖μ‖ ≤ 1) :
-    spectralRadius ℂ (Module.End.toContinuousLinearMap V E) ≤ 1 := by
-  have hSpec : spectrum ℂ (Module.End.toContinuousLinearMap V E) = spectrum ℂ E :=
-    AlgEquiv.spectrum_eq (Module.End.toContinuousLinearMap V) E
-  rw [spectralRadius]
-  refine iSup₂_le fun μ hμ ↦ ?_
-  have hμE : μ ∈ spectrum ℂ E := hSpec ▸ hμ
-  have hEig : Module.End.HasEigenvalue E μ := Module.End.hasEigenvalue_iff_mem_spectrum.mpr hμE
-  exact_mod_cast h μ hEig
+    spectralRadius ℂ (Module.End.toContinuousLinearMap V E) ≤ 1 :=
+  spectralRadius_le_of_forall_eigenvalue_nnnorm_le E 1 fun μ hμ ↦ by
+    exact_mod_cast h μ hμ
+
+/-- A unital matrix endomorphism has eigenvalue `1`, with the identity matrix
+as an eigenvector. -/
+theorem eigenvalue_one_of_map_one_eq_one
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hOne : T 1 = 1) : Module.End.HasEigenvalue T 1 := by
+  apply Module.End.hasEigenvalue_of_hasEigenvector
+  rw [Module.End.hasEigenvector_iff]
+  refine ⟨Module.End.mem_eigenspace_iff.mpr ?_, one_ne_zero⟩
+  simpa only [hOne, one_smul]
+
+namespace IsPositiveMap
+
+section RussoDyeSpectral
+
+open scoped MatrixOrder Matrix.Norms.L2Operator
+
+/-- **Wolf Proposition 6.1, Equation (6.2)**: the spectral radius of a positive
+matrix map is at most `‖T 1‖∞`.
+
+The spectral radius is computed for the continuous endomorphism induced by
+`T`, using the matrix C*-operator norm. -/
+theorem spectralRadius_le_nnnorm_map_one
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) :
+    spectralRadius ℂ
+      (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) T) ≤
+        ‖T 1‖₊ :=
+  spectralRadius_le_of_forall_eigenvalue_nnnorm_le T ‖T 1‖₊ fun μ hμ ↦ by
+    exact_mod_cast hT.eigenvalue_norm_le_norm_map_one μ hμ
+
+/-- **Wolf Proposition 6.1, unital case**: every eigenvalue of a positive
+unital matrix map lies in the closed unit disk. -/
+theorem eigenvalue_norm_le_one_of_map_one_eq_one
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hOne : T 1 = 1)
+    (μ : ℂ) (hμ : Module.End.HasEigenvalue T μ) :
+    ‖μ‖ ≤ 1 := by
+  simpa only [hOne, norm_one] using hT.eigenvalue_norm_le_norm_map_one μ hμ
+
+/-- **Wolf Proposition 6.1, unital case**: a positive unital matrix map has
+spectral radius exactly `1`.
+
+The upper bound is Equation (6.2), while the reverse inequality follows from
+the identity eigenvector. -/
+theorem spectralRadius_eq_one_of_map_one_eq_one
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hOne : T 1 = 1) :
+    spectralRadius ℂ
+      (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) T) = 1 := by
+  apply le_antisymm
+  · simpa only [hOne, nnnorm_one] using hT.spectralRadius_le_nnnorm_map_one
+  · have hSpec :
+        spectrum ℂ (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) T) =
+          spectrum ℂ T :=
+      AlgEquiv.spectrum_eq
+        (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) T
+    have hOneSpec : (1 : ℂ) ∈
+        spectrum ℂ (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) T) := by
+      rw [hSpec]
+      exact Module.End.hasEigenvalue_iff_mem_spectrum.mp
+        (eigenvalue_one_of_map_one_eq_one hOne)
+    rw [spectralRadius]
+    simpa using (@le_iSup₂ ENNReal ℂ
+      (· ∈ spectrum ℂ
+        (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) T)) _
+      (fun μ _ ↦ (‖μ‖₊ : ENNReal)) 1 hOneSpec)
+
+end RussoDyeSpectral
+
+end IsPositiveMap
 
 /-!
 ## Spectral-radius bound for trace-preserving Kraus maps

--- a/QICLean/Channel/Peripheral/SpectralRadius.lean
+++ b/QICLean/Channel/Peripheral/SpectralRadius.lean
@@ -44,6 +44,8 @@ pre-existing trace-preserving results are retained independently.
   `IsPositiveMap.spectralRadius_eq_one_of_map_one_eq_one`: the unital case.
 * `IsPositiveMap.eigenvalue_one_exists_of_tracePreserving`: the
   trace-preserving fixed point.
+* `IsPositiveMap.spectralRadius_eq_one_of_tracePreserving`: the
+  trace-preserving spectral-radius equality.
 * `spectralRadius_le_of_forall_eigenvalue_nnnorm_le`: the norm-agnostic step
   from pointwise eigenvalue bounds to a spectral-radius bound.
 * `Kraus.eigenvalue_norm_le_one_of_isTP`, `Kraus.spectralRadius_mapLM_le_one_of_isTP`:
@@ -54,7 +56,7 @@ pre-existing trace-preserving results are retained independently.
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 6.1][Wolf2012Quantum]
 -/
 
-open scoped Matrix ComplexOrder
+open scoped Matrix ComplexOrder NNReal
 open Matrix
 
 variable {D : ℕ}
@@ -272,7 +274,27 @@ theorem eigenvalue_one_of_map_one_eq_one
   apply Module.End.hasEigenvalue_of_hasEigenvector
   rw [Module.End.hasEigenvector_iff]
   refine ⟨Module.End.mem_eigenspace_iff.mpr ?_, one_ne_zero⟩
-  simpa only [hOne, one_smul]
+  simp only [hOne, one_smul]
+
+/-- The norm-agnostic passage from a closed-unit-disk eigenvalue bound and the
+eigenvalue `1` to spectral radius exactly `1`. -/
+private theorem spectralRadius_eq_one_of_eigenvalue_bounds
+    {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V] [FiniteDimensional ℂ V]
+    (E : V →ₗ[ℂ] V)
+    (hBound : ∀ μ, Module.End.HasEigenvalue E μ → ‖μ‖ ≤ 1)
+    (hOne : Module.End.HasEigenvalue E 1) :
+    spectralRadius ℂ (Module.End.toContinuousLinearMap V E) = 1 := by
+  apply le_antisymm
+  · exact spectralRadius_le_one_of_forall_eigenvalue_norm_le_one E hBound
+  · have hSpec : spectrum ℂ (Module.End.toContinuousLinearMap V E) = spectrum ℂ E :=
+      AlgEquiv.spectrum_eq (Module.End.toContinuousLinearMap V) E
+    have hOneSpec : (1 : ℂ) ∈ spectrum ℂ (Module.End.toContinuousLinearMap V E) := by
+      rw [hSpec]
+      exact Module.End.hasEigenvalue_iff_mem_spectrum.mp hOne
+    rw [spectralRadius]
+    simpa using (@le_iSup₂ ENNReal ℂ
+      (· ∈ spectrum ℂ (Module.End.toContinuousLinearMap V E)) _
+      (fun μ _ ↦ (‖μ‖₊ : ENNReal)) 1 hOneSpec)
 
 namespace IsPositiveMap
 
@@ -315,24 +337,30 @@ theorem spectralRadius_eq_one_of_map_one_eq_one
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsPositiveMap T) (hOne : T 1 = 1) :
     spectralRadius ℂ
+      (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) T) = 1 :=
+  spectralRadius_eq_one_of_eigenvalue_bounds T
+    (hT.eigenvalue_norm_le_one_of_map_one_eq_one hOne)
+    (eigenvalue_one_of_map_one_eq_one hOne)
+
+/-- **Wolf Proposition 6.1, trace-preserving case**: a positive
+trace-preserving matrix map has spectral radius exactly `1`.
+
+The closed-unit-disk bound is the existing orbit-and-trace result, and the
+reverse inequality follows from the existing positive semidefinite fixed
+point. -/
+theorem spectralRadius_eq_one_of_tracePreserving
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    spectralRadius ℂ
       (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) T) = 1 := by
-  apply le_antisymm
-  · simpa only [hOne, nnnorm_one] using hT.spectralRadius_le_nnnorm_map_one
-  · have hSpec :
-        spectrum ℂ (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) T) =
-          spectrum ℂ T :=
-      AlgEquiv.spectrum_eq
-        (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) T
-    have hOneSpec : (1 : ℂ) ∈
-        spectrum ℂ (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) T) := by
-      rw [hSpec]
-      exact Module.End.hasEigenvalue_iff_mem_spectrum.mp
-        (eigenvalue_one_of_map_one_eq_one hOne)
-    rw [spectralRadius]
-    simpa using (@le_iSup₂ ENNReal ℂ
-      (· ∈ spectrum ℂ
-        (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) T)) _
-      (fun μ _ ↦ (‖μ‖₊ : ENNReal)) 1 hOneSpec)
+  apply spectralRadius_eq_one_of_eigenvalue_bounds T
+  · exact hT.eigenvalue_norm_le_one_of_tracePreserving hTP
+  · obtain ⟨ρ, _, hρne, hρ⟩ := hT.eigenvalue_one_exists_of_tracePreserving hTP
+    apply Module.End.hasEigenvalue_of_hasEigenvector
+    rw [Module.End.hasEigenvector_iff]
+    refine ⟨Module.End.mem_eigenspace_iff.mpr ?_, hρne⟩
+    simpa only [one_smul] using hρ
 
 end RussoDyeSpectral
 

--- a/QICLean/Channel/Peripheral/SpectralRadius.lean
+++ b/QICLean/Channel/Peripheral/SpectralRadius.lean
@@ -14,27 +14,38 @@ import Mathlib.Topology.Algebra.Module.FiniteDimension
 /-!
 # Spectral radius of positive maps — Wolf Proposition 6.1
 
-**Wolf Proposition 6.1**: For a positive trace-preserving (or unital) map
-$T: M_d(\mathbb{C}) \to M_d(\mathbb{C})$, the spectral radius is $1$, all eigenvalues
-lie in the unit disk, and $1$ is an eigenvalue.
+**Wolf Proposition 6.1**: if
+$T: M_d(\mathbb{C}) \to M_d(\mathbb{C})$ is positive and $d \ge 1$, then
+$\varrho(T) \le \|T(\mathbf 1)\|_\infty$.  If $T$ is unital or
+trace-preserving, then $1$ is an eigenvalue, the spectral radius is $1$, and
+all eigenvalues lie in the closed unit disk.
 
-The eigenvalue modulus bound $|\lambda| \le 1$ is provided by
-`IsPositiveMap.eigenvalue_norm_le_one_of_tracePreserving` in
-`TNLean.Channel.Determinant.Bound`.  Eigenvalue-$1$ existence is proved here
-using the Perron--Frobenius theorem (`exists_posSemidef_eigenvector`) together
-with trace preservation.
+Wolf invokes the Russo--Dye estimate
+$\|T(X)\|_\infty \le \|T(\mathbf 1)\|_\infty\|X\|_\infty$.  No standalone
+Russo--Dye theorem is available in the pinned Mathlib.  For finite matrices,
+this file derives precisely the estimate needed by Proposition 6.1 from
+Wolf's Theorem 5.6 (`schwarz_inequality_commuting_dominant_operator`), taking
+the dominant operator to be the identity after normalizing the map.  This
+retains the sharp coefficient one and does not use the four-positive-parts
+bound.
 
-The general $\varrho(T) \le \|T(\mathbf 1)\|_\infty$ bound for arbitrary
-positive maps relies on the Russo--Dye theorem and is documented in
-`docs/paper-gaps/wolf_prop61_russo_dye_factor.tex`.
+The norm in these declarations is the matrix C*-operator norm (Wolf's
+$\|\cdot\|_\infty$), not the Frobenius norm or Mathlib's row-sum norm.  The
+pre-existing trace-preserving results are retained independently.
 
 ## Main result
 
-* `IsPositiveMap.eigenvalue_one_exists_of_tracePreserving`:
-  nonzero PSD fixed point for positive trace-preserving maps.
-* `spectralRadius_le_one_of_forall_eigenvalue_norm_le_one`: the norm-agnostic
-  step transporting a pointwise eigenvalue bound to a spectral-radius bound,
-  shared by every operator-norm choice used for this map.
+* `IsPositiveMap.norm_apply_le_norm_map_one_mul_norm`: the sharp matrix
+  Russo--Dye estimate used by Wolf.
+* `IsPositiveMap.eigenvalue_norm_le_norm_map_one` and
+  `IsPositiveMap.spectralRadius_le_nnnorm_map_one`: Equations (6.3) and (6.2).
+* `eigenvalue_one_of_map_one_eq_one`,
+  `IsPositiveMap.eigenvalue_norm_le_one_of_map_one_eq_one`, and
+  `IsPositiveMap.spectralRadius_eq_one_of_map_one_eq_one`: the unital case.
+* `IsPositiveMap.eigenvalue_one_exists_of_tracePreserving`: the
+  trace-preserving fixed point.
+* `spectralRadius_le_of_forall_eigenvalue_nnnorm_le`: the norm-agnostic step
+  from pointwise eigenvalue bounds to a spectral-radius bound.
 * `Kraus.eigenvalue_norm_le_one_of_isTP`, `Kraus.spectralRadius_mapLM_le_one_of_isTP`:
   eigenvalue and spectral-radius bounds for trace-preserving Kraus maps.
 

--- a/blueprint/src/chapter/ch02_channels_peripheral_spectrum_and_primitivity.tex
+++ b/blueprint/src/chapter/ch02_channels_peripheral_spectrum_and_primitivity.tex
@@ -141,6 +141,27 @@
     $\varrho(T)\leq1$. The eigenvalue $1$ gives the reverse inequality.
 \end{proof}
 
+\begin{theorem}[Positive trace-preserving maps have unit spectral radius]
+    \label{thm:positive_tp_spectral_radius}
+    \lean{IsPositiveMap.eigenvalue_norm_le_one_of_tracePreserving,
+        IsPositiveMap.eigenvalue_one_exists_of_tracePreserving,
+        IsPositiveMap.spectralRadius_eq_one_of_tracePreserving}
+    \leanok
+    \uses{def:positive_map, def:trace_preserving}
+    Let $D\geq1$, and let $T:\MN{D}\to\MN{D}$ be positive and
+    trace-preserving. Then $1$ is an eigenvalue with a nonzero positive
+    semidefinite eigenvector, every eigenvalue belongs to the closed unit
+    disk, and $\varrho(T)=1$. No complete-positivity assumption is made.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:positive_tp_eigenvalue_disk, thm:eigenvalue_one_tp}
+    Theorem~\ref{thm:positive_tp_eigenvalue_disk} places every eigenvalue in
+    the closed unit disk. Theorem~\ref{thm:eigenvalue_one_tp} supplies a
+    nonzero positive semidefinite fixed point, so $1$ is an eigenvalue.
+    Hence $\varrho(T)\leq1$ and $\varrho(T)\geq1$, respectively.
+\end{proof}
+
 \begin{definition}[Primitive map]\label{def:primitive_channel}
     \lean{IsPrimitive}
     \leanok

--- a/blueprint/src/chapter/ch02_channels_peripheral_spectrum_and_primitivity.tex
+++ b/blueprint/src/chapter/ch02_channels_peripheral_spectrum_and_primitivity.tex
@@ -47,6 +47,100 @@
     below use the unit-circle set of Definition~\ref{def:peripheral_eigenvalues}.
 \end{remark}
 
+\begin{theorem}[Russo--Dye estimate for positive matrix maps]
+    \label{thm:positive_map_russo_dye_estimate}
+    \lean{IsPositiveMap.norm_apply_le_norm_map_one_mul_norm}
+    \leanok
+    \uses{def:positive_map, thm:schwarz_commuting_dominant}
+    Let $D\geq1$, and let $T:\MN{D}\to\MN{D}$ be positive. Then, for every
+    $X\in\MN{D}$,
+    \begin{align}
+        \|T(X)\|_\infty
+        &\leq \|T(\Id)\|_\infty\,\|X\|_\infty.
+        \label{eq:positive_map_russo_dye_estimate}
+    \end{align}
+    This is the Russo--Dye estimate invoked in the proof of
+    \cite[Proposition~6.1]{Wolf2012Quantum}, at local source line~84. Here
+    $\|\cdot\|_\infty$ is the C$^*$-operator norm, rather than the Frobenius
+    norm or a row-sum norm.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:schwarz_commuting_dominant}
+    Put $c=\|T(\Id)\|_\infty$. If $c>0$, normalize the map by
+    $S=c^{-1}T$. Positivity gives $T(\Id)\geq0$, and the operator-norm order
+    bound gives $T(\Id)\leq c\Id$; hence $S(\Id)\leq\Id$.
+    For a contraction $A$, one has $A^\dagger A\leq\Id$. Apply
+    Theorem~\ref{thm:schwarz_commuting_dominant} to $S$, with dominant
+    operator $\Id$, to obtain
+    \begin{align}
+        S(A)^\dagger S(A)
+        &\leq S(\Id)\leq\Id.
+        \notag
+    \end{align}
+    The C$^*$-identity therefore gives $\|S(A)\|_\infty\leq1$.
+    If $c=0$, the same argument applied directly to $T$ gives
+    $T(A)^\dagger T(A)\leq T(\Id)=0$, and thus $T(A)=0$. Finally, rescale
+    an arbitrary nonzero $X$ to the contraction
+    $A=\|X\|_\infty^{-1}X$. This proves
+    (\ref{eq:positive_map_russo_dye_estimate}) with coefficient one.
+\end{proof}
+
+\begin{theorem}[Spectral-radius bound for positive matrix maps]
+    \label{thm:positive_map_spectral_radius_bound}
+    \lean{IsPositiveMap.eigenvalue_norm_le_norm_map_one,
+        IsPositiveMap.spectralRadius_le_nnnorm_map_one}
+    \leanok
+    \uses{def:positive_map}
+    Let $D\geq1$, and let $T:\MN{D}\to\MN{D}$ be positive. Every eigenvalue
+    $\mu$ of $T$ satisfies
+    \begin{align}
+        |\mu|&\leq\|T(\Id)\|_\infty,
+        \tag{6.3}
+    \end{align}
+    and consequently
+    \begin{align}
+        \varrho(T)&\leq\|T(\Id)\|_\infty.
+        \tag{6.2}
+    \end{align}
+    This is \cite[Proposition~6.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:positive_map_russo_dye_estimate}
+    If $T(X)=\mu X$ for a nonzero $X$, then
+    Theorem~\ref{thm:positive_map_russo_dye_estimate} gives
+    \begin{align}
+        |\mu|\,\|X\|_\infty
+        &=\|T(X)\|_\infty
+        \leq\|T(\Id)\|_\infty\,\|X\|_\infty.
+        \notag
+    \end{align}
+    Division by $\|X\|_\infty>0$ proves (6.3). In finite dimension the
+    spectral values are precisely the eigenvalues, so taking the supremum of
+    their moduli proves (6.2).
+\end{proof}
+
+\begin{theorem}[Positive unital maps have unit spectral radius]
+    \label{thm:positive_unital_spectral_radius}
+    \lean{eigenvalue_one_of_map_one_eq_one,
+        IsPositiveMap.eigenvalue_norm_le_one_of_map_one_eq_one,
+        IsPositiveMap.spectralRadius_eq_one_of_map_one_eq_one}
+    \leanok
+    \uses{def:positive_map, def:unital_linear_map}
+    Let $D\geq1$, and let $T:\MN{D}\to\MN{D}$ be positive and unital. Then
+    $1$ is an eigenvalue of $T$, every eigenvalue belongs to the closed unit
+    disk, and $\varrho(T)=1$. No complete-positivity assumption is made.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:positive_map_spectral_radius_bound}
+    Unitality gives $T(\Id)=\Id$, so the nonzero identity matrix is an
+    eigenvector with eigenvalue $1$. Theorem~\ref{thm:positive_map_spectral_radius_bound}
+    gives $|\mu|\leq\|\Id\|_\infty=1$ for every eigenvalue $\mu$ and
+    $\varrho(T)\leq1$. The eigenvalue $1$ gives the reverse inequality.
+\end{proof}
+
 \begin{definition}[Primitive map]\label{def:primitive_channel}
     \lean{IsPrimitive}
     \leanok

--- a/docs/paper-gaps/wolf_prop61_russo_dye_factor.tex
+++ b/docs/paper-gaps/wolf_prop61_russo_dye_factor.tex
@@ -9,74 +9,101 @@
 
 \title{Wolf Proposition~6.1 --- The Russo--Dye Factor}
 \author{}
-\date{2026-08-04}
+\date{2026-08-23}
 
 \begin{document}
 \maketitle
-\gapnote{scope-restriction}{open}
+\gapnote{scope-restriction}{resolved}
 
 \section{The assertion}
 
-Wolf, \emph{Quantum Channels \& Operations}, Proposition~6.1:
-``If $T$ is a positive map on $\mathcal M_d(\mathbb C)$, then its
-spectral radius satisfies $\varrho(T)\le\|T(\mathbf 1)\|_\infty$.  If in
-addition $T$ is unital or trace-preserving, then there is an eigenvalue
-$\lambda=1$.''
+Let $d\geq1$, and let $T:\MN{d}\to\MN{d}$ be positive. Wolf's
+Proposition~6.1 states~\cite[Proposition~6.1]{Wolf2012Quantum}
+\begin{align}
+    \varrho(T)&\leq\|T(\Id)\|_\infty.
+    \tag{6.2}
+\end{align}
+If $T$ is unital or trace-preserving, then $1$ is an eigenvalue,
+$\varrho(T)=1$, and every eigenvalue lies in the closed unit disk.
+The local source is
+\path{Notes/WolfNoteTexSource/ch06_spectral_properties.tex}, lines~73--91.
 
-The proof invokes the Russo--Dye theorem
-$\|T(X)\|_\infty\le\|T(\mathbf 1)\|_\infty\,\|X\|_\infty$ to bound
-every eigenvalue modulus by $\|T(\mathbf 1)\|_\infty$, and hence the
-spectral radius.
+At line~84 Wolf invokes the Russo--Dye estimate
+\begin{align}
+    \|T(X)\|_\infty
+    &\leq\|T(\Id)\|_\infty\,\|X\|_\infty.
+    \label{eq:russo-dye-estimate}
+\end{align}
+If $T(X)=\lambda X$ and $X\neq0$, cancellation of
+$\|X\|_\infty$ gives
+\begin{align}
+    |\lambda|&\leq\|T(\Id)\|_\infty,
+    \tag{6.3}
+\end{align}
+and taking the largest eigenvalue modulus gives (6.2).
 
 \section{The formalization}
 
-The trace-preserving case is the one needed by the rest of the chapter.
-It is established by two theorems:
+The general coefficient-one statement is formalized in
+\doclink{QICLean/Channel/Peripheral/SpectralRadius}. The main declarations
+are:
 \begin{itemize}
-\item \leanid{IsPositiveMap.eigenvalue\_norm\_le\_one\_of\_tracePreserving}
-  in \doclink{QICLean/Channel/Determinant/Bound} proves $|\lambda|\le1$ for
-  every eigenvalue of a positive trace-preserving map via an orbit-and-trace
-  argument that decomposes an eigenvector into Hermitian parts and
-  difference-of-density-matrices components;
-\item \leanid{IsPositiveMap.eigenvalue\_one\_exists\_of\_tracePreserving}
-  in \doclink{QICLean/Channel/Peripheral/SpectralRadius} proves that
-  $1$ is an eigenvalue with a nonzero positive-semidefinite eigenvector,
-  using the Perron--Frobenius theorem
-  (\leanid{exists\_posSemidef\_eigenvector} in
-  \doclink{QICLean/Channel/PerronFrobenius/Existence}) together with trace
-  preservation to force the Perron eigenvalue to~$1$.
+\item \leanid{IsPositiveMap.norm\_apply\_le\_norm\_map\_one\_mul\_norm}
+  proves (\ref{eq:russo-dye-estimate}) for every matrix $X$;
+\item \leanid{IsPositiveMap.eigenvalue\_norm\_le\_norm\_map\_one}
+  proves Equation~(6.3);
+\item \leanid{IsPositiveMap.spectralRadius\_le\_nnnorm\_map\_one}
+  proves Equation~(6.2);
+\item \leanid{eigenvalue\_one\_of\_map\_one\_eq\_one},
+  \leanid{IsPositiveMap.eigenvalue\_norm\_le\_one\_of\_map\_one\_eq\_one},
+  and
+  \leanid{IsPositiveMap.spectralRadius\_eq\_one\_of\_map\_one\_eq\_one}
+  give the three unital conclusions without assuming complete positivity.
 \end{itemize}
-Together these give $\varrho(T)=1$ for the trace-preserving case, which is the
-statement required by Proposition~6.3 (Ces\`aro means) and later results.
 
-The unital case follows by duality: the trace adjoint $T^*$ is
-trace-preserving, its spectrum coincides with that of~$T$, and the
-eigenvalue-$1$ conclusion carries over.  This dual implication has not yet been
-wired as a separate lemma.
+The trace-preserving results remain available as independent sibling
+theorems. In particular,
+\leanid{IsPositiveMap.eigenvalue\_norm\_le\_one\_of\_tracePreserving} in
+\doclink{QICLean/Channel/Determinant/Bound} gives the closed-unit-disk bound,
+and \leanid{IsPositiveMap.eigenvalue\_one\_exists\_of\_tracePreserving} gives
+a nonzero positive-semidefinite fixed point.
 
-The general ``$\varrho(T)\le\|T(\mathbf 1)\|_\infty$ for every positive map''
-has not been formalized.  A possible elimination plan would follow the
-Russo--Dye route for the matrix algebra by: (a) using
-\leanid{PositiveLinearMap.norm\_apply\_le\_of\_nonneg} from Mathlib to obtain
-the factor-$1$ bound on positive-semidefinite inputs; (b) decomposing an
-arbitrary matrix into four positive-semidefinite parts via the standard
-Hermitian/anti-Hermitian and positive/negative-part decomposition; (c) obtaining
-$\|T(X)\|\le 4\|T(\mathbf 1)\|\|X\|$ and, from it, a characterisation of
-the spectral radius.  Steps (a) and (b) are available; step~(c) would yield
-a factor-$4$ certificate, weaker than the source's factor~$1$.  To recover
-the optimal factor one would need the full Russo--Dye theorem
-$\|T\|=\|T(\mathbf 1)\|$ for positive maps on C$^\ast$-algebras, which
-is not yet present in Mathlib.\footnote{Mathlib~\texttt{PositiveLinearMap.norm\_apply\_le\_of\_nonneg}
-already proves $\|T(X)\|\le\|T(\mathbf 1)\|\|X\|$ for $X\ge0$; the missing
-step is the extension to arbitrary $X$ without the factor~$4$.}
+\section{The proof route}
+
+The pinned version of Mathlib has no standalone Russo--Dye theorem or theorem
+identifying the operator-norm unit ball with the closed convex hull of the
+unitaries. The formal proof instead derives exactly
+(\ref{eq:russo-dye-estimate}) from Wolf's
+Theorem~5.6~\cite[Theorem~5.6]{Wolf2012Quantum}, already formalized as
+\leanid{KadisonSchwarz.schwarz\_inequality\_commuting\_dominant\_operator}.
+This is an alternative derivation of the estimate used by Wolf, not a
+formalization of the convex-hull theorem itself.
+
+Set $c=\|T(\Id)\|_\infty$. For $c>0$, the normalized map
+$S=c^{-1}T$ is positive and subunital. If $\|A\|_\infty\leq1$, then
+$A^\dagger A\leq\Id$. Wolf's Theorem~5.6, with dominant operator $\Id$,
+gives
+\begin{align}
+    S(A)^\dagger S(A)&\leq S(\Id)\leq\Id.
+\end{align}
+The C$^*$-identity yields $\|S(A)\|_\infty\leq1$. The case $c=0$ is treated
+separately: the same inequality gives
+$T(A)^\dagger T(A)\leq T(\Id)=0$, hence $T(A)=0$. Rescaling an arbitrary
+nonzero $X$ proves (\ref{eq:russo-dye-estimate}). No decomposition into four
+positive parts and no factor four enters the argument.
+
+The formal hypotheses match the source boundary: positivity and $d\geq1$.
+The norm is Mathlib's matrix C$^*$-operator norm, corresponding to Wolf's
+$\|\cdot\|_\infty$; it is not the Frobenius norm or the row-sum matrix norm.
 
 \section{Verdict}
 
-This is a \emph{scope restriction}.  The trace-preserving and unital cases of
-Wolf Proposition~6.1 are fully proved; the general bound
-$\varrho(T)\le\|T(\mathbf 1)\|_\infty$ for arbitrary positive maps is not
-yet formalized.  The trace-preserving case is the one invoked throughout the
-remainder of Chapter~6 and is complete.\footnote{Tracking: \href{https://github.com/LionSR/TNLean/issues/3984}{TNLean issue \#3984}.}
+The former scope restriction is resolved. Equation~(6.2), Equation~(6.3), and
+the unital conclusions of Wolf Proposition~6.1 are formalized for arbitrary
+positive matrix maps with the sharp coefficient one and without a
+complete-positivity assumption. The formal proof uses Wolf's Theorem~5.6 to
+derive the norm estimate that the source obtains from Russo--Dye.\footnote{Tracking:
+\ghissue{36}.}
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_prop61_russo_dye_factor.tex
+++ b/docs/paper-gaps/wolf_prop61_russo_dye_factor.tex
@@ -66,7 +66,9 @@ theorems. In particular,
 \leanid{IsPositiveMap.eigenvalue\_norm\_le\_one\_of\_tracePreserving} in
 \doclink{QICLean/Channel/Determinant/Bound} gives the closed-unit-disk bound,
 and \leanid{IsPositiveMap.eigenvalue\_one\_exists\_of\_tracePreserving} gives
-a nonzero positive-semidefinite fixed point.
+a nonzero positive-semidefinite fixed point. These are assembled by
+\leanid{IsPositiveMap.spectralRadius\_eq\_one\_of\_tracePreserving}, which
+proves the trace-preserving spectral-radius equality.
 
 \section{The proof route}
 

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -510,18 +510,31 @@ Perron–Frobenius theorem — are indexed in
 
 ### Section 6.1 Spectral radius and determinant
 
-#### Wolf Proposition 6.1 (Spectral radius of positive maps) — TRACE-PRESERVING CASE FORMALIZED
+#### Wolf Proposition 6.1 (Spectral radius of positive maps) — FORMALIZED
 
+* `IsPositiveMap.norm_apply_le_norm_map_one_mul_norm` — the sharp
+  Russo--Dye estimate `‖T(X)‖∞ ≤ ‖T(1)‖∞ ‖X‖∞` for every positive
+  matrix map, using the matrix C*-operator norm.
+* `IsPositiveMap.eigenvalue_norm_le_norm_map_one` — Wolf Equation (6.3),
+  `|μ| ≤ ‖T(1)‖∞` for every eigenvalue.
+* `IsPositiveMap.spectralRadius_le_nnnorm_map_one` — Wolf Equation (6.2),
+  `ρ(T) ≤ ‖T(1)‖∞` for every positive map on a nonzero matrix algebra.
+* `eigenvalue_one_of_map_one_eq_one`,
+  `IsPositiveMap.eigenvalue_norm_le_one_of_map_one_eq_one`, and
+  `IsPositiveMap.spectralRadius_eq_one_of_map_one_eq_one` — for a positive
+  unital map, eigenvalue $1$, the closed-unit-disk bound, and spectral radius
+  exactly $1$, without complete positivity.
 * `IsPositiveMap.eigenvalue_norm_le_one_of_tracePreserving` — every eigenvalue of a
   positive trace-preserving map lies in the closed unit disk, in
   `QICLean.Channel.Determinant.Bound`.
 * `IsPositiveMap.eigenvalue_one_exists_of_tracePreserving` — eigenvalue $1$ exists
   (nonzero PSD fixed point), in `QICLean.Channel.Peripheral.SpectralRadius`.
 
-The general bound `ρ(T) ≤ ‖T(1)‖∞` for arbitrary positive maps relies on the
-Russo--Dye theorem, which yields factor $1$; this general bound is not yet
-formalized.  A factor-$4$ route via the PSD decomposition is a possible
-elimination plan.  Documented in
+The pinned Mathlib has no standalone Russo--Dye theorem. The formal proof
+derives its sharp matrix norm estimate from Wolf Theorem 5.6, using the
+identity as a commuting dominant operator after normalizing by `‖T(1)‖∞`.
+Thus no four-positive-parts estimate and no factor $4$ occur. The resolved
+proof-route note is
 `docs/paper-gaps/wolf_prop61_russo_dye_factor.tex`.
 
 

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -529,6 +529,9 @@ Perron–Frobenius theorem — are indexed in
   `QICLean.Channel.Determinant.Bound`.
 * `IsPositiveMap.eigenvalue_one_exists_of_tracePreserving` — eigenvalue $1$ exists
   (nonzero PSD fixed point), in `QICLean.Channel.Peripheral.SpectralRadius`.
+* `IsPositiveMap.spectralRadius_eq_one_of_tracePreserving` — a positive
+  trace-preserving map has spectral radius exactly $1$, by combining the two
+  preceding results.
 
 The pinned Mathlib has no standalone Russo--Dye theorem. The formal proof
 derives its sharp matrix norm estimate from Wolf Theorem 5.6, using the


### PR DESCRIPTION
## Summary

- prove the sharp positive-map estimate
  `‖T(X)‖∞ ≤ ‖T(1)‖∞ ‖X‖∞` on nonzero complex matrix algebras;
- derive Wolf Equations (6.3) and (6.2), and package the unital and trace-preserving conclusions of Proposition 6.1;
- synchronize the Blueprint, Chapter 6 coverage index, and the resolved proof-route note.

## Mathematical route

The pinned Mathlib version has no standalone Russo--Dye convex-hull theorem. The formal proof derives the finite-matrix estimate needed in Wolf's line 84 from Wolf Theorem 5.6: after normalizing by `c = ‖T(1)‖∞`, the identity is used as the commuting dominant operator. The case `c = 0` is proved separately. This gives coefficient one and does not pass through the four-positive-parts estimate.

The hypotheses require only positivity, not complete positivity. The norm is the matrix C*-operator norm. The trace-preserving radius-one theorem reuses the established closed-unit-disk eigenvalue bound and the established nonzero positive semidefinite fixed point.

## Verification

- `lake build QICLean.Channel.Peripheral.SpectralRadius`
- immediate downstream builds for `Peripheral.UnitalKraus`, `Irreducible.SpectralRadius`, and `Kraus.MixedMap.SpectralRadius`
- Blueprint synchronization: 1924/1924 theorem-like entries, 100%
- `chktex` on the changed Blueprint chapter
- `texra-blueprint paper-gaps check`
- exact-head kernel `#print axioms` audit for all seven headline declarations: only `propext`, `Classical.choice`, and `Quot.sound`
- independent exact-head adversarial audit: no vacuity signal

Closes #36.
