### PR TITLE
feat(channel): formalize Wolf stationary subspaces

### DIFF
--- a/QICLean/Channel/FixedPoint/StationarySupport.lean
+++ b/QICLean/Channel/FixedPoint/StationarySupport.lean
@@ -23,10 +23,13 @@ Propositions 6.9--6.11).
   point of an irreducible channel.
 * `stationarySupport_eq_one`: for an irreducible channel, the stationary support
   is full (`= 1`).
-* TODO (Wolf Proposition 6.9): upgrade to the non-vacuous equivalence between
-  irreducibility and full support of stationary states.
-* TODO (Wolf Proposition 6.10): formalize minimality of stationary support without an
-  irreducibility hypothesis.
+* `IsPositiveMap.exists_maximalSupport_fixedPoint` in `MaximalSupportBasic`
+  gives Wolf Proposition 6.9.
+* `IsPositiveMap.trace_one_sub_stationaryProj_mul_map_stationaryProj_eq_zero`,
+  `IsPositiveMap.map_density_le_stationaryProj`, and
+  `IsPositiveMap.map_density_le_projection_iff_le_traceAdjointMap` in
+  `StationarySupportRestriction` give Wolf Propositions 6.10--6.11 with
+  their positive trace-preserving hypotheses.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -123,7 +126,7 @@ private lemma stationaryState_ne_zero
       _ = 0 := this
   exact one_ne_zero h10
 
-/-- Proposition 6.9: for an irreducible channel, the stationary support is full. -/
+/-- For an irreducible channel, the stationary support is full. -/
 theorem stationarySupport_eq_one
     {E : Mat →ₗ[ℂ] Mat} (hE : IsChannel E)
     (hIrr : IsIrreducibleMap E) (hD : 0 < D) :
@@ -145,15 +148,5 @@ theorem stationarySupport_eq_one
         hρ_psd.supportProj_ne_zero_of_ne_zero hρ_ne
     exact hP_ne hP0
   · simpa [P] using hP1
-
-/-
-TODO (Wolf Propositions 6.9–6.10):
-The original declarations `irreducible_iff_support_full` and
-`stationary_support_minimal` were removed because their previous formulations
-were vacuous/trivial. They should be replaced by:
-* a non-vacuous Proposition 6.9 equivalence (irreducibility ↔ full support of
-  stationary states), and
-* Proposition 6.10 minimality of stationary support without assuming irreducibility.
--/
 
 end Channel

--- a/QICLean/Channel/FixedPoint/StationarySupportRestriction.lean
+++ b/QICLean/Channel/FixedPoint/StationarySupportRestriction.lean
@@ -6,8 +6,12 @@ Authors: TNLean contributors
 import QICLean.Algebra.HermitianHelpers
 import QICLean.Algebra.OrthogonalProjection
 import QICLean.Channel.FixedPoint.MaximalSupportBasic
+import QICLean.Channel.FixedPoint.MeanErgodicAdjoint
 import QICLean.Channel.FixedPoint.StationaryProjection
+import QICLean.Channel.Schwarz.TwoPositive
 import QICLean.Analysis.SupportCompression
+import QICLean.Analysis.MarginalSupport
+import QICLean.Algebra.PositiveSemidefiniteNormalization
 
 /-!
 # Restriction to the support of a stationary positive matrix
@@ -243,6 +247,296 @@ theorem map_supported_on_fixedPoint_support
   rw [hXeq, T.map_sub, T.map_smul, T.map_smul, T.map_sub, T.map_sub]
   simp only [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_smul, Matrix.smul_mul]
   rw [hmA₁p, hmA₁m, hmA₂p, hmA₂m]
