### PR TITLE
feat(analysis): prove corrected Slater duality

### DIFF
--- a/QICLean/Analysis/ConicProgram.lean
+++ b/QICLean/Analysis/ConicProgram.lean
@@ -10,10 +10,11 @@ import Mathlib.Analysis.LocallyConvex.Separation
 import Mathlib.Data.EReal.Basic
 
 /-!
-# Conic programs, strict feasibility, and weak duality
+# Conic programs and corrected Slater duality
 
 This file defines the primal and dual conic programs in Wolf's convention, their strict-feasibility
-and optimizer predicates, and proves weak duality. The source is Wolf, *Quantum Channels &
+and optimizer predicates, weak duality, and the corrected finite-dimensional Slater theorem. The
+source is Wolf, *Quantum Channels &
 Operations*, Chapter 4, `Notes/WolfNoteTexSource/ch04_convex_structure.tex`, lines 39--78,
 especially equations `conic-primal` and `conic-dual`.
 
@@ -21,9 +22,10 @@ The optimization values lie in `EReal`. Thus an infeasible primal problem has va
 infeasible dual problem has value `-∞`, a primal problem unbounded below has value `-∞`, and a
 dual problem unbounded above has value `+∞`.
 
-The strict-feasibility and optimizer predicates deliberately keep value equality separate from
-attainment. No Slater strong-duality assertion is made here: Wolf's claim at lines 72--78 needs a
-finiteness or opposite-feasibility condition for its attainment clause.
+The strict-feasibility and optimizer predicates keep value equality separate from attainment.
+Wolf's claim at lines 72--78 is false without a finiteness or opposite-feasibility condition. The
+theorems below restore the missing hypothesis: primal strict feasibility together with a finite
+primal value gives dual attainment and equality of values, and the dual statement is analogous.
 -/
 
 noncomputable section
@@ -190,7 +192,7 @@ theorem values_eq_of_feasible_of_objectives_eq {K : ProperCone ℝ V}
   obtain ⟨hxopt, hyopt⟩ := optimizers_of_feasible_of_objectives_eq hx hy hxy
   rw [primalValue_eq_of_isPrimalOptimizer hxopt, dualValue_eq_of_isDualOptimizer hyopt,
     hxy]
-section SlaterCore
+section SlaterSeparation
 
 variable {W Z : Type*}
 variable [NormedAddCommGroup W] [InnerProductSpace ℝ W] [FiniteDimensional ℝ W]
@@ -289,10 +291,10 @@ private theorem exists_dual_of_strictlyFeasible_of_isGLB
   have hD_smul {t : ℝ} (ht : 0 ≤ t) {z : A.range × ℝ} (hz : z ∈ D) : t • z ∈ D := by
     obtain ⟨⟨x, s⟩, ⟨hxC, hs⟩, rfl⟩ := hz
     refine ⟨t • (x, s), ?_, ?_⟩
-    refine ⟨C.smul_mem ht hxC, ?_⟩
-    change 0 ≤ t * s
-    exact mul_nonneg ht hs
-    exact (slaterLift A d).map_smul t (x, s)
+    · refine ⟨C.smul_mem ht hxC, ?_⟩
+      change 0 ≤ t * s
+      exact mul_nonneg ht hs
+    · exact (slaterLift A d).map_smul t (x, s)
   have hfD_closure : ∀ z ∈ closure D, f z ≤ f q := by
     exact closure_minimal hfD (isClosed_Iic.preimage f.continuous)
   have htwo_q : (2 : ℝ) • q ∈ closure D := by
@@ -409,7 +411,7 @@ private theorem exists_dual_of_strictlyFeasible_of_isGLB
       _ = p := by
         rw [hraw, ← mul_assoc, inv_mul_cancel₀ hscale_ne, one_mul]
 
-end SlaterCore
+end SlaterSeparation
 
 section Slater
 

--- a/QICLean/Analysis/ConicProgram.lean
+++ b/QICLean/Analysis/ConicProgram.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: QICLean contributors
 -/
 import Mathlib.Analysis.Convex.Cone.InnerDual
+import Mathlib.Analysis.InnerProductSpace.Dual
+import Mathlib.Analysis.LocallyConvex.Separation
 import Mathlib.Data.EReal.Basic
 
 /-!
@@ -187,5 +189,225 @@ theorem values_eq_of_feasible_of_objectives_eq {K : ProperCone ℝ V}
   obtain ⟨hxopt, hyopt⟩ := optimizers_of_feasible_of_objectives_eq hx hy hxy
   rw [primalValue_eq_of_isPrimalOptimizer hxopt, dualValue_eq_of_isDualOptimizer hyopt,
     hxy]
