### PR TITLE
feat(channel): formalize source-general Wolf Corollary 6.6

### DIFF
--- a/QICLean/Channel/FixedPoint.lean
+++ b/QICLean/Channel/FixedPoint.lean
@@ -9,6 +9,7 @@ Authors: QICLean contributors
 -- Generated aggregator module: QICLean.Channel.FixedPoint
 
 import QICLean.Channel.FixedPoint.AbstractAlgebra
+import QICLean.Channel.FixedPoint.AbstractCornerFixedPoints
 import QICLean.Channel.FixedPoint.Algebra
 import QICLean.Channel.FixedPoint.BlockForm
 import QICLean.Channel.FixedPoint.BrouwerDensityMatrices

--- a/QICLean/Channel/FixedPoint/AbstractCornerFixedPoints.lean
+++ b/QICLean/Channel/FixedPoint/AbstractCornerFixedPoints.lean
@@ -1,0 +1,316 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Channel.FixedPoint.AbstractAlgebra
+import QICLean.Channel.FixedPoint.CornerAlgebra
+import QICLean.Channel.FixedPoint.SupportCompressedDensityBlocks
+
+/-!
+# Support-corner fixed points for positive maps
+
+This file proves Wolf Corollary 6.6 under the hypotheses printed in the
+source: `T` is positive and trace preserving, and its trace adjoint satisfies
+the Schwarz inequality. No Kraus representation or complete positivity is
+assumed.
+
+For a positive-semidefinite stationary matrix `ρ`, let `Q` be its support
+projection. The corner-restricted adjoint fixed points
+`{Y ∈ Q M_D(ℂ) Q | Q T*(Y) Q = Y}` form a star-subalgebra of the corner
+algebra. Wolf states the result for a maximum-rank stationary point; the proof
+here works for every positive-semidefinite stationary point, and hence includes
+that source case.
+
+The multiplication proof follows Wolf exactly: compress `T` to the support of
+`ρ`, identify the displayed set with the fixed points of the compressed trace
+adjoint, apply the full-support Schwarz fixed-point algebra theorem, and extend
+the product back through the support isometry.
+
+## Main declarations
+
+* `IsPositiveMap.stationaryCornerAdjointFixedPointsStarSubalgebra`: Wolf
+  Corollary 6.6 and Equation (6.61), under the source hypotheses.
+* `IsPositiveMap.mem_stationaryCornerAdjointFixedPointsStarSubalgebra`: the
+  exact displayed membership condition in Equation (6.61).
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.6 and
+  Equation (6.61); local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1423--1437.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+noncomputable section
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+namespace IsPositiveMap
+
+/-- Multiplication closure for the support-corner fixed points of the trace
+adjoint of a positive trace-preserving map whose trace adjoint is Schwarz.
+
+The proof is the support-compression route in Wolf Corollary 6.6: the
+compressed map has a positive-definite stationary point, so Wolf Theorem 6.12
+applies to its trace adjoint. Source: local Wolf TeX, lines 1423--1437. -/
+theorem stationaryCornerAdjointFixed_mul
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {ρ : Mat} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ)
+    {Y₁ Y₂ : Mat}
+    (hY₁mem : Kraus.stationaryProj hρ * Y₁ * Kraus.stationaryProj hρ = Y₁)
+    (hY₂mem : Kraus.stationaryProj hρ * Y₂ * Kraus.stationaryProj hρ = Y₂)
+    (hY₁fix : Kraus.stationaryProj hρ * Matrix.traceAdjointMap T Y₁ *
+      Kraus.stationaryProj hρ = Y₁)
+    (hY₂fix : Kraus.stationaryProj hρ * Matrix.traceAdjointMap T Y₂ *
+      Kraus.stationaryProj hρ = Y₂) :
+    Kraus.stationaryProj hρ * Matrix.traceAdjointMap T (Y₁ * Y₂) *
+      Kraus.stationaryProj hρ = Y₁ * Y₂ := by
+  classical
+  let Q : Mat := Kraus.stationaryProj hρ
+  obtain ⟨n, V, hV, hVrange⟩ :=
+    (Kraus.isOrthogonalProjection_stationaryProj hρ).exists_range_isometry
+  let T' : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] Matrix (Fin n) (Fin n) ℂ :=
+    stationarySupportCompression T V
+  let E : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] Matrix (Fin n) (Fin n) ℂ :=
+    Matrix.traceAdjointMap T'
+  have hT'pos : IsPositiveMap T' :=
+    stationarySupportCompression_isPositiveMap hT V
+  have hT'tp : IsTracePreservingMap T' :=
+    stationarySupportCompression_isTracePreservingMap
+      hT hTP hρ hρfix V hV hVrange
+  have hEpos : IsPositiveMap E := hT'pos.traceAdjointMap
+  have hESchwarz : IsSchwarzMap E := by
+    simpa only [E, T'] using
+      hSchwarz.traceAdjointMap_stationarySupportCompression hT V hV
+  obtain ⟨σ, hσpd, hσfix⟩ :=
+    exists_posDef_fixedPoint_stationarySupportCompression
+      hρ hρfix V hV hVrange
+  have hσEfix : Matrix.traceAdjointMap E σ = σ := by
+    change Matrix.traceAdjointMap (Matrix.traceAdjointMap T') σ = σ
+    rw [Matrix.traceAdjointMap_traceAdjointMap]
+    simpa only [T'] using hσfix
+  have hEapply (X : Matrix (Fin n) (Fin n) ℂ) :
+      E X = Vᴴ * Matrix.traceAdjointMap T (V * X * Vᴴ) * V := by
+    change Matrix.traceAdjointMap T' X = _
+    rw [Matrix.traceAdjointMap_stationarySupportCompression]
+    rfl
+  have hexpand {Y : Mat} (hY : Q * Y * Q = Y) :
+      V * (Vᴴ * Y * V) * Vᴴ = Y := by
+    calc
+      V * (Vᴴ * Y * V) * Vᴴ = (V * Vᴴ) * Y * (V * Vᴴ) := by
+        simp only [Matrix.mul_assoc]
+      _ = Q * Y * Q := by rw [hVrange]
+      _ = Y := hY
+  have hcompressFixed {Y : Mat}
+      (hYmem : Q * Y * Q = Y)
+      (hYfix : Q * Matrix.traceAdjointMap T Y * Q = Y) :
+      E (Vᴴ * Y * V) = Vᴴ * Y * V := by
+    rw [hEapply]
+    rw [hexpand hYmem]
+    calc
+      Vᴴ * Matrix.traceAdjointMap T Y * V =
+          Vᴴ * (Q * Matrix.traceAdjointMap T Y * Q) * V := by
+        rw [show Q = V * Vᴴ by simpa only [Q] using hVrange.symm]
+        calc
+          Vᴴ * Matrix.traceAdjointMap T Y * V =
+              (Vᴴ * V) * Vᴴ * Matrix.traceAdjointMap T Y * V * (Vᴴ * V) := by
+            rw [hV]
+            simp
+          _ = Vᴴ * ((V * Vᴴ) * Matrix.traceAdjointMap T Y * (V * Vᴴ)) * V := by
+            simp only [Matrix.mul_assoc]
+      _ = Vᴴ * Y * V := by rw [hYfix]
+  let X₁ : Matrix (Fin n) (Fin n) ℂ := Vᴴ * Y₁ * V
+  let X₂ : Matrix (Fin n) (Fin n) ℂ := Vᴴ * Y₂ * V
+  have hX₁fix : E X₁ = X₁ := by
+    simpa only [X₁] using hcompressFixed hY₁mem hY₁fix
+  have hX₂fix : E X₂ = X₂ := by
+    simpa only [X₂] using hcompressFixed hY₂mem hY₂fix
+  have hX₁₂fix : E (X₁ * X₂) = X₁ * X₂ :=
+    SchwarzMap.mul_mem_fixedPoints E hEpos hESchwarz hσpd hσEfix hX₁fix hX₂fix
+  have hQidem : Q * Q = Q := by
+    simpa only [Q] using (Kraus.isOrthogonalProjection_stationaryProj hρ).2
+  have hQY₁ : Q * Y₁ = Y₁ := by
+    conv_lhs => rw [← hY₁mem]
+    rw [← Matrix.mul_assoc, ← Matrix.mul_assoc, hQidem]
+    exact hY₁mem
+  have hY₂Q : Y₂ * Q = Y₂ := by
+    conv_lhs => rw [← hY₂mem]
+    rw [Matrix.mul_assoc, hQidem]
+    exact hY₂mem
+  have hY₁Q : Y₁ * Q = Y₁ := by
+    conv_lhs => rw [← hY₁mem]
+    rw [Matrix.mul_assoc, hQidem]
+    exact hY₁mem
+  have hmulExpand : V * (X₁ * X₂) * Vᴴ = Y₁ * Y₂ := by
+    dsimp only [X₁, X₂]
+    calc
+      V * ((Vᴴ * Y₁ * V) * (Vᴴ * Y₂ * V)) * Vᴴ =
+          (V * Vᴴ) * Y₁ * (V * Vᴴ) * Y₂ * (V * Vᴴ) := by
+        simp only [Matrix.mul_assoc]
+      _ = Q * Y₁ * Q * Y₂ * Q := by rw [hVrange]
+      _ = Y₁ * Y₂ := by
+        calc
+          Q * Y₁ * Q * Y₂ * Q = (Q * Y₁) * Q * (Y₂ * Q) := by
+            simp only [Matrix.mul_assoc]
+          _ = Y₁ * Y₂ := by rw [hQY₁, hY₁Q, hY₂Q]
+  calc
+    Q * Matrix.traceAdjointMap T (Y₁ * Y₂) * Q =
+        (V * Vᴴ) * Matrix.traceAdjointMap T
+          (V * (X₁ * X₂) * Vᴴ) * (V * Vᴴ) := by
+      rw [hVrange, hmulExpand]
+    _ = V * (Vᴴ * Matrix.traceAdjointMap T
+          (V * (X₁ * X₂) * Vᴴ) * V) * Vᴴ := by
+      simp only [Matrix.mul_assoc]
+    _ = V * E (X₁ * X₂) * Vᴴ := by rw [hEapply]
+    _ = V * (X₁ * X₂) * Vᴴ := by rw [hX₁₂fix]
+    _ = Y₁ * Y₂ := hmulExpand
+
+/-- The support projection is the unit of the support-corner adjoint fixed
+points. This is unitality of the trace adjoint after stationary-support
+compression. -/
+theorem stationaryCornerAdjointFixed_one
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    {ρ : Mat} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ) :
+    Kraus.stationaryProj hρ *
+        Matrix.traceAdjointMap T (Kraus.stationaryProj hρ) *
+      Kraus.stationaryProj hρ = Kraus.stationaryProj hρ := by
+  classical
+  let Q : Mat := Kraus.stationaryProj hρ
+  obtain ⟨n, V, hV, hVrange⟩ :=
+    (Kraus.isOrthogonalProjection_stationaryProj hρ).exists_range_isometry
+  let T' : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] Matrix (Fin n) (Fin n) ℂ :=
+    stationarySupportCompression T V
+  have hT'tp : IsTracePreservingMap T' :=
+    stationarySupportCompression_isTracePreservingMap
+      hT hTP hρ hρfix V hV hVrange
+  have hEone : Matrix.traceAdjointMap T' (1 : Matrix (Fin n) (Fin n) ℂ) = 1 :=
+    isTracePreservingMap_iff_traceAdjointMap_one.mp hT'tp
+  have hEapply :
+      Matrix.traceAdjointMap T' (1 : Matrix (Fin n) (Fin n) ℂ) =
+        Vᴴ * Matrix.traceAdjointMap T
+          (V * (1 : Matrix (Fin n) (Fin n) ℂ) * Vᴴ) * V := by
+    rw [Matrix.traceAdjointMap_stationarySupportCompression]
+    rfl
+  change Kraus.stationaryProj hρ *
+      Matrix.traceAdjointMap T (Kraus.stationaryProj hρ) *
+    Kraus.stationaryProj hρ = Kraus.stationaryProj hρ
+  rw [← hVrange]
+  calc
+    (V * Vᴴ) * Matrix.traceAdjointMap T (V * Vᴴ) * (V * Vᴴ) =
+        V * (Vᴴ * Matrix.traceAdjointMap T
+          (V * (1 : Matrix (Fin n) (Fin n) ℂ) * Vᴴ) * V) * Vᴴ := by
+      simp [Matrix.mul_assoc]
+    _ = V * Matrix.traceAdjointMap T'
+          (1 : Matrix (Fin n) (Fin n) ℂ) * Vᴴ := by rw [hEapply]
+    _ = V * (1 : Matrix (Fin n) (Fin n) ℂ) * Vᴴ := by rw [hEone]
+    _ = V * Vᴴ := by rw [Matrix.mul_one]
+
+/-- **Wolf Corollary 6.6, Equation (6.61).**
+
+Let `T` be positive and trace preserving, with Schwarz trace adjoint, and let
+`Q` be the support projection of a positive-semidefinite stationary matrix
+`ρ`. Then
+`{Y ∈ Q M_D(ℂ) Q | Q T*(Y) Q = Y}` is a star-subalgebra of the corner
+algebra `Q M_D(ℂ) Q`.
+
+Wolf chooses `ρ` of maximum rank. The support-compression proof only uses that
+`ρ` is positive semidefinite and stationary, so this statement strengthens the
+choice of support while retaining exactly the source hypotheses on `T`. No
+complete positivity or Kraus representation is assumed. -/
+noncomputable def stationaryCornerAdjointFixedPointsStarSubalgebra
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {ρ : Mat} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ) :
+    letI hQ : IsIdempotentElem (Kraus.stationaryProj hρ) :=
+      (Kraus.isOrthogonalProjection_stationaryProj hρ).2
+    letI : Semiring hQ.Corner := instSemiringCorner _ hQ
+    letI : Algebra ℂ hQ.Corner := MatrixCorner.instAlgebraComplexCorner hQ
+    letI : Star hQ.Corner := MatrixCorner.cornerStar hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hρ).1.eq
+    letI : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hρ).1.eq
+    letI : StarModule ℂ hQ.Corner := MatrixCorner.cornerStarModuleComplex hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hρ).1.eq
+    StarSubalgebra ℂ hQ.Corner :=
+  letI hQ : IsIdempotentElem (Kraus.stationaryProj hρ) :=
+    (Kraus.isOrthogonalProjection_stationaryProj hρ).2
+  letI : Semiring hQ.Corner := instSemiringCorner _ hQ
+  letI : Algebra ℂ hQ.Corner := MatrixCorner.instAlgebraComplexCorner hQ
+  letI : Star hQ.Corner := MatrixCorner.cornerStar hQ
+    (Kraus.isOrthogonalProjection_stationaryProj hρ).1.eq
+  letI : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+    (Kraus.isOrthogonalProjection_stationaryProj hρ).1.eq
+  letI : StarModule ℂ hQ.Corner := MatrixCorner.cornerStarModuleComplex hQ
+    (Kraus.isOrthogonalProjection_stationaryProj hρ).1.eq
+  let Q : Mat := Kraus.stationaryProj hρ
+  have hQherm : Qᴴ = Q :=
+    (Kraus.isOrthogonalProjection_stationaryProj hρ).1.eq
+  { carrier := {Y : hQ.Corner |
+      Q * Matrix.traceAdjointMap T Y.1 * Q = Y.1}
+    zero_mem' := by
+      change Q * Matrix.traceAdjointMap T (0 : Mat) * Q = (0 : Mat)
+      simp
+    add_mem' := by
+      intro X Y hX hY
+      change Q * Matrix.traceAdjointMap T (X.1 + Y.1) * Q = X.1 + Y.1
+      rw [map_add, Matrix.mul_add, Matrix.add_mul, hX, hY]
+    one_mem' := by
+      change Q * Matrix.traceAdjointMap T Q * Q = Q
+      exact stationaryCornerAdjointFixed_one hT hTP hρ hρfix
+    mul_mem' := by
+      intro X Y hX hY
+      change Q * Matrix.traceAdjointMap T (X.1 * Y.1) * Q = X.1 * Y.1
+      have hXmem : Q * X.1 * Q = X.1 := by
+        obtain ⟨hL, hR⟩ := (Subsemigroup.mem_corner_iff hQ).mp X.2
+        rw [Matrix.mul_assoc, hR, hL]
+      have hYmem : Q * Y.1 * Q = Y.1 := by
+        obtain ⟨hL, hR⟩ := (Subsemigroup.mem_corner_iff hQ).mp Y.2
+        rw [Matrix.mul_assoc, hR, hL]
+      exact stationaryCornerAdjointFixed_mul
+        hT hTP hSchwarz hρ hρfix hXmem hYmem hX hY
+    algebraMap_mem' := by
+      intro c
+      change Q * Matrix.traceAdjointMap T (c • Q) * Q = c • Q
+      rw [map_smul, Matrix.mul_smul, Matrix.smul_mul,
+        stationaryCornerAdjointFixed_one hT hTP hρ hρfix]
+    star_mem' := by
+      intro X hX
+      change Q * Matrix.traceAdjointMap T X.1ᴴ * Q = X.1ᴴ
+      rw [hT.traceAdjointMap.map_conjTranspose]
+      have h := congrArg Matrix.conjTranspose hX
+      simpa [Matrix.conjTranspose_mul, hQherm, Matrix.mul_assoc] using h }
+
+/-- Membership in the source-general corner fixed-point star-algebra is exactly
+the displayed condition `Q T*(Y) Q = Y` of Wolf Equation (6.61). -/
+@[simp] theorem mem_stationaryCornerAdjointFixedPointsStarSubalgebra
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {ρ : Mat} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ)
+    (hQ : IsIdempotentElem (Kraus.stationaryProj hρ) :=
+      (Kraus.isOrthogonalProjection_stationaryProj hρ).2)
+    (Y : hQ.Corner) :
+    letI : Semiring hQ.Corner := instSemiringCorner _ hQ
+    letI : Algebra ℂ hQ.Corner := MatrixCorner.instAlgebraComplexCorner hQ
+    letI : Star hQ.Corner := MatrixCorner.cornerStar hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hρ).1.eq
+    letI : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hρ).1.eq
+    letI : StarModule ℂ hQ.Corner := MatrixCorner.cornerStarModuleComplex hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hρ).1.eq
+    Y ∈ stationaryCornerAdjointFixedPointsStarSubalgebra
+      hT hTP hSchwarz hρ hρfix ↔
+      Kraus.stationaryProj hρ * Matrix.traceAdjointMap T Y.1 *
+        Kraus.stationaryProj hρ = Y.1 :=
+  Iff.rfl
+
+end IsPositiveMap