+
+/-- A density matrix supported on an orthogonal projection is dominated by
+that projection. -/
+private theorem density_le_of_supported_on_projection
+    {A Q : Mat} (hA : A ∈ densityMatrices D)
+    (hQ : IsOrthogonalProjection Q) (hAsupport : Q * A * Q = A) :
+    A ≤ Q := by
+  let : Nonempty (Fin D) := Matrix.nonempty_of_trace_eq_one A hA.2
+  have hOneSubA : ((1 : Mat) - A).PosSemidef := by
+    simpa [hA.2] using hA.1.trace_smul_one_sub_self_posSemidef
+  have hcorner := hOneSubA.conjTranspose_mul_mul_same Q
+  rw [hQ.1.eq] at hcorner
+  have heq : Q * ((1 : Mat) - A) * Q = Q - A := by
+    rw [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_one, hQ.2, hAsupport]
+  rw [heq] at hcorner
+  exact sub_nonneg.mp hcorner.nonneg
+
+/-- A positive semidefinite matrix below a projection is supported on that
+projection. -/
+private theorem supported_on_projection_of_posSemidef_le
+    {A Q : Mat} (hA : A.PosSemidef) (hQ : IsOrthogonalProjection Q)
+    (hAQ : A ≤ Q) :
+    Q * A * Q = A := by
+  let P : Mat := 1 - Q
+  have hP : IsOrthogonalProjection P := by
+    simpa only [P] using hQ.one_sub
+  have hdiff : (Q - A).PosSemidef := (sub_nonneg.mpr hAQ).posSemidef
+  have htrace_nonneg : (0 : ℂ) ≤ Matrix.trace (P * A) :=
+    (isOrthogonalProjection_posSemidef hP).trace_mul_nonneg hA
+  have htrace_diff_nonneg : (0 : ℂ) ≤ Matrix.trace (P * (Q - A)) :=
+    (isOrthogonalProjection_posSemidef hP).trace_mul_nonneg hdiff
+  have hPQ : P * Q = 0 := by
+    simp only [P, Matrix.sub_mul, Matrix.one_mul, hQ.2, sub_self]
+  have htrace_le : Matrix.trace (P * A) ≤ 0 := by
+    rw [Matrix.mul_sub, Matrix.trace_sub, hPQ, Matrix.trace_zero,
+      zero_sub] at htrace_diff_nonneg
+    exact neg_nonneg.mp htrace_diff_nonneg
+  have htrace : Matrix.trace (P * A) = 0 :=
+    le_antisymm htrace_le htrace_nonneg
+  have hPAzero : P * A = 0 :=
+    hA.proj_mul_eq_zero_of_trace_eq_zero hP.1 hP.2 htrace
+  have hQA : Q * A = A := by
+    change (1 - Q) * A = 0 at hPAzero
+    rw [Matrix.sub_mul, Matrix.one_mul, sub_eq_zero] at hPAzero
+    exact hPAzero.symm
+  have hAQright : A * Q = A := by
+    have hQAstar := congrArg Matrix.conjTranspose hQA
+    simpa [Matrix.conjTranspose_mul, hA.isHermitian.eq, hQ.1.eq] using hQAstar
+  rw [hQA, hAQright]
+
+/-- A positive semidefinite matrix below a projection vanishes on the
+orthogonal-complement corner. -/
+private theorem one_sub_projection_mul_eq_zero_of_posSemidef_le
+    {A Q : Mat} (hA : A.PosSemidef) (hQ : IsOrthogonalProjection Q)
+    (hAQ : A ≤ Q) :
+    (1 - Q) * A = 0 := by
+  have hsupport := supported_on_projection_of_posSemidef_le hA hQ hAQ
+  have hQA : Q * A = A := by
+    calc
+      Q * A = Q * (Q * A * Q) := by rw [hsupport]
+      _ = (Q * Q) * A * Q := by simp only [Matrix.mul_assoc]
+      _ = Q * A * Q := by rw [hQ.2]
+      _ = A := hsupport
+  rw [Matrix.sub_mul, Matrix.one_mul, hQA, sub_self]
+
+/-- A positive trace-preserving map sends density matrices to density
+matrices. -/
+private theorem map_mem_densityMatrices
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T) {A : Mat} (hA : A ∈ densityMatrices D) :
+    T A ∈ densityMatrices D :=
+  ⟨hT A hA.1, by rw [hTP A, hA.2]⟩
+
+/-- **Wolf Proposition 6.10, displayed trace identity.** Let `Q` be the
+support projection of a stationary density matrix `σ` for a positive
+trace-preserving map `T`. Then the part of `T Q` on the orthogonal complement of `Q` has zero
+trace:
+`tr ((1 - Q) * T Q) = 0`.
+
+Source: Wolf, Proposition 6.10; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1241--1257. -/
+theorem trace_one_sub_stationaryProj_mul_map_stationaryProj_eq_zero
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    (_hTP : IsTracePreservingMap T)
+    {σ : Mat} (hσ : σ ∈ densityMatrices D) (hσfix : T σ = σ) :
+    let Q := Kraus.stationaryProj hσ.1
+    Matrix.trace ((1 - Q) * T Q) = 0 := by
+  dsimp only
+  let Q : Mat := Kraus.stationaryProj hσ.1
+  have hQ : IsOrthogonalProjection Q :=
+    Kraus.isOrthogonalProjection_stationaryProj hσ.1
+  have hQpsd : Q.PosSemidef := isOrthogonalProjection_posSemidef hQ
+  have hQsupport : Q * Q * Q = Q := by rw [hQ.2, hQ.2]
+  have hTQsupport : Q * T Q * Q = T Q := by
+    simpa only [Q] using map_posSemidef_supported_on_fixedPoint_support
+      hT hσ.1 hσfix hQpsd (by simpa only [Q] using hQsupport)
+  have hQTQ : Q * T Q = T Q := by
+    calc
+      Q * T Q = Q * (Q * T Q * Q) := by rw [hTQsupport]
+      _ = (Q * Q) * T Q * Q := by simp only [Matrix.mul_assoc]
+      _ = Q * T Q * Q := by rw [hQ.2]
+      _ = T Q := hTQsupport
+  rw [Matrix.sub_mul, Matrix.one_mul, hQTQ, sub_self, Matrix.trace_zero]
+
+/-- **Wolf Proposition 6.10, Equation (6.50).** Let `Q` be the support
+projection of a stationary density matrix `σ` for a positive
+trace-preserving map `T`. Every density matrix `ρ` satisfying `ρ ≤ Q` also
+satisfies `T ρ ≤ Q`.
+
+Source: Wolf, Proposition 6.10, Equation (6.50); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1241--1257. -/
+theorem map_density_le_stationaryProj
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    {σ : Mat} (hσ : σ ∈ densityMatrices D) (hσfix : T σ = σ)
+    {ρ : Mat} (hρ : ρ ∈ densityMatrices D)
+    (hρQ : ρ ≤ Kraus.stationaryProj hσ.1) :
+    T ρ ≤ Kraus.stationaryProj hσ.1 := by
+  let Q : Mat := Kraus.stationaryProj hσ.1
+  change T ρ ≤ Q
+  let : Nonempty (Fin D) := Matrix.nonempty_of_trace_eq_one ρ hρ.2
+  have hQ : IsOrthogonalProjection Q :=
+    Kraus.isOrthogonalProjection_stationaryProj hσ.1
+  have hρQ' : ρ ≤ Q := hρQ
+  have hρsupport : Q * ρ * Q = ρ :=
+    supported_on_projection_of_posSemidef_le hρ.1 hQ hρQ'
+  have hTρsupport : Q * T ρ * Q = T ρ := by
+    exact map_posSemidef_supported_on_fixedPoint_support
+      hT hσ.1 hσfix hρ.1 hρsupport
+  exact density_le_of_supported_on_projection
+    (map_mem_densityMatrices hT hTP hρ) hQ hTρsupport
+
+/-- **Wolf Proposition 6.11 (stationary subspaces II).** For a positive
+trace-preserving map `T` and a Hermitian projection `Q`, preservation of every
+density matrix below `Q` is equivalent to the sub-harmonic inequality
+`Q ≤ T*(Q)`.
+
+Source: Wolf, Proposition 6.11; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1262--1285. -/
+theorem map_density_le_projection_iff_le_traceAdjointMap
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T) {Q : Mat}
+    (hQ : IsOrthogonalProjection Q) :
+    (∀ ρ : Mat, ρ ∈ densityMatrices D → ρ ≤ Q → T ρ ≤ Q) ↔
+      Q ≤ Matrix.traceAdjointMap T Q := by
+  constructor
+  · intro hpreserves
+    cases isEmpty_or_nonempty (Fin D) with
+    | inl hD =>
+        let := hD
+        have hQzero : Q = 0 := Subsingleton.elim _ _
+        simp [hQzero]
+    | inr hD =>
+        let x₀ : Fin D := Classical.choice hD
+        by_cases hQzero : Q = 0
+        · simp [hQzero]
+        · let P : Mat := 1 - Q
+          let q : Mat := Matrix.normalizePosSemidef x₀ Q
+          let B : Mat := Matrix.traceAdjointMap T P
+          have hQpsd : Q.PosSemidef := isOrthogonalProjection_posSemidef hQ
+          have hP : IsOrthogonalProjection P := by
+            simpa only [P] using hQ.one_sub
+          have hPpsd : P.PosSemidef := isOrthogonalProjection_posSemidef hP
+          have htrace_re_pos : 0 < Q.trace.re :=
+            (Complex.lt_def.mp (hQpsd.trace_pos_of_ne_zero hQzero)).1
+          have htrace_re_ne : Q.trace.re ≠ 0 := htrace_re_pos.ne'
+          have hq : q ∈ densityMatrices D :=
+            ⟨Matrix.normalizePosSemidef_posSemidef x₀ hQpsd,
+              Matrix.normalizePosSemidef_trace x₀ hQpsd⟩
+          have hqsupport : Q * q * Q = q := by
+            simp only [q, Matrix.normalizePosSemidef, htrace_re_ne, ite_false,
+              Matrix.mul_smul, Matrix.smul_mul, hQ.2]
+          have hqQ : q ≤ Q :=
+            density_le_of_supported_on_projection hq hQ hqsupport
+          have hTqQ : T q ≤ Q := hpreserves q hq hqQ
+          have hTq : T q ∈ densityMatrices D :=
+            map_mem_densityMatrices hT hTP hq
+          have hPTq : P * T q = 0 := by
+            simpa only [P] using
+              one_sub_projection_mul_eq_zero_of_posSemidef_le hTq.1 hQ hTqQ
+          have hpairq : Matrix.trace (B * q) = 0 := by
+            dsimp only [B]
+            rw [Matrix.trace_traceAdjointMap_mul, hPTq, Matrix.trace_zero]
+          have hrecover : (Q.trace.re : ℂ) • q = Q := by
+            simpa only [q] using
+              Matrix.trace_re_smul_normalizePosSemidef x₀ hQpsd
+          have hpairQ : Matrix.trace (B * Q) = 0 := by
+            rw [← hrecover, Matrix.mul_smul, Matrix.trace_smul, hpairq]
+            simp
+          have hBpsd : B.PosSemidef := by
+            exact hT.traceAdjointMap P hPpsd
+          have htraceQB : Matrix.trace (Q * B) = 0 := by
+            calc
+              Matrix.trace (Q * B) = Matrix.trace (B * Q) :=
+                Matrix.trace_mul_comm Q B
+              _ = 0 := hpairQ
+          have hQB : Q * B = 0 :=
+            hBpsd.proj_mul_eq_zero_of_trace_eq_zero hQ.1 hQ.2 htraceQB
+          have hBQ : B * Q = 0 := by
+            have hQBstar := congrArg Matrix.conjTranspose hQB
+            simpa [Matrix.conjTranspose_mul, hBpsd.isHermitian.eq, hQ.1.eq]
+              using hQBstar
+          have hBsupport : P * B * P = B := by
+            change (1 - Q) * B * (1 - Q) = B
+            rw [Matrix.sub_mul, Matrix.one_mul, hQB, sub_zero,
+              Matrix.mul_sub, Matrix.mul_one, hBQ, sub_zero]
+          have hAdjOne : Matrix.traceAdjointMap T (1 : Mat) = 1 :=
+            isTracePreservingMap_iff_traceAdjointMap_one.mp hTP
+          have hB_eq : B = 1 - Matrix.traceAdjointMap T Q := by
+            dsimp only [B, P]
+            rw [map_sub, hAdjOne]
+          have hAdjQ_eq : Matrix.traceAdjointMap T Q = 1 - B := by
+            rw [hB_eq]
+            module
+          have hAdjQpsd : (Matrix.traceAdjointMap T Q).PosSemidef :=
+            hT.traceAdjointMap Q hQpsd
+          have hcorner :
+              (P * Matrix.traceAdjointMap T Q * P).PosSemidef := by
+            have hcompressed := hAdjQpsd.conjTranspose_mul_mul_same P
+            rwa [hP.1.eq] at hcompressed
+          have hcorner_eq :
+              P * Matrix.traceAdjointMap T Q * P =
+                Matrix.traceAdjointMap T Q - Q := by
+            rw [hAdjQ_eq]
+            calc
+              P * (1 - B) * P = P * P - P * B * P := by noncomm_ring
+              _ = P - B := by rw [hP.2, hBsupport]
+              _ = (1 - B) - Q := by
+                dsimp only [P]
+                abel
+          rw [hcorner_eq] at hcorner
+          exact sub_nonneg.mp hcorner.nonneg
+  · intro hsubharmonic ρ hρ hρQ
+    let P : Mat := 1 - Q
+    have hP : IsOrthogonalProjection P := by
+      simpa only [P] using hQ.one_sub
+    have hPpsd : P.PosSemidef := isOrthogonalProjection_posSemidef hP
+    have hTρ : T ρ ∈ densityMatrices D :=
+      map_mem_densityMatrices hT hTP hρ
+    have hdiff :
+        (Matrix.traceAdjointMap T Q - Q).PosSemidef :=
+      (sub_nonneg.mpr hsubharmonic).posSemidef
+    have hpair_order :
+        Matrix.trace (Q * ρ) ≤
+          Matrix.trace (Matrix.traceAdjointMap T Q * ρ) := by
+      have hnonneg := hdiff.trace_mul_nonneg hρ.1
+      rw [Matrix.sub_mul, Matrix.trace_sub] at hnonneg
+      exact sub_nonneg.mp hnonneg
+    have hPrho : (1 - Q) * ρ = 0 :=
+      one_sub_projection_mul_eq_zero_of_posSemidef_le hρ.1 hQ hρQ
+    have hQrho : Q * ρ = ρ := by
+      rw [Matrix.sub_mul, Matrix.one_mul, sub_eq_zero] at hPrho
+      exact hPrho.symm
+    have hAdjTrace :
+        1 ≤ Matrix.trace (Matrix.traceAdjointMap T Q * ρ) := by
+      calc
+        1 = Matrix.trace (Q * ρ) := by rw [hQrho, hρ.2]
+        _ ≤ Matrix.trace (Matrix.traceAdjointMap T Q * ρ) := hpair_order
+    have htraceP :
+        Matrix.trace (P * T ρ) =
+          1 - Matrix.trace (Matrix.traceAdjointMap T Q * ρ) := by
+      calc
+        Matrix.trace (P * T ρ) =
+            Matrix.trace (T ρ) - Matrix.trace (Q * T ρ) := by
+          dsimp only [P]
+          rw [Matrix.sub_mul, Matrix.one_mul, Matrix.trace_sub]
+        _ = 1 - Matrix.trace (Matrix.traceAdjointMap T Q * ρ) := by
+          rw [hTρ.2, ← Matrix.trace_traceAdjointMap_mul]
+    have htrace_nonneg : (0 : ℂ) ≤ Matrix.trace (P * T ρ) :=
+      hPpsd.trace_mul_nonneg hTρ.1
+    have htrace_le : Matrix.trace (P * T ρ) ≤ 0 := by
+      calc
+        Matrix.trace (P * T ρ) =
+            1 - Matrix.trace (Matrix.traceAdjointMap T Q * ρ) := htraceP
+        _ ≤ 0 := sub_nonpos.mpr hAdjTrace
+    have htrace_zero : Matrix.trace (P * T ρ) = 0 :=
+      le_antisymm htrace_le htrace_nonneg
+    have hPTρ : P * T ρ = 0 :=
+      hTρ.1.proj_mul_eq_zero_of_trace_eq_zero hP.1 hP.2 htrace_zero
+    have hQTρ : Q * T ρ = T ρ := by
+      change (1 - Q) * T ρ = 0 at hPTρ
+      rw [Matrix.sub_mul, Matrix.one_mul, sub_eq_zero] at hPTρ
+      exact hPTρ.symm
+    have hTρQ : T ρ * Q = T ρ := by
+      have hQTρstar := congrArg Matrix.conjTranspose hQTρ
+      simpa [Matrix.conjTranspose_mul, hTρ.1.isHermitian.eq, hQ.1.eq]
+        using hQTρstar
+    have hTρsupport : Q * T ρ * Q = T ρ := by
+      rw [hQTρ, hTρQ]
+    exact density_le_of_supported_on_projection hTρ hQ hTρsupport
 
 /-- Compression of a linear map along an isometric inclusion. -/
 noncomputable def stationarySupportCompression