+section SlaterCore
+
+variable {W Z : Type*}
+variable [NormedAddCommGroup W] [InnerProductSpace ℝ W] [FiniteDimensional ℝ W]
+variable [NormedAddCommGroup Z] [InnerProductSpace ℝ Z] [FiniteDimensional ℝ Z]
+
+local instance : CompleteSpace W := FiniteDimensional.complete ℝ W
+local instance : CompleteSpace Z := FiniteDimensional.complete ℝ Z
+
+/-- The lifted map used in the finite-dimensional separation proof. Its codomain is restricted to
+the range of `A`, so the map is surjective without requiring `A` itself to be surjective. -/
+private def slaterLift (A : W →ₗ[ℝ] Z) (d : W) : W × ℝ →ₗ[ℝ] A.range × ℝ :=
+  (A.rangeRestrict.comp (LinearMap.fst ℝ W ℝ)).prod
+    ((innerₛₗ ℝ d).comp (LinearMap.fst ℝ W ℝ) + LinearMap.snd ℝ W ℝ)
+
+omit [FiniteDimensional ℝ W] [FiniteDimensional ℝ Z] in
+@[simp]
+private theorem slaterLift_apply (A : W →ₗ[ℝ] Z) (d : W) (x : W) (r : ℝ) :
+    slaterLift A d (x, r) =
+      (⟨A x, LinearMap.mem_range_self A x⟩, inner ℝ d x + r) :=
+  rfl
+
+omit [FiniteDimensional ℝ W] [FiniteDimensional ℝ Z] in
+private theorem slaterLift_surjective (A : W →ₗ[ℝ] Z) (d : W) :
+    Function.Surjective (slaterLift A d) := by
+  rintro ⟨z, r⟩
+  obtain ⟨x, hx⟩ := z.property
+  refine ⟨(x, r - inner ℝ d x), ?_⟩
+  ext
+  · exact hx
+  · simp [slaterLift]
+
+omit [FiniteDimensional ℝ Z] in
+/-- The separation argument underlying both corrected Slater theorems. The cone need not be
+closed. In particular, the proof never assumes that a linear image of a closed cone is closed. -/
+private theorem exists_dual_of_strictlyFeasible_of_isGLB
+    (C : PointedCone ℝ W) (A : W →ₗ[ℝ] Z) (d : W) (r : Z) (p : ℝ)
+    (hstrict : ∃ x ∈ interior (C : Set W), A x = r)
+    (hp : IsGLB ((fun x : W ↦ inner ℝ d x) '' {x | x ∈ C ∧ A x = r}) p) :
+    ∃ y : Z, (∀ x ∈ C, inner ℝ (A x) y ≤ inner ℝ d x) ∧ inner ℝ r y = p := by
+  obtain ⟨x₀, hx₀, hAx₀⟩ := hstrict
+  let D : Set (A.range × ℝ) :=
+    slaterLift A d '' ((C : Set W) ×ˢ Set.Ici 0)
+  have hD_convex : Convex ℝ D := by
+    exact (C.convex.prod (convex_Ici (0 : ℝ))).linear_image (slaterLift A d)
+  have hL_open : IsOpenMap (slaterLift A d) :=
+    LinearMap.isOpenMap_of_finiteDimensional _ (slaterLift_surjective A d)
+  have hx₀_one : (x₀, (1 : ℝ)) ∈ interior ((C : Set W) ×ˢ Set.Ici 0) := by
+    rw [interior_prod_eq, interior_Ici]
+    exact ⟨hx₀, by simp⟩
+  have ha₀ : slaterLift A d (x₀, 1) ∈ interior D :=
+    hL_open.image_interior_subset _ ⟨_, hx₀_one, rfl⟩
+  have hD_interior : (interior D).Nonempty := ⟨_, ha₀⟩
+  let rA : A.range := ⟨r, ⟨x₀, hAx₀⟩⟩
+  let q : A.range × ℝ := (rA, p)
+  have hq_not_interior : q ∉ interior D := by
+    intro hq
+    obtain ⟨ε, hε, hball⟩ := Metric.isOpen_iff.mp isOpen_interior q hq
+    have hnear : (rA, p - ε / 2) ∈ Metric.ball q ε := by
+      rw [Metric.mem_ball, dist_prod_same_left, Real.dist_eq]
+      have hdiff : p - ε / 2 - p = -(ε / 2) := by ring
+      rw [hdiff, abs_neg, abs_of_pos (by positivity)]
+      linarith
+    have hbelow : (rA, p - ε / 2) ∈ D := interior_subset (hball hnear)
+    obtain ⟨⟨x, s⟩, ⟨hxC, hs⟩, hxs⟩ := hbelow
+    have hAx : A x = r := by
+      have := congr_arg (fun z : A.range × ℝ ↦ (z.1 : Z)) hxs
+      simpa [rA] using this
+    have hobj : inner ℝ d x + s = p - ε / 2 := by
+      have := congr_arg Prod.snd hxs
+      simpa using this
+    have hp_le : p ≤ inner ℝ d x :=
+      hp.1 ⟨x, ⟨hxC, hAx⟩, rfl⟩
+    change 0 ≤ s at hs
+    have hx_le : inner ℝ d x ≤ p - ε / 2 := by linarith
+    linarith
+  let S : Set ℝ := (fun x : W ↦ inner ℝ d x) '' {x | x ∈ C ∧ A x = r}
+  change IsGLB S p at hp
+  have hS_nonempty : S.Nonempty := by
+    exact ⟨inner ℝ d x₀, ⟨x₀, ⟨interior_subset hx₀, hAx₀⟩, rfl⟩⟩
+  have hp_closure : p ∈ closure S := hp.mem_closure hS_nonempty
+  let g : ℝ → A.range × ℝ := fun t ↦ (rA, t)
+  have hg_continuous : Continuous g := by fun_prop
+  have hg_mapsTo : MapsTo g S D := by
+    rintro t ⟨x, ⟨hxC, hAx⟩, rfl⟩
+    refine ⟨(x, 0), ⟨hxC, by simp⟩, ?_⟩
+    ext
+    · exact hAx
+    · simp [g, slaterLift]
+  have hq_closure : q ∈ closure D := by
+    exact map_mem_closure hg_continuous hp_closure hg_mapsTo
+  obtain ⟨f, hf_ne, hfD⟩ :=
+    geometric_hahn_banach_of_nonempty_interior_point hD_convex hq_not_interior hD_interior
+  have hzero_D : (0 : A.range × ℝ) ∈ D := by
+    refine ⟨(0, 0), ⟨by simp, by simp⟩, ?_⟩
+    exact (slaterLift A d).map_zero
+  have hD_smul {t : ℝ} (ht : 0 ≤ t) {z : A.range × ℝ} (hz : z ∈ D) : t • z ∈ D := by
+    obtain ⟨⟨x, s⟩, ⟨hxC, hs⟩, rfl⟩ := hz
+    refine ⟨t • (x, s), ?_, ?_⟩
+    refine ⟨C.smul_mem ht hxC, ?_⟩
+    change 0 ≤ t * s
+    exact mul_nonneg ht hs
+    exact (slaterLift A d).map_smul t (x, s)
+  have hfD_closure : ∀ z ∈ closure D, f z ≤ f q := by
+    exact closure_minimal hfD (isClosed_Iic.preimage f.continuous)
+  have htwo_q : (2 : ℝ) • q ∈ closure D := by
+    exact map_mem_closure (continuous_const_smul (2 : ℝ)) hq_closure
+      (fun _ hz ↦ hD_smul (by norm_num) hz)
+  have hfq_nonneg : 0 ≤ f q := by simpa using hfD 0 hzero_D
+  have hfq_nonpos : f q ≤ 0 := by
+    have := hfD_closure _ htwo_q
+    simp only [map_smul] at this
+    change 2 * f q ≤ f q at this
+    linarith
+  have hfq : f q = 0 := le_antisymm hfq_nonpos hfq_nonneg
+  have hfD_nonpos : ∀ z ∈ D, f z ≤ 0 := by
+    intro z hz
+    simpa [hfq] using hfD z hz
+  let α : ℝ := f (0, 1)
+  have hvertical : (0, 1) ∈ D := by
+    refine ⟨(0, 1), ⟨by simp, by simp⟩, ?_⟩
+    rw [slaterLift_apply]
+    ext <;> simp
+  have hα_nonpos : α ≤ 0 := hfD_nonpos _ hvertical
+  have hα_ne : α ≠ 0 := by
+    intro hα
+    have hf_eq_of_fst_eq {z w : A.range × ℝ} (hzw : z.1 = w.1) : f z = f w := by
+      calc
+        f z = f (z.1, 0) + f (0, z.2) := by
+          rw [← map_add]
+          congr 1
+          ext <;> simp
+        _ = f (z.1, 0) := by
+          have hz : (0, z.2) = z.2 • ((0, 1) : A.range × ℝ) := by ext <;> simp
+          rw [hz, map_smul, show f (0, 1) = 0 by exact hα]
+          simp
+        _ = f (w.1, 0) := by rw [hzw]
+        _ = f (w.1, 0) + f (0, w.2) := by
+          have hw : (0, w.2) = w.2 • ((0, 1) : A.range × ℝ) := by ext <;> simp
+          rw [hw, map_smul, show f (0, 1) = 0 by exact hα]
+          simp
+        _ = f w := by
+          rw [← map_add]
+          congr 1
+          ext <;> simp
+    have hfirst : (slaterLift A d (x₀, 1)).1 = q.1 := by
+      ext
+      simpa [q, rA] using hAx₀
+    have hfa₀ : f (slaterLift A d (x₀, 1)) = 0 :=
+      (hf_eq_of_fst_eq hfirst).trans hfq
+    have himage_open : IsOpen (f '' interior D) :=
+      f.isOpenMap_of_ne_zero hf_ne _ isOpen_interior
+    have himage_subset : f '' interior D ⊆ Set.Iic 0 := by
+      rintro _ ⟨z, hz, rfl⟩
+      exact hfD_nonpos z (interior_subset hz)
+    have hzero_interior : (0 : ℝ) ∈ interior (Set.Iic 0) :=
+      interior_maximal himage_subset himage_open ⟨_, ha₀, hfa₀⟩
+    rw [interior_Iic] at hzero_interior
+    change (0 : ℝ) < 0 at hzero_interior
+    exact (lt_irrefl 0) hzero_interior
+  have hα_neg : α < 0 := lt_of_le_of_ne hα_nonpos hα_ne
+  let fA : StrongDual ℝ A.range :=
+    f.comp (ContinuousLinearMap.inl ℝ A.range ℝ)
+  let _ : CompleteSpace A.range := FiniteDimensional.complete ℝ A.range
+  let u : A.range := (InnerProductSpace.toDual ℝ A.range).symm fA
+  have hf_decomp (z : A.range) (t : ℝ) : f (z, t) = inner ℝ u z + α * t := by
+    calc
+      f (z, t) = f (z, 0) + f (0, t) := by
+        rw [← map_add]
+        congr 1
+        ext <;> simp
+      _ = fA z + t • f (0, 1) := by
+        change f (z, 0) + f (0, t) = f (z, 0) + t • f (0, 1)
+        congr 1
+        have ht : (0, t) = t • ((0, 1) : A.range × ℝ) := by ext <;> simp
+        rw [ht, map_smul]
+      _ = inner ℝ u z + α * t := by
+        rw [← InnerProductSpace.toDual_symm_apply]
+        simp [u, fA, α, mul_comm]
+  let scale : ℝ := -α
+  have hscale_pos : 0 < scale := by simp [scale, hα_neg]
+  have hscale_ne : scale ≠ 0 := ne_of_gt hscale_pos
+  let y : Z := scale⁻¹ • (u : Z)
+  refine ⟨y, ?_, ?_⟩
+  · intro x hxC
+    have hxD : slaterLift A d (x, 0) ∈ D := by
+      exact ⟨(x, 0), ⟨hxC, by simp⟩, rfl⟩
+    have hsep := hfD_nonpos _ hxD
+    rw [slaterLift_apply, hf_decomp] at hsep
+    simp only [add_zero] at hsep
+    let Ax : A.range := ⟨A x, LinearMap.mem_range_self A x⟩
+    have hraw : inner ℝ (u : Z) (A x) ≤ scale * inner ℝ d x := by
+      change inner ℝ (u : Z) (A x) + α * inner ℝ d x ≤ 0 at hsep
+      dsimp [scale]
+      linarith
+    have hinner : inner ℝ (A x) (u : Z) = inner ℝ u Ax := by
+      rw [real_inner_comm]
+      rfl
+    calc
+      inner ℝ (A x) y = scale⁻¹ * inner ℝ (A x) (u : Z) := by
+        simp [y, inner_smul_right]
+      _ = scale⁻¹ * inner ℝ u Ax := by rw [hinner]
+      _ ≤ inner ℝ d x := (inv_mul_le_iff₀ hscale_pos).2 (by simpa [Ax] using hraw)
+  · have hq_eq : inner ℝ u rA + α * p = 0 := by
+      have h := hfq
+      change f (rA, p) = 0 at h
+      rwa [hf_decomp] at h
+    have hraw : inner ℝ (u : Z) r = scale * p := by
+      change inner ℝ (u : Z) r + α * p = 0 at hq_eq
+      dsimp [scale]
+      linarith
+    have hinner : inner ℝ r (u : Z) = inner ℝ (u : Z) r := real_inner_comm _ _
+    calc
+      inner ℝ r y = scale⁻¹ * inner ℝ r (u : Z) := by
+        simp [y, inner_smul_right]
+      _ = scale⁻¹ * inner ℝ (u : Z) r := by rw [hinner]
+      _ = p := by
+        rw [hraw, ← mul_assoc, inv_mul_cancel₀ hscale_ne, one_mul]
+
+end SlaterCore
 
 end ConicProgram