--- a/QICLean/Channel/FixedPoint/AbstractCornerFixedPoints.lean
+++ b/QICLean/Channel/FixedPoint/AbstractCornerFixedPoints.lean
@@ -22,7 +22,8 @@ algebra. Wolf states the result for a maximum-rank stationary point; the proof
 here works for every positive-semidefinite stationary point, and hence includes
 that source case.
 
-The multiplication proof follows Wolf exactly: compress `T` to the support of
+The multiplication proof follows the support-compression route of Wolf
+Corollary 6.6: compress `T` to the support of
 `ρ`, identify the displayed set with the fixed points of the compressed trace
 adjoint, apply the full-support Schwarz fixed-point algebra theorem, and extend
 the product back through the support isometry.

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -265,8 +265,7 @@ channel-level argument below uses its Kraus analogue.
 
 This subsection establishes the results on the corner algebra,
 $*$-structure, and compression of a PSD fixed point onto its support sector
-needed for the completely positive finite-Kraus specialization of
-\cite[Corollary~6.6]{Wolf2012Quantum}: the corner carries a
+used in \cite[Corollary~6.6]{Wolf2012Quantum}: the corner carries a
 $\C$-algebra and $*$-structure, the two standard presentations of the corner
 are identified, and the compression of a PSD fixed point onto its support
 sector is positive definite.