--- a/QICLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
+++ b/QICLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
@@ -72,6 +72,46 @@ theorem Matrix.traceAdjointMap_stationarySupportCompression
     _ = (IsPositiveMap.stationarySupportCompression
           (Matrix.traceAdjointMap T) V A * B).trace := rfl
 
+/-- **Wolf Equation (6.53).** If `A` is fixed by the trace adjoint of a
+positive trace-preserving map `T`, then its compression `Vᴴ * A * V` is fixed
+by the trace adjoint of the restriction of `T` to the support of a stationary
+positive matrix.
+
+The argument uses the support intertwining of Equation (6.52) and the
+trace-adjoint identity, without complete positivity or a Schwarz hypothesis.
+
+Source: Wolf, Lemma 6.5, Equation (6.53); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1345--1376. -/
+theorem Matrix.traceAdjointMap_stationarySupportCompression_fixed
+    {T : MatD →ₗ[ℂ] MatD} (hT : IsPositiveMap T)
+    (_hTP : IsTracePreservingMap T)
+    {ρ : MatD} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (hVrange : V * Vᴴ = Kraus.stationaryProj hρ)
+    {A : MatD} (hAfix : Matrix.traceAdjointMap T A = A) :
+    Matrix.traceAdjointMap (IsPositiveMap.stationarySupportCompression T V)
+        (Vᴴ * A * V) = Vᴴ * A * V := by
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro B
+  rw [Matrix.trace_traceAdjointMap_mul]
+  have hintertwine := IsPositiveMap.stationarySupportCompression_intertwine
+    hT hρ hρfix V hV hVrange B
+  have htraceIntertwine :
+      (Vᴴ * A * V * IsPositiveMap.stationarySupportCompression T V B).trace =
+        (A * T (V * B * Vᴴ)).trace := by
+    rw [hintertwine]
+    simpa only [Matrix.mul_assoc] using
+      (Matrix.trace_mul_cycle (A * V)
+        (IsPositiveMap.stationarySupportCompression T V B) Vᴴ).symm
+  rw [htraceIntertwine]
+  calc
+    (A * T (V * B * Vᴴ)).trace =
+        (Matrix.traceAdjointMap T A * (V * B * Vᴴ)).trace :=
+      (Matrix.trace_traceAdjointMap_mul T A (V * B * Vᴴ)).symm
+    _ = (A * (V * B * Vᴴ)).trace := by rw [hAfix]
+    _ = (Vᴴ * A * V * B).trace := by
+      simpa only [Matrix.mul_assoc] using Matrix.trace_mul_cycle (A * V) B Vᴴ
+
 /-- Compression along an isometry preserves the Schwarz inequality for a
 positive map.
 

