### PR TITLE
feat(analysis): bound one Jordan block asymptotically

### DIFF
--- a/QICLean/Analysis.lean
+++ b/QICLean/Analysis.lean
@@ -32,6 +32,7 @@ import QICLean.Analysis.HayashiMarkovStructure
 import QICLean.Analysis.IdempotentEndomorphism
 import QICLean.Analysis.InjectiveRangeProjector
 import QICLean.Analysis.IsometricCompression
+import QICLean.Analysis.JordanBlockAsymptotics
 import QICLean.Analysis.JordanBlockPower
 import QICLean.Analysis.JordanSimilarity
 import QICLean.Analysis.KleinInequality

--- a/QICLean/Analysis/JordanBlockAsymptotics.lean
+++ b/QICLean/Analysis/JordanBlockAsymptotics.lean
@@ -1,0 +1,188 @@
+/-
+Copyright (c) 2026 Sirui Lu and QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import QICLean.Analysis.JordanBlockPower
+import Mathlib.Data.Nat.Choose.Bounds
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Ring
+
+/-!
+# Polynomial scaling of one Jordan block
+
+This file derives the source-shaped polynomial-exponential scaling of a
+single Jordan block from Wolf's Equation (8.104).  For a block of dimension
+`D`, eigenvalue `a` with `0 < ‖a‖ ≤ 1`, and `D - 1 ≤ n`, the norm of its
+`n`-th power is bounded above and below by explicit positive constants times
+
+`‖a‖ ^ n * n ^ (D - 1)`.
+
+In the application to Wolf's Theorem "Asymptotic convergence I", `‖a‖` is
+the largest subperipheral modulus `μ` and `D` is the largest corresponding
+Jordan-block dimension `d_μ`.  Selecting that block from a Jordan normal form,
+proving eventual dominance in the block direct sum, and passing from a chosen
+similarity factor to Wolf's infimum `κ_T` are deliberately outside this file.
+The assumption `0 < ‖a‖` also records the source boundary at `μ = 0`, where a
+nontrivial nilpotent block has nonzero small positive powers but the displayed
+scaling factor vanishes.
+
+Source: Wolf (2012), Chapter 8, Equations (8.104), (8.106), and (8.107), local
+source `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1225--1266.
+-/
+
+open scoped Matrix.Norms.L2Operator
+
+namespace Matrix
+
+private theorem div_pow_le_choose_cast (n k : ℕ) (hk : k ≤ n) :
+    ((n : ℝ) / (k : ℝ)) ^ k ≤ (n.choose k : ℝ) := by
+  induction k generalizing n with
+  | zero => simp
+  | succ k ih =>
+      obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : n ≠ 0)
+      have hkm : k ≤ m := by omega
+      by_cases hk0 : k = 0
+      · subst k
+        simp
+      · have hkpos : 0 < (k : ℝ) := by positivity
+        have hksuccpos : 0 < (k + 1 : ℝ) := by positivity
+        have hratio : ((m + 1 : ℕ) : ℝ) / (k + 1 : ℕ) ≤ (m : ℝ) / k := by
+          norm_num only [Nat.cast_add, Nat.cast_one]
+          rw [div_le_div_iff₀ hksuccpos hkpos]
+          have hkmR : (k : ℝ) ≤ m := by exact_mod_cast hkm
+          nlinarith
+        have hpowratio :
+            (((m + 1 : ℕ) : ℝ) / (k + 1 : ℕ)) ^ k ≤ ((m : ℝ) / k) ^ k := by
+          gcongr
+        have hih := ih m hkm
+        calc
+          (((m + 1 : ℕ) : ℝ) / (k + 1 : ℕ)) ^ (k + 1) =
+              (((m + 1 : ℕ) : ℝ) / (k + 1 : ℕ)) ^ k *
+                (((m + 1 : ℕ) : ℝ) / (k + 1 : ℕ)) := by rw [pow_succ]
+          _ ≤ ((m : ℝ) / k) ^ k * (((m + 1 : ℕ) : ℝ) / (k + 1 : ℕ)) := by
+            gcongr
+          _ ≤ (m.choose k : ℝ) * (((m + 1 : ℕ) : ℝ) / (k + 1 : ℕ)) := by
+            gcongr
+          _ = ((m + 1).choose (k + 1) : ℝ) := by
+            field_simp
+            exact_mod_cast (by
+              simpa [Nat.mul_comm] using (Nat.add_one_mul_choose_eq m k))
+
+/-- The lower polynomial-exponential estimate for one Jordan block, obtained
+from the lower half of Wolf's Equation (8.104) with `k₀ = D - 1` and
+`(n / k₀) ^ k₀ ≤ n.choose k₀`.
+
+The hypotheses `0 < ‖a‖` and `D - 1 ≤ n` make explicit the positive-modulus
+and sufficiently-large-positive-power range used by the source argument. -/
+theorem le_l2_opNorm_jordanBlock_pow_polynomial (D : ℕ) [NeZero D]
+    (a : ℂ) (n : ℕ) (ha : 0 < ‖a‖) (hn : D - 1 ≤ n) :
+    ((‖a‖ * (D - 1 : ℕ))⁻¹) ^ (D - 1) * ‖a‖ ^ n *
+        (n : ℝ) ^ (D - 1) ≤ ‖jordanBlock D a ^ n‖ := by
+  let k := D - 1
+  have hk : k ≤ min n (D - 1) := le_min hn le_rfl
+  have hbase := le_l2_opNorm_jordanBlock_pow D a n k hk
+  by_cases hk0 : k = 0
+  · simpa [k, hk0] using hbase
+  · have hkpos : 0 < (k : ℝ) := by positivity
+    have hchoose : ((n : ℝ) / (k : ℝ)) ^ k ≤ (n.choose k : ℝ) :=
+      div_pow_le_choose_cast n k hn
+    have hpow : ‖a‖ ^ n = ‖a‖ ^ (n - k) * ‖a‖ ^ k := by
+      rw [← pow_add, Nat.sub_add_cancel hn]
+    have halg : ((‖a‖ * (k : ℝ))⁻¹) ^ k * ‖a‖ ^ n * (n : ℝ) ^ k =
+        ‖a‖ ^ (n - k) * ((n : ℝ) / (k : ℝ)) ^ k := by
+      rw [hpow]
+      field_simp [mul_pow]
+      rw [← mul_pow, ← mul_pow]
+      congr 1
+      field_simp [ha.ne', hkpos.ne']
+    change ((‖a‖ * (k : ℝ))⁻¹) ^ k * ‖a‖ ^ n * (n : ℝ) ^ k ≤ _
+    calc
+      ((‖a‖ * (k : ℝ))⁻¹) ^ k * ‖a‖ ^ n * (n : ℝ) ^ k =
+          ‖a‖ ^ (n - k) * ((n : ℝ) / (k : ℝ)) ^ k := halg
+      _ ≤ ‖a‖ ^ (n - k) * (n.choose k : ℝ) := by gcongr
+      _ ≤ ‖jordanBlock D a ^ n‖ := hbase
+
+/-- An explicit upper polynomial-exponential estimate for one Jordan block,
+derived from the upper half of Wolf's Equation (8.104).  The constant
+`D * ‖a‖⁻¹ ^ (D - 1)` is deliberately block-local; Wolf only asserts the
+existence of a global `C₂` after the eventual largest-block argument. -/
+theorem l2_opNorm_jordanBlock_pow_le_polynomial (D : ℕ) [NeZero D]
+    (a : ℂ) (n : ℕ) (ha : 0 < ‖a‖) (ha1 : ‖a‖ ≤ 1)
+    (hn : D - 1 ≤ n) :
+    ‖jordanBlock D a ^ n‖ ≤
+      (D : ℝ) * (‖a‖⁻¹) ^ (D - 1) * ‖a‖ ^ n *
+        (n : ℝ) ^ (D - 1) := by
+  let kTop := D - 1
+  have hD : kTop + 1 = D := by
+    have := NeZero.pos D
+    omega
+  have hmin : min n (D - 1) = kTop := by simp [kTop, hn]
+  have hsum := l2_opNorm_jordanBlock_pow_le D a n
+  rw [hmin] at hsum
+  have hterm : ∀ k ∈ Finset.range (kTop + 1),
+      ‖a‖ ^ (n - k) * (n.choose k : ℝ) ≤
+        ‖a‖ ^ (n - kTop) * (n : ℝ) ^ kTop := by
+    intro k hk
+    have hkTop : k ≤ kTop := by
+      rw [Finset.mem_range] at hk
+      omega
+    have hpowNorm : ‖a‖ ^ (n - k) ≤ ‖a‖ ^ (n - kTop) := by
+      exact pow_le_pow_of_le_one (norm_nonneg a) ha1 (by omega)
+    have hchoose : (n.choose k : ℝ) ≤ (n : ℝ) ^ k := by
+      exact_mod_cast Nat.choose_le_pow n k
+    have hpowNat : (n : ℝ) ^ k ≤ (n : ℝ) ^ kTop := by
+      by_cases hkTop0 : kTop = 0
+      · have hk0 : k = 0 := by omega
+        subst k
+        simp [hkTop0]
+      · have hn1 : 1 ≤ n := by omega
+        exact pow_right_mono₀ (by exact_mod_cast hn1) hkTop
+    exact mul_le_mul hpowNorm (hchoose.trans hpowNat)
+      (Nat.cast_nonneg _) (pow_nonneg (norm_nonneg a) _)
+  have hsumBound :
+      (∑ k ∈ Finset.range (kTop + 1), ‖a‖ ^ (n - k) * (n.choose k : ℝ)) ≤
+        (D : ℝ) * (‖a‖ ^ (n - kTop) * (n : ℝ) ^ kTop) := by
+    calc
+      (∑ k ∈ Finset.range (kTop + 1), ‖a‖ ^ (n - k) * (n.choose k : ℝ)) ≤
+          ∑ _k ∈ Finset.range (kTop + 1),
+            ‖a‖ ^ (n - kTop) * (n : ℝ) ^ kTop :=
+        Finset.sum_le_sum fun k hk ↦ hterm k hk
+      _ = (D : ℝ) * (‖a‖ ^ (n - kTop) * (n : ℝ) ^ kTop) := by
+        simp [hD]
+  have hpow : ‖a‖ ^ n = ‖a‖ ^ (n - kTop) * ‖a‖ ^ kTop := by
+    rw [← pow_add, Nat.sub_add_cancel hn]
+  have hfactor : (‖a‖⁻¹) ^ kTop * ‖a‖ ^ n = ‖a‖ ^ (n - kTop) := by
+    rw [hpow]
+    calc
+      (‖a‖⁻¹) ^ kTop * (‖a‖ ^ (n - kTop) * ‖a‖ ^ kTop) =
+          ‖a‖ ^ (n - kTop) * ((‖a‖⁻¹) ^ kTop * ‖a‖ ^ kTop) := by ring
+      _ = ‖a‖ ^ (n - kTop) := by
+        rw [← mul_pow, inv_mul_cancel₀ ha.ne', one_pow, mul_one]
+  calc
+    ‖jordanBlock D a ^ n‖ ≤
+        ∑ k ∈ Finset.range (kTop + 1), ‖a‖ ^ (n - k) * (n.choose k : ℝ) := hsum
+    _ ≤ (D : ℝ) * (‖a‖ ^ (n - kTop) * (n : ℝ) ^ kTop) := hsumBound
+    _ = (D : ℝ) * (‖a‖⁻¹) ^ kTop * ‖a‖ ^ n * (n : ℝ) ^ kTop := by
+      rw [← hfactor]
+      ring
+
+/-- Two-sided polynomial-exponential scaling for one positive-modulus Jordan
+block.  This is the single-block prerequisite used in Wolf's proof of
+Equations (8.106)--(8.107), not the full channel theorem. -/
+theorem l2_opNorm_jordanBlock_pow_polynomial_bounds (D : ℕ) [NeZero D]
+    (a : ℂ) (n : ℕ) (ha : 0 < ‖a‖) (ha1 : ‖a‖ ≤ 1)
+    (hn : D - 1 ≤ n) :
+    ((‖a‖ * (D - 1 : ℕ))⁻¹) ^ (D - 1) * ‖a‖ ^ n *
+          (n : ℝ) ^ (D - 1) ≤ ‖jordanBlock D a ^ n‖ ∧
+      ‖jordanBlock D a ^ n‖ ≤
+        (D : ℝ) * (‖a‖⁻¹) ^ (D - 1) * ‖a‖ ^ n *
+          (n : ℝ) ^ (D - 1) :=
+  ⟨le_l2_opNorm_jordanBlock_pow_polynomial D a n ha hn,
+    l2_opNorm_jordanBlock_pow_le_polynomial D a n ha ha1 hn⟩
+
+end Matrix

--- a/QICLean/Analysis/JordanBlockAsymptotics.lean
+++ b/QICLean/Analysis/JordanBlockAsymptotics.lean
@@ -32,7 +32,8 @@ nontrivial nilpotent block has nonzero small positive powers but the displayed
 scaling factor vanishes.
 
 Source: Wolf (2012), Chapter 8, Equations (8.104), (8.106), and (8.107), local
-source `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1225--1266.
+source `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1197--1214
+and 1225--1266.
 -/
 
 open scoped Matrix.Norms.L2Operator

--- a/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
@@ -53,6 +53,45 @@
 % argument; the full Jordan-scaling theorem is therefore not marked \leanok.
 \end{proof}
 
+\begin{theorem}[Single-block polynomial scaling prerequisite]
+    \label{thm:wolf_single_jordan_block_polynomial_scaling}
+    \lean{Matrix.l2_opNorm_jordanBlock_pow_polynomial_bounds,
+      Matrix.le_l2_opNorm_jordanBlock_pow_polynomial,
+      Matrix.l2_opNorm_jordanBlock_pow_le_polynomial}
+    \leanok
+    Let $D\ge 1$, let $J_D(\lambda)$ be a Jordan block, and suppose that
+    $0<|\lambda|\le1$ and $D-1\le n$.  Then
+    \begin{align}
+      \bigl(|\lambda|(D-1)\bigr)^{-(D-1)}
+        |\lambda|^n n^{D-1}
+      &\le \lVert J_D(\lambda)^n\rVert_\infty,\\
+      \lVert J_D(\lambda)^n\rVert_\infty
+      &\le D|\lambda|^{-(D-1)}
+        |\lambda|^n n^{D-1}.
+    \end{align}
+    At $D=1$ the inverse-power factor in the first line is interpreted as
+    the zeroth power and hence equals one.  This is the fixed-block estimate
+    used in the proof of Wolf's Equations~(8.106)--(8.107), before selecting
+    the largest subperipheral block and comparing the full direct sum.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:jordan_block_power_norm}
+    In the lower half of Equation~(8.104), take $k_0=D-1$ and use
+    $\binom{n}{k_0}\ge(n/k_0)^{k_0}$.  For the upper half, each of the $D$
+    summands is at most
+    $|\lambda|^{n-D+1}n^{D-1}$: monotonicity in the exponent uses
+    $|\lambda|\le1$, and $\binom nk\le n^k\le n^{D-1}$.  Finally factor
+    $|\lambda|^{n-D+1}=|\lambda|^{-(D-1)}|\lambda|^n$.
+
+% This theorem is only the single-block prerequisite.  A formalization of
+% the channel statement with \widehat T^n-\widehat T_\varphi^n still needs a
+% Jordan-form existence theorem, the direct-sum eventual-maximum argument,
+% and a justified passage from a chosen similarity to Wolf's infimum
+% \kappa_T; see the associated paper-gap note.
+\end{proof}
+
 \begin{theorem}[Noncommutative upper-triangular word bound]
     \label{thm:wolf_upper_triangular_word_bound}
     \lean{Matrix.wolf_eq_105_seminorm}

--- a/docs/paper-gaps/wolf_thm823_jordan_scaling_qualifications.tex
+++ b/docs/paper-gaps/wolf_thm823_jordan_scaling_qualifications.tex
@@ -45,11 +45,31 @@ The equality $\mu=0$ still does not imply emptiness: it means exactly that
 every subperipheral eigenvalue is zero.  A zero-eigenvalue Jordan block of
 dimension $D>1$ is nilpotent but its positive powers need not vanish for
 $1\le n<D$.  Consequently an upper bound by
-$C_2\mu^n n^{d_\mu-1}=0$ cannot hold in that range.  A qualified zero-modulus
-statement must either start at the nilpotence index or treat the finite initial
-range separately without the printed factor.  The zeroth power also requires
-an explicit convention for $0^0$ and does not belong to the positive-power
-argument at source lines~1247--1266.
+$C_2\mu^n n^{d_\mu-1}=0$ cannot hold in that range.  This phenomenon already
+occurs for the classical three-state transition which sends state~$1$ to
+itself, state~$2$ to state~$1$, and state~$3$ to state~$2$: its
+column-stochastic matrix is
+\begin{equation}
+  P=\begin{pmatrix}1&1&0\\0&0&1\\0&0&0\end{pmatrix}.
+\end{equation}
+Indeed, $P(e_3-e_1)=e_2-e_1\ne0$ and $P(e_2-e_1)=0$, which exhibits a
+size-two Jordan chain at zero.  The associated measure-and-prepare quantum
+channel is positive and trace preserving.  Its phase-weighted peripheral map
+kills this chain, so at $n=1$ the left side of Equation~(8.107) is nonzero
+while its printed right side is zero.  Thus this is not merely a boundary case
+outside the theorem's hypotheses.  A qualified zero-modulus statement must
+either start at the nilpotence index or treat the finite initial range
+separately without the printed factor.  The source's $n\in\mathbb N$ is used
+as a positive exponent in this proof; Lean's natural numbers include zero,
+whose zeroth power also requires an explicit $0^0$ convention and does not
+belong to the argument at source lines~1247--1266.
+
+For $0<\mu\le1$ and $d_\mu-1\le n$, the exact fixed-block consequence of
+Equation~(8.104) is formalized as
+\leanid{Matrix.l2_opNorm_jordanBlock_pow_polynomial_bounds} in
+\doclink{QICLean/Analysis/JordanBlockAsymptotics.lean}.  It proves the
+two-sided $\mu^n n^{d_\mu-1}$ scaling for one supplied block; it does not
+silently extend that formula across the zero-modulus boundary.
 
 \section{The block-diagonal comparison}
 
@@ -89,10 +109,12 @@ declaration does not assume a minimizing basis.
 \textbf{Verdict: source qualifications and missing Jordan-form
 infrastructure.}
 
-The shared modulus and the basis-level similarity inequality are proved.
-The full two-sided theorem still requires a constructive Jordan decomposition,
-largest-block data $d_\mu$, the direct-sum norm maximum, eventual dominance,
-and a justified passage to $\kappa_T$.  Until those dependencies are supplied,
+The shared modulus, the basis-level similarity inequality, and the
+positive-modulus single-block scaling are proved.  The full statement for
+$\widehat T^n-\widehat T_\varphi^n$ still requires a constructive Jordan
+decomposition, largest-block data $d_\mu$, the direct-sum norm maximum,
+eventual dominance, the zero-modulus/positive-exponent qualification, and a
+justified passage to $\kappa_T$.  Until those dependencies are supplied,
 Equations~(8.106)--(8.109) should not be marked formalized.  Tracking:
 \href{https://github.com/LionSR/QICLean/issues/297}{QICLean issue \#297}.
 

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -2,7 +2,8 @@
 
 Concordance between formalized declarations and the theorem/proposition
 numbering of M. Wolf, *Quantum Channels & Operations: Guided Tour* (2012),
-Chapters 2 and 6. This table used to live as compiled Lean documentation
+Chapters 2, 6, and the currently compiled Chapter 8 prerequisites. This table
+used to live as compiled Lean documentation
 modules (`WolfChapter2Index.lean`, `WolfChapter6Index.lean`,
 `WolfChapter6Wrappers.lean`); those modules carried zero declarations of
 mathematical content beyond two dead re-export theorems, so the concordance
@@ -1296,3 +1297,43 @@ clause 3.
 
 The assembled quantum Perron–Frobenius theorem for transfer maps lives in the
 tensor-network layer; it is indexed in `TNLean.Wielandt.WolfChapter6TNIndex`.
+
+---
+
+## Wolf Lecture Notes — Chapter 8: Distance measures and convergence
+
+### Equation 8.104 (Jordan-block power estimate) — FORMALIZED
+
+In `QICLean.Analysis.JordanBlockPower`:
+
+* `Matrix.jordanBlock_pow` gives the truncated binomial expansion of a Jordan
+  block power.
+* `Matrix.l2_opNorm_jordanBlock_pow_bounds` gives the two-sided operator-norm
+  estimate in Equation (8.104), with its lower and upper halves also
+  exposed separately.
+
+### Theorem “Asymptotic convergence I” (Equations 8.106–8.109) — PREREQUISITES FORMALIZED
+
+The full channel theorem is not yet formalized. The following compiled,
+source-shaped prerequisites are available:
+
+* `Module.End.subperipheralModulus` in
+  `QICLean.Analysis.SubperipheralSpectrum` is Wolf's largest subperipheral
+  modulus `μ`, totalized to zero for an empty subperipheral spectrum; the same
+  module proves attainment and strict inequality `μ < 1` in the nonempty case.
+* `Matrix.l2_opNorm_pow_similarity_bounds` in
+  `QICLean.Analysis.JordanSimilarity` proves Equation (8.108) for one chosen
+  similarity, retaining its actual condition factor rather than replacing it
+  by the infimum `κ_T` without an attainment or limiting argument.
+* `Matrix.l2_opNorm_jordanBlock_pow_polynomial_bounds` in
+  `QICLean.Analysis.JordanBlockAsymptotics` derives the two-sided
+  `μ^n n^(d_μ-1)` scaling for one supplied positive-modulus block in the
+  source range `d_μ - 1 ≤ n`.
+
+The remaining obligations for the norm of
+`T̂^n - T̂_ϕ^n` are a Jordan-form existence/decomposition API, largest-block
+data, the direct-sum eventual-maximum argument, the `μ = 0`/positive-exponent
+qualification, and a justified passage to Wolf's `κ_T` infimum. These are
+recorded in
+`docs/paper-gaps/wolf_thm823_jordan_scaling_qualifications.tex`; issue #297
+therefore remains open.


### PR DESCRIPTION
## Summary
- formalize the fixed-Jordan-block estimate used in Wolf Eq. (8.104) and the asymptotic argument around Eqs. (8.106)--(8.108)
- prove explicit lower and upper bounds of order `‖a‖ⁿ n^(D - 1)` under the exact nonzero-modulus and sufficiently-large-`n` hypotheses
- document the unformalized global Jordan-normal-form passage, including the `μ = 0` nilpotent case and the source inequality-direction issue, instead of silently inventing that proof route
- sync the Blueprint declarations, proof dependencies, coverage, and paper-gap record

This is the source-faithful fixed-block prerequisite only. Jordan decomposition, blockwise maxima/eventual dominance, zero-modulus nilpotence, and the `κ` infimum passage remain open.

Refs #297

## Source
- `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, around Eq. (8.104) and Eqs. (8.106)--(8.108)

## Validation
- `lake build QICLean.Analysis.JordanBlockAsymptotics -q --log-level=info`
- Blueprint declaration sync: 1948/1948
- Blueprint reader-prose and paper-gap checks
- `lake exe lint_style`
- import-aggregator, oversized-file, numbered-declaration, forbidden-placeholder, and diff checks
- new source-facing theorem axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`