@@ -407,48 +406,37 @@ sector is positive definite.
 
 \begin{theorem}[Corner-restricted fixed points form a $*$-algebra]%
     \label{thm:cornerFixedPointsStarSubalgebra}
-    \lean{Kraus.cornerFixedPointsStarSubalgebra}
+    \lean{IsPositiveMap.stationaryCornerAdjointFixedPointsStarSubalgebra}
     \leanok
-    \uses{thm:compression_on_support_posDef, rem:corner_algebra_star_instances,
-        thm:adjointFixedPointsStarSubalgebra, thm:support_proj_fixed}
-    Let $T(X)=\sum_iK_iXK_i^\dagger$ be a trace-preserving finite Kraus map,
-    with adjoint $T^*(Y)=\sum_iK_i^\dagger YK_i$. Let $\rho\succeq0$ satisfy
+    \uses{thm:stationarySupport_compression, rem:corner_algebra_star_instances,
+        thm:fixedPointsStarSubalgebra}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, and suppose
+    that $T^*$ satisfies the Schwarz inequality. Let $\rho\succeq0$ satisfy
     $T(\rho)=\rho$, and let $Q=\supp(\rho)$. Then
     \begin{align}
         \{Y\in Q\MN{D}Q\mid QT^*(Y)Q=Y\}
         \label{eq:spectral_corner_fixed_set}
     \end{align}