--- a/blueprint/src/chapter/ch09_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
@@ -426,6 +426,80 @@ that Loewner domination transfers the support.
     linearity of $T$ gives (\ref{eq:spectral_ds_support_invariance}).
 \end{proof}
 
+\begin{theorem}[Stationary subspaces]%
+    \label{thm:wolf_stationary_subspaces}
+    \lean{IsPositiveMap.trace_one_sub_stationaryProj_mul_map_stationaryProj_eq_zero,
+        IsPositiveMap.map_density_le_stationaryProj}
+    \leanok
+    \uses{thm:stationarySupport_restriction}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, let
+    $\sigma$ be a density operator with $T(\sigma)=\sigma$, and let $Q$ be
+    the support projection of $\sigma$. Then
+    \begin{align}
+        \tr\!\left[(\Id-Q)T(Q)\right]&=0,
+        \label{eq:wolf_stationary_subspace_trace}\\
+        \rho\preceq Q&\quad\Longrightarrow\quad T(\rho)\preceq Q
+        \label{eq:wolf_stationary_subspace_order}
+    \end{align}
+    for every density operator $\rho\in\MN{D}$. This is
+    \cite[Proposition~6.10]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:stationarySupport_restriction}
+    Since $Q$ is positive and supported on itself,
+    Theorem~\ref{thm:stationarySupport_restriction} gives
+    $QT(Q)Q=T(Q)$, hence $(\Id-Q)T(Q)=0$ and
+    (\ref{eq:wolf_stationary_subspace_trace}) follows. If
+    $\rho\preceq Q$, positivity shows that $\rho$ is supported on $Q$.
+    The same theorem therefore gives $QT(\rho)Q=T(\rho)$. Finally,
+    positivity and trace preservation make $T(\rho)$ a density operator;
+    a density operator supported on $Q$ is bounded above by $Q$, which proves
+    (\ref{eq:wolf_stationary_subspace_order}).
+\end{proof}
+
+\begin{theorem}[Stationary subspaces II]%
+    \label{thm:wolf_stationary_subspaces_ii}
+    \lean{IsPositiveMap.map_density_le_projection_iff_le_traceAdjointMap}
+    \leanok
+    \uses{def:positive_map, def:trace_preserving}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, and let
+    $Q\in\MN{D}$ be a Hermitian projection. Then the following are
+    equivalent:
+    \begin{enumerate}
+        \item every density operator $\rho\preceq Q$ satisfies
+              $T(\rho)\preceq Q$;
+        \item $T^*(Q)\succeq Q$.
+    \end{enumerate}
+    This is \cite[Proposition~6.11]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Put $P=\Id-Q$. For the forward implication, apply the preservation
+    hypothesis to the trace normalization of $Q$. Trace-pairing positivity
+    gives $QT^*(P)=0$, hence
+    $PT^*(P)P=T^*(P)$. Since $T^*(\Id)=\Id$, this rewrites as
+    \begin{align}
+        T^*(Q)-PT^*(Q)P=Q,
+        \notag
+    \end{align}
+    and compression preserves positivity, so $T^*(Q)\succeq Q$.
+    Conversely, for a density operator $\rho\preceq Q$, one has
+    $Q\rho=\rho$. Thus
+    \begin{align}
+        0
+        \leq \tr[T(\rho)P]
+        =1-\tr[\rho T^*(Q)]
+        \leq1-\tr[\rho Q]
+        =0.
+        \notag
+    \end{align}
+    Positivity then forces $PT(\rho)=0$, so $T(\rho)$ is supported on $Q$;
+    its unit trace gives $T(\rho)\preceq Q$.
+\end{proof}
+
 \begin{theorem}[Restriction to full-rank fixed points]%
     \label{thm:stationarySupport_compression}
     \lean{IsPositiveMap.exists_maximalSupportCompression}

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -58,6 +58,39 @@
 
 % Completed support transport recorded in
 % docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.
