### PR TITLE
feat(channel): formalize determinant composition

### DIFF
--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -25,6 +25,7 @@ import QICLean.Channel.Determinant
 import QICLean.Channel.Determinant.Basic
 import QICLean.Channel.Determinant.Bound
 import QICLean.Channel.Determinant.ChoiBound
+import QICLean.Channel.Determinant.Composition
 import QICLean.Channel.Determinant.HeisenbergDual
 import QICLean.Channel.Determinant.HilbertSchmidt
 import QICLean.Channel.Determinant.UnitaryCharacterization

--- a/QICLean/Channel/Determinant.lean
+++ b/QICLean/Channel/Determinant.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import QICLean.Channel.Determinant.Basic
 import QICLean.Channel.Determinant.Bound
 import QICLean.Channel.Determinant.ChoiBound
+import QICLean.Channel.Determinant.Composition
 import QICLean.Channel.Determinant.HilbertSchmidt
 import QICLean.Channel.Determinant.HeisenbergDual
 import QICLean.Channel.Determinant.UnitaryCharacterization
@@ -14,23 +15,25 @@ import QICLean.Channel.Determinant.UnitaryCharacterization
 # Determinants of quantum channels
 
 Thin module assembling the determinant development for quantum channels from
-six focused sub-modules.
+seven focused sub-modules.
 
 The division follows the same organization as the earlier `Full/` and
 `Growth/` developments:
 
-* `TNLean.Channel.Determinant.Basic` — determinant definitions and unitary
+* `QICLean.Channel.Determinant.Basic` — determinant definitions and unitary
   channels.
-* `TNLean.Channel.Determinant.Bound` — Wolf Theorem 6.1(1), the determinant
+* `QICLean.Channel.Determinant.Bound` — Wolf Theorem 6.1(1), the determinant
   bound for positive trace-preserving maps.
-* `TNLean.Channel.Determinant.ChoiBound` — Wolf Eq. (6.27), the determinant
+* `QICLean.Channel.Determinant.ChoiBound` — Wolf Eq. (6.27), the determinant
   of an arbitrary linear map bounded by the purity of its Choi--Jamiolkowski
   operator.
-* `TNLean.Channel.Determinant.HilbertSchmidt` — spectral and Hilbert--Schmidt
+* `QICLean.Channel.Determinant.Composition` — Wolf Eq. (6.22), its exact
+  algebraic equality split, and determinant monotonicity under composition.
+* `QICLean.Channel.Determinant.HilbertSchmidt` — spectral and Hilbert--Schmidt
   auxiliary lemmas for the rigidity argument.
-* `TNLean.Channel.Determinant.HeisenbergDual` — Heisenberg-dual
+* `QICLean.Channel.Determinant.HeisenbergDual` — Heisenberg-dual
   multiplicativity from determinant saturation.
-* `TNLean.Channel.Determinant.UnitaryCharacterization` — Wolf Theorem 6.1(2)
+* `QICLean.Channel.Determinant.UnitaryCharacterization` — Wolf Theorem 6.1(2)
   for CPTP maps.
 
 ## Main definitions
@@ -42,6 +45,9 @@ The division follows the same organization as the earlier `Full/` and
 ## Main statements
 
 * `channelDet_eq_linearMap_det` — `channelDet` agrees with `LinearMap.det`.
+* `channelDet_comp` — Wolf Equation (6.22), determinant multiplicativity.
+* `channelDet_norm_comp_le_of_positive_tracePreserving` — the inequality in
+  Wolf's determinant-monotonicity corollary.
 * `channelDet_norm_le_one_of_positive_tracePreserving` — Wolf Theorem 6.1(1).
 * `channelDet_norm_eq_one_iff_exists_unitaryChannel` — Wolf Theorem 6.1(2)
   for CPTP maps.