-    is a $*$-subalgebra of the corner algebra $Q\MN{D}Q$. Within the
-    finite-Kraus setting, this strengthens the maximum-rank-fixed-point case
-    by allowing an arbitrary positive semidefinite fixed point. At maximum
-    rank it gives the completely positive finite-Kraus specialization of
-    \cite[Corollary~6.6]{Wolf2012Quantum}, whose hypothesis is an abstract
-    unital Schwarz map.
-    % Scope restriction (finite Kraus family): see
-    % docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex.
+    is a $*$-subalgebra of the corner algebra $Q\MN{D}Q$. Wolf chooses a
+    maximum-rank fixed point; the formal theorem strengthens the support
+    choice to an arbitrary PSD fixed point while retaining exactly the
+    source assumptions on $T$. This is
+    \cite[Corollary~6.6 and Equation~(6.61)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:supported_kraus_corner_compression,
-        thm:compression_on_support_posDef, thm:adjointFixedPointsStarSubalgebra,
-        thm:support_proj_fixed}
+    \uses{thm:stationarySupport_compression,
+        thm:fixedPointsStarSubalgebra}
     The set in (\ref{eq:spectral_corner_fixed_set}) is the fixed-point set
-    of the compressed map $\widetilde{T}^*$ on the support sector. Since
-    $\rho$ is fixed by $T$, Theorem~\ref{thm:support_proj_fixed} gives
-    $(\Id-Q)K_iQ=0$, so the compressed family $QK_iQ$ is supported on the
-    corner and is trace-preserving there:
-    $\sum_i(QK_iQ)^\dagger(QK_iQ)=Q$.
-    Theorem~\ref{thm:supported_kraus_corner_compression} compresses this
-    family to a unital map on the support sector, while the compression of
-    $\rho$ is a positive-definite fixed point by
-    Theorem~\ref{thm:compression_on_support_posDef}. The structure theorem
-    for fixed points of unital Schwarz maps with a positive-definite fixed
-    point (Theorem~\ref{thm:adjointFixedPointsStarSubalgebra}) makes the
-    compressed fixed points a $*$-algebra. The compression isomorphism is
-    multiplicative and star-preserving, intertwines the compressed adjoint
-    map with the corner-restricted map, and transports this structure back
-    to the corner.
+    of the compressed map $\widetilde{T}^*$ on the support sector.
+    The stationary-support compression is positive and trace preserving,
+    its adjoint remains Schwarz, and the compression of $\rho$ is positive
+    definite. Theorem~\ref{thm:fixedPointsStarSubalgebra} therefore makes
+    $\Fix(\widetilde{T}^*)$ a $*$-algebra. Compression by the support
+    isometry identifies products and adjoints in that algebra with products
+    and adjoints in $Q\MN{D}Q$, and the trace-adjoint compression identity
+    identifies its fixed equation with $QT^*(Y)Q=Y$.
 \end{proof}
 
 \section{Wedderburn decomposition of the fixed-point algebra}

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -406,10 +406,10 @@ sector is positive definite.
 
 \begin{theorem}[Corner-restricted fixed points form a $*$-algebra]%
     \label{thm:cornerFixedPointsStarSubalgebra}