+\begin{lemma}[Fixed observables after stationary-support restriction]%
+    \label{lem:trace_adjoint_stationary_support_compression_fixed}
+    \lean{Matrix.traceAdjointMap_stationarySupportCompression_fixed}
+    \leanok
+    \uses{thm:stationarySupport_restriction}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, let
+    $\rho\succeq0$ satisfy $T(\rho)=\rho$, and let
+    $V:\mathcal H\to\C^D$ be an isometry onto the support of $\rho$. Define
+    $\widetilde T(Y)=V^*T(VYV^*)V$. If $T^*(A)=A$, then
+    \begin{align}
+        \widetilde T^*(V^*AV)=V^*AV.
+        \label{eq:wolf_stationary_support_adjoint_fixed}
+    \end{align}
+    This is Equation~(6.53) of~\cite{Wolf2012Quantum}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{thm:stationarySupport_restriction}
+    For every $B\in\mathcal B(\mathcal H)$, the support intertwining
+    identity $T(VBV^*)=V\widetilde T(B)V^*$ and trace-pairing duality give
+    \begin{align}
+        \tr\!\left[\widetilde T^*(V^*AV)B\right]
+        &=\tr\!\left[V^*AV\widetilde T(B)\right]\\
+        &=\tr\!\left[AT(VBV^*)\right]\\
+        &=\tr\!\left[T^*(A)VBV^*\right]\\
+        &=\tr\!\left[V^*AVB\right].
+        \notag
+    \end{align}
+    Nondegeneracy of the trace pairing proves
+    (\ref{eq:wolf_stationary_support_adjoint_fixed}).
+\end{proof}
+
 \begin{theorem}[Density blocks after restriction to maximal stationary support]%
     \label{thm:maximal_support_compression_density_blocks}
     \lean{IsPositiveMap.exists_block_densities_of_maximalSupportCompression,
@@ -66,6 +99,7 @@
         IsSchwarzMap.traceAdjointMap_stationarySupportCompression}
     \leanok
     \uses{thm:stationarySupport_compression,
+        lem:trace_adjoint_stationary_support_compression_fixed,
         thm:mean_ergodic_projection_density_block_form}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, and suppose
     that $T^*$ satisfies the Schwarz inequality. Set
