### PR TITLE
feat(channel): generalize Choi compression to rectangular maps

### DIFF
--- a/QICLean/Channel/Schwarz/ChoiCompression.lean
+++ b/QICLean/Channel/Schwarz/ChoiCompression.lean
@@ -13,28 +13,28 @@ import Mathlib.Analysis.InnerProductSpace.PiL2
 /-!
 # Choi compression for the rank-one test
 
-This file records the matrix identity connecting the pure-state ampliation test
-for `k`-positivity with the Choi-matrix compression appearing in Wolf Chapter 3,
-Proposition 3.1, equation (3.4).
+This file connects the pure-state ampliation test for `k`-positivity with the
+Choi-matrix compression in Wolf Chapter 3, Proposition 3.1, equation (3.4).
 
-The Choi matrix is normalized using `Matrix.omegaVec`, so the vector attached to
-a matrix $X\in M_{D\times k}(\mathbb{C})$ has component $D^{-1/2}X_{i,p}$ at
-the pair $(i,p)$.
+For a map $T : M_d(\mathbb{C}) \to M_{d'}(\mathbb{C})$, the Choi matrix acts
+on the output-first space $\mathbb{C}^{d'}\otimes\mathbb{C}^d$. With the
+`Matrix.omegaVec` normalization, the vector for $X\in M_{d\times k}(\mathbb{C})$
+has component $d^{-1/2}X_{a,p}$ at $(a,p)$.
 
 ## Main definitions
 
 * `ChoiJamiolkowski.rightCompression`: the right-factor Choi compression,
   written in the index convention of the blockwise ampliation.
-* `ChoiJamiolkowski.rightTensorMatrix`: the matrix form of the right tensor
-  factor acting on the Choi auxiliary index.
+* `ChoiJamiolkowski.rightTensorMatrix`: the right tensor factor on the input
+  Choi index, defaulting to the equal-dimension specialization.
 * `ChoiJamiolkowski.compressedOmegaVector`: the vector with component
-  $D^{-1/2}X_{i,p}$ at the pair $(i,p)$.
+  $d^{-1/2}X_{a,p}$ at the pair $(a,p)$.
 
 ## Main results
 
 * `ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression`: the
   ampliation of the associated rank-one matrix is exactly that compression.
-* `ChoiJamiolkowski.rightTensorMatrix_mul_choiMatrix_mul_conjTranspose`: the
+* `ChoiJamiolkowski.rightTensorMatrix_mul_choiMatrix_mul_conjTranspose_rectangular`: the
   same compression is the sandwich by the right tensor factor.
 * `ChoiJamiolkowski.compressedOmegaVector_hasSchmidtRankLE`: the compressed
   maximally entangled vector has Schmidt rank at most the compression dimension.
@@ -42,26 +42,22 @@ the pair $(i,p)$.
   maximally entangled vector has Schmidt rank equal to the rank of the
   right-factor matrix.
 * `ChoiJamiolkowski.hasSchmidtRankLE_iff_exists_rank_le_compressedOmegaVector`:
-  Wolf's square-matrix parametrization of vectors of bounded Schmidt rank.
+  the square-input parametrization of vectors of bounded Schmidt rank.
 * `ChoiJamiolkowski.isNPositiveMap_iff_forall_rightCompression_posSemidef`:
-  `k`-positivity is equivalent to positivity of all rectangular right-factor
-  Choi compressions.
+  `k`-positivity is equivalent to positivity of all right-factor compressions.
 * `ChoiJamiolkowski.rightTensorMatrix_mul_rightTensorMatrix`: right tensor
   factors multiply by multiplying the corresponding right-factor matrices.
-* Fixed-column compression lemma:
-  a square right-factor sandwich controls each rectangular compression whose
-  columns it fixes; see
-  `rightCompression_posSemidef_of_rightTensorMatrix_sandwich_posSemidef_of_mul_eq_self`.
+* Fixed-column compression: a square right-factor sandwich controls every
+  rectangular compression whose columns it fixes; see
+  `rightCompression_posSemidef_of_projection_sandwich_of_mul_eq_self_rectangular`.
 * `Matrix.exists_mul_conjTranspose_of_isHermitian_idempotent_rank`: a Hermitian
   idempotent matrix of rank `k` factors as `P = V * Vᴴ`.
 * `Matrix.exists_isHermitian_idempotent_rank_mul_eq_self`: every rectangular
-  right factor with `k ≤ D` is fixed by some Hermitian idempotent rank-`k`
-  projection.
-* `IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_isHermitian_idempotent_rank`:
-  `k`-positivity implies positivity of the Choi sandwich compressed by a
-  Hermitian idempotent of rank `k`.
-* `isNPositiveMap_iff_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef`:
-  Wolf's rank-`k` projection form of the Choi criterion.
+  right factor with `k ≤ d` is fixed by a Hermitian idempotent rank-`k` projection.
+* `IsNPositiveMap.rightProjection_choiMatrix_sandwich_posSemidef_rectangular`:
+  `k`-positivity makes every rank-`k` input-projection Choi sandwich positive.
+* `isNPositiveMap_iff_forall_rankProjection_choiMatrix_sandwich_posSemidef_rectangular`:
+  Wolf's rank-`k` projection form of the rectangular Choi criterion.
 
 ## References
 
@@ -74,9 +70,8 @@ open Matrix Finset
 
 namespace Matrix
 
-/-- Over a finite complex coordinate space, nonnegativity of all matrix
-quadratic forms already implies positive semidefiniteness.  The Hermitian part
-is recovered by the complex polarization identity. -/
+/-- Over finite complex coordinates, nonnegative quadratic forms imply positive
+semidefiniteness; the Hermitian part follows from complex polarization. -/
 theorem posSemidef_of_dotProduct_mulVec_nonneg_complex
     {n : Type*} [Fintype n] {M : Matrix n n ℂ}
     (hM : ∀ x : n → ℂ, (0 : ℂ) ≤ star x ⬝ᵥ (M *ᵥ x)) : M.PosSemidef := by
@@ -111,9 +106,8 @@ end Matrix
 
 namespace Submodule
 
-/-- In a finite-dimensional vector space, any subspace of dimension at most `r`
-is contained in a subspace of dimension exactly `r`, provided `r` is no larger
-than the ambient dimension. -/
+/-- A finite-dimensional subspace of dimension at most `r` lies in one of dimension
+exactly `r`, provided `r` is no larger than the ambient dimension. -/
 theorem exists_le_finrank_eq {K V : Type*} [Field K] [AddCommGroup V] [Module K V]
     [Module.Finite K V] (W : Submodule K V) {r : ℕ}
     (hW : Module.finrank K W ≤ r) (hr : r ≤ Module.finrank K V) :
@@ -152,13 +146,10 @@ end Submodule
 
 namespace Matrix
 
-/-- Every finite-dimensional Hermitian idempotent matrix of rank `k` has a
-factorization `P = V * Vᴴ` with `k` columns.  The proof identifies `P` with the
-orthogonal projection onto its range, chooses an orthonormal basis of that range,
-and takes the basis vectors as the columns of `V`.
-
-This is the finite-dimensional projection factorization used in Wolf,
-Proposition 3.1, item 2. -/
+/-- Every finite-dimensional Hermitian idempotent matrix of rank `k` factors as
+`P = V * Vᴴ` with `k` columns. The proof identifies `P` with the orthogonal
+projection onto its range and uses an orthonormal basis of that range as the
+columns of `V`. This is the factorization in Wolf, Proposition 3.1, item 2. -/
 theorem exists_mul_conjTranspose_of_isHermitian_idempotent_rank
     {D k : ℕ} (P : Matrix (Fin D) (Fin D) ℂ)
     (hP : P.IsHermitian) (hP_idem : P * P = P) (hrank : P.rank = k) :
@@ -312,47 +303,47 @@ end Matrix
 
 namespace ChoiJamiolkowski
 
-variable {D k : ℕ}
+variable {d d' k : ℕ}
 
-/-- The right-factor Choi compression, written in the index convention of the
-blockwise ampliation.  Here `X : Matrix (Fin D) (Fin k) ℂ` carries the original
-Choi auxiliary index and the `k`-dimensional ampliation index.  The
-$(i,p),(j,q)$ entry is
+/-- The right-factor Choi compression in the blockwise-ampliation convention.
+Here `X : Matrix (Fin d) (Fin k) ℂ` carries the input Choi and ampliation indices,
+while `i,j : Fin d'` are output indices. The $(i,p),(j,q)$ entry is
 $\sum_{a,b} X_{a,p}\,\tau_{(i,a),(j,b)}\,\overline{X_{b,q}}$, where $\tau$ is
 the Choi matrix of `T`. -/
 noncomputable def rightCompression
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (X : Matrix (Fin D) (Fin k) ℂ) :
-    Matrix (Fin D × Fin k) (Fin D × Fin k) ℂ :=
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (X : Matrix (Fin d) (Fin k) ℂ) :
+    Matrix (Fin d' × Fin k) (Fin d' × Fin k) ℂ :=
   Matrix.of fun ip jq =>
-    ∑ a : Fin D, ∑ b : Fin D,
-      X a ip.2 * choiMatrix T (ip.1, a) (jq.1, b) * star (X b jq.2)
+    ∑ a : Fin d, ∑ b : Fin d,
+      X a ip.2 * ChoiRectangular.choiMatrix T (ip.1, a) (jq.1, b) * star (X b jq.2)
 
-/-- The entry formula for the right-factor compression of the Choi matrix.  The
-$(i,p),(j,q)$ entry is
+/-- The entry formula for the Choi right-factor compression: its $(i,p),(j,q)$ entry is
 $\sum_{a,b} X_{a,p}\,\tau_{(i,a),(j,b)}\,\overline{X_{b,q}}$, where $\tau$ is
 the Choi matrix of `T`. -/
 theorem rightCompression_apply
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (X : Matrix (Fin D) (Fin k) ℂ) (i j : Fin D) (p q : Fin k) :
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (X : Matrix (Fin d) (Fin k) ℂ) (i j : Fin d') (p q : Fin k) :
     rightCompression T X (i, p) (j, q) =
-      ∑ a : Fin D, ∑ b : Fin D,
-        X a p * choiMatrix T (i, a) (j, b) * star (X b q) :=
+      ∑ a : Fin d, ∑ b : Fin d,
+        X a p * ChoiRectangular.choiMatrix T (i, a) (j, b) * star (X b q) :=
   rfl
 
 /-- The matrix representing the right tensor factor in the Choi-compression
-index convention.  Its entry from the Choi index `(j,a)` to the compressed
-index `(i,p)` is $\delta_{ij}X_{a,p}$.  This is the matrix form used in
-Wolf, Chapter 3, Proposition 3.1, item 2. -/
-noncomputable def rightTensorMatrix (X : Matrix (Fin D) (Fin k) ℂ) :
-    Matrix (Fin D × Fin k) (Fin D × Fin D) ℂ :=
+index convention. Its entry from the output-input Choi index `(j,a)` to the
+output-ampliation index `(i,p)` is $\delta_{ij}X_{a,p}$. The optional output
+dimension defaults to the input dimension. Source: Wolf, Chapter 3,
+Proposition 3.1, lines 89--115. -/
+noncomputable def rightTensorMatrix (X : Matrix (Fin d) (Fin k) ℂ) (d' : ℕ := d) :
+    Matrix (Fin d' × Fin k) (Fin d' × Fin d) ℂ :=
   Matrix.of fun ip ja => if ip.1 = ja.1 then X ja.2 ip.2 else 0
 
-/-- The right-tensor matrix for `X * Xᴴ` factors as `R_Xᴴ * R_X` in the
-index convention used for Choi compression. -/
+/-- In the Choi-compression convention, the right-tensor matrix for `X * Xᴴ`
+factors as `R_Xᴴ * R_X`. -/
 theorem rightTensorMatrix_mul_conjTranspose_eq_conjTranspose_mul_self
-    (X : Matrix (Fin D) (Fin k) ℂ) :
-    rightTensorMatrix (X * Xᴴ) = (rightTensorMatrix X)ᴴ * rightTensorMatrix X := by
+    (X : Matrix (Fin d) (Fin k) ℂ) :
+    rightTensorMatrix (d' := d') (X * Xᴴ) =
+      (rightTensorMatrix (d' := d') X)ᴴ * rightTensorMatrix (d' := d') X := by
   classical
   ext ⟨i, a⟩ ⟨j, b⟩
   by_cases hij : i = j
@@ -366,11 +357,11 @@ theorem rightTensorMatrix_mul_conjTranspose_eq_conjTranspose_mul_self
     have hji : ¬j = i := fun hji => hij hji.symm
     simp [hij, hji]
 
-/-- Multiplication by a square right tensor factor corresponds to multiplication
-of the underlying right-factor matrices. -/
+/-- Multiplying by a square right tensor factor multiplies the underlying matrices. -/
 theorem rightTensorMatrix_mul_rightTensorMatrix
-    (X : Matrix (Fin D) (Fin k) ℂ) (P : Matrix (Fin D) (Fin D) ℂ) :
-    rightTensorMatrix X * rightTensorMatrix P = rightTensorMatrix (P * X) := by
+    (X : Matrix (Fin d) (Fin k) ℂ) (P : Matrix (Fin d) (Fin d) ℂ) :
+    rightTensorMatrix (d' := d') X * rightTensorMatrix (d' := d') P =
+      rightTensorMatrix (d' := d') (P * X) := by
   classical
   ext ⟨i, p⟩ ⟨j, a⟩
   simp only [rightTensorMatrix, Matrix.of_apply, Matrix.mul_apply, Fintype.sum_prod_type]
@@ -384,10 +375,11 @@ right-factor compression entries.  In Wolf's notation this is the identity
 between $(\mathbf{1}\otimes X)\tau(\mathbf{1}\otimes X)^\dagger$ and the
 matrix with entries
 $\sum_{a,b} X_{a,p}\tau_{(i,a),(j,b)}\overline{X_{b,q}}$. -/
-theorem rightTensorMatrix_mul_choiMatrix_mul_conjTranspose
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (X : Matrix (Fin D) (Fin k) ℂ) :
-    rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ =
+theorem rightTensorMatrix_mul_choiMatrix_mul_conjTranspose_rectangular
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (X : Matrix (Fin d) (Fin k) ℂ) :
+    rightTensorMatrix (d' := d') X * ChoiRectangular.choiMatrix T *
+        (rightTensorMatrix (d' := d') X)ᴴ =
       rightCompression T X := by
   classical
   ext ⟨i, p⟩ ⟨j, q⟩
@@ -400,42 +392,45 @@ theorem rightTensorMatrix_mul_choiMatrix_mul_conjTranspose
     simp [Ne.symm hx]
   · simp
 
-/-- The quadratic form of the Choi sandwich by the right tensor factor is the
-Choi quadratic form evaluated on the pulled-back vector. -/
-theorem rightTensor_choiMatrix_quadraticForm_eq
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
+/-- A right-factor Choi-sandwich quadratic form is the Choi form on the pullback. -/
+theorem rightTensor_choiMatrix_quadraticForm_eq_rectangular
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (X : Matrix (Fin d) (Fin k) ℂ) (η : Fin d' × Fin k → ℂ) :
     star η ⬝ᵥ
-        ((rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ) *ᵥ η) =
-      star ((rightTensorMatrix X)ᴴ *ᵥ η) ⬝ᵥ
-        (choiMatrix T *ᵥ ((rightTensorMatrix X)ᴴ *ᵥ η)) := by
+        ((rightTensorMatrix (d' := d') X * ChoiRectangular.choiMatrix T *
+            (rightTensorMatrix (d' := d') X)ᴴ) *ᵥ η) =
+      star ((rightTensorMatrix (d' := d') X)ᴴ *ᵥ η) ⬝ᵥ
+        (ChoiRectangular.choiMatrix T *ᵥ
+          ((rightTensorMatrix (d' := d') X)ᴴ *ᵥ η)) := by
   have hmul :
-      ((rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ) *ᵥ η) =
-        rightTensorMatrix X *ᵥ
-          (choiMatrix T *ᵥ ((rightTensorMatrix X)ᴴ *ᵥ η)) := by
+      ((rightTensorMatrix (d' := d') X * ChoiRectangular.choiMatrix T *
+          (rightTensorMatrix (d' := d') X)ᴴ) *ᵥ η) =
+        rightTensorMatrix (d' := d') X *ᵥ
+          (ChoiRectangular.choiMatrix T *ᵥ
+            ((rightTensorMatrix (d' := d') X)ᴴ *ᵥ η)) := by
     simp [Matrix.mulVec_mulVec, Matrix.mul_assoc]
   have hstar :
-      star ((rightTensorMatrix X)ᴴ *ᵥ η) = star η ᵥ* rightTensorMatrix X := by
+      star ((rightTensorMatrix (d' := d') X)ᴴ *ᵥ η) =
+        star η ᵥ* rightTensorMatrix (d' := d') X := by
     rw [Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose]
   rw [hmul, Matrix.dotProduct_mulVec, ← hstar]
 
-/-- The quadratic form of the right-factor compression is the Choi quadratic
-form evaluated on the vector pulled back by the adjoint right tensor factor. -/
-theorem rightCompression_quadraticForm_eq_choiMatrix_quadraticForm
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
+/-- A right-compression quadratic form is the Choi form on the adjoint pullback. -/
+theorem rightCompression_quadraticForm_eq_choiMatrix_quadraticForm_rectangular
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (X : Matrix (Fin d) (Fin k) ℂ) (η : Fin d' × Fin k → ℂ) :
     star η ⬝ᵥ (rightCompression T X *ᵥ η) =
-      star ((rightTensorMatrix X)ᴴ *ᵥ η) ⬝ᵥ
-        (choiMatrix T *ᵥ ((rightTensorMatrix X)ᴴ *ᵥ η)) := by
-  rw [← rightTensorMatrix_mul_choiMatrix_mul_conjTranspose (T := T) (X := X)]
-  exact rightTensor_choiMatrix_quadraticForm_eq T X η
+      star ((rightTensorMatrix (d' := d') X)ᴴ *ᵥ η) ⬝ᵥ
+        (ChoiRectangular.choiMatrix T *ᵥ
+          ((rightTensorMatrix (d' := d') X)ᴴ *ᵥ η)) := by
+  rw [← rightTensorMatrix_mul_choiMatrix_mul_conjTranspose_rectangular (T := T) (X := X)]
+  exact rightTensor_choiMatrix_quadraticForm_eq_rectangular T X η
 
-/-- The coefficient matrix of the vector pulled back by the adjoint right
-tensor factor is the product of the coefficient matrix of the compressed vector
-with the adjoint of the right-factor matrix. -/
+/-- The coefficient matrix of an adjoint right-tensor pullback is the compressed
+vector's coefficient matrix times the adjoint right-factor matrix. -/
 theorem schmidtCoeffMatrix_rightTensorMatrix_conjTranspose_mulVec
-    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
-    Matrix.schmidtCoeffMatrix ((rightTensorMatrix X)ᴴ *ᵥ η) =
+    (X : Matrix (Fin d) (Fin k) ℂ) (η : Fin d' × Fin k → ℂ) :
+    Matrix.schmidtCoeffMatrix ((rightTensorMatrix (d' := d') X)ᴴ *ᵥ η) =
       Matrix.schmidtCoeffMatrix η * Xᴴ := by
   classical
   ext j a
@@ -447,12 +442,13 @@ theorem schmidtCoeffMatrix_rightTensorMatrix_conjTranspose_mulVec
     simp [hij]
   · simp
 
-/-- Pulling a vector back by the adjoint right tensor factor gives a vector of
-Schmidt rank at most the compression dimension. -/
+/-- An adjoint right-tensor pullback has Schmidt rank at most the compression size. -/
 theorem rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE
-    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
-    Matrix.HasSchmidtRankLE k ((rightTensorMatrix X)ᴴ *ᵥ η) := by
-  have hrank : (Matrix.schmidtCoeffMatrix ((rightTensorMatrix X)ᴴ *ᵥ η)).rank ≤ k := by
+    (X : Matrix (Fin d) (Fin k) ℂ) (η : Fin d' × Fin k → ℂ) :
+    Matrix.HasSchmidtRankLE k ((rightTensorMatrix (d' := d') X)ᴴ *ᵥ η) := by
+  have hrank :
+      (Matrix.schmidtCoeffMatrix
+        ((rightTensorMatrix (d' := d') X)ᴴ *ᵥ η)).rank ≤ k := by
     rw [schmidtCoeffMatrix_rightTensorMatrix_conjTranspose_mulVec]
     calc
       (Matrix.schmidtCoeffMatrix η * Xᴴ).rank ≤ (Xᴴ).rank :=
@@ -462,26 +458,27 @@ theorem rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE
       _ = k := by simp
   simpa [Matrix.HasSchmidtRankLE, Matrix.schmidtRank] using hrank
 
-/-- Every vector of Schmidt rank at most `k` is obtained by pulling back a
-vector in the `D × k` compressed space through the adjoint of a right tensor
-factor. -/
+/-- Every vector of Schmidt rank at most `k` in the output-input tensor product
+is obtained by pulling back a vector in the output-ampliation tensor product
+through the adjoint of a right tensor factor. -/
 theorem exists_rightTensorMatrix_conjTranspose_mulVec_of_hasSchmidtRankLE
-    {ψ : Fin D × Fin D → ℂ} (hψ : Matrix.HasSchmidtRankLE k ψ) :
-    ∃ X : Matrix (Fin D) (Fin k) ℂ, ∃ η : Fin D × Fin k → ℂ,
-      (rightTensorMatrix X)ᴴ *ᵥ η = ψ := by
+    {ψ : Fin d' × Fin d → ℂ} (hψ : Matrix.HasSchmidtRankLE k ψ) :
+    ∃ X : Matrix (Fin d) (Fin k) ℂ, ∃ η : Fin d' × Fin k → ℂ,
+      (rightTensorMatrix (d' := d') X)ᴴ *ᵥ η = ψ := by
   classical
-  let A : Matrix (Fin D) (Fin D) ℂ := Matrix.schmidtCoeffMatrix ψ
+  let A : Matrix (Fin d') (Fin d) ℂ := Matrix.schmidtCoeffMatrix ψ
   have hA : A.rank ≤ k := by
     simpa [A, Matrix.HasSchmidtRankLE, Matrix.schmidtRank] using hψ
   obtain ⟨B, C, hBC⟩ := Matrix.exists_mul_eq_of_rank_le A hA
-  let X : Matrix (Fin D) (Fin k) ℂ := Cᴴ
-  let η : Fin D × Fin k → ℂ := fun ip => B ip.1 ip.2
+  let X : Matrix (Fin d) (Fin k) ℂ := Cᴴ
+  let η : Fin d' × Fin k → ℂ := fun ip => B ip.1 ip.2
   refine ⟨X, η, ?_⟩
   ext ip
   rcases ip with ⟨j, a⟩
   calc
-    ((rightTensorMatrix X)ᴴ *ᵥ η) (j, a)
-        = Matrix.schmidtCoeffMatrix ((rightTensorMatrix X)ᴴ *ᵥ η) j a := rfl
+    ((rightTensorMatrix (d' := d') X)ᴴ *ᵥ η) (j, a)
+        = Matrix.schmidtCoeffMatrix
+          ((rightTensorMatrix (d' := d') X)ᴴ *ᵥ η) j a := rfl
     _ = (B * C) j a := by
         rw [schmidtCoeffMatrix_rightTensorMatrix_conjTranspose_mulVec]
         have hηcoeff : Matrix.schmidtCoeffMatrix η = B := by
@@ -492,8 +489,7 @@ theorem exists_rightTensorMatrix_conjTranspose_mulVec_of_hasSchmidtRankLE
     _ = A j a := by rw [hBC]
     _ = ψ (j, a) := rfl
 
-/-- The coefficient vector obtained from the normalized maximally entangled
-vector by applying `X` on the right tensor factor. -/
+/-- Apply `X` on the right factor of the normalized maximally entangled vector. -/
 noncomputable def compressedOmegaVector (X : Matrix (Fin D) (Fin k) ℂ) :
     Fin D × Fin k → ℂ :=
   fun ip => ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * X ip.1 ip.2
@@ -518,8 +514,8 @@ theorem compressedOmegaVector_schmidtRank_eq_rank [NeZero D]
   exact Matrix.rank_smul_of_mem_nonZeroDivisors X
     (mem_nonZeroDivisors_of_ne_zero hc_ne)
 
-/-- The vector obtained by applying a `D × k` matrix on the right tensor factor
-of the maximally entangled vector has Schmidt rank at most `k`. -/
+/-- Applying a `D × k` right factor to the maximally entangled vector gives
+Schmidt rank at most `k`. -/
 theorem compressedOmegaVector_hasSchmidtRankLE
     (X : Matrix (Fin D) (Fin k) ℂ) :
     Matrix.HasSchmidtRankLE k (compressedOmegaVector X) := by
@@ -527,8 +523,7 @@ theorem compressedOmegaVector_hasSchmidtRankLE
     compressedOmegaVector] using
     Matrix.rank_le_card_width (Matrix.schmidtCoeffMatrix (compressedOmegaVector X))
 
-/-- If the square compression matrix has rank at most k, then the associated
-compressed maximally entangled vector has Schmidt rank at most k. -/
+/-- A square compression of rank at most `k` gives Schmidt rank at most `k`. -/
 theorem compressedOmegaVector_hasSchmidtRankLE_of_rank_le [NeZero D]
     {X : Matrix (Fin D) (Fin D) ℂ} {k : ℕ} (hX : X.rank ≤ k) :
     Matrix.HasSchmidtRankLE k (compressedOmegaVector X) := by
@@ -585,20 +580,20 @@ theorem hasSchmidtRankLE_iff_exists_rank_le_compressedOmegaVector [NeZero D]
 rank-one matrix $|\psi\rangle\langle\psi|$ by `T` is the right-factor Choi
 compression by `X`. -/
 theorem nPositiveAmpliation_rankOne_eq_rightCompression
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (X : Matrix (Fin D) (Fin k) ℂ) :
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (X : Matrix (Fin d) (Fin k) ℂ) :
     nPositiveAmpliation k T
         (Matrix.vecMulVec (compressedOmegaVector X) (star (compressedOmegaVector X))) =
       rightCompression T X := by
   classical
   ext ⟨i, p⟩ ⟨j, q⟩
-  let c : ℂ := (1 : ℂ) / ((D : ℝ).sqrt : ℂ)
+  let c : ℂ := (1 : ℂ) / ((d : ℝ).sqrt : ℂ)
   have hblock :
       (Matrix.of fun a b =>
           Matrix.vecMulVec (compressedOmegaVector X) (star (compressedOmegaVector X))
             (a, p) (b, q)) =
-        ∑ a : Fin D, ∑ b : Fin D,
-          (X a p * star (X b q)) • Matrix.bipartiteSlice (Matrix.omegaProj D) a b := by
+        ∑ a : Fin d, ∑ b : Fin d,
+          (X a p * star (X b q)) • Matrix.bipartiteSlice (Matrix.omegaProj d) a b := by
     calc
       (Matrix.of fun a b =>
           Matrix.vecMulVec (compressedOmegaVector X) (star (compressedOmegaVector X))
@@ -607,8 +602,8 @@ theorem nPositiveAmpliation_rankOne_eq_rightCompression
             ext a b
             simp [compressedOmegaVector, c, Matrix.vecMulVec_apply]
             ring
-      _ = ∑ a : Fin D, ∑ b : Fin D,
-          (X a p * star (X b q)) • Matrix.bipartiteSlice (Matrix.omegaProj D) a b := by
+      _ = ∑ a : Fin d, ∑ b : Fin d,
+          (X a p * star (X b q)) • Matrix.bipartiteSlice (Matrix.omegaProj d) a b := by
             rw [Matrix.matrix_eq_sum_single
               (Matrix.of fun a b => (X a p * star (X b q)) * (c * star c))]
             simp [ChoiJamiolkowski.omegaSlice_eq_single, c, Matrix.smul_single,
@@ -620,29 +615,32 @@ theorem nPositiveAmpliation_rankOne_eq_rightCompression
         = T (Matrix.of fun a b =>
             Matrix.vecMulVec (compressedOmegaVector X) (star (compressedOmegaVector X))
               (a, p) (b, q)) i j := rfl
-    _ = T (∑ a : Fin D, ∑ b : Fin D,
-          (X a p * star (X b q)) • Matrix.bipartiteSlice (Matrix.omegaProj D) a b) i j := by
+    _ = T (∑ a : Fin d, ∑ b : Fin d,
+          (X a p * star (X b q)) • Matrix.bipartiteSlice (Matrix.omegaProj d) a b) i j := by
         rw [hblock]
-    _ = (∑ a : Fin D, ∑ b : Fin D,
-          (X a p * star (X b q)) • T (Matrix.bipartiteSlice (Matrix.omegaProj D) a b)) i j := by
+    _ = (∑ a : Fin d, ∑ b : Fin d,
+          (X a p * star (X b q)) • T (Matrix.bipartiteSlice (Matrix.omegaProj d) a b)) i j := by
         simp [map_sum]
     _ = rightCompression T X (i, p) (j, q) := by
         rw [rightCompression_apply]
-        simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul, choiMatrix_apply]
+        simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul,
+          ChoiRectangular.choiMatrix_apply]
         apply Finset.sum_congr rfl
         intro a _
         apply Finset.sum_congr rfl
         intro b _
         ring_nf
 
-/-- Rectangular compression form of Wolf, Proposition 3.1, equation (3.4), for
-endomorphisms of matrix algebras: when `D > 0`, `k`-positivity is equivalent to
-positivity of every right-factor compression of the Choi matrix by a matrix in
-`M_{D,k}`. -/
-theorem isNPositiveMap_iff_forall_rightCompression_posSemidef [NeZero D]
-    (k : ℕ) (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+/-- Rectangular compression form of Wolf, Proposition 3.1, equation (3.4):
+when `d > 0`, `k`-positivity of a map from `M_d(ℂ)` to `M_{d'}(ℂ)` is
+equivalent to positivity of every right-factor compression of its Choi matrix
+by a matrix in `M_{d,k}(ℂ)`. Source: Wolf, Chapter 3, Proposition 3.1,
+lines 89--115. -/
+theorem isNPositiveMap_iff_forall_rightCompression_posSemidef [NeZero d]
+    (k : ℕ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
     IsNPositiveMap k T ↔
-      ∀ X : Matrix (Fin D) (Fin k) ℂ, (rightCompression T X).PosSemidef := by
+      ∀ X : Matrix (Fin d) (Fin k) ℂ, (rightCompression T X).PosSemidef := by
   constructor
   · intro hT X
     rw [← nPositiveAmpliation_rankOne_eq_rightCompression (T := T) (X := X)]
@@ -651,13 +649,13 @@ theorem isNPositiveMap_iff_forall_rightCompression_posSemidef [NeZero D]
   · intro hX
     rw [isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef]
     intro φ
-    let X : Matrix (Fin D) (Fin k) ℂ :=
-      fun a p => (((D : ℝ).sqrt : ℂ)) * φ (a, p)
+    let X : Matrix (Fin d) (Fin k) ℂ :=
+      fun a p => (((d : ℝ).sqrt : ℂ)) * φ (a, p)
     have hvec : compressedOmegaVector X = φ := by
-      have hDpos : 0 < (D : ℝ) := by
-        exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
-      have hsqrt_ne : ((D : ℝ).sqrt : ℂ) ≠ 0 := by
-        exact_mod_cast (Real.sqrt_ne_zero'.mpr hDpos)
+      have hdpos : 0 < (d : ℝ) := by
+        exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne d)
+      have hsqrt_ne : ((d : ℝ).sqrt : ℂ) ≠ 0 := by
+        exact_mod_cast (Real.sqrt_ne_zero'.mpr hdpos)
       ext ip
       rcases ip with ⟨i, p⟩
       simp only [compressedOmegaVector, X]
@@ -666,41 +664,50 @@ theorem isNPositiveMap_iff_forall_rightCompression_posSemidef [NeZero D]
     rw [nPositiveAmpliation_rankOne_eq_rightCompression]
     exact hX X
 
-/-- Converse Schmidt-rank test for Wolf's Choi criterion.  If all
-Schmidt-rank-`≤ k` vectors have nonnegative Choi quadratic form, then the map
-is `k`-positive. -/
-theorem isNPositiveMap_of_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg [NeZero D]
-    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (hψ : ∀ ψ : Fin D × Fin D → ℂ, Matrix.HasSchmidtRankLE k ψ →
-      (0 : ℂ) ≤ star ψ ⬝ᵥ (choiMatrix T *ᵥ ψ)) :
+/-- Converse Schmidt-rank test for Wolf's Choi criterion. If all vectors of
+Schmidt rank at most `k` in the output-input tensor product have nonnegative
+Choi quadratic form, then the map is `k`-positive.
+Wolf prints "Schmidt-rank `k`". The exact-rank test is vacuous when `k > d'`,
+whereas the standard criterion is the at-most-`k` statement proved here. See
+`docs/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.tex`.
+Source: Wolf, Chapter 3, Proposition 3.1, lines 89--115. -/
+theorem isNPositiveMap_of_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg_rectangular
+    [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hψ : ∀ ψ : Fin d' × Fin d → ℂ, Matrix.HasSchmidtRankLE k ψ →
+      (0 : ℂ) ≤ star ψ ⬝ᵥ (ChoiRectangular.choiMatrix T *ᵥ ψ)) :
     IsNPositiveMap k T := by
   rw [isNPositiveMap_iff_forall_rightCompression_posSemidef]
   intro X
   refine Matrix.posSemidef_of_dotProduct_mulVec_nonneg_complex ?_
   intro η
-  rw [rightCompression_quadraticForm_eq_choiMatrix_quadraticForm (T := T) (X := X) (η := η)]
+  rw [rightCompression_quadraticForm_eq_choiMatrix_quadraticForm_rectangular
+    (T := T) (X := X) (η := η)]
   exact hψ _ (rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE X η)
 
 /-- A `k`-positive map has positive Choi sandwiches by every right tensor
-factor `X : M_{D,k}(\mathbb{C})`.  This is the forward implication of the
+factor `X : M_{d,k}(\mathbb{C})`. This is the forward implication of the
 projection-compression formulation before requiring that `X` comes from a
 rank-`k` Hermitian projection. -/
-theorem IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef [NeZero D]
-    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (hT : IsNPositiveMap k T) (X : Matrix (Fin D) (Fin k) ℂ) :
-    (rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ).PosSemidef := by
-  rw [rightTensorMatrix_mul_choiMatrix_mul_conjTranspose]
+theorem IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_rectangular [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsNPositiveMap k T) (X : Matrix (Fin d) (Fin k) ℂ) :
+    (rightTensorMatrix (d' := d') X * ChoiRectangular.choiMatrix T *
+      (rightTensorMatrix (d' := d') X)ᴴ).PosSemidef := by
+  rw [rightTensorMatrix_mul_choiMatrix_mul_conjTranspose_rectangular]
   exact (isNPositiveMap_iff_forall_rightCompression_posSemidef k T).mp hT X
 
 /-- If a right-factor matrix `P` is presented as `V * Vᴴ`, then its Choi
 sandwich is a compression of the rectangular Choi sandwich for `V`. -/
-theorem rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (V : Matrix (Fin D) (Fin k) ℂ) :
-    rightTensorMatrix (V * Vᴴ) * choiMatrix T * (rightTensorMatrix (V * Vᴴ))ᴴ =
-      (rightTensorMatrix V)ᴴ *
-        (rightTensorMatrix V * choiMatrix T * (rightTensorMatrix V)ᴴ) *
-          rightTensorMatrix V := by
+theorem rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq_rectangular
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (V : Matrix (Fin d) (Fin k) ℂ) :
+    rightTensorMatrix (d' := d') (V * Vᴴ) * ChoiRectangular.choiMatrix T *
+        (rightTensorMatrix (d' := d') (V * Vᴴ))ᴴ =
+      (rightTensorMatrix (d' := d') V)ᴴ *
+        (rightTensorMatrix (d' := d') V * ChoiRectangular.choiMatrix T *
+          (rightTensorMatrix (d' := d') V)ᴴ) *
+          rightTensorMatrix (d' := d') V := by
   rw [rightTensorMatrix_mul_conjTranspose_eq_conjTranspose_mul_self]
   simp [Matrix.mul_assoc]
 
@@ -708,52 +715,228 @@ theorem rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq
 Choi sandwich is positive semidefinite. To recover the full statement of Wolf,
 Proposition 3.1, item 2, for an arbitrary rank-`k` orthogonal projection `P`,
 one additionally needs a factorization `P = V * Vᴴ`. -/
+theorem IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_mul_conjTranspose_rectangular
+    [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsNPositiveMap k T) (V : Matrix (Fin d) (Fin k) ℂ) :
+    (rightTensorMatrix (d' := d') (V * Vᴴ) * ChoiRectangular.choiMatrix T *
+      (rightTensorMatrix (d' := d') (V * Vᴴ))ᴴ).PosSemidef := by
+  rw [rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq_rectangular]
+  have hV := IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_rectangular hT V
+  exact hV.conjTranspose_mul_mul_same (rightTensorMatrix (d' := d') V)
+
+/-- Forward projection-compression consequence in Wolf, Proposition 3.1,
+item 2.  If `P = Pᴴ`, `P * P = P`, and `rank(P) = k`, then the right-factor
+Choi sandwich by `P` is positive semidefinite under `k`-positivity. -/
+theorem IsNPositiveMap.rightProjection_choiMatrix_sandwich_posSemidef_rectangular
+    [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsNPositiveMap k T) {P : Matrix (Fin d) (Fin d) ℂ}
+    (hP : P.IsHermitian) (hP_idem : P * P = P) (hrank : P.rank = k) :
+    (rightTensorMatrix (d' := d') P * ChoiRectangular.choiMatrix T *
+      (rightTensorMatrix (d' := d') P)ᴴ).PosSemidef := by
+  obtain ⟨V, rfl⟩ :=
+    Matrix.exists_mul_conjTranspose_of_isHermitian_idempotent_rank P hP hP_idem hrank
+  exact
+    IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_mul_conjTranspose_rectangular
+      hT V
+
+/-- If a square right factor `P` fixes the columns of `X`, then
+positivity of the Choi sandwich by `P` implies positivity of the rectangular
+right compression by `X`.  This is the algebraic half of the converse direction
+in Wolf, Proposition 3.1, item 2; the remaining geometric step is to choose a
+rank-`k` projection `P` with `P * X = X`. Source: Wolf, Chapter 3,
+Proposition 3.1 proof, lines 110--111. -/
+theorem rightCompression_posSemidef_of_projection_sandwich_of_mul_eq_self_rectangular
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    {P : Matrix (Fin d) (Fin d) ℂ} {X : Matrix (Fin d) (Fin k) ℂ}
+    (hPX : P * X = X)
+    (hP : (rightTensorMatrix (d' := d') P * ChoiRectangular.choiMatrix T *
+      (rightTensorMatrix (d' := d') P)ᴴ).PosSemidef) :
+    (rightCompression T X).PosSemidef := by
+  rw [← rightTensorMatrix_mul_choiMatrix_mul_conjTranspose_rectangular]
+  have hR :
+      rightTensorMatrix (d' := d') X * rightTensorMatrix (d' := d') P =
+        rightTensorMatrix (d' := d') X := by
+    rw [rightTensorMatrix_mul_rightTensorMatrix, hPX]
+  rw [← hR]
+  simpa [Matrix.mul_assoc] using
+    hP.conjTranspose_mul_mul_same (rightTensorMatrix (d' := d') X)ᴴ
+
+/-- Converse projection-compression implication in Wolf, Proposition 3.1,
+item 2. If every rank-`k` Hermitian input projection gives a positive Choi
+sandwich and `k ≤ d`, then `T` is `k`-positive. The theorem includes `k = 0`;
+normalization requires nonempty input dimension, while the output dimension is
+unrestricted. Source: Wolf, Chapter 3, Proposition 3.1, lines 89--115. -/
+theorem isNPositiveMap_of_forall_rankProjection_choiMatrix_sandwich_posSemidef_rectangular
+    [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hkd : k ≤ d)
+    (hP : ∀ P : Matrix (Fin d) (Fin d) ℂ,
+      P.IsHermitian → P * P = P → P.rank = k →
+        (rightTensorMatrix (d' := d') P * ChoiRectangular.choiMatrix T *
+          (rightTensorMatrix (d' := d') P)ᴴ).PosSemidef) :
+    IsNPositiveMap k T := by
+  rw [isNPositiveMap_iff_forall_rightCompression_posSemidef]
+  intro X
+  obtain ⟨P, hHerm, hIdem, hrank, hPX⟩ :=
+    Matrix.exists_isHermitian_idempotent_rank_mul_eq_self hkd X
+  exact
+    rightCompression_posSemidef_of_projection_sandwich_of_mul_eq_self_rectangular
+    hPX (hP P hHerm hIdem hrank)
+
+/-- Wolf's rank-`k` projection form of the rectangular Choi criterion: under
+`d > 0` and `k ≤ d`, `k`-positivity is equivalent to positivity of all Choi
+sandwiches by rank-`k` Hermitian idempotent projections on the input factor.
+The theorem includes `k = 0`; the output dimension is unrestricted. Source:
+Wolf, Chapter 3, Proposition 3.1, lines 89--115. -/
+theorem isNPositiveMap_iff_forall_rankProjection_choiMatrix_sandwich_posSemidef_rectangular
+    [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ} (hkd : k ≤ d) :
+    IsNPositiveMap k T ↔
+      ∀ P : Matrix (Fin d) (Fin d) ℂ,
+        P.IsHermitian → P * P = P → P.rank = k →
+          (rightTensorMatrix (d' := d') P * ChoiRectangular.choiMatrix T *
+            (rightTensorMatrix (d' := d') P)ᴴ).PosSemidef := by
+  constructor
+  · intro hT P hHerm hIdem hrank
+    exact
+      IsNPositiveMap.rightProjection_choiMatrix_sandwich_posSemidef_rectangular
+        hT hHerm hIdem hrank
+  · exact
+      isNPositiveMap_of_forall_rankProjection_choiMatrix_sandwich_posSemidef_rectangular
+        hkd
+
+/-- Forward direction of Wolf's Schmidt-rank expectation criterion. If `T` is
+`k`-positive, then the rectangular Choi quadratic form is nonnegative on every
+output-input vector of Schmidt rank at most `k`. Source: Wolf, Chapter 3,
+Proposition 3.1, lines 89--115, with the exact-rank
+wording correction recorded in
+`docs/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.tex`. -/
+theorem IsNPositiveMap.choiMatrix_quadraticForm_nonneg_of_hasSchmidtRankLE_rectangular [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsNPositiveMap k T) {ψ : Fin d' × Fin d → ℂ}
+    (hψ : Matrix.HasSchmidtRankLE k ψ) :
+    0 ≤ star ψ ⬝ᵥ (ChoiRectangular.choiMatrix T *ᵥ ψ) := by
+  obtain ⟨X, η, hη⟩ :=
+    exists_rightTensorMatrix_conjTranspose_mulVec_of_hasSchmidtRankLE hψ
+  have hcomp : (rightCompression T X).PosSemidef :=
+    (isNPositiveMap_iff_forall_rightCompression_posSemidef k T).mp hT X
+  have hq := hcomp.dotProduct_mulVec_nonneg η
+  rw [rightCompression_quadraticForm_eq_choiMatrix_quadraticForm_rectangular] at hq
+  simpa [hη] using hq
+
+/-- Schmidt-rank expectation criterion for Wolf's rectangular Choi matrix:
+`k`-positivity is equivalent to nonnegativity of the Choi quadratic form on all
+output-input vectors of Schmidt rank at most `k`. The input dimension is
+nonempty; `k = 0` and an empty output dimension are permitted.
+Wolf's exact-rank wording is not valid under only `k ≤ d`; see
+`docs/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.tex`.
+Source: Wolf, Chapter 3, Proposition 3.1, lines 89--115. -/
+theorem isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg_rectangular
+    [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ} :
+    IsNPositiveMap k T ↔
+      ∀ ψ : Fin d' × Fin d → ℂ, Matrix.HasSchmidtRankLE k ψ →
+        (0 : ℂ) ≤ star ψ ⬝ᵥ (ChoiRectangular.choiMatrix T *ᵥ ψ) := by
+  constructor
+  · intro hT ψ hψ
+    exact IsNPositiveMap.choiMatrix_quadraticForm_nonneg_of_hasSchmidtRankLE_rectangular hT hψ
+  · intro hψ
+    exact isNPositiveMap_of_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg_rectangular hψ
+
+/-! ### Equal-dimension specializations -/
+variable {D : ℕ}
+/-- Equal-dimension specialization of the rectangular right-tensor sandwich. -/
+theorem rightTensorMatrix_mul_choiMatrix_mul_conjTranspose
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin k) ℂ) :
+    rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ =
+      rightCompression T X := by
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    (rightTensorMatrix_mul_choiMatrix_mul_conjTranspose_rectangular
+      (d' := D) T X)
+/-- Equal-dimension specialization of the rectangular Choi-sandwich quadratic form. -/
+theorem rightTensor_choiMatrix_quadraticForm_eq
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
+    star η ⬝ᵥ
+        ((rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ) *ᵥ η) =
+      star ((rightTensorMatrix X)ᴴ *ᵥ η) ⬝ᵥ
+        (choiMatrix T *ᵥ ((rightTensorMatrix X)ᴴ *ᵥ η)) := by
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    (rightTensor_choiMatrix_quadraticForm_eq_rectangular (d' := D) T X η)
+/-- Equal-dimension specialization of the rectangular right-compression quadratic form. -/
+theorem rightCompression_quadraticForm_eq_choiMatrix_quadraticForm
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
+    star η ⬝ᵥ (rightCompression T X *ᵥ η) =
+      star ((rightTensorMatrix X)ᴴ *ᵥ η) ⬝ᵥ
+        (choiMatrix T *ᵥ ((rightTensorMatrix X)ᴴ *ᵥ η)) := by
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    (rightCompression_quadraticForm_eq_choiMatrix_quadraticForm_rectangular
+      (d' := D) T X η)
+/-- Equal-dimension specialization of the converse bounded-Schmidt-rank Choi test. -/
+theorem isNPositiveMap_of_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hψ : ∀ ψ : Fin D × Fin D → ℂ, Matrix.HasSchmidtRankLE k ψ →
+      (0 : ℂ) ≤ star ψ ⬝ᵥ (choiMatrix T *ᵥ ψ)) :
+    IsNPositiveMap k T := by
+  apply
+    isNPositiveMap_of_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg_rectangular
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using hψ
+/-- Equal-dimension specialization of rectangular Choi-sandwich positivity. -/
+theorem IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsNPositiveMap k T) (X : Matrix (Fin D) (Fin k) ℂ) :
+    (rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ).PosSemidef := by
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    (IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_rectangular
+      (d' := D) hT X)
+/-- Equal-dimension specialization of the factorized Choi-sandwich identity. -/
+theorem rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (V : Matrix (Fin D) (Fin k) ℂ) :
+    rightTensorMatrix (V * Vᴴ) * choiMatrix T * (rightTensorMatrix (V * Vᴴ))ᴴ =
+      (rightTensorMatrix V)ᴴ *
+        (rightTensorMatrix V * choiMatrix T * (rightTensorMatrix V)ᴴ) *
+          rightTensorMatrix V := by
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    (rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq_rectangular
+      (d' := D) T V)
+/-- Equal-dimension specialization of the factorized-projection Choi sandwich. -/
 theorem IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_mul_conjTranspose
     [NeZero D]
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsNPositiveMap k T) (V : Matrix (Fin D) (Fin k) ℂ) :
     (rightTensorMatrix (V * Vᴴ) * choiMatrix T *
       (rightTensorMatrix (V * Vᴴ))ᴴ).PosSemidef := by
-  rw [rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq]
-  exact
-    (IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef hT V).conjTranspose_mul_mul_same
-      (rightTensorMatrix V)
-
-/-- Forward projection-compression consequence in Wolf, Proposition 3.1,
-item 2.  If `P = Pᴴ`, `P * P = P`, and `rank(P) = k`, then the right-factor
-Choi sandwich by `P` is positive semidefinite under `k`-positivity. -/
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    (IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_mul_conjTranspose_rectangular
+      (d' := D) hT V)
+/-- Equal-dimension specialization of the forward rank-`k` projection Choi sandwich. -/
 theorem IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_isHermitian_idempotent_rank
     [NeZero D]
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsNPositiveMap k T) {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : P.IsHermitian) (hP_idem : P * P = P) (hrank : P.rank = k) :
     (rightTensorMatrix P * choiMatrix T * (rightTensorMatrix P)ᴴ).PosSemidef := by
-  obtain ⟨V, rfl⟩ :=
-    Matrix.exists_mul_conjTranspose_of_isHermitian_idempotent_rank P hP hP_idem hrank
-  exact IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_mul_conjTranspose hT V
-
-/-- If a square right factor `P` fixes the columns of `X`, then
-positivity of the Choi sandwich by `P` implies positivity of the rectangular
-right compression by `X`.  This is the algebraic half of the converse direction
-in Wolf, Proposition 3.1, item 2; the remaining geometric step is to choose a
-rank-`k` projection `P` with `P * X = X`.
-
-Source: Wolf, Chapter 3, Proposition 3.1 proof, lines 110--111. -/
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    (IsNPositiveMap.rightProjection_choiMatrix_sandwich_posSemidef_rectangular
+      (d' := D) hT hP hP_idem hrank)
+/-- Equal-dimension specialization of fixed-column compression. -/
 theorem rightCompression_posSemidef_of_rightTensorMatrix_sandwich_posSemidef_of_mul_eq_self
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     {P : Matrix (Fin D) (Fin D) ℂ} {X : Matrix (Fin D) (Fin k) ℂ}
     (hPX : P * X = X)
     (hP : (rightTensorMatrix P * choiMatrix T * (rightTensorMatrix P)ᴴ).PosSemidef) :
     (rightCompression T X).PosSemidef := by
-  rw [← rightTensorMatrix_mul_choiMatrix_mul_conjTranspose]
-  have hR : rightTensorMatrix X * rightTensorMatrix P = rightTensorMatrix X := by
-    rw [rightTensorMatrix_mul_rightTensorMatrix, hPX]
-  rw [← hR]
-  simpa [Matrix.mul_assoc] using hP.conjTranspose_mul_mul_same (rightTensorMatrix X)ᴴ
-
-/-- Converse projection-compression implication in Wolf, Proposition 3.1,
-item 2.  If every rank-`k` Hermitian projection gives a positive Choi sandwich
-and `k ≤ D`, then `T` is `k`-positive. -/
+  apply
+    rightCompression_posSemidef_of_projection_sandwich_of_mul_eq_self_rectangular
+      hPX
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using hP
+/-- Equal-dimension specialization of the projection-compression converse. -/
 theorem isNPositiveMap_of_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef
     [NeZero D]
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
@@ -762,16 +945,13 @@ theorem isNPositiveMap_of_forall_rankProjection_rightTensor_choiMatrix_sandwich_
       P.IsHermitian → P * P = P → P.rank = k →
         (rightTensorMatrix P * choiMatrix T * (rightTensorMatrix P)ᴴ).PosSemidef) :
     IsNPositiveMap k T := by
-  rw [isNPositiveMap_iff_forall_rightCompression_posSemidef]
-  intro X
-  obtain ⟨P, hHerm, hIdem, hrank, hPX⟩ :=
-    Matrix.exists_isHermitian_idempotent_rank_mul_eq_self hkD X
-  exact rightCompression_posSemidef_of_rightTensorMatrix_sandwich_posSemidef_of_mul_eq_self
-    hPX (hP P hHerm hIdem hrank)
-
-/-- Wolf's rank-`k` projection form of the Choi criterion: under `D > 0` and
-`k ≤ D`, `k`-positivity is equivalent to positivity of all Choi sandwiches by
-rank-`k` Hermitian idempotent right projections. -/
+  apply
+    isNPositiveMap_of_forall_rankProjection_choiMatrix_sandwich_posSemidef_rectangular
+      hkD
+  intro P hHerm hIdem hrank
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    hP P hHerm hIdem hrank
+/-- Equal-dimension specialization of Wolf's rank-`k` projection criterion. -/
 theorem isNPositiveMap_iff_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef
     [NeZero D]
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ} (hkD : k ≤ D) :
@@ -779,44 +959,28 @@ theorem isNPositiveMap_iff_forall_rankProjection_rightTensor_choiMatrix_sandwich
       ∀ P : Matrix (Fin D) (Fin D) ℂ,
         P.IsHermitian → P * P = P → P.rank = k →
           (rightTensorMatrix P * choiMatrix T * (rightTensorMatrix P)ᴴ).PosSemidef := by
-  constructor
-  · intro hT P hHerm hIdem hrank
-    exact
-      IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_isHermitian_idempotent_rank
-        hT hHerm hIdem hrank
-  · exact
-      isNPositiveMap_of_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef
-        hkD
-
-/-- Forward direction of Wolf's Schmidt-rank expectation criterion.  If `T` is
-`k`-positive, then the Choi quadratic form is nonnegative on every vector of
-Schmidt rank at most `k`. -/
-theorem IsNPositiveMap.choiMatrix_quadraticForm_nonneg_of_hasSchmidtRankLE [NeZero D]
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    (isNPositiveMap_iff_forall_rankProjection_choiMatrix_sandwich_posSemidef_rectangular
+      (d' := D) (T := T) hkD)
+/-- Equal-dimension specialization of the forward bounded-Schmidt-rank Choi test. -/
+theorem IsNPositiveMap.choiMatrix_quadraticForm_nonneg_of_hasSchmidtRankLE
+    [NeZero D]
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsNPositiveMap k T) {ψ : Fin D × Fin D → ℂ}
     (hψ : Matrix.HasSchmidtRankLE k ψ) :
     0 ≤ star ψ ⬝ᵥ (choiMatrix T *ᵥ ψ) := by
-  obtain ⟨X, η, hη⟩ :=
-    exists_rightTensorMatrix_conjTranspose_mulVec_of_hasSchmidtRankLE (D := D) hψ
-  have hcomp : (rightCompression T X).PosSemidef :=
-    (isNPositiveMap_iff_forall_rightCompression_posSemidef k T).mp hT X
-  have hq := hcomp.dotProduct_mulVec_nonneg η
-  rw [rightCompression_quadraticForm_eq_choiMatrix_quadraticForm] at hq
-  simpa [hη] using hq
-
-/-- Schmidt-rank expectation criterion for Wolf's Choi matrix:
-`k`-positivity is equivalent to nonnegativity of the Choi quadratic form on all
-vectors of Schmidt rank at most `k`. -/
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    (IsNPositiveMap.choiMatrix_quadraticForm_nonneg_of_hasSchmidtRankLE_rectangular
+      (d' := D) hT hψ)
+/-- Equal-dimension specialization of the bounded-Schmidt-rank Choi criterion. -/
 theorem isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg
     [NeZero D]
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ} :
     IsNPositiveMap k T ↔
       ∀ ψ : Fin D × Fin D → ℂ, Matrix.HasSchmidtRankLE k ψ →
         (0 : ℂ) ≤ star ψ ⬝ᵥ (choiMatrix T *ᵥ ψ) := by
-  constructor
-  · intro hT ψ hψ
-    exact IsNPositiveMap.choiMatrix_quadraticForm_nonneg_of_hasSchmidtRankLE hT hψ
-  · intro hψ
-    exact isNPositiveMap_of_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg hψ
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    (isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg_rectangular
+      (d' := D) (T := T))
 
 end ChoiJamiolkowski

--- a/blueprint/src/chapter/ch04_positive_not_cp_supporting_results.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_supporting_results.tex
@@ -333,11 +333,14 @@ the Schmidt-rank Choi criterion, the rectangular compression criterion, and
 the rank-$k$ projection criterion. Throughout, $R_X$ and $C_T(X)$ are the
 right-tensor factor and Choi compression of
 Definitions~\ref{def:choi_right_tensor_factor}
-and~\ref{def:choi_right_compression}.
+and~\ref{def:choi_right_compression}. Here
+$T:\MN{d}\to\MN{d'}$, $X\in M_{d\times k}(\C)$, the Choi matrix acts on
+$\C^{d'}\otimes\C^d$, and the compressed matrix acts on
+$\C^{d'}\otimes\C^k$.
 
 \begin{theorem}[Right tensor sandwich formula]
     \label{thm:choi_right_tensor_sandwich}
-    \lean{ChoiJamiolkowski.rightTensorMatrix_mul_choiMatrix_mul_conjTranspose}
+    \lean{ChoiJamiolkowski.rightTensorMatrix_mul_choiMatrix_mul_conjTranspose_rectangular}
     \leanok
     \uses{def:choi_right_compression, def:choi_right_tensor_factor}
     If $\tau$ is the Choi matrix of $T$, then
@@ -369,11 +372,11 @@ and~\ref{def:choi_right_compression}.
     \lean{ChoiJamiolkowski.compressedOmegaVector_hasSchmidtRankLE}
     \leanok
     \uses{def:schmidt_rank, def:choi_right_compression}
-    For $X\in\MN{D,k}(\C)$, the vector
+    For $X\in M_{d\times k}(\C)$, the vector
     \begin{align}
         \psi_X
-         & =\left(D^{-1/2}X_{i,p}\right)_{(i,p)}
-        \in\C^D\otimes\C^k
+         & =\left(d^{-1/2}X_{a,p}\right)_{(a,p)}
+        \in\C^d\otimes\C^k
         \label{eq:schwarz_compressed_omega}
     \end{align}
     has Schmidt rank at most $k$.
@@ -390,15 +393,15 @@ and~\ref{def:choi_right_compression}.
     \lean{ChoiJamiolkowski.compressedOmegaVector_schmidtRank_eq_rank}
     \leanok
     \uses{def:schmidt_rank, def:choi_right_compression}
-    Assume $D>0$. For $X\in\MN{D,k}(\C)$, the vector $\psi_X$ in
+    Assume $d>0$. For $X\in M_{d\times k}(\C)$, the vector $\psi_X$ in
     (\ref{eq:schwarz_compressed_omega}) satisfies
     $\SR(\psi_X)=\rank X$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    The coefficient matrix of $\psi_X$ is $D^{-1/2}X$. Since $D>0$, the
-    scalar $D^{-1/2}$ is nonzero, and multiplication by this scalar preserves
+    The coefficient matrix of $\psi_X$ is $d^{-1/2}X$. Since $d>0$, the
+    scalar $d^{-1/2}$ is nonzero, and multiplication by this scalar preserves
     rank.
 \end{proof}
 
@@ -409,11 +412,11 @@ and~\ref{def:choi_right_compression}.
     \leanok
     \uses{def:schmidt_rank, def:choi_right_compression,
         thm:compressed_omega_schmidt_rank_eq_rank}
-    Assume $D>0$. For every $\psi\in\C^D\otimes\C^D$, there is
-    $X\in\MN{D}(\C)$ such that
+    Assume $d>0$. For every $\psi\in\C^d\otimes\C^d$, there is
+    $X\in\MN{d}$ such that
     \begin{align}
         \psi_{(i,p)}
-         & =D^{-1/2}X_{i,p}, \notag \\
+         & =d^{-1/2}X_{i,p}, \notag \\
         \rank X
          & =\SR(\psi).
         \label{eq:schwarz_square_schmidt_representative}
@@ -424,8 +427,8 @@ and~\ref{def:choi_right_compression}.
 
 \begin{proof}
     \leanok
-    Take $X_{i,p}=D^{1/2}\psi_{(i,p)}$. Since $D>0$, this gives
-    $D^{-1/2}X_{i,p}=\psi_{(i,p)}$. The rank identity follows from
+    Take $X_{i,p}=d^{1/2}\psi_{(i,p)}$. Since $d>0$, this gives
+    $d^{-1/2}X_{i,p}=\psi_{(i,p)}$. The rank identity follows from
     Theorem~\ref{thm:compressed_omega_schmidt_rank_eq_rank}. The bounded-rank
     statement follows by comparison with the assumed Schmidt-rank bound.
 \end{proof}
@@ -436,17 +439,17 @@ and~\ref{def:choi_right_compression}.
     \leanok
     \uses{def:schmidt_rank, def:choi_right_compression,
         thm:square_schmidt_rank_exact_parametrization}
-    Assume $D>0$. A vector $\psi\in\C^D\otimes\C^D$ has Schmidt rank at most
-    $k$ if and only if there is a matrix $X\in\MD(\C)$ of rank at most $k$
-    such that $\psi_{(i,j)}=D^{-1/2}X_{i,j}$.
+    Assume $d>0$. A vector $\psi\in\C^d\otimes\C^d$ has Schmidt rank at most
+    $k$ if and only if there is a matrix $X\in\MN{d}$ of rank at most $k$
+    such that $\psi_{(i,j)}=d^{-1/2}X_{i,j}$.
 \end{lemma}
 
 \begin{proof}
     \leanok
     The forward direction is the bounded-rank part of
     Theorem~\ref{thm:square_schmidt_rank_exact_parametrization}. Conversely,
-    if $\psi_{(i,j)}=D^{-1/2}X_{i,j}$, then
-    $C_\psi=D^{-1/2}X$, so $\rank(C_\psi)=\rank(X)$ because multiplication
+    if $\psi_{(i,j)}=d^{-1/2}X_{i,j}$, then
+    $C_\psi=d^{-1/2}X$, so $\rank(C_\psi)=\rank(X)$ because multiplication
     by a nonzero scalar preserves rank.
 \end{proof}
 
@@ -456,13 +459,14 @@ and~\ref{def:choi_right_compression}.
         ChoiJamiolkowski.rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE}
     \leanok
     \uses{def:schmidt_rank, def:choi_right_tensor_factor}
-    Let $X\in\MN{D,k}(\C)$ and let $\eta\in\C^D\otimes\C^k$. Then
-    $R_X^\dagger\eta\in\C^D\otimes\C^D$ has Schmidt rank at most $k$.
+    Let $X\in M_{d\times k}(\C)$ and let
+    $\eta\in\C^{d'}\otimes\C^k$. Then
+    $R_X^\dagger\eta\in\C^{d'}\otimes\C^d$ has Schmidt rank at most $k$.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    If $\eta$ is read as a $D\times k$ coefficient matrix $E$, then the
+    If $\eta$ is read as a $d'\times k$ coefficient matrix $E$, then the
     coefficient matrix of $R_X^\dagger\eta$ is $EX^\dagger$. Therefore
     $\rank(EX^\dagger)\le\rank(X^\dagger)=\rank(X)\le k$.
 \end{proof}
@@ -473,8 +477,9 @@ and~\ref{def:choi_right_compression}.
     \leanok
     \uses{def:schmidt_rank, def:choi_right_tensor_factor,
         lem:matrix_rank_factorization_coordinate}
-    If $\psi\in\C^D\otimes\C^D$ has Schmidt rank at most $k$, then there
-    exist $X\in\MN{D,k}(\C)$ and $\eta\in\C^D\otimes\C^k$ such that
+    If $\psi\in\C^{d'}\otimes\C^d$ has Schmidt rank at most $k$, then there
+    exist $X\in M_{d\times k}(\C)$ and
+    $\eta\in\C^{d'}\otimes\C^k$ such that
     $\psi=R_X^\dagger\eta$.
 \end{lemma}
 
@@ -489,12 +494,13 @@ and~\ref{def:choi_right_compression}.
 
 \begin{theorem}[Quadratic form of a right Choi compression]
     \label{thm:choi_right_compression_quadratic_form}
-    \lean{ChoiJamiolkowski.rightTensor_choiMatrix_quadraticForm_eq,
-        ChoiJamiolkowski.rightCompression_quadraticForm_eq_choiMatrix_quadraticForm}
+    \lean{ChoiJamiolkowski.rightTensor_choiMatrix_quadraticForm_eq_rectangular,
+        ChoiJamiolkowski.rightCompression_quadraticForm_eq_choiMatrix_quadraticForm_rectangular}
     \leanok
     \uses{def:choi_right_compression, def:choi_right_tensor_factor,
         thm:choi_right_tensor_sandwich}
-    For $X\in\MN{D,k}(\C)$ and $\eta\in\C^D\otimes\C^k$,
+    For $X\in M_{d\times k}(\C)$ and
+    $\eta\in\C^{d'}\otimes\C^k$,
     \begin{align}
         \langle\eta,C_T(X)\eta\rangle
          & =\langle R_X^\dagger\eta,\tau_T R_X^\dagger\eta\rangle.
@@ -519,7 +525,7 @@ and~\ref{def:choi_right_compression}.
     \uses{def:blockwise_ampliation, def:choi_right_compression}
     Applying the $k$-fold ampliation of $T$ to the rank-one matrix
     $\ketbra{\psi}{\psi}$, where
-    $\psi_{(a,p)}=D^{-1/2}X_{a,p}$, is exactly the right-factor compression
+    $\psi_{(a,p)}=d^{-1/2}X_{a,p}$, is exactly the right-factor compression
     of the Choi matrix of $T$ by $X$.
 \end{lemma}
 
@@ -528,29 +534,29 @@ and~\ref{def:choi_right_compression}.
     In entries, both sides are
     \begin{align}
         \sum_{a,b}X_{a,p}
-        T\!\left(D^{-1}E_{a,b}\right)_{i,j}
+        T\!\left(d^{-1}E_{a,b}\right)_{i,j}
         \overline{X_{b,q}}.
         \notag
     \end{align}
-    If $\psi_{(a,p)}=D^{-1/2}X_{a,p}$, then for fixed $p,q$, the corresponding
+    If $\psi_{(a,p)}=d^{-1/2}X_{a,p}$, then for fixed $p,q$, the corresponding
     block of $\ketbra{\psi}{\psi}$ is
     \begin{align}
         (\ketbra{\psi}{\psi})_{(\cdot,p),(\cdot,q)}
-         & =D^{-1}\sum_{a,b}X_{a,p}\overline{X_{b,q}}E_{a,b}.
+         & =d^{-1}\sum_{a,b}X_{a,p}\overline{X_{b,q}}E_{a,b}.
         \notag
     \end{align}
     Hence
     \begin{align}
-        T\!\left(D^{-1}\sum_{a,b}
+        T\!\left(d^{-1}\sum_{a,b}
            X_{a,p}\overline{X_{b,q}}E_{a,b}\right)_{i,j}
-         & =D^{-1}\sum_{a,b}X_{a,p}\overline{X_{b,q}}
+         & =d^{-1}\sum_{a,b}X_{a,p}\overline{X_{b,q}}
                                    (T(E_{a,b}))_{i,j} \notag \\
          & =\sum_{a,b}X_{a,p}\tau_{(i,a),(j,b)}
         \overline{X_{b,q}}.
         \notag
     \end{align}
     where the second equality uses
-    $\tau_{(i,a),(j,b)}=D^{-1}(T(E_{a,b}))_{i,j}$.
+    $\tau_{(i,a),(j,b)}=d^{-1}(T(E_{a,b}))_{i,j}$.
 \end{proof}
 
 \begin{lemma}[Right-tensor multiplication]
@@ -558,7 +564,7 @@ and~\ref{def:choi_right_compression}.
     \lean{ChoiJamiolkowski.rightTensorMatrix_mul_rightTensorMatrix}
     \leanok
     \uses{def:choi_right_tensor_factor}
-    Let $X\in\MN{D,k}(\C)$ and $P\in\MN{D,D}(\C)$. Then the right-tensor
+    Let $X\in M_{d\times k}(\C)$ and $P\in\MN{d}$. Then the right-tensor
     factors satisfy $R_XR_P=R_{PX}$.
 \end{lemma}
 
@@ -571,11 +577,11 @@ and~\ref{def:choi_right_compression}.
 
 \begin{lemma}[Square sandwich implies fixed rectangular compression]
     \label{lem:square_sandwich_fixed_rectangular_compression}
-    \lean{ChoiJamiolkowski.rightCompression_posSemidef_of_rightTensorMatrix_sandwich_posSemidef_of_mul_eq_self}
+    \lean{ChoiJamiolkowski.rightCompression_posSemidef_of_projection_sandwich_of_mul_eq_self_rectangular}
     \leanok
     \uses{thm:choi_right_tensor_sandwich, lem:right_tensor_multiplication}
-    Let $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ have Choi matrix $\tau$. Suppose
-    $P\in\MN{D,D}(\C)$ and $X\in\MN{D,k}(\C)$ satisfy $PX=X$. If
+    Let $T:\MN{d}\to\MN{d'}$ have Choi matrix $\tau$. Suppose
+    $P\in\MN{d}$ and $X\in M_{d\times k}(\C)$ satisfy $PX=X$. If
     $R_P\tau R_P^\dagger\ge0$, then the rectangular right compression of
     $\tau$ by $X$ is positive semidefinite.
 \end{lemma}
@@ -599,14 +605,14 @@ and~\ref{def:choi_right_compression}.
     \label{lem:rank_k_projection_fixing_rectangular_factor}
     \lean{Matrix.exists_isHermitian_idempotent_rank_mul_eq_self}
     \leanok
-    Let $X\in\MN{D,k}(\C)$ and suppose $k\le D$. Then there exists a
-    Hermitian projection $P\in\MN{D,D}(\C)$ of rank $k$ such that $PX=X$.
+    Let $X\in M_{d\times k}(\C)$ and suppose $k\le d$. Then there exists a
+    Hermitian projection $P\in\MN{d}$ of rank $k$ such that $PX=X$.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    The column space of $X$ has dimension at most $k$. Since $k\le D$, extend
-    this column space to a $k$-dimensional subspace $U\subseteq\C^D$. Let $P$
+    The column space of $X$ has dimension at most $k$. Since $k\le d$, extend
+    this column space to a $k$-dimensional subspace $U\subseteq\C^d$. Let $P$
     be the orthogonal projection onto $U$. Then $P$ is Hermitian and
     idempotent, its rank is $\dim U=k$, and it fixes each column of $X$.
 \end{proof}
@@ -616,7 +622,7 @@ and~\ref{def:choi_right_compression}.
     \lean{ChoiJamiolkowski.rightTensorMatrix_mul_conjTranspose_eq_conjTranspose_mul_self}
     \leanok
     \uses{def:choi_right_tensor_factor}
-    For every $V\in\MN{D,k}(\C)$, the right-tensor factor satisfies
+    For every $V\in M_{d\times k}(\C)$, the right-tensor factor satisfies
     $R_{VV^\dagger}=R_V^\dagger R_V$.
 \end{lemma}
 
@@ -628,12 +634,12 @@ and~\ref{def:choi_right_compression}.
 
 \begin{lemma}[Factorized right-tensor Choi sandwich]
     \label{lem:factorized_right_tensor_choi_sandwich}
-    \lean{ChoiJamiolkowski.rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq}
+    \lean{ChoiJamiolkowski.rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq_rectangular}
     \leanok
     \uses{def:choi_right_tensor_factor,
         lem:right_tensor_factorization_mul_adjoint}
-    Let $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ have Choi matrix $\tau$. For every
-    $V\in\MN{D,k}(\C)$,
+    Let $T:\MN{d}\to\MN{d'}$ have Choi matrix $\tau$. For every
+    $V\in M_{d\times k}(\C)$,
     \begin{align}
         R_{VV^\dagger}\tau R_{VV^\dagger}^\dagger
          & =R_V^\dagger(R_V\tau R_V^\dagger)R_V.
@@ -650,13 +656,13 @@ and~\ref{def:choi_right_compression}.
 
 \begin{theorem}[Factorized right projections in the Choi criterion]
     \label{thm:factorized_right_projection_choi_sandwich}
-    \lean{ChoiJamiolkowski.IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_mul_conjTranspose}
+    \lean{ChoiJamiolkowski.IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_mul_conjTranspose_rectangular}
     \leanok
     \uses{lem:factorized_right_tensor_choi_sandwich,
         thm:k_positive_right_tensor_choi_sandwiches}
-    Assume $D>0$. Let $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ be $k$-positive,
+    Assume $d>0$. Let $T:\MN{d}\to\MN{d'}$ be $k$-positive,
     with Choi matrix $\tau$. If a right-factor matrix has the form
-    $P=VV^\dagger$ with $V\in\MN{D,k}(\C)$, then
+    $P=VV^\dagger$ with $V\in M_{d\times k}(\C)$, then
     $R_P\tau R_P^\dagger\geq0$.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch04_positive_not_cp_two_positive_schmidt_and_choi.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_two_positive_schmidt_and_choi.tex
@@ -492,8 +492,8 @@ Section~\ref{sec:app_positive_not_cp_ky_fan}.
     \lean{isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef}
     \leanok
     \uses{def:k_positive_map, def:blockwise_ampliation}
-    A linear map $E:\MN{D}\to\MN{D}$ is $k$-positive if and only if, for
-    every vector $\phi\in\C^D\otimes\C^k$,
+    A linear map $E:\MN{d}\to\MN{d'}$ is $k$-positive if and only if, for
+    every vector $\phi\in\C^d\otimes\C^k$,
     $E^{(k)}(\ketbra{\phi}{\phi})\ge0$.
     This is the pure-state reduction used in
     \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum}.
@@ -503,7 +503,7 @@ Section~\ref{sec:app_positive_not_cp_ky_fan}.
     \leanok
     The forward implication is the definition of $k$-positivity, since
     $\ketbra{\phi}{\phi}$ is positive semidefinite. Conversely, every
-    positive semidefinite matrix on $\C^D\otimes\C^k$ is a finite sum
+    positive semidefinite matrix on $\C^d\otimes\C^k$ is a finite sum
     $\sum_i\ketbra{\phi_i}{\phi_i}$, and
     \begin{align}
         E^{(k)}\!\left(\sum_i\ketbra{\phi_i}{\phi_i}\right)
@@ -519,6 +519,11 @@ Section~\ref{sec:app_positive_not_cp_ky_fan}.
 The right-tensor identities, parametrizations of bounded Schmidt rank, and
 projection factorizations used in this subsection are proved in
 Section~\ref{sec:app_positive_not_cp_choi_compression}.
+Wolf states item~3 of Proposition~3.1 using Schmidt rank exactly $k$.
+Under the stated assumption $k\le d$, that test set is empty when $k>d'$.
+The dimension-generic criterion below therefore uses Schmidt rank at most
+$k$; the source wording is analyzed in
+\cite{gap:wolf_prop3_1_exact_schmidt_rank_scope}.
 
 \begin{definition}[Right compression of the Choi matrix]\label{def:choi_right_compression}
     \lean{ChoiJamiolkowski.rightCompression,
@@ -526,39 +531,41 @@ Section~\ref{sec:app_positive_not_cp_choi_compression}.
         ChoiJamiolkowski.compressedOmegaVector}
     \leanok
     \uses{def:blockwise_ampliation}
-    For $X\in\MN{D,k}(\C)$ and a Choi matrix $\tau$, the right-factor
-    compression in the blockwise ampliation index convention has entries
+    Let $T:\MN{d}\to\MN{d'}$ have Choi matrix $\tau$ on
+    $\C^{d'}\otimes\C^d$. For $X\in M_{d\times k}(\C)$, the right-factor
+    compression is the matrix on $\C^{d'}\otimes\C^k$ with entries
     \begin{align}
         C_{(i,p),(j,q)}
          & =\sum_{a,b}X_{a,p}\tau_{(i,a),(j,b)}
         \overline{X_{b,q}}.
         \label{eq:schwarz_right_choi_compression}
     \end{align}
-    The associated vector has coefficients $D^{-1/2}X_{i,p}$.
+    The associated vector on $\C^d\otimes\C^k$ has coefficients
+    $d^{-1/2}X_{a,p}$.
 \end{definition}
 
 \begin{definition}[Right tensor factor for Choi compression]
     \label{def:choi_right_tensor_factor}
     \lean{ChoiJamiolkowski.rightTensorMatrix}
     \leanok
-    For $X\in\MN{D,k}(\C)$, let $R_X$ be the matrix from
-    $\C^D\otimes\C^D$ to $\C^D\otimes\C^k$ with entries
+    For $X\in M_{d\times k}(\C)$, let $R_X$ be the matrix from
+    $\C^{d'}\otimes\C^d$ to $\C^{d'}\otimes\C^k$ with entries
     \begin{align}
         (R_X)_{(i,p),(j,a)}
          & =\delta_{i,j}X_{a,p}.
         \label{eq:schwarz_right_tensor_factor}
     \end{align}
 \end{definition}
-\begin{theorem}[Schmidt-rank Choi expectation from $k$-positivity]
+\begin{theorem}[Rectangular Schmidt-rank Choi expectation from $k$-positivity]
     \label{thm:k_positive_schmidt_rank_choi_expectation}
-    \lean{ChoiJamiolkowski.IsNPositiveMap.choiMatrix_quadraticForm_nonneg_of_hasSchmidtRankLE}
+    \lean{ChoiJamiolkowski.IsNPositiveMap.choiMatrix_quadraticForm_nonneg_of_hasSchmidtRankLE_rectangular}
     \leanok
     \uses{lem:right_tensor_adjoint_schmidt_rank_representatives,
         thm:choi_right_compression_quadratic_form,
         thm:k_positive_iff_right_choi_compressions}
-    Assume $D>0$. If $T$ is $k$-positive, then
+    Assume $d>0$. If $T:\MN{d}\to\MN{d'}$ is $k$-positive, then
     $\langle\psi,\tau_T\psi\rangle\ge0$ for every
-    $\psi\in\C^D\otimes\C^D$ with $\SR(\psi)\le k$.
+    $\psi\in\C^{d'}\otimes\C^d$ with $\SR(\psi)\le k$.
 \end{theorem}
 
 \begin{proof}
@@ -572,23 +579,25 @@ Section~\ref{sec:app_positive_not_cp_choi_compression}.
     with $\langle\psi,\tau_T\psi\rangle$.
 \end{proof}
 
-\begin{theorem}[Converse Schmidt-rank Choi test]
+\begin{theorem}[Converse rectangular Schmidt-rank Choi test]
     \label{thm:schmidt_rank_choi_test_converse}
-    \lean{ChoiJamiolkowski.isNPositiveMap_of_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg}
+    \lean{ChoiJamiolkowski.isNPositiveMap_of_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg_rectangular}
     \leanok
     \uses{lem:right_tensor_adjoint_schmidt_rank,
         thm:choi_right_compression_quadratic_form,
         thm:k_positive_iff_right_choi_compressions}
-    Assume $D>0$. If $\langle\psi,\tau_T\psi\rangle\ge0$ for every
-    $\psi\in\C^D\otimes\C^D$ with $\SR(\psi)\le k$, then $T$ is
-    $k$-positive.
+    Assume $d>0$. Let $T:\MN{d}\to\MN{d'}$. If
+    $\langle\psi,\tau_T\psi\rangle\ge0$ for every
+    $\psi\in\C^{d'}\otimes\C^d$ with $\SR(\psi)\le k$, then $T$ is
+    $k$-positive. This includes $k=0$ and imposes no nonemptiness assumption
+    on the output factor.
 \end{theorem}
 
 \begin{proof}
     \leanok
     By Theorem~\ref{thm:k_positive_iff_right_choi_compressions}, it is enough
     to prove that $C_T(X)$ is positive semidefinite for each
-    $X\in\MN{D,k}(\C)$. For any $\eta$,
+    $X\in M_{d\times k}(\C)$. For any $\eta$,
     (\ref{eq:schwarz_right_compression_quadratic}) identifies
     $\langle\eta,C_T(X)\eta\rangle$ with
     $\langle R_X^\dagger\eta,\tau_T R_X^\dagger\eta\rangle$, and
@@ -599,15 +608,15 @@ Section~\ref{sec:app_positive_not_cp_choi_compression}.
     so $C_T(X)$ is positive semidefinite.
 \end{proof}
 
-\begin{theorem}[Schmidt-rank Choi criterion]
+\begin{theorem}[Rectangular Schmidt-rank Choi criterion]
     \label{thm:schmidt_rank_choi_test_iff}
-    \lean{ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg}
+    \lean{ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg_rectangular}
     \leanok
     \uses{thm:k_positive_schmidt_rank_choi_expectation,
         thm:schmidt_rank_choi_test_converse}
-    Assume $D>0$. Then $T$ is $k$-positive if and only if
+    Assume $d>0$. A map $T:\MN{d}\to\MN{d'}$ is $k$-positive if and only if
     $\langle\psi,\tau_T\psi\rangle\ge0$ for every
-    $\psi\in\C^D\otimes\C^D$ with $\SR(\psi)\le k$.
+    $\psi\in\C^{d'}\otimes\C^d$ with $\SR(\psi)\le k$.
 \end{theorem}
 
 \begin{proof}
@@ -621,9 +630,9 @@ Section~\ref{sec:app_positive_not_cp_choi_compression}.
     \leanok
     \uses{thm:k_positive_rank_one_test, def:choi_right_compression,
         lem:rank_one_ampliation_choi_compression}
-    Assume $D>0$. A linear map
-    $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ is $k$-positive if and only if, for every
-    $X\in\MN{D,k}(\C)$, the right-factor compression of the Choi matrix of
+    Assume $d>0$. A linear map
+    $T:\MN{d}\to\MN{d'}$ is $k$-positive if and only if, for every
+    $X\in M_{d\times k}(\C)$, the right-factor compression of the Choi matrix of
     $T$ by $X$ is positive semidefinite.
 \end{theorem}
 
@@ -638,8 +647,8 @@ Section~\ref{sec:app_positive_not_cp_choi_compression}.
         \label{eq:schwarz_ampliation_compression}
     \end{align}
     Conversely, given a vector $\psi$ on the ampliated space, take
-    $X_{i,p}=D^{1/2}\psi_{(i,p)}$. Since $D>0$, this choice satisfies
-    $D^{-1/2}X_{i,p}=\psi_{(i,p)}$. Substituting this vector in
+    $X_{a,p}=d^{1/2}\psi_{(a,p)}$. Since $d>0$, this choice satisfies
+    $d^{-1/2}X_{a,p}=\psi_{(a,p)}$. Substituting this vector in
     (\ref{eq:schwarz_ampliation_compression}) gives
     $(T\otimes\id_k)(\ketbra{\psi}{\psi})=C_T(X)$.
     Positivity of $C_T(X)$ is therefore positivity of the ampliation on the
@@ -649,13 +658,13 @@ Section~\ref{sec:app_positive_not_cp_choi_compression}.
 
 \begin{theorem}[Right tensor Choi sandwiches of a $k$-positive map]
     \label{thm:k_positive_right_tensor_choi_sandwiches}
-    \lean{ChoiJamiolkowski.IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef}
+    \lean{ChoiJamiolkowski.IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_rectangular}
     \leanok
     \uses{thm:k_positive_iff_right_choi_compressions,
         thm:choi_right_tensor_sandwich}
-    Assume $D>0$. If
-    $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ is $k$-positive, then, for every
-    $X\in\MN{D,k}(\C)$,
+    Assume $d>0$. If
+    $T:\MN{d}\to\MN{d'}$ is $k$-positive, then, for every
+    $X\in M_{d\times k}(\C)$,
     \begin{align}
         R_X\tau R_X^\dagger
          & \ge0,
@@ -667,18 +676,18 @@ Section~\ref{sec:app_positive_not_cp_choi_compression}.
 \begin{proof}
     \leanok
     By Theorem~\ref{thm:k_positive_iff_right_choi_compressions},
-    $C_T(X)\ge0$ for every $X\in\MN{D,k}(\C)$. The sandwich formula
+    $C_T(X)\ge0$ for every $X\in M_{d\times k}(\C)$. The sandwich formula
     (\ref{eq:schwarz_right_tensor_sandwich}) identifies
     $R_X\tau R_X^\dagger$ with $C_T(X)$.
 \end{proof}
-\begin{theorem}[Rank-$k$ right projections in the Choi criterion]
+\begin{theorem}[Rank-$k$ input projections in the rectangular Choi criterion]
     \label{thm:rank_k_right_projection_choi_sandwich_forward}
-    \lean{ChoiJamiolkowski.IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_isHermitian_idempotent_rank}
+    \lean{ChoiJamiolkowski.IsNPositiveMap.rightProjection_choiMatrix_sandwich_posSemidef_rectangular}
     \leanok
     \uses{lem:rank_k_hermitian_projection_factorization,
         thm:factorized_right_projection_choi_sandwich}
-    Assume $D>0$. Let $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ be $k$-positive,
-    with Choi matrix $\tau$. If $P\in\MN{D,D}(\C)$ is Hermitian, satisfies
+    Assume $d>0$. Let $T:\MN{d}\to\MN{d'}$ be $k$-positive,
+    with Choi matrix $\tau$. If $P\in\MN{d}$ is Hermitian, satisfies
     $P^2=P$, and has rank $k$, then $R_P\tau R_P^\dagger\geq0$.
     This is the forward rank-$k$ projection-compression direction of
     \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum}.
@@ -687,28 +696,28 @@ Section~\ref{sec:app_positive_not_cp_choi_compression}.
 \begin{proof}
     \leanok
     By Lemma~\ref{lem:rank_k_hermitian_projection_factorization}, write
-    $P=VV^\dagger$ with $V\in\MN{D,k}(\C)$. The conclusion is then exactly
+    $P=VV^\dagger$ with $V\in M_{d\times k}(\C)$. The conclusion is then exactly
     Theorem~\ref{thm:factorized_right_projection_choi_sandwich}.
 \end{proof}
 
-\begin{theorem}[Projection-compression converse for the Choi criterion]
+\begin{theorem}[Projection-compression converse for the rectangular Choi criterion]
     \label{thm:rank_k_right_projection_choi_sandwich_converse}
-    \lean{ChoiJamiolkowski.isNPositiveMap_of_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef}
+    \lean{ChoiJamiolkowski.isNPositiveMap_of_forall_rankProjection_choiMatrix_sandwich_posSemidef_rectangular}
     \leanok
     \uses{thm:k_positive_iff_right_choi_compressions,
         lem:square_sandwich_fixed_rectangular_compression,
         lem:rank_k_projection_fixing_rectangular_factor}
-    Assume $D>0$ and $k\le D$. Let
-    $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ have Choi matrix $\tau$. Suppose that
+    Assume $d>0$ and $k\le d$. Let
+    $T:\MN{d}\to\MN{d'}$ have Choi matrix $\tau$. Suppose that
     $R_P\tau R_P^\dagger\geq0$ for every Hermitian projection
-    $P\in\MN{D,D}(\C)$ of rank $k$. Then $T$ is $k$-positive.
+    $P\in\MN{d}$ of rank $k$. Then $T$ is $k$-positive.
 \end{theorem}
 
 \begin{proof}
     \leanok
     By Theorem~\ref{thm:k_positive_iff_right_choi_compressions}, it is enough
     to prove positivity of the right-factor compression by an arbitrary
-    $X\in\MN{D,k}(\C)$. Choose a rank-$k$ Hermitian projection $P$ with
+    $X\in M_{d\times k}(\C)$. Choose a rank-$k$ Hermitian projection $P$ with
     $PX=X$ using
     Lemma~\ref{lem:rank_k_projection_fixing_rectangular_factor}. The assumed
     positivity of $R_P\tau R_P^\dagger$, together with
@@ -716,15 +725,15 @@ Section~\ref{sec:app_positive_not_cp_choi_compression}.
     positivity of the rectangular compression by $X$.
 \end{proof}
 
-\begin{theorem}[Rank-$k$ projection form of the Choi criterion]
+\begin{theorem}[Rank-$k$ input-projection form of the rectangular Choi criterion]
     \label{thm:rank_k_right_projection_choi_criterion}
-    \lean{ChoiJamiolkowski.isNPositiveMap_iff_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef}
+    \lean{ChoiJamiolkowski.isNPositiveMap_iff_forall_rankProjection_choiMatrix_sandwich_posSemidef_rectangular}
     \leanok
     \uses{thm:rank_k_right_projection_choi_sandwich_forward,
         thm:rank_k_right_projection_choi_sandwich_converse}
-    Assume $D>0$ and $k\le D$. A linear map
-    $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ is $k$-positive if and only if, for every
-    Hermitian projection $P\in\MN{D,D}(\C)$ of rank $k$,
+    Assume $d>0$ and $k\le d$. A linear map
+    $T:\MN{d}\to\MN{d'}$ is $k$-positive if and only if, for every
+    Hermitian projection $P\in\MN{d}$ of rank $k$,
     $R_P\tau R_P^\dagger\geq0$, where $\tau$ is the Choi matrix of $T$.
     This is the rank-$k$ projection formulation of
     \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum}.

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -301,3 +301,13 @@
   year        = {2026},
   note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_radon_nikodym_nonempty_family.pdf}},
 }
+
+@techreport{gap:wolf_prop3_1_exact_schmidt_rank_scope,
+  author      = {The {QICLean} contributors},
+  title       = {Exact-Rank Wording in {Wolf}'s {Choi} Criterion},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_prop3\_1\_exact\_schmidt\_rank\_scope},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.pdf}},
+}

--- a/docs/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.tex
+++ b/docs/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.tex
@@ -1,0 +1,104 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Exact-Rank Wording in Wolf's Choi Criterion}
+\author{}
+\date{2026-08-23}
+
+\begin{document}
+\maketitle
+\gapnote{false-source}{resolved}
+
+\section{The printed criterion}
+
+Let $T:M_d(\C)\to M_{d'}(\C)$ be linear and let
+\begin{align}
+    \tau_T
+      &=(T\otimes\operatorname{id}_d)
+        \bigl(\ketbra{\Omega_d}{\Omega_d}\bigr)
+      \in M_{d'}(\C)\otimes M_d(\C).
+\end{align}
+Wolf's Proposition~3.1 assumes $k\le d$ and states, among its three
+equivalent conditions, that
+\begin{align}
+    \langle\psi,\tau_T\psi\rangle&\ge0
+    &&\text{whenever }\operatorname{SR}(\psi)=k.
+    \tag{Wolf 3.1(3)}
+\end{align}
+The local source prints ``Schmidt-rank $n$'' both in the statement and in the
+last sentence of the proof.
+\footnote{Source: \path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex},
+lines 89--115. Tracked by
+\href{https://github.com/LionSR/QICLean/issues/24}{QICLean issue \#24}.}
+
+\section{The dimension defect}
+
+Every vector in $\C^{d'}\otimes\C^d$ satisfies
+\begin{align}
+    \operatorname{SR}(\psi)&\le\min\{d',d\}.
+\end{align}
+Consequently, when $d'<k\le d$, there is no vector of Schmidt rank exactly
+$k$. Condition~(Wolf 3.1(3)) is then vacuous and cannot characterize
+$k$-positivity.
+
+For example, take $d=2$, $d'=1$, $k=2$, and
+$T(X)=-\tr(X)$. There is no Schmidt-rank-two vector in
+$\C^1\otimes\C^2$, so the printed quadratic-form condition holds. On the
+other hand, applying $T\otimes\operatorname{id}_2$ to a nonzero product
+projector gives a negative rank-one matrix. Thus $T$ is not $2$-positive.
+
+The last step of the printed proof has a second, related loss: a vector of the
+form $(\one\otimes X)^\dagger\widetilde\psi$ has Schmidt rank at most
+$\operatorname{rank}(X)$, but need not have rank equal to
+$\operatorname{rank}(X)$. Hence that step
+directly proves the bounded-rank condition, not the exact-rank condition.
+
+\section{The corrected statement}
+
+The dimension-generic Choi criterion is
+\begin{align}
+    T\text{ is $k$-positive}
+    \quad\Longleftrightarrow\quad
+    \langle\psi,\tau_T\psi\rangle&\ge0
+    &&\text{for every }\psi\text{ with }\operatorname{SR}(\psi)\le k.
+    \tag{corrected Wolf 3.1(3)}
+\end{align}
+This is the condition proved by the compression argument: factoring the
+coefficient matrix of $\psi$ through $\C^k$ writes
+$\psi=R_X^\dagger\eta$, and positivity of the right compression
+$R_X\tau_T R_X^\dagger$ gives the desired quadratic-form inequality.
+
+For $d>0$, the formal theorem covers independent input and output dimensions,
+including $k=0$ and $d'=0$.
+\footnote{Formal declarations:
+\leanid{ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg_rectangular}
+and
+\leanid{ChoiJamiolkowski.isNPositiveMap_iff_forall_rankProjection_choiMatrix_sandwich_posSemidef_rectangular}
+in \doclink{QICLean/Channel/Schwarz/ChoiCompression}.}
+The projection formulation additionally assumes $k\le d$, exactly as needed
+to choose a rank-$k$ projection on the input factor.
+
+If one also assumes $k\le d'$, an exact-rank formulation may be recovered
+from the bounded-rank formulation by a separate density argument: coefficient
+matrices of rank exactly $k$ are dense among matrices of rank at most $k$, and
+the quadratic form is continuous. This argument is not the proof printed by
+Wolf and is not used in the formal criterion.
+
+\section{Conclusion}
+
+Wolf's exact-rank wording is false under the printed hypothesis $k\le d$.
+Replacing exact Schmidt rank by Schmidt rank at most $k$ gives the standard
+rectangular Choi criterion and matches the compression proof. The formal
+statement and the Blueprint use this corrected wording; no additional route
+is attributed to the source.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -486,6 +486,30 @@ so that the cited formal statements are available from the main project import.
 
 ---
 
+## Wolf Lecture Notes — Chapter 3: Positive Maps
+
+### Section 3.1 Choi criteria for n-positive maps
+
+#### Wolf Proposition 3.1 — FORMALIZED WITH A SOURCE WORDING CORRECTION
+
+- `ChoiJamiolkowski.isNPositiveMap_iff_forall_rightCompression_posSemidef`
+  — Equation (3.4) for a rectangular map `M_d(ℂ) → M_{d'}(ℂ)`: positivity
+  of every input-factor compression by `X : M_{d×k}(ℂ)` is equivalent to
+  `k`-positivity ✓
+- `ChoiJamiolkowski.isNPositiveMap_iff_forall_rankProjection_choiMatrix_sandwich_posSemidef_rectangular`
+  — item 2, with rank-`k` Hermitian projections on the input factor, under
+  `d > 0` and `k ≤ d` ✓
+- `ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg_rectangular`
+  — item 3 on the output-first space `ℂ^{d'} ⊗ ℂ^d`, using the mathematically
+  correct condition `SR(ψ) ≤ k` ✓
+- Wolf prints exact Schmidt rank `k`, which is vacuous when `k > d'` and is
+  not what the displayed compression proof establishes. The counterexample,
+  corrected statement, and scope of a possible exact-rank reformulation are
+  recorded in
+  `docs/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.tex`.
+
+---
+
 ## Wolf Chapter 6 — Spectral Properties: Public Theorem Index
 
 This module serves as a **navigational index** that maps the formalized theorems


### PR DESCRIPTION
## Summary

Complete the residual rectangular scope of Wolf Chapter 3, Proposition 3.1, using the exact source factor order from `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines 89–115.

- generalize the right compression and right tensor factor from endomorphisms `M_D(ℂ) → M_D(ℂ)` to maps `M_d(ℂ) → M_{d'}(ℂ)`;
- use the existing `ChoiRectangular.choiMatrix` on the output⊗input space `ℂ^{d'} ⊗ ℂ^d`;
- keep the Hermitian rank-`k` projection on the input factor, exactly as in Wolf item 2;
- prove the rectangular rank-one ampliation identity, compression criterion, projection criterion, and bounded-Schmidt-rank quadratic-form criterion;
- preserve every public equal-dimension theorem name as a wrapper for existing consumers;
- state the actual dimension boundaries: `d > 0` for normalization, `k ≤ d` for the projection criterion, with `k = 0` and `d' = 0` permitted where the mathematics permits them.

Wolf prints “Schmidt-rank `k`” in item 3. Under only `k ≤ d` this is false when `k > d'`, because the test set is empty. The new paper-gap note gives the concrete counterexample `d = 2`, `d' = 1`, `k = 2`, `T(X) = -tr(X)`, and records why Wolf's displayed compression proof establishes Schmidt rank at most `k`. The formal theorem uses that corrected standard statement; no density argument absent from the paper is attributed to Wolf.

Closes #24.

## Validation

- `lake build QICLean.Channel.Schwarz.ChoiCompression QICLean.Channel.SchmidtNumber QICLean.Channel.NPositivityChainStrict QICLean.Channel.PositiveMapDetection -q --log-level=info`
- `lake exe lint_style`
- Blueprint–Lean sync after regeneration (1945/1945)
- `texra-blueprint web` (all chapters rendered)
- `texra-blueprint --root . paper-gaps check`
- reader-facing prose check
- oversized-file and numbered-module policy checks
- `git diff --check origin/main...HEAD`
- forbidden-bypass scan
- `#print axioms` for the rectangular compression, projection, and Schmidt-rank equivalences: only `propext`, `Classical.choice`, and `Quot.sound`
