### PR TITLE
doc(blueprint): prune proof-only statement dependencies

### DIFF
--- a/blueprint/src/chapter/ch04_positive_not_cp_positivity_reduction_and_breuer_hall.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_positivity_reduction_and_breuer_hall.tex
@@ -303,9 +303,7 @@ equivalence in Proposition~3.6 below.
     \label{thm:wolf_prop_3_6}
     \lean{wolf_prop_3_6}
     \leanok
-    \uses{def:maps_psd_cone_onto, cor:psd_cone_face_span_dimension,
-        thm:positive_hermitian_rank_preserver_standard_form,
-        thm:conjugation_maps_psd_cone_onto}
+    \uses{def:maps_psd_cone_onto}
     Let $T:\MN{D}\to\MN{D}$ be a complex-linear map. The following are
     equivalent:
     \begin{enumerate}

--- a/blueprint/src/chapter/ch09_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
@@ -431,7 +431,6 @@ that Loewner domination transfers the support.
     \lean{IsPositiveMap.trace_one_sub_stationaryProj_mul_map_stationaryProj_eq_zero,
         IsPositiveMap.map_density_le_stationaryProj}
     \leanok
-    \uses{thm:stationarySupport_restriction}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, let
     $\sigma$ be a density operator with $T(\sigma)=\sigma$, and let $Q$ be
     the support projection of $\sigma$. Then

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -62,7 +62,6 @@
     \label{lem:trace_adjoint_stationary_support_compression_fixed}
     \lean{Matrix.traceAdjointMap_stationarySupportCompression_fixed}
     \leanok
-    \uses{thm:stationarySupport_restriction}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, let
     $\rho\succeq0$ satisfy $T(\rho)=\rho$, and let
     $V:\mathcal H\to\C^D$ be an isometry onto the support of $\rho$. Define
@@ -99,7 +98,6 @@
         IsSchwarzMap.traceAdjointMap_stationarySupportCompression}
     \leanok
     \uses{thm:stationarySupport_compression,
-        lem:trace_adjoint_stationary_support_compression_fixed,
         thm:mean_ergodic_projection_density_block_form}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, and suppose
     that $T^*$ satisfies the Schwarz inequality. Set


### PR DESCRIPTION
## Summary

This corrective change removes six proof-only dependency edges from theorem statements while retaining every corresponding edge on the proofs that actually use it.

- Wolf Proposition 3.6 now lists only the definition of PSD-cone surjectivity at statement level; its face-dimension, rank-preserver, and cone-automorphism results remain proof dependencies.
- The stationary-subspace and maximal-support entries no longer expose the three proof-only stationary-support dependencies introduced with PR #373; each remains attached to its proof.
- No Lean declaration, mathematical statement, proof, terminology, or source attribution changes.

This is a dependency-graph correction following #89 and #373. It also resolves the remaining Blueprint hygiene recorded in #41 and #20.

Refs #89. Refs #41. Refs #20.

## Checks

- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- python3 scripts/blueprint_lean_sync.py --root . --ci (1928/1928)
- chktex on the three changed chapter files
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- texra-blueprint --root . paper-gaps check
- git diff --check origin/main...HEAD
- leanblueprint pdf (308 pages; no LaTeX errors or undefined references/citations)