@@ -91,6 +125,7 @@
 \begin{proof}
     \leanok
     \uses{thm:stationarySupport_compression,
+        lem:trace_adjoint_stationary_support_compression_fixed,
         thm:mean_ergodic_projection_density_block_form,
         thm:posdef_left_kronecker_trace_one}
     Theorem~\ref{thm:stationarySupport_compression} gives positivity, trace

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -251,18 +251,14 @@ channel-level argument below uses its Kraus analogue.
 
 \begin{remark}[Stationary-support formulations]%
     \label{rem:stationary_support_todo}
-    The nontrivial formulations needed here are the following results from
-    Wolf:
-    \begin{itemize}
-        \item the converse direction
-              of~\cite[Proposition~6.10]{Wolf2012Quantum}: if the support
-              projection of every positive semidefinite fixed point is full,
-              then the channel is irreducible;
-        \item \cite[Proposition~6.11]{Wolf2012Quantum}: minimality of the
-              stationary support among invariant projections, without
-              assuming irreducibility.
-    \end{itemize}
-    These statements are not used elsewhere in this chapter.
+    The numbered source results are separated from the irreducible-channel
+    specialization above. Wolf's Proposition~6.9 is the maximal-support
+    theorem formalized in
+    Theorem~\ref{thm:maximalSupport_fixedPoint}; Propositions~6.10 and~6.11
+    are Theorems~\ref{thm:wolf_stationary_subspaces}
+    and~\ref{thm:wolf_stationary_subspaces_ii}. Thus no converse
+    irreducibility statement or ``minimal stationary support'' statement is
+    attributed to these proposition numbers.
 \end{remark}
 
 \subsection{Faithful compression onto the support sector}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -749,7 +749,28 @@ Formalized in the tensor-network layer; indexed in
 
 ### Section 6.4 Fixed points
 
