### PR TITLE
doc(blueprint): keep proof dependencies on proofs

### DIFF
--- a/blueprint/src/chapter/ch09_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
@@ -431,7 +431,6 @@ that Loewner domination transfers the support.
     \lean{IsPositiveMap.trace_one_sub_stationaryProj_mul_map_stationaryProj_eq_zero,
         IsPositiveMap.map_density_le_stationaryProj}
     \leanok
-    \uses{thm:stationarySupport_restriction}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, let
     $\sigma$ be a density operator with $T(\sigma)=\sigma$, and let $Q$ be
     the support projection of $\sigma$. Then

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -62,7 +62,6 @@
     \label{lem:trace_adjoint_stationary_support_compression_fixed}
     \lean{Matrix.traceAdjointMap_stationarySupportCompression_fixed}
     \leanok
-    \uses{thm:stationarySupport_restriction}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, let
     $\rho\succeq0$ satisfy $T(\rho)=\rho$, and let
     $V:\mathcal H\to\C^D$ be an isometry onto the support of $\rho$. Define
@@ -99,7 +98,6 @@
         IsSchwarzMap.traceAdjointMap_stationarySupportCompression}
     \leanok
     \uses{thm:stationarySupport_compression,
-        lem:trace_adjoint_stationary_support_compression_fixed,
         thm:mean_ergodic_projection_density_block_form}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, and suppose
     that $T^*$ satisfies the Schwarz inequality. Set


### PR DESCRIPTION
Refs #41 and follows up #373.

Moves three proof-only Blueprint dependency edges off theorem statements while retaining the corresponding proof edges:

- Proposition 6.10 depends on the stationary-support restriction only in its proof;
- Equation (6.53) depends on the support intertwining theorem only in its proof;
- the maximal-support density-block theorem uses the fixed-observable compression lemma only in its proof.

This follows the statement/proof dependency rule in `docs/blueprint_style_guide.md`. No Lean or mathematical prose changes.

Validation at exact head `f67c93c36fe88e842d65a8b5c366c3f64dc1b856`:

- `git diff --check`;
- generated Blueprint/Lean sync: 1928/1928;
- the full web renderer parsed all source chapters through the output-rendering stage before a manually stopped slow image-render phase; #373's identical prose/render had already passed exact-head CI.
