### PR TITLE
feat(analysis): separate conic strict feasibility and attainment

### DIFF
--- a/QICLean/Analysis/ConicProgram.lean
+++ b/QICLean/Analysis/ConicProgram.lean
@@ -7,18 +7,20 @@ import Mathlib.Analysis.Convex.Cone.InnerDual
 import Mathlib.Data.EReal.Basic
 
 /-!
-# Conic programs and weak duality
+# Conic programs, strict feasibility, and weak duality
 
-This file defines the primal and dual conic programs in Wolf's convention and proves weak
-duality. The source is Wolf, *Quantum Channels & Operations*, Chapter 4,
-`Notes/WolfNoteTexSource/ch04_convex_structure.tex`, lines 39--71, especially equations
-`conic-primal` and `conic-dual`.
+This file defines the primal and dual conic programs in Wolf's convention, their strict-feasibility
+and optimizer predicates, and proves weak duality. The source is Wolf, *Quantum Channels &
+Operations*, Chapter 4, `Notes/WolfNoteTexSource/ch04_convex_structure.tex`, lines 39--78,
+especially equations `conic-primal` and `conic-dual`.
 
 The optimization values lie in `EReal`. Thus an infeasible primal problem has value `+∞`, an
 infeasible dual problem has value `-∞`, a primal problem unbounded below has value `-∞`, and a
 dual problem unbounded above has value `+∞`.
 
-No strong-duality or attainment assertion is made here.
+The strict-feasibility and optimizer predicates deliberately keep value equality separate from
+attainment. No Slater strong-duality assertion is made here: Wolf's claim at lines 72--78 needs a
+finiteness or opposite-feasibility condition for its attainment clause.
 -/
 
 noncomputable section