-#### Wolf Section 6 stationary-support state (Propositions 6.9--6.11, Lems. 6.4--6.5)
+#### Wolf Section 6 stationary-support state (Propositions 6.9--6.11, Lemma 6.5)
+
+In `QICLean.Channel.FixedPoint.MaximalSupportBasic`:
+
+* `IsPositiveMap.exists_maximalSupport_fixedPoint` — Wolf Proposition 6.9:
+  the support of the fixed point $T_\infty(\mathbf 1)$ contains the support
+  and range of every fixed point.
+
+In `QICLean.Channel.FixedPoint.StationarySupportRestriction`:
+
+* `IsPositiveMap.trace_one_sub_stationaryProj_mul_map_stationaryProj_eq_zero`
+  and `IsPositiveMap.map_density_le_stationaryProj` — the displayed trace and
+  order conclusions of Wolf Proposition 6.10.
+* `IsPositiveMap.map_density_le_projection_iff_le_traceAdjointMap` — Wolf
+  Proposition 6.11: density operators below a Hermitian projection $Q$ are
+  preserved below $Q$ exactly when $T^*(Q)\succeq Q$.
+
+In `QICLean.Channel.FixedPoint.SupportCompressedDensityBlocks`:
+
+* `Matrix.traceAdjointMap_stationarySupportCompression_fixed` — Wolf
+  Equation (6.53): an adjoint fixed point compresses to an adjoint fixed point
+  of the stationary-support restriction.
 
 In `QICLean.Channel.FixedPoint.StationarySupport`:
 