--- a/QICLean/Analysis/ConicProgram.lean
+++ b/QICLean/Analysis/ConicProgram.lean
@@ -5,6 +5,7 @@ Authors: QICLean contributors
 -/
 import Mathlib.Analysis.Convex.Cone.InnerDual
 import Mathlib.Analysis.InnerProductSpace.Dual
+import Mathlib.Analysis.InnerProductSpace.ProdL2
 import Mathlib.Analysis.LocallyConvex.Separation
 import Mathlib.Data.EReal.Basic
 
@@ -409,5 +410,423 @@ private theorem exists_dual_of_strictlyFeasible_of_isGLB
         rw [hraw, ← mul_assoc, inv_mul_cancel₀ hscale_ne, one_mul]
 
 end SlaterCore
+
+section Slater
+
+/-- A real greatest lower bound of a nonempty family gives the corresponding finite infimum in
+the extended reals. -/
+private theorem ereal_iInf_eq_of_isGLB {I : Type*} [Nonempty I] (f : I → ℝ) (p : ℝ)
+    (hp : IsGLB (Set.range f) p) : (⨅ i, (f i : EReal)) = (p : EReal) := by
+  have hb : BddBelow (Set.range f) := hp.bddBelow
+  have hb' : BddBelow (Set.range fun i ↦ (f i : WithTop ℝ)) := by
+    refine ⟨(p : WithTop ℝ), ?_⟩
+    rintro _ ⟨i, rfl⟩
+    exact WithTop.coe_le_coe.mpr (hp.1 (Set.mem_range_self i))
+  change (⨅ i, ((f i : WithTop ℝ) : WithBot (WithTop ℝ))) =
+    ((p : WithTop ℝ) : WithBot (WithTop ℝ))
+  calc
+    (⨅ i, ((f i : WithTop ℝ) : WithBot (WithTop ℝ))) =
+        ((↑(⨅ i, (f i : WithTop ℝ)) : WithBot (WithTop ℝ))) :=
+      (WithBot.coe_iInf (fun i ↦ (f i : WithTop ℝ)) hb').symm
+    _ = ((↑(⨅ i, f i) : WithTop ℝ) : WithBot (WithTop ℝ)) := by
+      exact congrArg (fun z : WithTop ℝ ↦ (z : WithBot (WithTop ℝ)))
+        (WithTop.coe_iInf hb).symm
+    _ = ((p : WithTop ℝ) : WithBot (WithTop ℝ)) := by rw [hp.ciInf_eq]
+
+/-- A real least upper bound of a nonempty family gives the corresponding finite supremum in the
+extended reals. -/
+private theorem ereal_iSup_eq_of_isLUB {I : Type*} [Nonempty I] (f : I → ℝ) (p : ℝ)
+    (hp : IsLUB (Set.range f) p) : (⨆ i, (f i : EReal)) = (p : EReal) := by
+  have hb : BddAbove (Set.range f) := hp.bddAbove
+  have hb' : BddAbove (Set.range fun i ↦ (f i : WithTop ℝ)) := OrderTop.bddAbove _
+  change (⨆ i, ((f i : WithTop ℝ) : WithBot (WithTop ℝ))) =
+    ((p : WithTop ℝ) : WithBot (WithTop ℝ))
+  calc
+    (⨆ i, ((f i : WithTop ℝ) : WithBot (WithTop ℝ))) =
+        ((↑(⨆ i, (f i : WithTop ℝ)) : WithBot (WithTop ℝ))) :=
+      (WithBot.coe_iSup hb').symm
+    _ = ((↑(⨆ i, f i) : WithTop ℝ) : WithBot (WithTop ℝ)) := by
+      exact congrArg (fun z : WithTop ℝ ↦ (z : WithBot (WithTop ℝ)))
+        (WithTop.coe_iSup f hb).symm
+    _ = ((p : WithTop ℝ) : WithBot (WithTop ℝ)) := by rw [hp.ciSup_eq]
+
+omit [FiniteDimensional ℝ V] [FiniteDimensional ℝ V'] in
+/-- A finite extended-real infimum of a nonempty real family is its real greatest lower bound. -/
+private theorem isGLB_of_ereal_iInf_eq {I : Type*} [Nonempty I] (f : I → ℝ) (p : ℝ)
+    (hp : (⨅ i, (f i : EReal)) = (p : EReal)) : IsGLB (Set.range f) p := by
+  constructor
+  · rintro _ ⟨i, rfl⟩
+    apply EReal.coe_le_coe_iff.mp
+    rw [← hp]
+    exact iInf_le _ i
+  · intro a ha
+    apply EReal.coe_le_coe_iff.mp
+    rw [← hp]
+    refine le_iInf fun i ↦ ?_
+    exact EReal.coe_le_coe (ha (Set.mem_range_self i))
+
+omit [FiniteDimensional ℝ V] [FiniteDimensional ℝ V'] in
+/-- A finite extended-real supremum of a nonempty real family is its real least upper bound. -/
+private theorem isLUB_of_ereal_iSup_eq {I : Type*} [Nonempty I] (f : I → ℝ) (p : ℝ)
+    (hp : (⨆ i, (f i : EReal)) = (p : EReal)) : IsLUB (Set.range f) p := by
+  constructor
+  · rintro _ ⟨i, rfl⟩
+    apply EReal.coe_le_coe_iff.mp
+    rw [← hp]
+    exact le_iSup (fun i ↦ (f i : EReal)) i
+  · intro a ha
+    apply EReal.coe_le_coe_iff.mp
+    rw [← hp]
+    refine iSup_le fun i ↦ ?_
+    exact EReal.coe_le_coe (ha (Set.mem_range_self i))
+
+omit [FiniteDimensional ℝ V] [FiniteDimensional ℝ V'] in
+/-- A real greatest lower bound realizes Wolf's extended-real primal value. This is the finite
+primal-optimum hypothesis used below; it does not assert that the infimum is attained. -/
+theorem primalValue_eq_coe_of_isGLB {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'}
+    {c : V} {b : V'} {p : ℝ}
+    (hp : IsGLB ((fun x : V ↦ inner ℝ c x) '' primalFeasible K T b) p) :
+    primalValue K T c b = (p : EReal) := by
+  let _ : Nonempty (primalFeasible K T b) := by
+    by_contra h
+    rw [not_nonempty_iff] at h
+    have hp_all : ∀ a : ℝ, a ≤ p := by
+      intro a
+      apply hp.2
+      rintro _ ⟨x, hx, rfl⟩
+      exact False.elim (@IsEmpty.false (primalFeasible K T b) h ⟨x, hx⟩)
+    exact (not_le_of_gt (lt_add_one p)) (hp_all (p + 1))
+  apply ereal_iInf_eq_of_isGLB
+  have hrange :
+      Set.range (fun x : primalFeasible K T b ↦ inner ℝ c (x : V)) =
+        (fun x : V ↦ inner ℝ c x) '' primalFeasible K T b := by
+    ext z
+    constructor
+    · rintro ⟨x, rfl⟩
+      exact ⟨x, x.property, rfl⟩
+    · rintro ⟨x, hx, rfl⟩
+      exact ⟨⟨x, hx⟩, rfl⟩
+  rw [hrange]
+  exact hp
+
+omit [FiniteDimensional ℝ V] [FiniteDimensional ℝ V'] in
+/-- For a nonempty primal feasible set, saying that Wolf's extended-real primal value is the real
+number `p` is exactly saying that `p` is the greatest lower bound of the real objective values. -/
+theorem primalValue_eq_coe_iff_isGLB {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'}
+    {c : V} {b : V'} {p : ℝ} (hfeasible : (primalFeasible K T b).Nonempty) :
+    primalValue K T c b = (p : EReal) ↔
+      IsGLB ((fun x : V ↦ inner ℝ c x) '' primalFeasible K T b) p := by
+  let _ : Nonempty (primalFeasible K T b) := hfeasible.to_subtype
+  have hrange :
+      Set.range (fun x : primalFeasible K T b ↦ inner ℝ c (x : V)) =
+        (fun x : V ↦ inner ℝ c x) '' primalFeasible K T b := by
+    ext z
+    constructor
+    · rintro ⟨x, rfl⟩
+      exact ⟨x, x.property, rfl⟩
+    · rintro ⟨x, hx, rfl⟩
+      exact ⟨⟨x, hx⟩, rfl⟩
+  constructor
+  · intro hp
+    rw [← hrange]
+    exact isGLB_of_ereal_iInf_eq _ p hp
+  · exact primalValue_eq_coe_of_isGLB
+
+/-- A real least upper bound realizes Wolf's extended-real dual value. This is the finite
+dual-optimum hypothesis used below; it does not assert that the supremum is attained. -/
+theorem dualValue_eq_coe_of_isLUB {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'}
+    {c : V} {b : V'} {p : ℝ}
+    (hp : IsLUB ((fun y : V' ↦ inner ℝ b y) '' dualFeasible K T c) p) :
+    dualValue K T c b = (p : EReal) := by
+  let _ : Nonempty (dualFeasible K T c) := by
+    by_contra h
+    rw [not_nonempty_iff] at h
+    have hp_all : ∀ a : ℝ, p ≤ a := by
+      intro a
+      apply hp.2
+      rintro _ ⟨y, hy, rfl⟩
+      exact False.elim (@IsEmpty.false (dualFeasible K T c) h ⟨y, hy⟩)
+    exact (not_le_of_gt (sub_one_lt p)) (hp_all (p - 1))
+  apply ereal_iSup_eq_of_isLUB
+  have hrange :
+      Set.range (fun y : dualFeasible K T c ↦ inner ℝ b (y : V')) =
+        (fun y : V' ↦ inner ℝ b y) '' dualFeasible K T c := by
+    ext z
+    constructor
+    · rintro ⟨y, rfl⟩
+      exact ⟨y, y.property, rfl⟩
+    · rintro ⟨y, hy, rfl⟩
+      exact ⟨⟨y, hy⟩, rfl⟩
+  rw [hrange]
+  exact hp
+
+/-- For a nonempty dual feasible set, saying that Wolf's extended-real dual value is the real
+number `p` is exactly saying that `p` is the least upper bound of the real objective values. -/
+theorem dualValue_eq_coe_iff_isLUB {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'}
+    {c : V} {b : V'} {p : ℝ} (hfeasible : (dualFeasible K T c).Nonempty) :
+    dualValue K T c b = (p : EReal) ↔
+      IsLUB ((fun y : V' ↦ inner ℝ b y) '' dualFeasible K T c) p := by
+  let _ : Nonempty (dualFeasible K T c) := hfeasible.to_subtype
+  have hrange :
+      Set.range (fun y : dualFeasible K T c ↦ inner ℝ b (y : V')) =
+        (fun y : V' ↦ inner ℝ b y) '' dualFeasible K T c := by
+    ext z
+    constructor
+    · rintro ⟨y, rfl⟩
+      exact ⟨y, y.property, rfl⟩
+    · rintro ⟨y, hy, rfl⟩
+      exact ⟨⟨y, hy⟩, rfl⟩
+  constructor
+  · intro hp
+    rw [← hrange]
+    exact isLUB_of_ereal_iSup_eq _ p hp
+  · exact dualValue_eq_coe_of_isLUB
+
+/-- The dual conic problem written as a primal cone constraint. The first coordinate is free and
+the second coordinate is the dual slack. -/
+private def dualAsPrimalCone (K : ProperCone ℝ V) :
+    PointedCone ℝ (WithLp 2 (V' × V)) where
+  carrier := {w | w.snd ∈ ProperCone.innerDual (K : Set V)}
+  zero_mem' := by simp
+  add_mem' := by
+    intro x y hx hy
+    change x.snd ∈ ProperCone.innerDual (K : Set V) at hx
+    change y.snd ∈ ProperCone.innerDual (K : Set V) at hy
+    change (x + y).snd ∈ ProperCone.innerDual (K : Set V)
+    simpa using (ProperCone.innerDual (K : Set V)).add_mem hx hy
+  smul_mem' := by
+    intro a x hx
+    change x.snd ∈ ProperCone.innerDual (K : Set V) at hx
+    change (a : ℝ) • x.snd ∈ ProperCone.innerDual (K : Set V)
+    exact (ProperCone.innerDual (K : Set V)).smul_mem hx a.property
+
+/-- The equality map `(y, z) ↦ T† y + z` for the dual problem written as a primal problem. -/
+private def dualAsPrimalMap (T : V →ₗ[ℝ] V') : WithLp 2 (V' × V) →ₗ[ℝ] V :=
+  (T.toContinuousLinearMap.adjoint.toLinearMap.coprod LinearMap.id).comp
+    (WithLp.linearEquiv 2 ℝ (V' × V)).toLinearMap
+
+@[simp]
+private theorem dualAsPrimalMap_apply (T : V →ₗ[ℝ] V') (w : WithLp 2 (V' × V)) :
+    dualAsPrimalMap T w = T.toContinuousLinearMap.adjoint w.fst + w.snd :=
+  rfl
+
+/-- **Primal Slater attainment, corrected.** If Wolf's primal problem is strictly feasible and
+has the finite real optimum `p`, then the dual supremum is attained at objective value `p`.
+
+The finite-optimum hypothesis is necessary: primal strict feasibility alone permits an unbounded
+primal problem with an empty dual feasible set.
+Source: Wolf, Chapter 4, lines 72--75, with the missing finiteness hypothesis restored. -/
+theorem exists_isDualOptimizer_of_isPrimalStrictlyFeasible_of_isGLB
+    {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V} {b : V'} {p : ℝ}
+    (hstrict : IsPrimalStrictlyFeasible K T b)
+    (hp : IsGLB ((fun x : V ↦ inner ℝ c x) '' primalFeasible K T b) p) :
+    ∃ y : V', IsDualOptimizer K T c b y ∧ inner ℝ b y = p := by
+  obtain ⟨y, hybound, hyobj⟩ :=
+    exists_dual_of_strictlyFeasible_of_isGLB K.toPointedCone T c b p
+      (by simpa [IsPrimalStrictlyFeasible] using hstrict)
+      (by simpa [primalFeasible] using hp)
+  have hyfeasible : y ∈ dualFeasible K T c := by
+    change c - T.toContinuousLinearMap.adjoint y ∈ ProperCone.innerDual (K : Set V)
+    refine ProperCone.mem_innerDual.mpr fun x hxK ↦ ?_
+    rw [inner_sub_right, T.toContinuousLinearMap.adjoint_inner_right, ← real_inner_comm x c]
+    exact sub_nonneg.mpr (hybound x hxK)
+  refine ⟨y, ⟨hyfeasible, ?_⟩, hyobj⟩
+  intro z hz
+  rw [hyobj]
+  apply hp.2
+  rintro _ ⟨x, hx, rfl⟩
+  exact weak_duality_pointwise hx hz
+
+/-- **Primal Slater strong duality, corrected.** Under primal strict feasibility and a finite
+real primal optimum, Wolf's extended-real primal and dual values are equal. Attainment is supplied
+separately by `exists_isDualOptimizer_of_isPrimalStrictlyFeasible_of_isGLB`. -/
+theorem values_eq_of_isPrimalStrictlyFeasible_of_isGLB
+    {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V} {b : V'} {p : ℝ}
+    (hstrict : IsPrimalStrictlyFeasible K T b)
+    (hp : IsGLB ((fun x : V ↦ inner ℝ c x) '' primalFeasible K T b) p) :
+    primalValue K T c b = dualValue K T c b := by
+  obtain ⟨y, hyopt, hyobj⟩ :=
+    exists_isDualOptimizer_of_isPrimalStrictlyFeasible_of_isGLB hstrict hp
+  rw [primalValue_eq_coe_of_isGLB hp, dualValue_eq_of_isDualOptimizer hyopt, hyobj]
+
+/-- **Dual Slater attainment, corrected.** If Wolf's dual problem is strictly feasible and has
+the finite real optimum `p`, then the primal infimum is attained at objective value `p`.
+
+The finite-optimum hypothesis is necessary: dual strict feasibility alone does not imply that the
+primal feasible set is nonempty.
+Source: Wolf, Chapter 4, lines 75--78, with the missing finiteness hypothesis restored. -/
+theorem exists_isPrimalOptimizer_of_isDualStrictlyFeasible_of_isLUB
+    {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V} {b : V'} {p : ℝ}
+    (hstrict : IsDualStrictlyFeasible K T c)
+    (hp : IsLUB ((fun y : V' ↦ inner ℝ b y) '' dualFeasible K T c) p) :
+    ∃ x : V, IsPrimalOptimizer K T c b x ∧ inner ℝ c x = p := by
+  let C : PointedCone ℝ (WithLp 2 (V' × V)) := dualAsPrimalCone K
+  let A : WithLp 2 (V' × V) →ₗ[ℝ] V := dualAsPrimalMap T
+  let d : WithLp 2 (V' × V) := WithLp.toLp 2 (-b, 0)
+  have hstrict' : ∃ w ∈ interior (C : Set (WithLp 2 (V' × V))), A w = c := by
+    obtain ⟨y₀, hy₀⟩ := hstrict
+    let z₀ : V := c - T.toContinuousLinearMap.adjoint y₀
+    refine ⟨WithLp.toLp 2 (y₀, z₀), ?_, ?_⟩
+    · let e : WithLp 2 (V' × V) ≃ₜ V' × V := WithLp.homeomorphProd 2 V' V
+      have hC : (C : Set (WithLp 2 (V' × V))) =
+          e ⁻¹' (Set.univ ×ˢ (ProperCone.innerDual (K : Set V) : Set V)) := by
+        ext w
+        constructor
+        · intro hw
+          change w.snd ∈ ProperCone.innerDual (K : Set V) at hw
+          change e w ∈ Set.univ ×ˢ (ProperCone.innerDual (K : Set V) : Set V)
+          exact ⟨Set.mem_univ _, hw⟩
+        · intro hw
+          have hw' : e w ∈
+              Set.univ ×ˢ (ProperCone.innerDual (K : Set V) : Set V) := hw
+          change w.snd ∈ ProperCone.innerDual (K : Set V)
+          exact hw'.2
+      rw [hC, ← e.preimage_interior, interior_prod_eq, interior_univ]
+      exact ⟨Set.mem_univ _, hy₀⟩
+    · simp [A, z₀, dualAsPrimalMap]
+  have hGLB :
+      IsGLB ((fun w : WithLp 2 (V' × V) ↦ inner ℝ d w) ''
+        {w | w ∈ C ∧ A w = c}) (-p) := by
+    constructor
+    · rintro _ ⟨w, ⟨hwC, hAw⟩, rfl⟩
+      have hz : w.snd ∈ ProperCone.innerDual (K : Set V) := by
+        exact hwC
+      have hy : w.fst ∈ dualFeasible K T c := by
+        change c - T.toContinuousLinearMap.adjoint w.fst ∈
+          ProperCone.innerDual (K : Set V)
+        have heq : c - T.toContinuousLinearMap.adjoint w.fst = w.snd := by
+          change T.toContinuousLinearMap.adjoint w.fst + w.snd = c at hAw
+          rw [← hAw]
+          abel
+        rw [heq]
+        exact hz
+      have hle := hp.1 ⟨w.fst, hy, rfl⟩
+      have hdw : inner ℝ d w = -inner ℝ b w.fst := by
+        rw [WithLp.prod_inner_apply]
+        simp [d]
+      change -p ≤ inner ℝ d w
+      rw [hdw]
+      linarith
+    · intro a ha
+      have hupper : p ≤ -a := by
+        apply hp.2
+        rintro _ ⟨y, hy, rfl⟩
+        let z : V := c - T.toContinuousLinearMap.adjoint y
+        let w : WithLp 2 (V' × V) := WithLp.toLp 2 (y, z)
+        have hwC : w ∈ C := by
+          change z ∈ ProperCone.innerDual (K : Set V)
+          change c - T.toContinuousLinearMap.adjoint y ∈
+            ProperCone.innerDual (K : Set V) at hy
+          exact hy
+        have hAw : A w = c := by
+          simp [A, w, z, dualAsPrimalMap]
+        have hle := ha ⟨w, ⟨hwC, hAw⟩, rfl⟩
+        have hdw : inner ℝ d w = -inner ℝ b y := by
+          rw [WithLp.prod_inner_apply]
+          simp [d, w]
+        change a ≤ inner ℝ d w at hle
+        rw [hdw] at hle
+        linarith
+      linarith
+  obtain ⟨x, hxbound, hxobj⟩ :=
+    exists_dual_of_strictlyFeasible_of_isGLB C A d c (-p) hstrict' hGLB
+  have hTx : T (-x) = b := by
+    let y : V' := T x + b
+    let w : WithLp 2 (V' × V) := WithLp.toLp 2 (y, 0)
+    have hyC : w ∈ C := by simp [C, dualAsPrimalCone, w]
+    have hbound := hxbound w hyC
+    have hbound' : inner ℝ (T.toContinuousLinearMap.adjoint y) x ≤
+        inner ℝ (-b) y := by
+      simpa [A, d, w, dualAsPrimalMap, WithLp.prod_inner_apply] using hbound
+    rw [T.toContinuousLinearMap.adjoint_inner_left, inner_neg_left] at hbound'
+    have hself_nonpos : inner ℝ y y ≤ 0 := by
+      dsimp [y]
+      rw [inner_add_right]
+      dsimp [y] at hbound'
+      rw [real_inner_comm (T x + b) b] at hbound'
+      linarith
+    have hy_zero : y = 0 := inner_self_eq_zero.mp (le_antisymm hself_nonpos real_inner_self_nonneg)
+    rw [map_neg]
+    exact neg_eq_of_add_eq_zero_right hy_zero
+  have hxK : -x ∈ K := by
+    have hdouble : -x ∈
+        ProperCone.innerDual (ProperCone.innerDual (K : Set V) : Set V) := by
+      refine ProperCone.mem_innerDual.mpr fun z hz ↦ ?_
+      let w : WithLp 2 (V' × V) := WithLp.toLp 2 (0, z)
+      have hzC : w ∈ C := by
+        change z ∈ ProperCone.innerDual (K : Set V)
+        exact hz
+      have hbound := hxbound w hzC
+      have hbound' : inner ℝ z x ≤ 0 := by
+        simpa [A, d, w, dualAsPrimalMap, WithLp.prod_inner_apply] using hbound
+      simpa [inner_neg_right] using neg_nonneg.mpr hbound'
+    rw [ProperCone.innerDual_innerDual K] at hdouble
+    exact hdouble
+  have hxfeasible : -x ∈ primalFeasible K T b := ⟨hxK, hTx⟩
+  have hxobj' : inner ℝ c (-x) = p := by
+    rw [inner_neg_right]
+    linarith
+  refine ⟨-x, ⟨hxfeasible, ?_⟩, hxobj'⟩
+  intro z hz
+  rw [hxobj']
+  apply hp.2
+  rintro _ ⟨y, hy, rfl⟩
+  exact weak_duality_pointwise hz hy
+
+/-- **Dual Slater strong duality, corrected.** Under dual strict feasibility and a finite real
+dual optimum, Wolf's extended-real primal and dual values are equal. Attainment is supplied
+separately by `exists_isPrimalOptimizer_of_isDualStrictlyFeasible_of_isLUB`. -/
+theorem values_eq_of_isDualStrictlyFeasible_of_isLUB
+    {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V} {b : V'} {p : ℝ}
+    (hstrict : IsDualStrictlyFeasible K T c)
+    (hp : IsLUB ((fun y : V' ↦ inner ℝ b y) '' dualFeasible K T c) p) :
+    primalValue K T c b = dualValue K T c b := by
+  obtain ⟨x, hxopt, hxobj⟩ :=
+    exists_isPrimalOptimizer_of_isDualStrictlyFeasible_of_isLUB hstrict hp
+  rw [primalValue_eq_of_isPrimalOptimizer hxopt, dualValue_eq_coe_of_isLUB hp, hxobj]
+
+/-- **Primal Slater attainment in Wolf's value notation.** If the primal problem is strictly
+feasible and its extended-real value is the finite real number `p`, then the dual optimum is
+attained at value `p`. -/
+theorem exists_isDualOptimizer_of_isPrimalStrictlyFeasible_of_primalValue_eq_coe
+    {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V} {b : V'} {p : ℝ}
+    (hstrict : IsPrimalStrictlyFeasible K T b)
+    (hvalue : primalValue K T c b = (p : EReal)) :
+    ∃ y : V', IsDualOptimizer K T c b y ∧ inner ℝ b y = p := by
+  apply exists_isDualOptimizer_of_isPrimalStrictlyFeasible_of_isGLB hstrict
+  exact (primalValue_eq_coe_iff_isGLB hstrict.feasible).mp hvalue
+
+/-- **Primal Slater strong duality in Wolf's value notation.** If the primal problem is strictly
+feasible and its extended-real value is finite, then the primal and dual values are equal. -/
+theorem values_eq_of_isPrimalStrictlyFeasible_of_primalValue_eq_coe
+    {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V} {b : V'} {p : ℝ}
+    (hstrict : IsPrimalStrictlyFeasible K T b)
+    (hvalue : primalValue K T c b = (p : EReal)) :
+    primalValue K T c b = dualValue K T c b := by
+  apply values_eq_of_isPrimalStrictlyFeasible_of_isGLB hstrict
+  exact (primalValue_eq_coe_iff_isGLB hstrict.feasible).mp hvalue
+
+/-- **Dual Slater attainment in Wolf's value notation.** If the dual problem is strictly feasible
+and its extended-real value is the finite real number `p`, then the primal optimum is attained at
+value `p`. -/
+theorem exists_isPrimalOptimizer_of_isDualStrictlyFeasible_of_dualValue_eq_coe
+    {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V} {b : V'} {p : ℝ}
+    (hstrict : IsDualStrictlyFeasible K T c)
+    (hvalue : dualValue K T c b = (p : EReal)) :
+    ∃ x : V, IsPrimalOptimizer K T c b x ∧ inner ℝ c x = p := by
+  apply exists_isPrimalOptimizer_of_isDualStrictlyFeasible_of_isLUB hstrict
+  exact (dualValue_eq_coe_iff_isLUB hstrict.feasible).mp hvalue
+
+/-- **Dual Slater strong duality in Wolf's value notation.** If the dual problem is strictly
+feasible and its extended-real value is finite, then the primal and dual values are equal. -/
+theorem values_eq_of_isDualStrictlyFeasible_of_dualValue_eq_coe
+    {K : ProperCone ℝ V} {T : V →ₗ[ℝ] V'} {c : V} {b : V'} {p : ℝ}
+    (hstrict : IsDualStrictlyFeasible K T c)
+    (hvalue : dualValue K T c b = (p : EReal)) :
+    primalValue K T c b = dualValue K T c b := by
+  apply values_eq_of_isDualStrictlyFeasible_of_isLUB hstrict
+  exact (dualValue_eq_coe_iff_isLUB hstrict.feasible).mp hvalue
+
+end Slater
 
 end ConicProgram

--- a/blueprint/src/chapter/ch04_convex_structure.tex
+++ b/blueprint/src/chapter/ch04_convex_structure.tex
@@ -107,18 +107,87 @@ This chapter follows the convex-optimization framework of
 \end{proof}
 
 % Wolf's lines 72--78 omit the finiteness conditions required by the
-% attainment clauses.  The counterexamples and the unresolved separation step
-% are recorded in docs/paper-gaps/wolf_slater_attainment_conditions.tex.
+% attainment clauses.  The counterexamples and corrected statement are
+% recorded in docs/paper-gaps/wolf_slater_attainment_conditions.tex.
+\begin{theorem}[Finite real values and real extrema]
+    \label{thm:conic_finite_value_extrema}
+    \lean{ConicProgram.primalValue_eq_coe_of_isGLB,
+        ConicProgram.primalValue_eq_coe_iff_isGLB,
+        ConicProgram.dualValue_eq_coe_of_isLUB,
+        ConicProgram.dualValue_eq_coe_iff_isLUB}
+    \leanok
+    \uses{def:conic_programs}
+    If $\mathcal F_p$ is nonempty and $p\in\R$, then $C_p=p$ in the
+    extended real line if and only if $p$ is the greatest lower bound of
+    $\{\langle c|x\rangle:x\in\mathcal F_p\}$.  If $\mathcal F_d$ is
+    nonempty, then $C_d=p$ if and only if $p$ is the least upper bound of
+    $\{\langle b|y\rangle:y\in\mathcal F_d\}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The embedding $\R\to\overline{\R}$ preserves and reflects order.  Thus
+    the defining extended-real infimum is $p\in\R$ exactly when $p$ is a
+    lower bound of all real objective values and every other real lower bound
+    is at most $p$.  The supremum statement is the order-dual argument.
+\end{proof}
+
 \begin{theorem}[Corrected Slater strong duality]
     \label{thm:conic_corrected_slater}
-    \uses{def:conic_strict_feasibility_and_attainment,
-        thm:conic_weak_duality}
+    \lean{ConicProgram.exists_isDualOptimizer_of_isPrimalStrictlyFeasible_of_isGLB,
+        ConicProgram.values_eq_of_isPrimalStrictlyFeasible_of_isGLB,
+        ConicProgram.exists_isPrimalOptimizer_of_isDualStrictlyFeasible_of_isLUB,
+        ConicProgram.values_eq_of_isDualStrictlyFeasible_of_isLUB,
+        ConicProgram.exists_isDualOptimizer_of_isPrimalStrictlyFeasible_of_primalValue_eq_coe,
+        ConicProgram.values_eq_of_isPrimalStrictlyFeasible_of_primalValue_eq_coe,
+        ConicProgram.exists_isPrimalOptimizer_of_isDualStrictlyFeasible_of_dualValue_eq_coe,
+        ConicProgram.values_eq_of_isDualStrictlyFeasible_of_dualValue_eq_coe}
+    \leanok
+    \uses{def:conic_strict_feasibility_and_attainment}
+    The finiteness hypotheses below correct the attainment sentences printed
+    at lines~72--78 of \cite[Chapter~4]{Wolf2012Quantum}; the counterexamples
+    to the unqualified statements are recorded in
+    \cite{gap:wolf_slater_attainment_conditions}.
     Suppose the primal problem is strictly feasible and $C_p\in\mathbb R$.
     Then $C_p=C_d$ and there is a dual optimizer $y^0\in\mathcal F_d$ with
     $\langle b|y^0\rangle=C_d$.  Dually, if the dual problem is strictly
     feasible and $C_d\in\mathbb R$, then $C_p=C_d$ and there is a primal
     optimizer $x^0\in\mathcal F_p$ with $\langle c|x^0\rangle=C_p$.
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:conic_weak_duality, thm:conic_finite_value_extrema}
+    Write the primal problem in the form
+    $\inf\{\langle d|x\rangle:x\in C,\ A(x)=r\}=p$ and consider the convex
+    set
+    \begin{align}
+        D=\{(A(x),\langle d|x\rangle+s):x\in C,\ s\geq0\}
+        \subseteq\operatorname{ran}(A)\times\R.
+        \label{eq:conic_slater_epigraph}
+    \end{align}
+    The map $(x,s)\mapsto(A(x),\langle d|x\rangle+s)$ onto
+    $\operatorname{ran}(A)\times\R$ is open.  Strict feasibility therefore
+    gives $D$ nonempty interior.  The greatest-lower-bound property places
+    $(r,p)$ in $\overline D\setminus\operatorname{int}D$, so a separating
+    functional $f$ satisfies $f\leq0$ on $D$ and $f(r,p)=0$.  If
+    $\alpha=f(0,1)$ vanished, the image under $f$ of an interior point of $D$
+    would make $0$ an interior point of $(-\infty,0]$, a contradiction.
+    Hence $\alpha<0$, and normalization by $-\alpha$ gives $y$ such that,
+    for every $x\in C$,
+    \begin{align}
+        \langle A(x)|y\rangle & \leq\langle d|x\rangle, \\
+        \langle r|y\rangle    & =p.
+        \label{eq:conic_slater_separator}
+    \end{align}
+    For $C=K$, $A=T$, $d=c$, and $r=b$,
+    (\ref{eq:conic_slater_separator}) is dual feasibility and dual attainment.
+    For the converse direction, write the dual as a primal problem on
+    $V'\times K^*$ with equality map $(y,z)\mapsto T^*(y)+z$ and objective
+    $\langle-b|y\rangle$.  The same separation argument gives $x$ with
+    $T(-x)=b$ and $-x\in K^{**}=K$, hence a primal optimizer.  Weak duality
+    then gives equality of the two extended-real values in both cases.
+\end{proof}
 
 \begin{theorem}[Complementary slackness]
     \label{thm:semidefinite_complementary_slackness}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -311,3 +311,13 @@
   year        = {2026},
   note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.pdf}},
 }
+
+@techreport{gap:wolf_slater_attainment_conditions,
+  author      = {The {QICLean} contributors},
+  title       = {Slater Strong Duality: Finiteness Conditions for Attainment},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_slater\_attainment\_conditions},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_slater_attainment_conditions.pdf}},
+}

--- a/docs/paper-gaps/wolf_slater_attainment_conditions.tex
+++ b/docs/paper-gaps/wolf_slater_attainment_conditions.tex
@@ -13,7 +13,7 @@
 
 \begin{document}
 \maketitle
-\gapnote{false-source}{open}
+\gapnote{false-source}{resolved}
 
 \section{Source passage}
 
@@ -53,35 +53,59 @@ $C_p=C_d$ and the dual supremum is attained.  Dually, if the dual problem is
 strictly feasible and $C_d\in\mathbb R$, then $C_p=C_d$ and the primal infimum
 is attained.
 
-The formal development currently contains the source-shaped strict-feasibility
-predicates and separate optimizer predicates in
-\doclink{QICLean/Analysis/ConicProgram}.  The declarations
-\leanid{ConicProgram.primalValue_eq_of_isPrimalOptimizer} and
-\leanid{ConicProgram.dualValue_eq_of_isDualOptimizer} prove that an optimizer
-realizes the corresponding extended-real value.  The declarations
-\leanid{ConicProgram.optimizers_of_feasible_of_objectives_eq} and
-\leanid{ConicProgram.values_eq_of_feasible_of_objectives_eq} prove that a
-feasible pair with equal objectives attains both values.
+The formal development in \doclink{QICLean/Analysis/ConicProgram} proves both
+directions.  The source-facing declarations
+\leanid{ConicProgram.exists_isDualOptimizer_of_isPrimalStrictlyFeasible_of_primalValue_eq_coe}
+and
+\leanid{ConicProgram.values_eq_of_isPrimalStrictlyFeasible_of_primalValue_eq_coe}
+give dual attainment and value equality from primal strict feasibility and
+$C_p=p\in\mathbb R$.  The declarations
+\leanid{ConicProgram.exists_isPrimalOptimizer_of_isDualStrictlyFeasible_of_dualValue_eq_coe}
+and
+\leanid{ConicProgram.values_eq_of_isDualStrictlyFeasible_of_dualValue_eq_coe}
+give the dual statement.  The equivalences
+\leanid{ConicProgram.primalValue_eq_coe_iff_isGLB} and
+\leanid{ConicProgram.dualValue_eq_coe_iff_isLUB} identify these hypotheses
+with the corresponding real greatest-lower-bound and least-upper-bound
+conditions whenever the feasible set is nonempty.
 
-\section{Remaining proof}
+\section{Separation argument}
 
-The unresolved step is the corrected Slater existence theorem itself.  Its
-proof must separate the appropriate finite-dimensional convex set and then
-show, using strict feasibility, that the coefficient of the objective
-coordinate is nonzero before normalizing the separating functional.  Mathlib's
-\leanid{ProperCone.relative_hyperplane_separation} concerns the closure of a
-linear image of a proper cone.  It does not prove that the unclosed image is
-closed, so it cannot by itself justify an optimizer in the original feasible
-set.  A completion must establish every closure or attainment hypothesis used
-in this argument; it must not replace that step by the false general claim that
-a linear image of a closed cone is closed.
+For a cone $C$, equality map $A$, objective vector $d$, and right-hand side
+$r$, the proof separates the lifted epigraph
+\begin{align}
+  D=\{(A(x),\langle d|x\rangle+s):x\in C,\ s\geq0\}
+  \subseteq\operatorname{ran}(A)\times\mathbb R.
+\end{align}
+The codomain is restricted to $\operatorname{ran}(A)$, so the lifted linear
+map is surjective and hence open in finite dimension.  Strict feasibility
+gives $D$ nonempty interior.  If $p$ is the finite greatest lower bound, then
+$(r,p)$ belongs to $\overline D$ but not to $\operatorname{int}D$.  A
+supporting functional $f$ therefore vanishes at $(r,p)$ and is nonpositive on
+$D$.  Its vertical coefficient $\alpha=f(0,1)$ is strictly negative: if it
+vanished, strict feasibility and openness of the nonzero functional would
+make $0$ an interior point of $(-\infty,0]$.  Normalizing by $-\alpha$ gives
+the required dual multiplier and its attained objective value.
+
+For the converse direction, the dual problem is written as a primal problem
+on $V'\times K^*$ with cone constraint on the second coordinate, equality map
+$(y,z)\mapsto T^*(y)+z$, and objective $\langle-b|y\rangle$.  The multiplier
+returned by the same separation argument yields $T(-x)=b$ and
+$-x\in K^{**}=K$.  This is precisely primal feasibility in Wolf's signs.
+At no point is a linear image of a closed cone assumed to be closed; only the
+closure membership of the single boundary point $(r,p)$ is used, and it
+follows from the greatest-lower-bound property.
 
 \section{Verdict}
 
-\textbf{Verdict: open source correction.} The strict-feasibility and attainment
-notions and the zero-gap certificate are formalized.  Strong duality with
-optimizer existence remains open until the corrected finite-optimum separation
-argument is proved.
+\textbf{Verdict: false as printed; corrected theorem resolved.} The two
+one-dimensional examples show that neither attainment sentence at lines
+72--78 follows from strict feasibility alone.  With the missing finite-real
+optimum hypothesis, both value equality and the optimizer on the opposite
+side are now formalized, with separate declarations for equality and
+attainment.  This resolves
+\href{https://github.com/LionSR/QICLean/issues/110}{QICLean issue \#110} while
+retaining the source correction.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Closes #110.

## Summary

- proves the finite-dimensional Slater separation argument using the lifted epigraph in `range(A) × ℝ`, without assuming that a linear image of a closed cone is closed;
- proves both corrected one-sided theorems in Wolf's signs: a finite primal value plus primal strict feasibility gives dual attainment, and a finite dual value plus dual strict feasibility gives primal attainment;
- keeps optimizer existence separate from equality of the extended-real values and proves that the `EReal` finite-value hypotheses are exactly the corresponding real `IsGLB` and `IsLUB` conditions on nonempty feasible sets;
- synchronizes the Chapter 4 Blueprint and resolves the corrected theorem in the paper-gap note while retaining the classification that Wolf's unqualified printed attainment statements are false.

The dual-to-primal reduction uses the cone `V' × K*`, equality map `(y, z) ↦ T† y + z`, and objective `⟨-b, y⟩`. The separating multiplier yields `T(-x) = b` and `-x ∈ K** = K`, so the adjoint orientation and all signs agree with `Notes/WolfNoteTexSource/ch04_convex_structure.tex`, lines 72–78.

## Source boundary

The finite-value hypotheses are necessary for the attainment clauses. The paper-gap note retains the two one-dimensional counterexamples:

- primal strict feasibility with an unbounded primal value and empty dual feasible set;
- dual strict feasibility with an infeasible primal problem.

This change therefore formalizes the corrected theorem, not the false statement as printed. It also supplies the conic-duality prerequisite for #111.

## Verification

- `lake env lean QICLean/Analysis/ConicProgram.lean`
- `git diff --check`
- forbidden-token scan for `sorry`, `admit`, `axiom`, and `native_decide`
- `#print axioms` on all twelve public declarations: only `propext`, `Classical.choice`, and `Quot.sound`
- Blueprint forward and reverse synchronization: Chapter 4 reports 33/33 linked declarations
- reader-facing prose, `chktex`, `latexindent`, and paper-gap reference checks
- direct PDF build of `docs/paper-gaps/wolf_slater_attainment_conditions.tex`
