### PR TITLE
feat(analysis): specialize Schur bound to Wolf modulus

### DIFF
--- a/QICLean/Analysis/SubperipheralSpectrum.lean
+++ b/QICLean/Analysis/SubperipheralSpectrum.lean
@@ -100,6 +100,16 @@ theorem subperipheralModulus_lt_one (T : Module.End ℂ V)
   rcases hr with ⟨z, hz, rfl⟩
   exact hz.2
 
+/-- Wolf's subperipheral modulus is at most one, including when the
+subperipheral spectrum is empty and the convention gives `μ = 0`. -/
+theorem subperipheralModulus_le_one (T : Module.End ℂ V) :
+    T.subperipheralModulus ≤ 1 := by
+  by_cases hT : T.subperipheralSpectrum.Nonempty
+  · exact (T.subperipheralModulus_lt_one hT).le
+  · rw [T.subperipheralModulus_eq_zero_of_empty
+      (Set.not_nonempty_iff_eq_empty.mp hT)]
+    exact zero_le_one
+
 /-- Exact qualification of the `μ = 0` case: the subperipheral spectrum is
 empty or contains only the zero eigenvalue. -/
 theorem subperipheralModulus_eq_zero_iff (T : Module.End ℂ V) :

--- a/QICLean/Analysis/UpperTriangularBound.lean
+++ b/QICLean/Analysis/UpperTriangularBound.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import QICLean.Analysis.SubperipheralSpectrum
 import Mathlib.Data.Matrix.Basic
 import Mathlib.LinearAlgebra.Matrix.IsDiag
 import Mathlib.Data.Fin.Basic
@@ -895,5 +896,49 @@ theorem wolf_eq_111_schur_form_refined
   exact h.trans (by gcongr; simpa [hΛ_norm] using l2_opNorm_pow_le_pow Λ n)
 
 end WolfEq111SchurForm
+
+section WolfEq111SubperipheralModulus
+
+open scoped Matrix.Norms.L2Operator
+
+variable {D : ℕ} {Λ N : Matrix (Fin D) (Fin D) ℂ} {n : ℕ}
+
+/-- **Wolf Eq. (8.111) with the shared subperipheral modulus.**
+
+This specializes `wolf_eq_111_schur_form` to Wolf's source-shaped `μ` from
+`Module.End.subperipheralModulus`.  The actual Schur data remain explicit:
+the channel-level theorem must still construct `Λ` and `N` for
+`T - T.peripheralWeightedProjection` and prove `‖Λ‖ = μ`.
+
+The natural exponent is stated only in its valid range `D - 1 ≤ n`.
+Source: Wolf (2012), Chapter 8, Equation (8.111), local source lines
+1299--1316. -/
+theorem wolf_eq_111_schur_form_subperipheralModulus
+    (T : Module.End ℂ (Fin D → ℂ))
+    (hΛ_diag : IsDiag Λ) (hN_sut : IsStrictlyUpperTriangular N)
+    (hDpos : D ≠ 0) (hn_ge : D - 1 ≤ n)
+    (hΛ_norm : ‖Λ‖ = T.subperipheralModulus) :
+    ‖(Λ + N) ^ n‖ ≤ T.subperipheralModulus ^ n +
+      (((D - 1 : ℕ) * n ^ (D - 1 : ℕ) : ℕ) : ℝ) *
+        T.subperipheralModulus ^ (n - (D - 1)) *
+          max ‖N‖ (‖N‖ ^ (D - 1)) := by
+  exact wolf_eq_111_schur_form hΛ_diag hN_sut hDpos hn_ge hΛ_norm
+    T.subperipheralModulus_le_one
+
+/-- The refined Equation (8.111) constant with the same shared
+subperipheral modulus and source hypothesis `2 * (D - 1) ≤ n`. -/
+theorem wolf_eq_111_schur_form_subperipheralModulus_refined
+    (T : Module.End ℂ (Fin D → ℂ))
+    (hΛ_diag : IsDiag Λ) (hN_sut : IsStrictlyUpperTriangular N)
+    (hDpos : D ≠ 0) (hn_ge : 2 * (D - 1) ≤ n)
+    (hΛ_norm : ‖Λ‖ = T.subperipheralModulus) :
+    ‖(Λ + N) ^ n‖ ≤ T.subperipheralModulus ^ n +
+      (((D - 1 : ℕ) * Nat.choose n (D - 1) : ℕ) : ℝ) *
+        T.subperipheralModulus ^ (n - (D - 1)) *
+          max ‖N‖ (‖N‖ ^ (D - 1)) := by
+  exact wolf_eq_111_schur_form_refined hΛ_diag hN_sut hDpos hn_ge hΛ_norm
+    T.subperipheralModulus_le_one
+
+end WolfEq111SubperipheralModulus
 
 end Matrix

--- a/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
@@ -168,3 +168,30 @@
     $\lVert\Lambda^n\rVert_\infty\le\lVert\Lambda\rVert_\infty^n$, and
     substitute the norm of the diagonal part.
 \end{proof}