@@ -758,10 +779,8 @@ In `QICLean.Channel.FixedPoint.StationarySupport`:
 * `Channel.stationarySupport` — support projection of the unique density-matrix
   fixed point of an irreducible channel.
 * `Channel.stationarySupport_eq_one` — irreducible channels have full
-  stationary support.
-* TODO: non-vacuous formalizations of Wolf Proposition 6.9 and Proposition 6.10
-  (`irreducible_iff_support_full`, `stationary_support_minimal`) remain to be
-  reinstated.
+  stationary support. This is a channel-specific consequence, not an alternate
+  formulation of Wolf Propositions 6.9--6.11.
 
 #### Wolf Theorem 6.12 (Fixed points form a *-algebra) — PARTIALLY FORMALIZED
 
@@ -936,6 +955,12 @@ In `QICLean.Channel.FixedPoint.StationarySupportRestriction`:
   support of an arbitrary stationary positive matrix.
 * `IsPositiveMap.map_supported_on_fixedPoint_support` — the extension to every
   supported matrix by decomposition into four positive matrices.
+* `IsPositiveMap.trace_one_sub_stationaryProj_mul_map_stationaryProj_eq_zero`
+  and `IsPositiveMap.map_density_le_stationaryProj` — Wolf Proposition 6.10
+  in its displayed trace and density-order forms.
+* `IsPositiveMap.map_density_le_projection_iff_le_traceAdjointMap` — Wolf
+  Proposition 6.11, identifying stationary projections with the
+  sub-harmonic inequality $Q\preceq T^*(Q)$.
 * `IsPositiveMap.stationarySupportCompression_isPositiveMap` and
   `IsPositiveMap.stationarySupportCompression_isTracePreservingMap` — the
   supported compression is positive and trace-preserving.
@@ -969,6 +994,9 @@ In `QICLean.Channel.FixedPoint.TraceAdjointDensityBlocks`:
 
 In `QICLean.Channel.FixedPoint.SupportCompressedDensityBlocks`:
 
+* `Matrix.traceAdjointMap_stationarySupportCompression_fixed` — Wolf
+  Equation (6.53), transporting trace-adjoint fixed points through the
+  stationary-support compression.
 * `IsPositiveMap.exists_block_densities_of_maximalSupportCompression` — the
   maximal-support compression has positive-definite density blocks, and its
   fixed points correspond exactly to the ambient fixed points carried by the


### PR DESCRIPTION
Closes #41.

Formalizes the exact remaining stationary-support package from Wolf Chapter 6:

- Proposition 6.10, including \(\operatorname{tr}[(1-Q)T(Q)]=0\) and \(\rho\le Q\Rightarrow T(\rho)\le Q\);
- Proposition 6.11, the equivalence between preservation below \(Q\) and \(Q\le T^*(Q)\);
- Equation (6.53), transporting trace-adjoint fixed points through the stationary-support compression.

The declarations retain Wolf's positive trace-preserving hypotheses. They reuse the existing scalar-domination support proof and Equation (6.52) intertwining; no CP, Schwarz, or new compression formalism is introduced. Stale proposition-number TODOs are corrected, and the Blueprint plus coverage index are synchronized.

Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1241–1376.

Validation at exact head `d53ced780c40bebaa0099c9ff8edc2823c6065b7`:

- focused builds: `StationarySupport`, `StationarySupportRestriction`, `SupportCompressedDensityBlocks`;
- Blueprint/Lean sync: 1916/1916 declarations covered;
- style, reader-facing prose, numbering, oversized-file, diff, and forbidden-token gates;
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`.

No `sorry`, `admit`, new `axiom`, `native_decide`, `unsafeCast`, or equivalent bypass.