@@ -63,6 +65,52 @@ Source: Wolf, Chapter 4, equation `conic-dual`, lines 61--65. -/
 def dualValue (K : ProperCone ℝ V) (T : V →ₗ[ℝ] V') (c : V) (b : V') : EReal :=
   ⨆ y : dualFeasible K T c, ((inner ℝ b (y : V') : ℝ) : EReal)
 
+/-- Wolf's primal problem is strictly feasible when the affine constraint meets the interior of
+the cone.
+
+Source: Wolf, Chapter 4, lines 72--75. -/
+def IsPrimalStrictlyFeasible (K : ProperCone ℝ V) (T : V →ₗ[ℝ] V') (b : V') : Prop :=
+  ∃ x ∈ interior (K : Set V), T x = b
+
+/-- Wolf's dual problem is strictly feasible when one of its slack vectors belongs to the interior
+of the dual cone.
+
+Source: Wolf, Chapter 4, lines 75--78. -/
+def IsDualStrictlyFeasible (K : ProperCone ℝ V) (T : V →ₗ[ℝ] V') (c : V) : Prop :=
+  ∃ y, c - T.toContinuousLinearMap.adjoint y ∈
+    interior (ProperCone.innerDual (K : Set V) : Set V)
+
+/-- A feasible point at which Wolf's primal infimum is attained.
+
+Source: Wolf, Chapter 4, equations `conic-primal` and the attainment discussion at lines 72--78. -/
+def IsPrimalOptimizer (K : ProperCone ℝ V) (T : V →ₗ[ℝ] V') (c : V) (b : V')
+    (x : V) : Prop :=
+  x ∈ primalFeasible K T b ∧
+    ∀ z ∈ primalFeasible K T b, inner ℝ c x ≤ inner ℝ c z
+
+/-- A feasible point at which Wolf's dual supremum is attained.
+
+Source: Wolf, Chapter 4, equations `conic-dual` and the attainment discussion at lines 72--78. -/
+def IsDualOptimizer (K : ProperCone ℝ V) (T : V →ₗ[ℝ] V') (c : V) (b : V')
+    (y : V') : Prop :=
+  y ∈ dualFeasible K T c ∧
+    ∀ z ∈ dualFeasible K T c, inner ℝ b z ≤ inner ℝ b y
+
+omit [FiniteDimensional ℝ V] [FiniteDimensional ℝ V'] in
+/-- Primal strict feasibility implies ordinary primal feasibility. -/
+theorem IsPrimalStrictlyFeasible.feasible {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {b : V'}
+    (h : IsPrimalStrictlyFeasible K T b) : (primalFeasible K T b).Nonempty := by
+  obtain ⟨x, hx, hTx⟩ := h
+  exact ⟨x, interior_subset hx, hTx⟩
+
+/-- Dual strict feasibility implies ordinary dual feasibility. -/
+theorem IsDualStrictlyFeasible.feasible {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V}
+    (h : IsDualStrictlyFeasible K T c) : (dualFeasible K T c).Nonempty := by
+  obtain ⟨y, hy⟩ := h
+  refine ⟨y, ?_⟩
+  change c - T.toContinuousLinearMap.adjoint y ∈ ProperCone.innerDual (K : Set V)
+  exact interior_subset hy
+
 /-- **Pointwise weak duality.** Every dual-feasible objective value is at most every
 primal-feasible objective value.
 
@@ -92,5 +140,52 @@ theorem weak_duality {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V} {b : 
   refine iSup_le fun y => ?_
   refine le_iInf fun x => ?_
   exact EReal.coe_le_coe (weak_duality_pointwise x.property y.property)
+
+omit [FiniteDimensional ℝ V] [FiniteDimensional ℝ V'] in
+/-- A primal optimizer realizes the extended-real primal value as a finite real value. -/
+theorem primalValue_eq_of_isPrimalOptimizer {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'}
+    {c : V} {b : V'} {x : V} (hx : IsPrimalOptimizer K T c b x) :
+    primalValue K T c b = (inner ℝ c x : EReal) := by
+  apply le_antisymm
+  · exact iInf_le_of_le ⟨x, hx.1⟩ le_rfl
+  · refine le_iInf fun z ↦ ?_
+    exact EReal.coe_le_coe (hx.2 z z.property)
+
+/-- A dual optimizer realizes the extended-real dual value as a finite real value. -/
+theorem dualValue_eq_of_isDualOptimizer {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'}
+    {c : V} {b : V'} {y : V'} (hy : IsDualOptimizer K T c b y) :
+    dualValue K T c b = (inner ℝ b y : EReal) := by
+  apply le_antisymm
+  · refine iSup_le fun z ↦ ?_
+    exact EReal.coe_le_coe (hy.2 z z.property)
+  · exact le_iSup_of_le ⟨y, hy.1⟩ le_rfl
+
+/-- A primal-dual feasible pair with equal objective values attains both extrema. This separates
+the zero-gap certificate from the existence statement in Slater's theorem.
+
+Source: Wolf, Chapter 4, lines 71--78. -/
+theorem optimizers_of_feasible_of_objectives_eq {K : ProperCone ℝ V}
+    {T : V →ₗ[ℝ] V'} {c : V} {b : V'} {x : V} {y : V'}
+    (hx : x ∈ primalFeasible K T b) (hy : y ∈ dualFeasible K T c)
+    (hxy : inner ℝ c x = inner ℝ b y) :
+    IsPrimalOptimizer K T c b x ∧ IsDualOptimizer K T c b y := by
+  constructor
+  · refine ⟨hx, fun z hz ↦ ?_⟩
+    rw [hxy]
+    exact weak_duality_pointwise hz hy
+  · refine ⟨hy, fun z hz ↦ ?_⟩
+    rw [← hxy]
+    exact weak_duality_pointwise hx hz
+
+/-- A zero-gap feasible pair gives equality of Wolf's extended-real primal and dual values, while
+also supplying optimizers on both sides. -/
+theorem values_eq_of_feasible_of_objectives_eq {K : ProperCone ℝ V}
+    {T : V →ₗ[ℝ] V'} {c : V} {b : V'} {x : V} {y : V'}
+    (hx : x ∈ primalFeasible K T b) (hy : y ∈ dualFeasible K T c)
+    (hxy : inner ℝ c x = inner ℝ b y) :
+    primalValue K T c b = dualValue K T c b := by
+  obtain ⟨hxopt, hyopt⟩ := optimizers_of_feasible_of_objectives_eq hx hy hxy
+  rw [primalValue_eq_of_isPrimalOptimizer hxopt, dualValue_eq_of_isDualOptimizer hyopt,
+    hxy]
 
 end ConicProgram

--- a/blueprint/src/chapter/ch04_convex_structure.tex
+++ b/blueprint/src/chapter/ch04_convex_structure.tex
@@ -34,6 +34,26 @@ This chapter follows the convex-optimization framework of
     require it.
 \end{definition}
 
+\begin{definition}[Strict feasibility and attainment]
+    \label{def:conic_strict_feasibility_and_attainment}
+    \lean{ConicProgram.IsPrimalStrictlyFeasible,
+        ConicProgram.IsDualStrictlyFeasible, ConicProgram.IsPrimalOptimizer,
+        ConicProgram.IsDualOptimizer,
+        ConicProgram.IsPrimalStrictlyFeasible.feasible,
+        ConicProgram.IsDualStrictlyFeasible.feasible}
+    \leanok
+    \uses{def:conic_programs}
+    Following \cite[Chapter~4, lines~72--78]{Wolf2012Quantum}, the primal
+    problem is \emph{strictly feasible} when there is an $x\in\operatorname{int}K$
+    with $T(x)=b$.  The dual problem is strictly feasible when there is a
+    $y\in V'$ such that $c-T^*(y)\in\operatorname{int}K^*$.  A primal
+    optimizer is an $x^0\in\mathcal F_p$ satisfying
+    $\langle c|x^0\rangle\leq\langle c|x\rangle$ for every
+    $x\in\mathcal F_p$; a dual optimizer is a $y^0\in\mathcal F_d$ satisfying
+    $\langle b|y\rangle\leq\langle b|y^0\rangle$ for every
+    $y\in\mathcal F_d$.
+\end{definition}
+
 \begin{theorem}[Weak duality]
     \label{thm:conic_weak_duality}
     \lean{ConicProgram.weak_duality_pointwise, ConicProgram.weak_duality}
@@ -60,3 +80,42 @@ This chapter follows the convex-optimization framework of
     $y\in\mathcal F_d$ and then the infimum over $x\in\mathcal F_p$ proves
     $C_d\leq C_p$.
 \end{proof}
+
+\begin{theorem}[A zero-gap feasible pair attains both values]
+    \label{thm:conic_zero_gap_optimizers}
+    \lean{ConicProgram.optimizers_of_feasible_of_objectives_eq,
+        ConicProgram.values_eq_of_feasible_of_objectives_eq,
+        ConicProgram.primalValue_eq_of_isPrimalOptimizer,
+        ConicProgram.dualValue_eq_of_isDualOptimizer}
+    \leanok
+    \uses{def:conic_strict_feasibility_and_attainment,
+        thm:conic_weak_duality}
+    If $x\in\mathcal F_p$, $y\in\mathcal F_d$, and
+    $\langle c|x\rangle=\langle b|y\rangle$, then $x$ and $y$ are primal and
+    dual optimizers, respectively, and
+    $C_p=C_d=\langle c|x\rangle=\langle b|y\rangle$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:conic_weak_duality}
+    For any $z\in\mathcal F_p$ and $w\in\mathcal F_d$, weak duality gives
+    $\langle b|w\rangle\leq\langle c|x\rangle
+    =\langle b|y\rangle\leq\langle c|z\rangle$.  Hence $x$ minimizes the
+    primal objective and $y$ maximizes the dual objective.  Taking the
+    corresponding infimum and supremum gives the asserted value equality.
+\end{proof}
+
+% Wolf's lines 72--78 omit the finiteness conditions required by the
+% attainment clauses.  The counterexamples and the unresolved separation step
+% are recorded in docs/paper-gaps/wolf_slater_attainment_conditions.tex.
+\begin{theorem}[Corrected Slater strong duality]
+    \label{thm:conic_corrected_slater}
+    \uses{def:conic_strict_feasibility_and_attainment,
+        thm:conic_weak_duality}
+    Suppose the primal problem is strictly feasible and $C_p\in\mathbb R$.
+    Then $C_p=C_d$ and there is a dual optimizer $y^0\in\mathcal F_d$ with
+    $\langle b|y^0\rangle=C_d$.  Dually, if the dual problem is strictly
+    feasible and $C_d\in\mathbb R$, then $C_p=C_d$ and there is a primal
+    optimizer $x^0\in\mathcal F_p$ with $\langle c|x^0\rangle=C_p$.
+\end{theorem}

--- a/docs/paper-gaps/wolf_slater_attainment_conditions.tex
+++ b/docs/paper-gaps/wolf_slater_attainment_conditions.tex
@@ -1,0 +1,89 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Slater Strong Duality: Finiteness Conditions for Attainment}
+\author{}
+\date{2026-08-24}
+
+\begin{document}
+\maketitle
+\gapnote{source-correction}{open}
+
+\section{Source passage}
+
+For a closed pointed convex cone $K\subseteq V$ with nonempty interior,
+Chapter~4 of \cite{Wolf2012Quantum} considers
+\begin{align}
+  C_p&=\inf\{\langle c|x\rangle:x\in K,\ T(x)=b\},\\
+  C_d&=\sup\{\langle b|y\rangle:c-T^*(y)\in K^*\}.
+\end{align}
+At lines~72--78 of the local source, primal strict feasibility is said to give
+$C_p=C_d$ and attainment of the dual supremum; the dual statement is said to
+give attainment of the primal infimum.
+
+\section{Missing boundary conditions}
+
+Strict feasibility on one side does not by itself ensure that the opposite
+feasible set is nonempty or that the relevant optimum is finite.  Both failures
+already occur in one dimension with $K=\mathbb R_{\geq0}$ and $T=0$.
+
+First take $b=0$ and $c=-1$.  The primal point $x=1$ is strictly feasible, but
+the primal objective $-x$ is unbounded below.  Dual feasibility would require
+$-1\in\mathbb R_{\geq0}$, so the dual feasible set is empty and no dual
+optimizer exists.
+
+Second take $b=1$ and $c=1$.  The dual slack equals $1$ for every $y$, hence the
+dual problem is strictly feasible.  The primal equality constraint is
+$0=1$, so the primal feasible set is empty and no primal optimizer exists.
+
+Thus the attainment sentences at lines~72--78 require a finiteness condition,
+or an equivalent opposite-feasibility and boundedness condition.
+
+\section{Corrected statement}
+
+The finite-dimensional Slater theorem in Wolf's signs and adjoint convention is:
+if the primal problem is strictly feasible and $C_p\in\mathbb R$, then
+$C_p=C_d$ and the dual supremum is attained.  Dually, if the dual problem is
+strictly feasible and $C_d\in\mathbb R$, then $C_p=C_d$ and the primal infimum
+is attained.
+
+The formal development currently contains the source-shaped strict-feasibility
+predicates and separate optimizer predicates in
+\doclink{QICLean/Analysis/ConicProgram}.  The declarations
+\leanid{ConicProgram.primalValue_eq_of_isPrimalOptimizer} and
+\leanid{ConicProgram.dualValue_eq_of_isDualOptimizer} prove that an optimizer
+realizes the corresponding extended-real value.  The declarations
+\leanid{ConicProgram.optimizers_of_feasible_of_objectives_eq} and
+\leanid{ConicProgram.values_eq_of_feasible_of_objectives_eq} prove that a
+feasible pair with equal objectives attains both values.
+
+\section{Remaining proof}
+
+The unresolved step is the corrected Slater existence theorem itself.  Its
+proof must separate the appropriate finite-dimensional convex set and then
+show, using strict feasibility, that the coefficient of the objective
+coordinate is nonzero before normalizing the separating functional.  Mathlib's
+\leanid{ProperCone.relative_hyperplane_separation} concerns the closure of a
+linear image of a proper cone.  It does not prove that the unclosed image is
+closed, so it cannot by itself justify an optimizer in the original feasible
+set.  A completion must establish every closure or attainment hypothesis used
+in this argument; it must not replace that step by the false general claim that
+a linear image of a closed cone is closed.
+
+\section{Verdict}
+
+\textbf{Verdict: open source correction.} The strict-feasibility and attainment
+notions and the zero-gap certificate are formalized.  Strong duality with
+optimizer existence remains open until the corrected finite-optimum separation
+argument is proved.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_slater_attainment_conditions.tex
+++ b/docs/paper-gaps/wolf_slater_attainment_conditions.tex
@@ -13,7 +13,7 @@
 
 \begin{document}
 \maketitle
-\gapnote{source-correction}{open}
+\gapnote{false-source}{open}
 
 \section{Source passage}
 


### PR DESCRIPTION
## Summary
- add source-shaped primal and dual strict-feasibility predicates for Wolf Ch4
- separate primal/dual optimizer predicates from extended-real value equality
- prove optimizer values are finite and a feasible zero-gap pair attains both extrema
- correct the Blueprint statement and document the exact remaining Slater separation/attainment gap

## Source boundary
Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 4, local source `Notes/WolfNoteTexSource/ch04_convex_structure.tex`, lines 39–78. The printed optimizer clauses require finite relevant optimum/opposite feasibility. This PR deliberately does not use the false generic claim that a linear image is closed and does not claim full Slater duality.

## Validation
Targeted Lean build, Blueprint synchronization, declaration checks, reader-facing prose checks, and proof-integrity checks were run in the isolated worktree.

Refs #110