-    \lean{IsPositiveMap.stationaryCornerAdjointFixedPointsStarSubalgebra}
+    \lean{IsPositiveMap.stationaryCornerAdjointFixedPointsStarSubalgebra,
+        IsPositiveMap.mem_stationaryCornerAdjointFixedPointsStarSubalgebra}
     \leanok
-    \uses{thm:stationarySupport_compression, rem:corner_algebra_star_instances,
-        thm:fixedPointsStarSubalgebra}
+    \uses{rem:corner_algebra_star_instances}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, and suppose
     that $T^*$ satisfies the Schwarz inequality. Let $\rho\succeq0$ satisfy
     $T(\rho)=\rho$, and let $Q=\supp(\rho)$. Then

--- a/docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex
+++ b/docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex
@@ -17,7 +17,7 @@
 \section{The assertion}
 
 Corollary 6.6 of \emph{Quantum Channels \& Operations} (Wolf 2012), stated at
-lines 1380--1510 of \texttt{Notes/WolfNoteTexSource/ch06\_spectral\_properties.tex},
+lines 1423--1437 of \texttt{Notes/WolfNoteTexSource/ch06\_spectral\_properties.tex},
 concerns a positive trace-preserving linear map $T$ on $M_D(\mathbb{C})$ whose trace
 adjoint $T^{*}$ is unital and satisfies the Schwarz inequality. For a maximum-rank
 positive semidefinite fixed point $\rho$ of $T$ with support projection $Q$, the corner-restricted