--- a/QICLean/Channel/Determinant/Composition.lean
+++ b/QICLean/Channel/Determinant/Composition.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Channel.Determinant.Bound
+
+/-!
+# Determinant under composition
+
+This file formalizes the algebraic and monotonicity parts of Wolf's determinant
+composition discussion.  The order is the one in Wolf Equation (6.22):
+`T₁.comp T₂` is the map denoted by `T₁ T₂` there.
+
+## Main statements
+
+* `channelDet_comp` — Wolf Equation (6.22), determinant multiplicativity.
+* `channelDet_norm_comp_eq_iff` — the exact algebraic equality split.
+* `channelDet_norm_comp_le_of_positive_tracePreserving` — the inequality in
+  Wolf's determinant-monotonicity corollary.
+
+The source's geometric replacement of `‖channelDet T₂‖ = 1` by
+"unitary conjugation or matrix transposition" depends on the still-missing
+positive trace-preserving saturation classification.  It is deliberately not
+claimed here.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Equation (6.22) and
+  the determinant-monotonicity corollary in Section 6.1.1][Wolf2012QChannels]
+
+## Tags
+
+quantum channel, determinant, composition, monotonicity
+-/
+open scoped Matrix ComplexOrder MatrixOrder
+
+variable {d : ℕ}
+
+local notation "MatrixEnd" => ChannelDeterminant.Internal.MatrixEnd
+
+/-- Wolf Equation (6.22): the channel determinant is multiplicative under
+composition.  Lean's `T₁.comp T₂` has the same order as Wolf's `T₁ T₂`.
+
+Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 338--342. -/
+@[simp]
+theorem channelDet_comp (T₁ T₂ : MatrixEnd d) :
+    channelDet (T₁.comp T₂) = channelDet T₁ * channelDet T₂ := by
+  simp only [channelDet_eq_linearMap_det, LinearMap.det_comp]
+
+/-- The algebraic equality case behind Wolf's determinant-monotonicity
+corollary: equality after right composition holds exactly when the left factor
+has zero determinant or the right factor has determinant of modulus one.
+
+Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 409--414,
+using Equation (6.22).  The further positive-map saturation classification is
+kept as a separate dependency. -/
+theorem channelDet_norm_comp_eq_iff (T₁ T₂ : MatrixEnd d) :
+    ‖channelDet (T₁.comp T₂)‖ = ‖channelDet T₁‖ ↔
+      channelDet T₁ = 0 ∨ ‖channelDet T₂‖ = 1 := by
+  rw [channelDet_comp, norm_mul]
+  constructor
+  · intro h
+    by_cases hT₁ : channelDet T₁ = 0
+    · exact Or.inl hT₁
+    · exact Or.inr ((mul_eq_left₀ (norm_ne_zero_iff.mpr hT₁)).mp h)
+  · rintro (hT₁ | hT₂)
+    · simp only [hT₁, norm_zero, zero_mul]
+    · simp only [hT₂, mul_one]
+
+/-- The inequality in Wolf's determinant-monotonicity corollary: for positive
+trace-preserving `T₁` and `T₂`, right composition by `T₂` cannot increase
+the modulus of the determinant of `T₁`.
+
+Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 409--414.
+The hypotheses on `T₁` are retained to match the source statement, although
+the determinant bound needed by the algebraic proof applies only to `T₂`. -/
+theorem channelDet_norm_comp_le_of_positive_tracePreserving
+    (T₁ T₂ : MatrixEnd d)
+    (_hPos₁ : IsPositiveMap T₁) (_hTP₁ : IsTracePreservingMap T₁)
+    (hPos₂ : IsPositiveMap T₂) (hTP₂ : IsTracePreservingMap T₂) :
+    ‖channelDet (T₁.comp T₂)‖ ≤ ‖channelDet T₁‖ := by
+  rw [channelDet_comp, norm_mul]
+  calc
+    ‖channelDet T₁‖ * ‖channelDet T₂‖ ≤ ‖channelDet T₁‖ * 1 :=
+      mul_le_mul_of_nonneg_left
+        (channelDet_norm_le_one_of_positive_tracePreserving hPos₂ hTP₂)
+        (norm_nonneg _)
+    _ = ‖channelDet T₁‖ := mul_one _

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -1060,6 +1060,58 @@ This section states the existence theorems from
     $|\det T|=\prod_i|\mu_i|\leq1$ follows by induction.
 \end{proof}
 
