### PR TITLE
feat(analysis): prove Wolf asymptotic upper bound

### DIFF
--- a/QICLean/Algebra/FrobeniusHilbert.lean
+++ b/QICLean/Algebra/FrobeniusHilbert.lean
@@ -27,6 +27,10 @@ to matrix superoperators without introducing a second norm on matrices.
   between matrix spaces.
 * `Matrix.frobeniusEuclideanMap_comp`: Frobenius transport preserves
   composition.
+* `Matrix.hilbertSchmidtOperatorNorm`: the induced Hilbert--Schmidt operator
+  norm of a matrix superoperator.
+* `Matrix.frobenius_norm_apply_le_hilbertSchmidtOperatorNorm`: its defining
+  application bound.
 -/
 
 open scoped Matrix Matrix.Norms.Frobenius
@@ -125,6 +129,26 @@ theorem frobeniusEuclideanMap_apply
         (frobeniusEquivEuclidean α α X))) =
     frobeniusEquivEuclidean β β (E X)
   rw [(frobeniusEquivEuclidean α α).symm_apply_apply]
+
+/-! ### Hilbert--Schmidt operator norm -/
+
+/-- The Hilbert--Schmidt `2 → 2` operator norm of a matrix superoperator,
+transported through column vectorization. -/
+noncomputable def hilbertSchmidtOperatorNorm
+    {α β : Type*} [Fintype α] [Fintype β]
+    (S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) : ℝ :=
+  ‖LinearMap.toContinuousLinearMap (frobeniusEuclideanMap S)‖
+
+/-- The defining application bound for the Hilbert--Schmidt `2 → 2`
+operator norm. -/
+theorem frobenius_norm_apply_le_hilbertSchmidtOperatorNorm
+    {α β : Type*} [Fintype α] [Fintype β]
+    (S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) (X : Matrix α α ℂ) :
+    ‖S X‖ ≤ hilbertSchmidtOperatorNorm S * ‖X‖ := by
+  have h := (LinearMap.toContinuousLinearMap (frobeniusEuclideanMap S)).le_opNorm
+    (frobeniusEquivEuclidean α α X)
+  simpa only [hilbertSchmidtOperatorNorm, frobeniusEuclideanMap_apply,
+    LinearMap.coe_toContinuousLinearMap', LinearIsometryEquiv.norm_map] using h
 
 /-- Transport a linear equivalence between finite matrix spaces through
 Frobenius vectorization. -/

--- a/QICLean/Analysis/AsymptoticStateConvergence.lean
+++ b/QICLean/Analysis/AsymptoticStateConvergence.lean
@@ -3,18 +3,21 @@ Copyright (c) 2026 Sirui Lu and QICLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
+import QICLean.Algebra.FrobeniusHilbert
+import QICLean.Analysis.TraceNormAbs
 import QICLean.Analysis.TraceNormContractionCoefficient
-import QICLean.Channel.Peripheral.SpectralProjection
+import QICLean.Channel.Peripheral.CesaroRecurrence
+import Mathlib.Analysis.InnerProductSpace.Trace
 
 /-!
 # Trace-norm convergence towards asymptotic states
 
-This file begins the formalization of Wolf's comparison between trace-norm
+This file formalizes the upper half of Wolf's comparison between trace-norm
 convergence of states and Hilbert--Schmidt operator-norm convergence of a
-positive trace-preserving map.  It proves the exact algebraic identities used
-before the norm estimates: the peripheral projection commutes with every
-iterate, the phase-weighted peripheral map kills the non-peripheral remainder,
-and hence the numerator in Equation (8.114) has Wolf's two equivalent forms.
+positive trace-preserving map. It proves the exact algebraic identities used in
+Equation (8.114), the norm estimates in Equations (8.115)--(8.116), and the
+upper bound in Equation (8.112). The converse bound in Equation (8.113) remains
+separate.
 
 ## References
 
@@ -23,13 +26,148 @@ Proposition "Convergence towards asymptotic states", Equations (8.112)--(8.117);
 local source `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1319--1364.
 -/
 
-open scoped Matrix
+open scoped Matrix Matrix.Norms.Frobenius ComplexOrder
 
 noncomputable section
 
 namespace Matrix
 
 variable {D : ℕ}
+
+/-- The sum of the squared singular values of a matrix is its squared
+Hilbert--Schmidt norm. -/
+lemma sum_sq_singularValues_eq_frobenius_sq
+    (A : Matrix (Fin D) (Fin D) ℂ) :
+    (∑ i : Fin D, (Matrix.toEuclideanLin A).singularValues i ^ 2) = ‖A‖ ^ 2 := by
+  rw [Finset.sum_congr rfl (fun i _ ↦
+    LinearMap.sq_singularValues_fin (Matrix.toEuclideanLin A)
+      finrank_euclideanSpace_fin i)]
+  rw [← (Matrix.toEuclideanLin A).isSymmetric_adjoint_comp_self.re_trace_eq_sum_eigenvalues
+    finrank_euclideanSpace_fin]
+  rw [Matrix.adjoint_toEuclideanLin_comp_self]
+  change ((LinearMap.trace ℂ _ (Matrix.toEuclideanLin (Aᴴ * A))).re) = _
+  rw [show LinearMap.trace ℂ _ (Matrix.toEuclideanLin (Aᴴ * A)) =
+      Matrix.trace (Aᴴ * A) by
+    exact Matrix.trace_toLin_eq (Aᴴ * A) (EuclideanSpace.basisFun (Fin D) ℂ).toBasis]
+  exact Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq A
+
+/-- Wolf's Schatten-norm comparison `‖A‖₁ ≤ √d ‖A‖₂` at the `p = 1`,
+`q = 2` instance of Equation (8.7). -/
+theorem traceNorm_le_sqrt_card_mul_frobenius
+    (A : Matrix (Fin D) (Fin D) ℂ) :
+    traceNorm A ≤ Real.sqrt D * ‖A‖ := by
+  rw [traceNorm_eq_sum_fin]
+  calc
+    (∑ i : Fin D, (Matrix.toEuclideanLin A).singularValues i) =
+        ∑ i : Fin D, (Matrix.toEuclideanLin A).singularValues i * 1 := by simp
+    _ ≤ Real.sqrt (∑ i : Fin D, (Matrix.toEuclideanLin A).singularValues i ^ 2) *
+        Real.sqrt (∑ _i : Fin D, (1 : ℝ) ^ 2) :=
+      Real.sum_mul_le_sqrt_mul_sqrt Finset.univ _ _
+    _ = Real.sqrt D * ‖A‖ := by
+      rw [sum_sq_singularValues_eq_frobenius_sq]
+      simp only [one_pow, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+        nsmul_eq_mul, mul_one]
+      rw [Real.sqrt_sq_eq_abs, abs_of_nonneg (norm_nonneg A), mul_comm]
+
+/-- Wolf's Hilbert--Schmidt `2 → 2` operator norm of a matrix
+superoperator, transported through column vectorization. This is the same
+operator norm as the largest-singular-value norm of its transfer matrix. -/
+def hilbertSchmidtOperatorNorm
+    (S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) : ℝ :=
+  ‖LinearMap.toContinuousLinearMap (frobeniusEuclideanMap S)‖
+
+/-- The defining application bound for the Hilbert--Schmidt `2 → 2`
+operator norm. -/
+lemma frobenius_norm_apply_le_hilbertSchmidtOperatorNorm
+    (S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    ‖S X‖ ≤ hilbertSchmidtOperatorNorm S * ‖X‖ := by
+  have h := (LinearMap.toContinuousLinearMap (frobeniusEuclideanMap S)).le_opNorm
+    (frobeniusEquivEuclidean (Fin D) (Fin D) X)
+  simpa only [hilbertSchmidtOperatorNorm, frobeniusEuclideanMap_apply,
+    LinearMap.coe_toContinuousLinearMap', LinearIsometryEquiv.norm_map] using h
+
+/-- The Hilbert--Schmidt distance between orthogonal pure-state projectors is
+`√2`, the equality used in Wolf Equation (8.116). -/
+lemma frobenius_norm_pureStateProj_sub_eq_sqrt_two
+    {ψ φ : Fin D → ℂ} (hψ : IsUnitVector ψ) (hφ : IsUnitVector φ)
+    (horth : AreOrthogonal ψ φ) :
+    ‖pureStateProj ψ - pureStateProj φ‖ = Real.sqrt 2 := by
+  let P := pureStateProj ψ
+  let Q := pureStateProj φ
+  have hPH : P.IsHermitian := (pureStateProj_posSemidef ψ).isHermitian
+  have hQH : Q.IsHermitian := (pureStateProj_posSemidef φ).isHermitian
+  have hPP : P * P = P := by
+    change vecMulVec ψ (fun p => star (ψ p)) * vecMulVec ψ (fun p => star (ψ p)) =
+      vecMulVec ψ (fun p => star (ψ p))
+    rw [Matrix.vecMulVec_mul_vecMulVec, hψ, one_smul]
+  have hQQ : Q * Q = Q := by
+    change vecMulVec φ (fun p => star (φ p)) * vecMulVec φ (fun p => star (φ p)) =
+      vecMulVec φ (fun p => star (φ p))
+    rw [Matrix.vecMulVec_mul_vecMulVec, hφ, one_smul]
+  have hPQ : P * Q = 0 := by
+    change vecMulVec ψ (fun p => star (ψ p)) * vecMulVec φ (fun p => star (φ p)) = 0
+    rw [Matrix.vecMulVec_mul_vecMulVec, horth, zero_smul]
+    ext
+    simp [Matrix.vecMulVec_apply]
+  have hQP : Q * P = 0 := by
+    have hs := congrArg star hPQ
+    simpa [star_mul, Matrix.star_eq_conjTranspose, hPH.eq, hQH.eq] using hs
+  have hsq : ‖P - Q‖ ^ 2 = 2 := by
+    rw [← trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq]
+    rw [(hPH.sub hQH).eq]
+    simp only [sub_mul, mul_sub, hPP, hQQ, hPQ, hQP, sub_zero, zero_sub,
+      sub_neg_eq_add]
+    have hPtr : P.trace = 1 := by
+      change (pureStateProj ψ).trace = 1
+      rw [trace_pureStateProj, dotProduct_comm]
+      exact hψ
+    have hQtr : Q.trace = 1 := by
+      change (pureStateProj φ).trace = 1
+      rw [trace_pureStateProj, dotProduct_comm]
+      exact hφ
+    rw [trace_add, hPtr, hQtr]
+    norm_num
+  change ‖P - Q‖ = Real.sqrt 2
+  have hsqrt_sq : (Real.sqrt 2) ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have hsqrt_nonneg : 0 ≤ Real.sqrt 2 := Real.sqrt_nonneg 2
+  nlinarith [norm_nonneg (P - Q)]
+
+/-- The orthogonal-pure-state supremum in Wolf Lemma 8.3 is bounded by the
+Hilbert--Schmidt operator norm with the exact `√d √2` constant used in
+Equations (8.115)--(8.116). -/
+lemma sSup_orthogonalPureStateTraceNorms_le_hilbertSchmidtOperatorNorm
+    (S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) :
+    sSup (orthogonalPureStateTraceNorms S) ≤
+      Real.sqrt D * hilbertSchmidtOperatorNorm S * Real.sqrt 2 := by
+  by_cases hS : (orthogonalPureStateTraceNorms S).Nonempty
+  · apply csSup_le hS
+    rintro r ⟨ψ, φ, hψ, hφ, horth, rfl⟩
+    calc
+      traceNorm (S (pureStateProj ψ - pureStateProj φ)) ≤
+          Real.sqrt D * ‖S (pureStateProj ψ - pureStateProj φ)‖ :=
+        traceNorm_le_sqrt_card_mul_frobenius _
+      _ ≤ Real.sqrt D *
+          (hilbertSchmidtOperatorNorm S * ‖pureStateProj ψ - pureStateProj φ‖) :=
+        mul_le_mul_of_nonneg_left
+          (frobenius_norm_apply_le_hilbertSchmidtOperatorNorm S _) (Real.sqrt_nonneg _)
+      _ = Real.sqrt D * hilbertSchmidtOperatorNorm S * Real.sqrt 2 := by
+        rw [frobenius_norm_pureStateProj_sub_eq_sqrt_two hψ hφ horth]
+        ring
+  · rw [Set.not_nonempty_iff_eq_empty.mp hS, Real.sSup_empty]
+    exact mul_nonneg
+      (mul_nonneg (Real.sqrt_nonneg _) (norm_nonneg _))
+      (Real.sqrt_nonneg _)
+
+private lemma half_sqrt_mul_sqrt_two (a h : ℝ) (ha : 0 ≤ a) :
+    (1 / 2 : ℝ) * (Real.sqrt a * h * Real.sqrt 2) =
+      Real.sqrt (a / 2) * h := by
+  rw [Real.sqrt_div ha]
+  have hsqrt2 : Real.sqrt 2 * Real.sqrt 2 = 2 := Real.mul_self_sqrt (by norm_num)
+  have hsqrt2ne : Real.sqrt 2 ≠ 0 := ne_of_gt (Real.sqrt_pos.2 (by norm_num))
+  field_simp [hsqrt2ne]
+  rw [pow_two, hsqrt2]
+  ring
 
 /-- Wolf's `Δ_T(ρ) = ‖ρ - T_φ(ρ)‖₁`: trace-norm distance to the peripheral
 spectral projection.
@@ -106,5 +244,63 @@ theorem traceNormAsymptoticDistance_pow_eq_sub_peripheralWeightedProjection_pow
         (ρ - T.peripheralProjection ρ)) := by
   rw [traceNormAsymptoticDistance_pow_eq, LinearMap.sub_apply,
     peripheralWeightedProjection_pow_apply_sub_peripheralProjection T ρ hn, sub_zero]
+
+/-- **Wolf Proposition, Equation (8.112).** For a positive trace-preserving
+map and a density matrix `ρ`, the distance of the positive iterate `Tⁿρ` from
+the asymptotic subspace is bounded by the Hilbert--Schmidt `2 → 2` norm of
+`Tⁿ - T_ϕⁿ`, with Wolf's exact `√(d/2)` constant.
+
+The explicit hypothesis `0 < n` records Wolf's positive-natural convention:
+with Lean's `0 ∈ ℕ`, the printed formula would be false at `n = 0` because
+both zeroth powers in the superoperator difference are the identity.
+
+Source: Wolf, Equations (8.112), (8.114)--(8.116); local source lines
+1323--1353. -/
+theorem traceNormAsymptoticDistance_pow_le_hilbertSchmidtOperatorNorm
+    (T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D)
+    {n : ℕ} (hn : 0 < n) :
+    traceNormAsymptoticDistance T ((T ^ n) ρ) ≤
+      Real.sqrt ((D : ℝ) / 2) *
+        hilbertSchmidtOperatorNorm
+          ((T ^ n) - T.peripheralWeightedProjection ^ n) *
+        traceNormAsymptoticDistance T ρ := by
+  let S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    (T ^ n) - T.peripheralWeightedProjection ^ n
+  have hDpos : 0 < D := by
+    simpa using Fintype.card_pos_iff.mpr
+      (Matrix.nonempty_of_trace_eq_one ρ hρ.2)
+  let : NeZero D := ⟨Nat.ne_of_gt hDpos⟩
+  have hρφ : T.peripheralProjection ρ ∈ densityMatrices D :=
+    ⟨hPos.peripheralProjection_isPositiveMap hTP ρ hρ.1,
+      by rw [hPos.peripheralProjection_isTracePreservingMap hTP, hρ.2]⟩
+  by_cases heq : ρ = T.peripheralProjection ρ
+  · have hsub : ρ - T.peripheralProjection ρ = 0 := sub_eq_zero.mpr heq
+    have hdist : traceNormAsymptoticDistance T ρ = 0 := by
+      rw [traceNormAsymptoticDistance, hsub, traceNorm_zero]
+    rw [hdist, mul_zero]
+    rw [traceNormAsymptoticDistance_pow_eq_sub_peripheralWeightedProjection_pow T ρ hn,
+      hsub, map_zero, traceNorm_zero]
+  · have hden : 0 < traceNorm (ρ - T.peripheralProjection ρ) :=
+      (traceNorm_pos_iff _).2 (sub_ne_zero.mpr heq)
+    have hratio :=
+      traceNorm_map_sub_div_traceNorm_le_half_sSup_orthogonal
+        S hρ hρφ heq
+    rw [← map_sub] at hratio
+    have hsup :=
+      sSup_orthogonalPureStateTraceNorms_le_hilbertSchmidtOperatorNorm S
+    have hratio' :
+        traceNorm (S (ρ - T.peripheralProjection ρ)) /
+            traceNorm (ρ - T.peripheralProjection ρ) ≤
+          (1 / 2 : ℝ) *
+            (Real.sqrt D * hilbertSchmidtOperatorNorm S * Real.sqrt 2) :=
+      hratio.trans (mul_le_mul_of_nonneg_left hsup (by norm_num))
+    rw [half_sqrt_mul_sqrt_two (D : ℝ) (hilbertSchmidtOperatorNorm S)
+      (Nat.cast_nonneg D)] at hratio'
+    have hmul := (div_le_iff₀ hden).mp hratio'
+    rw [traceNormAsymptoticDistance_pow_eq_sub_peripheralWeightedProjection_pow T ρ hn,
+      traceNormAsymptoticDistance]
+    simpa only [S] using hmul
 
 end Matrix

--- a/QICLean/Analysis/AsymptoticStateConvergence.lean
+++ b/QICLean/Analysis/AsymptoticStateConvergence.lean
@@ -6,8 +6,9 @@ Authors: Sirui Lu
 import QICLean.Algebra.FrobeniusHilbert
 import QICLean.Analysis.TraceNormAbs
 import QICLean.Analysis.TraceNormContractionCoefficient
+import QICLean.Analysis.TraceNormFrobenius
 import QICLean.Channel.Peripheral.CesaroRecurrence
-import Mathlib.Analysis.InnerProductSpace.Trace
+import QICLean.Channel.Peripheral.SchurAsymptoticConvergence
 
 /-!
 # Trace-norm convergence towards asymptotic states
@@ -33,59 +34,6 @@ noncomputable section
 namespace Matrix
 
 variable {D : ℕ}
-
-/-- The sum of the squared singular values of a matrix is its squared
-Hilbert--Schmidt norm. -/
-lemma sum_sq_singularValues_eq_frobenius_sq
-    (A : Matrix (Fin D) (Fin D) ℂ) :
-    (∑ i : Fin D, (Matrix.toEuclideanLin A).singularValues i ^ 2) = ‖A‖ ^ 2 := by
-  rw [Finset.sum_congr rfl (fun i _ ↦
-    LinearMap.sq_singularValues_fin (Matrix.toEuclideanLin A)
-      finrank_euclideanSpace_fin i)]
-  rw [← (Matrix.toEuclideanLin A).isSymmetric_adjoint_comp_self.re_trace_eq_sum_eigenvalues
-    finrank_euclideanSpace_fin]
-  rw [Matrix.adjoint_toEuclideanLin_comp_self]
-  change ((LinearMap.trace ℂ _ (Matrix.toEuclideanLin (Aᴴ * A))).re) = _
-  rw [show LinearMap.trace ℂ _ (Matrix.toEuclideanLin (Aᴴ * A)) =
-      Matrix.trace (Aᴴ * A) by
-    exact Matrix.trace_toLin_eq (Aᴴ * A) (EuclideanSpace.basisFun (Fin D) ℂ).toBasis]
-  exact Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq A
-
-/-- Wolf's Schatten-norm comparison `‖A‖₁ ≤ √d ‖A‖₂` at the `p = 1`,
-`q = 2` instance of Equation (8.7). -/
-theorem traceNorm_le_sqrt_card_mul_frobenius
-    (A : Matrix (Fin D) (Fin D) ℂ) :
-    traceNorm A ≤ Real.sqrt D * ‖A‖ := by
-  rw [traceNorm_eq_sum_fin]
-  calc
-    (∑ i : Fin D, (Matrix.toEuclideanLin A).singularValues i) =
-        ∑ i : Fin D, (Matrix.toEuclideanLin A).singularValues i * 1 := by simp
-    _ ≤ Real.sqrt (∑ i : Fin D, (Matrix.toEuclideanLin A).singularValues i ^ 2) *
-        Real.sqrt (∑ _i : Fin D, (1 : ℝ) ^ 2) :=
-      Real.sum_mul_le_sqrt_mul_sqrt Finset.univ _ _
-    _ = Real.sqrt D * ‖A‖ := by
-      rw [sum_sq_singularValues_eq_frobenius_sq]
-      simp only [one_pow, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
-        nsmul_eq_mul, mul_one]
-      rw [Real.sqrt_sq_eq_abs, abs_of_nonneg (norm_nonneg A), mul_comm]
-
-/-- Wolf's Hilbert--Schmidt `2 → 2` operator norm of a matrix
-superoperator, transported through column vectorization. This is the same
-operator norm as the largest-singular-value norm of its transfer matrix. -/
-def hilbertSchmidtOperatorNorm
-    (S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) : ℝ :=
-  ‖LinearMap.toContinuousLinearMap (frobeniusEuclideanMap S)‖
-
-/-- The defining application bound for the Hilbert--Schmidt `2 → 2`
-operator norm. -/
-lemma frobenius_norm_apply_le_hilbertSchmidtOperatorNorm
-    (S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    ‖S X‖ ≤ hilbertSchmidtOperatorNorm S * ‖X‖ := by
-  have h := (LinearMap.toContinuousLinearMap (frobeniusEuclideanMap S)).le_opNorm
-    (frobeniusEquivEuclidean (Fin D) (Fin D) X)
-  simpa only [hilbertSchmidtOperatorNorm, frobeniusEuclideanMap_apply,
-    LinearMap.coe_toContinuousLinearMap', LinearIsometryEquiv.norm_map] using h
 
 /-- The Hilbert--Schmidt distance between orthogonal pure-state projectors is
 `√2`, the equality used in Wolf Equation (8.116). -/
@@ -146,7 +94,7 @@ lemma sSup_orthogonalPureStateTraceNorms_le_hilbertSchmidtOperatorNorm
     calc
       traceNorm (S (pureStateProj ψ - pureStateProj φ)) ≤
           Real.sqrt D * ‖S (pureStateProj ψ - pureStateProj φ)‖ :=
-        traceNorm_le_sqrt_card_mul_frobenius _
+        traceNorm_le_sqrt_dim_mul_frobenius_norm _
       _ ≤ Real.sqrt D *
           (hilbertSchmidtOperatorNorm S * ‖pureStateProj ψ - pureStateProj φ‖) :=
         mul_le_mul_of_nonneg_left
@@ -302,5 +250,40 @@ theorem traceNormAsymptoticDistance_pow_le_hilbertSchmidtOperatorNorm
     rw [traceNormAsymptoticDistance_pow_eq_sub_peripheralWeightedProjection_pow T ρ hn,
       traceNormAsymptoticDistance]
     simpa only [S] using hmul
+
+section TransferMatrixNorm
+
+open scoped Matrix.Norms.L2Operator
+
+/-- **Wolf Proposition, Equation (8.112), transfer-matrix form.** For a
+positive trace-preserving map and a density matrix `ρ`, the distance of the
+positive iterate `Tⁿρ` from the asymptotic subspace is bounded using the
+largest-singular-value norm of Wolf's transfer matrices, with the exact
+constant `√(d/2)`.
+
+The explicit hypothesis `0 < n` records Wolf's positive-natural convention:
+at Lean's `n = 0`, the transfer-matrix difference on the right is zero while
+the initial asymptotic distance need not vanish.
+
+Source: Wolf, Equations (8.112), (8.114)--(8.116); local source lines
+1323--1354. -/
+theorem traceNormAsymptoticDistance_pow_le_transferMatrix_l2_opNorm
+    (T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D)
+    {n : ℕ} (hn : 0 < n) :
+    traceNormAsymptoticDistance T ((T ^ n) ρ) ≤
+      Real.sqrt ((D : ℝ) / 2) *
+        ‖transferMatrix T ^ n -
+          transferMatrix T.peripheralWeightedProjection ^ n‖ *
+        traceNormAsymptoticDistance T ρ := by
+  rw [transferMatrix_pow_sub_peripheralWeightedProjection_pow T hn,
+    ← transferMatrix_pow,
+    l2_opNorm_transferMatrix_eq_hilbertSchmidtOperatorNorm,
+    ← T.pow_sub_peripheralWeightedProjection_pow hn]
+  exact traceNormAsymptoticDistance_pow_le_hilbertSchmidtOperatorNorm
+    T hPos hTP hρ hn
+
+end TransferMatrixNorm
 
 end Matrix

--- a/QICLean/Analysis/TraceNormContractionCoefficient.lean
+++ b/QICLean/Analysis/TraceNormContractionCoefficient.lean
@@ -400,6 +400,37 @@ theorem orthogonalPureStateTraceNorms_nonempty_of_density
     eigenvectorUnitary_isUnitVector hQ.1 j,
     eigenvectorUnitary_areOrthogonal_of_mul_eq_zero hP hQ hPQ hi hj, rfl⟩
 
+/-- Wolf's Lemma 8.3 as the pointwise bound used in Equation (8.115): the
+trace-norm quotient of any two distinct density matrices is bounded by one
+half of the orthogonal-pure-state supremum. -/
+theorem traceNorm_map_sub_div_traceNorm_le_half_sSup_orthogonal
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D') (Fin D') ℂ)
+    {ρ₁ ρ₂ : Matrix (Fin D) (Fin D) ℂ}
+    (hρ₁ : ρ₁ ∈ densityMatrices D) (hρ₂ : ρ₂ ∈ densityMatrices D)
+    (hne : ρ₁ ≠ ρ₂) :
+    traceNorm (T ρ₁ - T ρ₂) / traceNorm (ρ₁ - ρ₂) ≤
+      (1 / 2 : ℝ) * sSup (orthogonalPureStateTraceNorms T) := by
+  let S := orthogonalPureStateTraceNorms T
+  have hH : (ρ₁ - ρ₂).IsHermitian := hρ₁.1.isHermitian.sub hρ₂.1.isHermitian
+  have htr : (ρ₁ - ρ₂).trace = 0 := by
+    rw [trace_sub, hρ₁.2, hρ₂.2, sub_self]
+  have hHne : ρ₁ - ρ₂ ≠ 0 := sub_ne_zero.mpr hne
+  obtain ⟨P, Q, hP, hPtr, hQ, hQtr, hPQ, hratio⟩ :=
+    exists_orthogonal_density_traceNorm_ratio T hH htr hHne
+  have hbS : BddAbove S := by
+    simpa [S, orthogonalPureStateTraceNorms] using
+      bddAbove_orthogonalPureStateTraceNorms T
+  have hpure_le : ∀ ψ φ, IsUnitVector ψ → IsUnitVector φ →
+      AreOrthogonal ψ φ →
+      traceNorm (T (pureStateProj ψ - pureStateProj φ)) ≤ sSup S := by
+    intro ψ φ hψ hφ horth
+    apply le_csSup hbS
+    exact ⟨ψ, φ, hψ, hφ, horth, rfl⟩
+  rw [← map_sub, hratio]
+  exact mul_le_mul_of_nonneg_left
+    (traceNorm_map_sub_le_of_orthogonal_density T hP hQ hPtr hQtr hPQ hpure_le)
+    (by norm_num)
+
 /-- **Wolf's trace-norm contraction coefficient formula** (Lemma 8.3,
 Eq. (8.81)).  For an arbitrary complex-linear map, the exact supremum of the
 trace-norm quotient over distinct density matrices equals one half of the
@@ -440,16 +471,8 @@ theorem traceNorm_contraction_coefficient_eq_half_sSup_orthogonal
     have hrat_le : ∀ r ∈ R, r ≤ (1 / 2 : ℝ) * sSup S := by
       intro r hr
       rcases hr with ⟨ρ₁, hρ₁, ρ₂, hρ₂, hne, rfl⟩
-      have hH : (ρ₁ - ρ₂).IsHermitian := hρ₁.1.isHermitian.sub hρ₂.1.isHermitian
-      have htr : (ρ₁ - ρ₂).trace = 0 := by
-        rw [trace_sub, hρ₁.2, hρ₂.2, sub_self]
-      have hHne : ρ₁ - ρ₂ ≠ 0 := sub_ne_zero.mpr hne
-      obtain ⟨P, Q, hP, hPtr, hQ, hQtr, hPQ, hratio⟩ :=
-        exists_orthogonal_density_traceNorm_ratio T hH htr hHne
-      rw [← map_sub, hratio]
-      exact mul_le_mul_of_nonneg_left
-        (traceNorm_map_sub_le_of_orthogonal_density T hP hQ hPtr hQtr hPQ hpure_le)
-        (by norm_num)
+      simpa [S] using
+        traceNorm_map_sub_div_traceNorm_le_half_sSup_orthogonal T hρ₁ hρ₂ hne
     have hbR : BddAbove R := ⟨(1 / 2 : ℝ) * sSup S, hrat_le⟩
     apply le_antisymm
     · exact csSup_le hR hrat_le

--- a/QICLean/Channel/TransferMatrix.lean
+++ b/QICLean/Channel/TransferMatrix.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Channel.Basic
+import QICLean.Algebra.FrobeniusHilbert
 import QICLean.Algebra.MatrixTracePairing
+import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.LinearAlgebra.Matrix.Vec
 import Mathlib.LinearAlgebra.Matrix.Trace
@@ -34,6 +36,11 @@ with composition. We also relate it to the Kraus representation.
 ## Main results
 
 * `transferMatrix_mulVec_eq`: `T̂ *ᵥ vec(ρ) = vec(T(ρ))`
+* `toEuclideanLin_transferMatrix`: the transfer matrix acts as the
+  Frobenius-vectorized superoperator.
+* `l2_opNorm_transferMatrix_eq_hilbertSchmidtOperatorNorm`: Wolf's
+  largest-singular-value transfer-matrix norm is the Hilbert--Schmidt
+  `2 → 2` operator norm.
 * `transferMatrix_comp`: `(S ∘ T)^ = Ŝ * T̂`
 * `transferMatrix_id`: the transfer matrix of the identity is the identity
 * `transferMatrix_pow`: transfer matrices preserve powers
@@ -185,6 +192,41 @@ theorem transferMatrix_mulVec_eq
   simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
   rw [Finset.sum_comm]
   congr 1; ext k; congr 1; ext l; ring
+
+section FrobeniusBridge
+
+open scoped Matrix.Norms.Frobenius
+
+/-- Under Euclidean column vectorization, `transferMatrix T` is exactly the
+linear map obtained by transporting `T` through the Frobenius isometry. -/
+theorem toEuclideanLin_transferMatrix
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.toEuclideanLin (transferMatrix T) = frobeniusEuclideanMap T := by
+  apply LinearMap.ext
+  intro x
+  obtain ⟨X, rfl⟩ := (frobeniusEquivEuclidean (Fin D) (Fin D)).surjective x
+  rw [frobeniusEuclideanMap_apply]
+  change WithLp.toLp 2 (transferMatrix T *ᵥ X.vec) = WithLp.toLp 2 (T X).vec
+  rw [transferMatrix_mulVec_eq]
+
+end FrobeniusBridge
+
+section L2OperatorNorm
+
+open scoped Matrix.Norms.L2Operator
+
+/-- The L² operator norm of Wolf's transfer matrix `T̂` is the induced
+Hilbert--Schmidt `2 → 2` norm of the matrix superoperator `T`. -/
+theorem l2_opNorm_transferMatrix_eq_hilbertSchmidtOperatorNorm
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    ‖transferMatrix T‖ = hilbertSchmidtOperatorNorm T := by
+  rw [Matrix.l2_opNorm_def]
+  change ‖LinearMap.toContinuousLinearMap
+      (Matrix.toEuclideanLin (transferMatrix T))‖ = _
+  rw [toEuclideanLin_transferMatrix]
+  rfl
+
+end L2OperatorNorm
 
 /-! ### Compatibility with composition -/
 

--- a/blueprint/src/chapter/ch03_channel_representations_self_dual.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_self_dual.tex
@@ -227,6 +227,37 @@ chapter boundary.
     coordinate.
 \end{proof}
 
+\begin{theorem}[Transfer-matrix and Hilbert--Schmidt operator norms]
+    \label{thm:transfer_matrix_hilbert_schmidt_operator_norm}
+    \lean{Matrix.hilbertSchmidtOperatorNorm,
+        Matrix.frobenius_norm_apply_le_hilbertSchmidtOperatorNorm,
+        toEuclideanLin_transferMatrix,
+        l2_opNorm_transferMatrix_eq_hilbertSchmidtOperatorNorm,
+        transferMatrixLM, transferMatrix_pow}
+    \leanok
+    \uses{def:mpu_transfer_matrix}
+    For a linear map $S:\MN{D}\to\MN{D}$, let
+    $\lVert S\rVert_{2\to2}$ be its operator norm for the
+    Hilbert--Schmidt norm. Then
+    \begin{align}
+        \lVert S(X)\rVert_2
+        &\leq \lVert S\rVert_{2\to2}\lVert X\rVert_2,\\
+        \lVert S\rVert_{2\to2}
+        &=\lVert\widehat S\rVert_\infty,
+    \end{align}
+    where the norm on the transfer matrix is its largest-singular-value
+    norm. The transfer representation also preserves subtraction and powers.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_transfer_matrix_vectorization}
+    Column vectorization is a Hilbert--Schmidt isometry, and
+    Theorem~\ref{thm:mpu_transfer_matrix_vectorization} identifies the action
+    of $S$ with multiplication by $\widehat S$. Thus the two induced operator
+    norms agree. Linearity and compatibility with composition give the
+    subtraction and power identities.
+\end{proof}
+
 \begin{lemma}[The same equivalence in the matrix units]
     \label{lem:transfer_matrix_units_hermitian_iff}
     \lean{transferMatrix_isHermitian_iff_traceAdjointMap_eq_self}

--- a/blueprint/src/chapter/ch12_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch12_entropy_trace_norm.tex
@@ -671,8 +671,7 @@ Theorem~\ref{thm:trace_norm_abs}.
         Matrix.sSup_orthogonalPureStateTraceNorms_le_hilbertSchmidtOperatorNorm}
     \leanok
     \uses{def:trace_norm,
-        thm:trace_norm_frobenius_comparison,
-        thm:transfer_matrix_hilbert_schmidt_operator_norm}
+        thm:trace_norm_frobenius_comparison}
     For $A\in\MN{D}$ and a complex-linear map $S:\MN{D}\to\MN{D}$,
     \begin{align}
         \lVert A\rVert_{\tr}&\leq\sqrt D\,\lVert A\rVert_2,\\
@@ -700,7 +699,7 @@ Theorem~\ref{thm:trace_norm_abs}.
     \leanok
     \uses{def:trace_norm_asymptotic_distance,
         def:peripheral_spectral_projections,
-        thm:transfer_matrix_hilbert_schmidt_operator_norm}
+        def:mpu_transfer_matrix}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, let $\rho$ be
     a density operator, and let $n>0$. Then
     \begin{align}
@@ -724,14 +723,20 @@ Theorem~\ref{thm:trace_norm_abs}.
     \uses{lem:trace_norm_asymptotic_distance_numerator,
         lem:trace_norm_contraction_pointwise,
         lem:asymptotic_hilbert_schmidt_estimates,
-        cor:peripheral_projection_channel}
+        cor:peripheral_projection_channel,
+        thm:transfer_matrix_hilbert_schmidt_operator_norm,
+        lem:wolf_positive_power_nonperipheral_identity}
     Apply the numerator identity to $S=T^n-T_\varphi^n$. The peripheral
     projection is again positive and trace preserving, so Lemma~8.3 applies to
     the distinct density matrices $\rho$ and $T_\phi(\rho)$. Then use
     $\lVert\cdot\rVert_{\tr}\leq\sqrt D\lVert\cdot\rVert_2$ and the
     $\sqrt2$ Hilbert--Schmidt distance of orthogonal pure states. The constants
     simplify as $\frac12\sqrt D\sqrt2=\sqrt{D/2}$; if
-    $\rho=T_\phi(\rho)$, both sides vanish directly.
+    $\rho=T_\phi(\rho)$, both sides vanish directly. Finally, the
+    positive-power identity identifies the transfer-matrix difference with
+    the transfer matrix of $T^n-T_\varphi^n$, whose largest-singular-value norm
+    equals the Hilbert--Schmidt operator norm
+    $\lVert T^n-T_\varphi^n\rVert_{2\to2}$.
 \end{proof}
 
 \begin{lemma}[Scaled positive-part trace estimate]

--- a/blueprint/src/chapter/ch12_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch12_entropy_trace_norm.tex
@@ -636,6 +636,102 @@ Theorem~\ref{thm:trace_norm_abs}.
     equality.
 \end{proof}
 
+\begin{lemma}[Pointwise form of the contraction-coefficient bound]
+    \label{lem:trace_norm_contraction_pointwise}
+    \lean{Matrix.traceNorm_map_sub_div_traceNorm_le_half_sSup_orthogonal}
+    \leanok
+    \uses{def:trace_norm, def:density_matrices}
+    Let $S:\MN{D}\to\MN{D'}$ be complex-linear and let
+    $\rho_1\neq\rho_2$ be density matrices. Then
+    \begin{align}
+        \frac{\lVert S(\rho_1)-S(\rho_2)\rVert_{\tr}}
+             {\lVert\rho_1-\rho_2\rVert_{\tr}}
+        \leq\frac12
+        \sup_{\substack{\lVert\psi\rVert=\lVert\phi\rVert=1\\
+                          \psi\perp\phi}}
+        \left\lVert S\left(\ketbra{\psi}{\psi}
+                     -\ketbra{\phi}{\phi}\right)\right\rVert_{\tr}.
+    \end{align}
+    This is the pointwise inequality from Wolf Lemma~8.3 used in
+    Equation~(8.115).
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:trace_norm_contraction_coefficient}
+    The proof is the upper-bound half of
+    Lemma~\ref{lem:trace_norm_contraction_coefficient}: normalize the positive
+    and negative parts of $\rho_1-\rho_2$ to orthogonally supported density
+    matrices and expand both in eigenprojectors.
+\end{proof}
+
+\begin{lemma}[Hilbert--Schmidt estimates for the asymptotic bound]
+    \label{lem:asymptotic_hilbert_schmidt_estimates}
+    \lean{Matrix.sum_sq_singularValues_eq_frobenius_sq,
+        Matrix.traceNorm_le_sqrt_card_mul_frobenius,
+        Matrix.hilbertSchmidtOperatorNorm,
+        Matrix.frobenius_norm_apply_le_hilbertSchmidtOperatorNorm,
+        Matrix.frobenius_norm_pureStateProj_sub_eq_sqrt_two,
+        Matrix.sSup_orthogonalPureStateTraceNorms_le_hilbertSchmidtOperatorNorm}
+    \leanok
+    \uses{def:trace_norm}
+    For $A\in\MN{D}$ and a complex-linear map $S:\MN{D}\to\MN{D}$,
+    \begin{align}
+        \lVert A\rVert_{\tr}&\leq\sqrt D\,\lVert A\rVert_2,\\
+        \lVert S(A)\rVert_2&\leq\lVert S\rVert_{2\to2}\lVert A\rVert_2.
+    \end{align}
+    If $\psi$ and $\phi$ are orthogonal unit vectors, then
+    $\lVert\ketbra{\psi}{\psi}-\ketbra{\phi}{\phi}\rVert_2=\sqrt2$.
+    Consequently the orthogonal-pure-state supremum for $S$ is at most
+    $\sqrt D\,\lVert S\rVert_{2\to2}\sqrt2$. These are precisely the
+    estimates in Wolf Equations~(8.115)--(8.116).
+\end{lemma}
+
+\begin{proof}\leanok
+    The first inequality is finite Cauchy--Schwarz applied to the singular
+    values. The second is the defining application bound for the operator norm
+    after Frobenius vectorization. Orthogonality makes the two rank-one
+    projectors multiply to zero, so the squared Hilbert--Schmidt norm of their
+    difference is the sum of their traces, namely $2$.
+\end{proof}
+
+\begin{theorem}[Convergence towards asymptotic states: upper bound]
+    \label{thm:trace_norm_asymptotic_distance_upper}
+    \lean{Matrix.traceNormAsymptoticDistance_pow_le_hilbertSchmidtOperatorNorm}
+    \leanok
+    \uses{def:trace_norm_asymptotic_distance,
+        def:peripheral_spectral_projections}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, let $\rho$ be
+    a density operator, and let $n>0$. Then
+    \begin{align}
+        \Delta_T(T^n(\rho))
+        \leq \sqrt{\frac D2}\,
+        \lVert T^n-T_\varphi^n\rVert_{2\to2}\,
+        \Delta_T(\rho).
+        \tag{8.112}
+    \end{align}
+    Here $\lVert\cdot\rVert_{2\to2}$ is the Hilbert--Schmidt operator norm,
+    equivalently Wolf's largest-singular-value norm of the transfer matrix.
+    The explicit $n>0$ records the paper's positive-natural convention: at
+    Lean's $n=0$, both superoperator powers are the identity, so the displayed
+    right-hand side vanishes. This is the upper assertion of~
+    \cite[Chapter~8, Proposition ``Convergence towards asymptotic states'',
+    Eqs.~(8.112), (8.114)--(8.116)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:trace_norm_asymptotic_distance_numerator,
+        lem:trace_norm_contraction_pointwise,
+        lem:asymptotic_hilbert_schmidt_estimates,
+        thm:peripheral_spectral_projection_properties}
+    Apply the numerator identity to $S=T^n-T_\varphi^n$. The peripheral
+    projection is again positive and trace preserving, so Lemma~8.3 applies to
+    the distinct density matrices $\rho$ and $T_\phi(\rho)$. Then use
+    $\lVert\cdot\rVert_{\tr}\leq\sqrt D\lVert\cdot\rVert_2$ and the
+    $\sqrt2$ Hilbert--Schmidt distance of orthogonal pure states. The constants
+    simplify as $\frac12\sqrt D\sqrt2=\sqrt{D/2}$; if
+    $\rho=T_\phi(\rho)$, both sides vanish directly.
+\end{proof}
+
 \begin{lemma}[Scaled positive-part trace estimate]
     \label{lem:scaled_posPart_trace_estimate}
     \lean{Matrix.re_trace_posPart_map_le_of_scaledTrace}

--- a/blueprint/src/chapter/ch12_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch12_entropy_trace_norm.tex
@@ -706,14 +706,15 @@ Theorem~\ref{thm:trace_norm_abs}.
     \begin{align}
         \Delta_T(T^n(\rho))
         \leq \sqrt{\frac D2}\,
-        \lVert T^n-T_\varphi^n\rVert_{2\to2}\,
+        \left\lVert \widehat T^{\,n}-\widehat T_\varphi^{\,n}\right\rVert_\infty\,
         \Delta_T(\rho).
         \tag{8.112}
     \end{align}
-    Here $\lVert\cdot\rVert_{2\to2}$ is the Hilbert--Schmidt operator norm,
-    equivalently Wolf's largest-singular-value norm of the transfer matrix.
+    Here the displayed transfer-matrix norm equals
+    $\lVert T^n-T_\varphi^n\rVert_{2\to2}$, the Hilbert--Schmidt operator norm
+    of the corresponding superoperator.
     The explicit $n>0$ records the paper's positive-natural convention: at
-    Lean's $n=0$, both superoperator powers are the identity, so the displayed
+    $n=0$, both superoperator powers are the identity, so the displayed
     right-hand side vanishes. This is the upper assertion of~
     \cite[Chapter~8, Proposition ``Convergence towards asymptotic states'',
     Eqs.~(8.112), (8.114)--(8.116)]{Wolf2012Quantum}.

--- a/blueprint/src/chapter/ch12_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch12_entropy_trace_norm.tex
@@ -539,7 +539,8 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{lemma}[Trace-norm contraction coefficient]
     \label{lem:trace_norm_contraction_coefficient}
-    \lean{Matrix.traceNorm_contraction_coefficient_eq_half_sSup_orthogonal}
+    \lean{Matrix.traceNorm_contraction_coefficient_eq_half_sSup_orthogonal,
+        Matrix.orthogonalPureStateTraceNorms_nonempty_of_density}
     \leanok
     \uses{def:trace_norm, def:density_matrices}
     Let $T:\MN{D}\to\MN{D'}$ be a complex-linear map. Then
@@ -666,14 +667,12 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{lemma}[Hilbert--Schmidt estimates for the asymptotic bound]
     \label{lem:asymptotic_hilbert_schmidt_estimates}
-    \lean{Matrix.sum_sq_singularValues_eq_frobenius_sq,
-        Matrix.traceNorm_le_sqrt_card_mul_frobenius,
-        Matrix.hilbertSchmidtOperatorNorm,
-        Matrix.frobenius_norm_apply_le_hilbertSchmidtOperatorNorm,
-        Matrix.frobenius_norm_pureStateProj_sub_eq_sqrt_two,
+    \lean{Matrix.frobenius_norm_pureStateProj_sub_eq_sqrt_two,
         Matrix.sSup_orthogonalPureStateTraceNorms_le_hilbertSchmidtOperatorNorm}
     \leanok
-    \uses{def:trace_norm}
+    \uses{def:trace_norm,
+        thm:trace_norm_frobenius_comparison,
+        thm:transfer_matrix_hilbert_schmidt_operator_norm}
     For $A\in\MN{D}$ and a complex-linear map $S:\MN{D}\to\MN{D}$,
     \begin{align}
         \lVert A\rVert_{\tr}&\leq\sqrt D\,\lVert A\rVert_2,\\
@@ -696,10 +695,12 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{theorem}[Convergence towards asymptotic states: upper bound]
     \label{thm:trace_norm_asymptotic_distance_upper}
-    \lean{Matrix.traceNormAsymptoticDistance_pow_le_hilbertSchmidtOperatorNorm}
+    \lean{Matrix.traceNormAsymptoticDistance_pow_le_transferMatrix_l2_opNorm,
+        Matrix.traceNormAsymptoticDistance_pow_le_hilbertSchmidtOperatorNorm}
     \leanok
     \uses{def:trace_norm_asymptotic_distance,
-        def:peripheral_spectral_projections}
+        def:peripheral_spectral_projections,
+        thm:transfer_matrix_hilbert_schmidt_operator_norm}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, let $\rho$ be
     a density operator, and let $n>0$. Then
     \begin{align}
@@ -722,7 +723,7 @@ Theorem~\ref{thm:trace_norm_abs}.
     \uses{lem:trace_norm_asymptotic_distance_numerator,
         lem:trace_norm_contraction_pointwise,
         lem:asymptotic_hilbert_schmidt_estimates,
-        thm:peripheral_spectral_projection_properties}
+        cor:peripheral_projection_channel}
     Apply the numerator identity to $S=T^n-T_\varphi^n$. The peripheral
     projection is again positive and trace preserving, so Lemma~8.3 applies to
     the distinct density matrices $\rho$ and $T_\phi(\rho)$. Then use


### PR DESCRIPTION
## Summary

Formalize the upper half of Wolf's Proposition “Convergence towards asymptotic states,” following the proof route in `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1319–1354.

- expose the pointwise upper-bound half of Wolf Lemma 8.3 for two distinct density matrices;
- prove `‖A‖₁ ≤ √d ‖A‖₂`, the Hilbert–Schmidt `2 → 2` application bound, and `‖|ψ⟩⟨ψ| - |φ⟩⟨φ|‖₂ = √2` for orthogonal unit vectors;
- prove Equation (8.112) with Wolf's exact `√(d/2)` constant for positive trace-preserving maps;
- keep the proof in the source order (8.114) → (8.115) → (8.116), using the existing peripheral projection and asymptotic-map notation `T_φ` and `T_ϕ`;
- synchronize the Blueprint statement, proof dependencies, and source attribution.

The Lean theorem explicitly assumes `0 < n`. This records the paper's positive-natural convention: with Lean's `n = 0`, `T⁰ - T_ϕ⁰ = 0`, so the printed inequality need not hold unless the initial asymptotic distance vanishes.

This is partial progress only. Equation (8.113) and the four-positive-parts converse route in Equation (8.117) remain open, so this PR does not close the tracking issue.

Refs #301.

## Validation

- `lake build QICLean.Analysis.AsymptoticStateConvergence -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (1953/1953)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `texra-blueprint --root . paper-gaps check`
- `git diff --check origin/main...HEAD`
- forbidden-bypass scan over both changed Lean files
- `#print axioms` for the pointwise Lemma 8.3 bound and Equation (8.112): only `propext`, `Classical.choice`, and `Quot.sound`