+
+\begin{corollary}[Schur estimate with Wolf's subperipheral modulus]
+    \label{cor:wolf_schur_form_subperipheral_modulus}
+    \lean{Matrix.wolf_eq_111_schur_form_subperipheralModulus,
+      Matrix.wolf_eq_111_schur_form_subperipheralModulus_refined}
+    \leanok
+    \uses{def:wolf_subperipheral_modulus,
+      thm:wolf_schur_form_spectral_radius_estimate}
+    Let $T$ be a complex endomorphism on the same $D$-dimensional coordinate
+    space as $\Lambda,N\in M_D(\mathbb C)$, and take
+    $\mu=\mu(T)$ from Definition~\ref{def:wolf_subperipheral_modulus}.
+    If $\Lambda$ is diagonal, $N$ is strictly upper triangular, and
+    $\lVert\Lambda\rVert_\infty=\mu$, then the coarse and refined estimates of
+    Theorem~\ref{thm:wolf_schur_form_spectral_radius_estimate} hold with this
+    shared source-shaped $\mu$.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    The shared modulus satisfies $\mu\le1$, including the empty-spectrum
+    convention $\mu=0$.  Apply the coarse estimate when $D-1\le n$ and the
+    refined estimate when $2(D-1)\le n$.
+
+% This corollary does not construct the unitary Schur representation of
+% \widehat T-\widehat T_\varphi or prove that its diagonal part has norm \mu.
+% Those remain channel-level obligations in Wolf Equation (8.111).
+\end{proof}

--- a/docs/paper-gaps/wolf_ch8_eq_8_103_negative_exponent.tex
+++ b/docs/paper-gaps/wolf_ch8_eq_8_103_negative_exponent.tex
@@ -78,6 +78,17 @@ the estimate once the Schur decomposition and its spectral identification are
 given; constructing that decomposition for $\widehat T-\widehat T_\varphi$
 remains part of the channel-level theorem.
 
+The specializations
+\leanid{Matrix.wolf_eq_111_schur_form_subperipheralModulus} and
+\leanid{Matrix.wolf_eq_111_schur_form_subperipheralModulus_refined} now use the
+shared source-shaped $\mu$ from
+\leanid{Module.End.subperipheralModulus} on the same $D$-dimensional coordinate
+space as the Schur matrices.  They discharge $\mu\le1$, including the empty
+subperipheral-spectrum convention.  They intentionally retain the hypothesis
+$\lVert\Lambda\rVert_\infty=\mu$: constructing the unitary Schur representation
+of $\widehat T-\widehat T_\varphi$ and proving this spectral identification
+remain separate channel-level obligations.
+
 \section{Verdict}
 
 \textbf{Verdict: source scope restriction.}


### PR DESCRIPTION
## Summary

- prove the shared source-shaped subperipheral modulus satisfies `μ ≤ 1`, including the empty-spectrum convention `μ = 0`
- specialize both landed Equation (8.111) Schur-form estimates to `Module.End.subperipheralModulus`
- couple `T` and `Λ,N` to the same `D`-dimensional coordinate space, avoiding an unrelated-endomorphism cosmetic substitution
- synchronize only the compiled corollaries with the Blueprint and update the existing exponent-scope paper-gap note

## Source boundary

This follows Wolf, `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1295–1317, and is intentionally a **non-closing** next leaf for #300.

The new declarations are:

- `Module.End.subperipheralModulus_le_one`;
- `Matrix.wolf_eq_111_schur_form_subperipheralModulus` under `D - 1 ≤ n`;
- `Matrix.wolf_eq_111_schur_form_subperipheralModulus_refined` under `2 * (D - 1) ≤ n`.

Both wrappers require `T : Module.End ℂ (Fin D → ℂ)` and `Λ,N : Matrix (Fin D) (Fin D) ℂ`, so the shared `μ` and Schur matrices live on the same operator dimension. They intentionally retain `‖Λ‖ = T.subperipheralModulus`.

## Exact remainder

The channel-level Equation (8.111) theorem remains open. It still must:

1. use `T_φ = Module.End.peripheralProjection` and `T_ϕ = Module.End.peripheralWeightedProjection` without conflating them;
2. prove the positive-power identity for `T̂^n - T̂_ϕ^n` from the peripheral/nonperipheral decomposition;
3. construct a unitary Schur representation of `T̂ - T̂_ϕ` in dimension `d²`;
4. prove the retained spectral identification `‖Λ‖∞ = T.subperipheralModulus`;
5. transfer the matrix estimate through the unitary similarity;
6. prove Wolf's `‖N‖∞ ≤ μ + 2√d` from positivity and trace preservation, without adding complete positivity;
7. keep the explicit exponent ranges and audit `μ = 0`, `d = 1`, and `n = 0`.

This PR does not introduce a Jordan decomposition or make any claim about `κ_T` attainment.

## Validation

- `lake exe cache get`
- `lake build QICLean.Analysis.SubperipheralSpectrum QICLean.Analysis.UpperTriangularBound -q --log-level=info`
- `lake exe lint_style`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- full Blueprint PDF build
- standalone `wolf_ch8_eq_8_103_negative_exponent.tex` PDF build
- `git diff --check`
- proof-integrity scan of both affected Lean modules: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`

Refs #300
Depends on merged #371