+\begin{theorem}[Determinant under composition]
+    \label{thm:channelDet_comp}
+    \lean{channelDet_comp}\leanok
+    \uses{def:channel_det}
+    For linear maps $T_1,T_2:\MN{D}\to\MN{D}$,
+    \begin{align}
+        \det(T_1T_2)=\det(T_1)\det(T_2),
+    \end{align}
+    where Lean's \texttt{T1.comp T2} has the same
+    composition order as $T_1T_2$.  This is
+    \cite[Equation~(6.22)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Rewrite the channel determinant as the determinant of the underlying
+    linear endomorphism and apply multiplicativity of the latter.
+\end{proof}
+
+\begin{theorem}[Determinant monotonicity under composition: algebraic part]
+    \label{thm:channelDet_comp_monotone_algebraic}
+    \lean{channelDet_norm_comp_le_of_positive_tracePreserving,
+        channelDet_norm_comp_eq_iff}\leanok
+    \uses{def:channel_det, def:positive_map, def:trace_preserving}
+    Let $T_1,T_2:\MN{D}\to\MN{D}$ be positive and trace-preserving.  Then
+    \begin{align}
+        |\det(T_1T_2)|\leq |\det T_1|.
+    \end{align}
+    For arbitrary linear maps, the equality
+    $|\det(T_1T_2)|=|\det T_1|$ holds exactly when
+    \begin{align}
+        \det T_1=0 \quad\text{or}\quad |\det T_2|=1.
+    \end{align}
+    This is the multiplicative and determinant-bound part of the
+    monotonicity corollary following
+    \cite[Theorem~6.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:channelDet_comp, thm:channelDet_norm_le_one}
+    Theorem~\ref{thm:channelDet_comp} gives
+    $|\det(T_1T_2)|=|\det T_1|\,|\det T_2|$.  The determinant bound for
+    $T_2$ proves the inequality.  Cancelling the nonzero factor
+    $|\det T_1|$ proves the equality split; when that factor is zero,
+    equality is automatic.
+
+    The source's further replacement of $|\det T_2|=1$ by ``unitary
+    conjugation or matrix transposition'' depends on the general positive
+    trace-preserving saturation classification.  Only its CPTP unitary branch
+    is currently available, so that geometric clause remains open in issue
+    \#38 rather than being weakened here.
+\end{proof}
+
 \begin{theorem}[Determinant one iff the channel is unitary]
     \label{thm:channelDet_norm_eq_one_iff_unitary}
     \lean{channelDet_norm_eq_one_iff_exists_unitaryChannel}\leanok

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -1108,8 +1108,8 @@ This section states the existence theorems from
     The source's further replacement of $|\det T_2|=1$ by ``unitary
     conjugation or matrix transposition'' depends on the general positive
     trace-preserving saturation classification.  Only its CPTP unitary branch
-    is currently available, so that geometric clause remains open in issue
-    \#38 rather than being weakened here.
+    is currently available, so that geometric clause remains open rather than
+    being weakened here.
 \end{proof}
 
 \begin{theorem}[Determinant one iff the channel is unitary]

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -1068,8 +1068,7 @@ This section states the existence theorems from
     \begin{align}
         \det(T_1T_2)=\det(T_1)\det(T_2),
     \end{align}
-    where Lean's \texttt{T1.comp T2} has the same
-    composition order as $T_1T_2$.  This is
+    where $T_1T_2=T_1\circ T_2$, so $T_2$ acts first.  This is
     \cite[Equation~(6.22)]{Wolf2012Quantum}.
 \end{theorem}
 

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -564,6 +564,36 @@ Thus no four-positive-parts estimate and no factor $4$ occur. The resolved
 proof-route note is
 `docs/paper-gaps/wolf_prop61_russo_dye_factor.tex`.
 
+#### Wolf Theorem "Determinants" and Equation (6.22) — PARTIALLY FORMALIZED
+
+* `channelDet_comp` — Wolf Equation (6.22),
+  `det(T₁.comp T₂) = det(T₁) det(T₂)`, with Lean composition in the
+  source's displayed order.
+* `channelDet_norm_le_one_of_positive_tracePreserving` — the magnitude bound
+  `|det T| ≤ 1` for every positive trace-preserving map.
+* `channelDet_norm_eq_one_iff_exists_unitaryChannel` — the CPTP specialization
+  of determinant saturation: a quantum channel has determinant magnitude one
+  exactly when it is a unitary conjugation.
+
+The remaining source clauses are that the determinant of every positive
+trace-preserving map is real, the full saturation alternative including maps
+unitarily equivalent to transposition, and the transposition parity/sign
+calculation.  These remain tracked in issue #38.
+
+#### Wolf Corollary "Monotonicity of the determinant" — PARTIALLY FORMALIZED
+
+* `channelDet_norm_comp_le_of_positive_tracePreserving` — for positive
+  trace-preserving `T₁,T₂`,
+  `|det(T₁.comp T₂)| ≤ |det T₁|`.
+* `channelDet_norm_comp_eq_iff` — the exact algebraic equality split
+  `|det(T₁.comp T₂)| = |det T₁|` iff
+  `det T₁ = 0` or `|det T₂| = 1`.
+
+Replacing the saturation condition `|det T₂| = 1` by Wolf's geometric
+alternative "unitary conjugation or matrix transposition" depends on the
+remaining general positive trace-preserving saturation classification above;
+the present declarations do not weaken or claim that open step.
+
 
 #### Wolf Lemma 6.1 (Dirichlet's simultaneous approximation) — FORMALIZED
 


### PR DESCRIPTION
## Summary

Formalize one source-complete leaf of Wolf's determinant discussion in `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`.

- prove Equation (6.22), `det(T₁T₂) = det(T₁) det(T₂)`, with `T₁.comp T₂` explicitly documented in Wolf's composition order (lines 338–342);
- derive the exact arbitrary-linear-map equality split
  `|det(T₁T₂)| = |det T₁| ↔ det T₁ = 0 ∨ |det T₂| = 1`;
- prove the positive trace-preserving monotonicity inequality
  `|det(T₁T₂)| ≤ |det T₁|` from Wolf's determinant bound (lines 409–414);
- add the focused determinant-composition module to both generated import aggregators;
- synchronize Blueprint and coverage, with proof-only dependencies attached to the proof rather than the theorem statement.

This deliberately does not replace `|det T₂| = 1` by an invented surrogate. Wolf's geometric equality clause requires the still-missing general positive trace-preserving saturation classification (unitary conjugation or transposition). Determinant reality, the transposition sign/parity statement, the geometric equality clause, positive inverse classification, and the Kraus-rank-two nonnegativity statement remain open, so #38 stays open.

Refs #38.

## Validation

- `lake build QICLean.Channel.Determinant.Composition QICLean.Channel.Determinant -q --log-level=info`
- Blueprint–Lean sync after regeneration (1948/1948)
- style linter
- import-aggregator, oversized-file, and numbered-module checks
- `git diff --check origin/main...HEAD`
- forbidden-bypass scan
- `#print axioms` for all three new declarations: only `propext`, `Classical.choice`, and `Quot.sound`

A full-root build was not run; the focused determinant modules are the scoped local gate, and CI will run the repository-wide checks.