--- a/docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex
+++ b/docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex
@@ -6,21 +6,21 @@
 
 \input{command}
 
-\title{Complete Positivity in the Projected Support Corner Star-Algebra}
+\title{Source-General Projected Support Corner Star-Algebra}
 \author{}
 \date{2026-07-30}
 
 \begin{document}
 \maketitle
-\gapnote{scope-restriction}{open}
+\gapnote{scope-restriction}{resolved}
 
 \section{The assertion}
 
 Corollary 6.6 of \emph{Quantum Channels \& Operations} (Wolf 2012), stated at
 lines 1380--1510 of \texttt{Notes/WolfNoteTexSource/ch06\_spectral\_properties.tex},
 concerns a positive trace-preserving linear map $T$ on $M_D(\mathbb{C})$ whose trace
-adjoint $T^{*}$ is unital and satisfies the Schwarz inequality. For a positive
-semidefinite fixed point $\rho$ of $T$ with support projection $Q$, the corner-restricted
+adjoint $T^{*}$ is unital and satisfies the Schwarz inequality. For a maximum-rank
+positive semidefinite fixed point $\rho$ of $T$ with support projection $Q$, the corner-restricted
 fixed-point set
 \[
     \{\, Y \in Q\,M_D(\mathbb{C})\,Q \;\mid\; Q\,T^{*}(Y)\,Q = Y \,\}
@@ -32,36 +32,43 @@ not as part of the hypothesis. The Schwarz inequality for the adjoint is strictl
 every completely positive unital map satisfies it, but positive maps that are not
 completely positive can satisfy it as well.
 
-\section{The restriction in the formalization}
+\section{The former restriction}
 
-The available Lean statement is \leanid{Kraus.cornerFixedPointsStarSubalgebra}, with the
+The earlier Lean statement was \leanid{Kraus.cornerFixedPointsStarSubalgebra}, with the
 membership characterization \leanid{Kraus.mem\_cornerFixedPointsStarSubalgebra}, both in
 \texttt{QICLean/Channel/FixedPoint/CornerFixedPoints.lean}. Its hypotheses are a family
 $K$ of Kraus operators with \leanid{IsTP} $K$ and a positive semidefinite fixed point of
 the induced map. Presenting the map by a Kraus family assumes complete positivity, so the
-Lean hypothesis set is strictly stronger than the source's. Under the repository
-faithfulness rule this declaration establishes the completely positive case of
-Corollary 6.6 and is not a formalization of the corollary itself.
+Lean hypothesis set there is strictly stronger than the source's. That declaration
+therefore remains a completely positive specialization rather than the source-facing
+formalization of Corollary 6.6.
 
-The corresponding Blueprint entry states the Kraus form explicitly in its hypotheses, so
-its \leanid{\textbackslash leanok} is honest for the restricted statement; it must not be
-read as the unrestricted corollary. The analogous restriction for Corollary 6.7 is
-recorded separately in \texttt{wolf\_cor67\_maximal\_support\_restriction.tex}.
+The analogous restriction for Corollary 6.7 is recorded separately in
+\texttt{wolf\_cor67\_maximal\_support\_restriction.tex}.
 
-\section{Elimination plan}
+\section{Resolution}
 
-No further material is needed from the source: the corollary is stated in full at the
-lines cited above, and the machinery to express its hypothesis without Kraus data already
-exists. The multiplicative domain of a bare linear map
-$E : M_D(\mathbb{C}) \to M_D(\mathbb{C})$ is available as \leanid{multiplicativeDomain} in
-\texttt{QICLean/Channel/Schwarz/AbstractMultiplicativeDomain.lean}, together with its
-membership characterization, so the Schwarz hypothesis can be carried directly.
+The source-general statement is
+\leanid{IsPositiveMap.stationaryCornerAdjointFixedPointsStarSubalgebra}, with membership
+characterization
+\leanid{IsPositiveMap.mem\_stationaryCornerAdjointFixedPointsStarSubalgebra}, in
+\texttt{QICLean/Channel/FixedPoint/AbstractCornerFixedPoints.lean}. Its hypotheses are
+exactly positivity and trace preservation of $T$ and the Schwarz inequality for $T^*$;
+it does not assume a Kraus representation or complete positivity. The declaration works
+for every positive semidefinite fixed point, and therefore includes the source's
+maximum-rank choice.
 
-The elimination is therefore to restate the corollary for a positive trace-preserving map
-whose trace adjoint is unital and Schwarz, discharging it through the general support
-compression and the now-available Theorem 6.14, and then to recover the present Kraus
-declarations as specializations rather than maintaining a parallel development. The
-source-general statement is the one that may carry a source-facing Blueprint entry for
-Corollary 6.6.
+The proof follows Wolf's lines 1433--1437. It compresses $T$ to the support of $\rho$;
+the compression is positive and trace preserving, has a positive-definite fixed point,
+and its trace adjoint remains Schwarz. Hence the abstract fixed-point algebra theorem
+\leanid{SchwarzMap.fixedPointsStarSubalgebra} applies. Extension through the support
+isometry transports multiplication back to the corner, while the trace-adjoint
+compression identity identifies the compressed fixed equation with $QT^*(Y)Q=Y$.
+
+\section{Verdict}
+
+The complete-positivity restriction is eliminated for Corollary 6.6. The Blueprint and
+numbering coverage now point to the source-general declaration; the Kraus declarations
+remain documented specializations.
 
 \end{document}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -973,29 +973,27 @@ In `QICLean.Channel.FixedPoint.StationarySpan`:
   Wolf Corollary 6.5: when the fixed-point subspace has dimension `r`, there
   exist `r` linearly independent stationary density matrices spanning it.
 
-#### Wolf Corollary 6.6 (projected support corner) — FORMALIZED (Kraus case)
+#### Wolf Corollary 6.6 (projected support corner) — FORMALIZED
 
-Wolf states the corollary for a positive trace-preserving map whose trace
-adjoint is unital and satisfies the Schwarz inequality; complete positivity is
-an example there, not a hypothesis. The declarations below assume a
-trace-preserving Kraus family, so they establish the completely positive case
-only.
+In `QICLean.Channel.FixedPoint.AbstractCornerFixedPoints`:
 
-In `QICLean.Channel.FixedPoint.CornerFixedPoints`:
-
-* `Kraus.cornerFixedPointsStarSubalgebra` — for a trace-preserving Schwarz map
-  `T* = adjointMap K` (unitality of `T*` is `IsTP K`) and a PSD fixed point `ρ`
-  of `T = map K` with support projection `Q := stationaryProj`, the
+* `IsPositiveMap.stationaryCornerAdjointFixedPointsStarSubalgebra` — for a
+  positive trace-preserving map `T` whose trace adjoint is Schwarz, and a PSD
+  fixed point `ρ` with support projection `Q := stationaryProj`, the
   corner-restricted fixed-point set `{Y ∈ Q M_D(ℂ) Q | Q T*(Y) Q = Y}` is a
   `StarSubalgebra` of the corner algebra `Q M_D(ℂ) Q`.
-* `Kraus.mem_cornerFixedPointsStarSubalgebra` — membership is exactly the
-  corner fixed-point condition `Q (adjointMap K Y) Q = Y`.
+* `IsPositiveMap.mem_stationaryCornerAdjointFixedPointsStarSubalgebra` —
+  membership is exactly the displayed corner fixed-point condition of Wolf
+  Equation (6.61).
 
-The proof compresses the supported family `Q Kᵢ Q` to the support sector via
-`exists_compressedTensor_of_supported_projection_with_letter_and_isometry`,
-where the compressed map is unital with a positive-definite fixed point, applies
-Wolf Theorem 6.12 there (`Kraus.adjointFixedPointsStarSubalgebra`), and transports
-the `*`-algebra structure back along the compression isomorphism.
+These are the source hypotheses: positivity and trace preservation of `T`,
+and the Schwarz inequality for `T*`; no Kraus representation or complete
+positivity is assumed. Wolf chooses a maximum-rank fixed point, while the Lean
+theorem proves the same conclusion for every PSD fixed point. The proof uses
+the source support-compression route and the abstract Wolf Theorem 6.12 fixed
+point algebra. The earlier declarations in
+`QICLean.Channel.FixedPoint.CornerFixedPoints` remain available as finite-Kraus
+specializations.
 
 #### Wolf Theorem 6.14 (density-block form of fixed points) — FORMALIZED
 


### PR DESCRIPTION
## Summary

- formalize Wolf Corollary 6.6 and Equation (6.61) from `Notes/WolfNoteTexSource/ch06_spectral_properties.tex` lines 1423--1437
- expose the corner fixed-point set as a star-subalgebra under exactly positivity and trace preservation of `T` plus the Schwarz inequality for its trace adjoint
- synchronize the Blueprint, Wolf numbering coverage, and the former Corollary 6.6 scope-gap note

Closes #393
Refs #39

## Source contract

The public theorem assumes `IsPositiveMap T`, `IsTracePreservingMap T`, and `IsSchwarzMap (Matrix.traceAdjointMap T)`. It does not assume complete positivity or a Kraus representation. Wolf chooses the projection onto a maximum-rank fixed point; the Lean theorem proves the same statement for every positive-semidefinite stationary point, hence includes the printed case.

## Proof route

This follows Wolf lines 1433--1437: compress `T` to the support of the stationary point, use the positive-definite compressed fixed point and the inherited Schwarz property to apply the abstract Wolf Theorem 6.12 fixed-point algebra result, then transport products through the support isometry. The trace-adjoint compression identity recovers the displayed equation `Q T*(Y) Q = Y`.

## Verification

- `lake build QICLean.Channel.FixedPoint.AbstractCornerFixedPoints -q --log-level=info`
- `lake exe lint_style`
- Blueprint--Lean synchronization and reverse coverage
- generated import aggregators, reader-facing prose, numbered-module policy, oversized-file guard, and diff check
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`

## Remaining scope

This closes the dedicated Corollary 6.6 subissue only. Source-general Corollary 6.7 remains #392, so parent issue #39 stays open.

Review request: audit the exact head against Wolf lines 1423--1437 and the positive + trace-preserving + Schwarz-adjoint hypothesis boundary.
