### PR TITLE
feat(topology): prove general compact-convex Brouwer theorem

### DIFF
--- a/QICLean/Topology.lean
+++ b/QICLean/Topology.lean
@@ -9,4 +9,5 @@ Authors: QICLean contributors
 -- Generated aggregator module: QICLean.Topology
 
 import QICLean.Topology.BrouwerProduct
+import QICLean.Topology.CompactConvexFixedPoint
 import QICLean.Topology.CompactRetractFixedPoint

--- a/QICLean/Topology/CompactConvexFixedPoint.lean
+++ b/QICLean/Topology/CompactConvexFixedPoint.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Topology.CompactRetractFixedPoint
+import Mathlib.Analysis.Calculus.LocalExtr.Basic
+import Mathlib.Analysis.Convex.Topology
+import Mathlib.Analysis.InnerProductSpace.Calculus
+import Mathlib.Topology.MetricSpace.HausdorffDistance
+
+/-!
+# Fixed points on compact convex sets
+
+This file proves the general compact-convex form of Brouwer's fixed-point
+result, Wolf Theorem 6.10. The source states the theorem but does not
+include a proof. We close the existing paper gap by the metric-projection route
+recorded in `docs/paper-gaps/wolf_brouwer_general_compact_convex.tex`.
+
+For a nonempty compact convex set `K` in a real inner-product space, a point
+minimizing squared distance exists by compactness. Its variational inequality
+implies that the resulting choice is unique implicitly (any two choices obey
+the same estimate), is `1`-Lipschitz, and restricts to the identity on `K`.
+It is therefore a continuous retraction, so
+`fixedPoint_of_compact_retract` applies.
+
+## Main definitions and results
+
+* `CompactConvex.metricProjection`: a nearest point of a nonempty compact set.
+* `CompactConvex.metricProjection_lipschitzWith`: convex metric projection is
+  `1`-Lipschitz.
+* `fixedPoint_of_compact_convex`: the coordinate-free compact-convex theorem.
+* `brouwer_fixedPoint_compactConvex`: Wolf Theorem 6.10 for
+  `S ⊆ Fin n → ℝ`.
+-/
+
+open scoped RealInnerProductSpace Topology
+
+namespace CompactConvex
+
+private theorem exists_metricProjection
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+    (K : Set E) (hK_comp : IsCompact K) (hK_ne : K.Nonempty) (x : E) :
+    ∃ p ∈ K, IsMinOn (fun z : E => ‖x - z‖ ^ 2) K p := by
+  exact hK_comp.exists_isMinOn hK_ne (by fun_prop)
+
+/-- A nearest point in a nonempty compact set, chosen by minimizing squared distance. -/
+noncomputable def metricProjection
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+    (K : Set E) (hK_comp : IsCompact K) (hK_ne : K.Nonempty) (x : E) : E :=
+  Classical.choose (exists_metricProjection K hK_comp hK_ne x)
+
+theorem metricProjection_mem
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+    (K : Set E) (hK_comp : IsCompact K) (hK_ne : K.Nonempty) (x : E) :
+    metricProjection K hK_comp hK_ne x ∈ K :=
+  (Classical.choose_spec (exists_metricProjection K hK_comp hK_ne x)).1
+
+theorem metricProjection_isMinOn
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+    (K : Set E) (hK_comp : IsCompact K) (hK_ne : K.Nonempty) (x : E) :
+    IsMinOn (fun z : E => ‖x - z‖ ^ 2) K (metricProjection K hK_comp hK_ne x) :=
+  (Classical.choose_spec (exists_metricProjection K hK_comp hK_ne x)).2
+
+/-- The variational inequality obeyed by a squared-distance minimizer on a convex set. -/
+theorem nearest_inner_nonpos
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+    {K : Set E} (hK_conv : Convex ℝ K) {x p y : E}
+    (hp : p ∈ K) (hmin : IsMinOn (fun z : E => ‖x - z‖ ^ 2) K p) (hy : y ∈ K) :
+    inner ℝ (x - p) (y - p) ≤ 0 := by
+  have htangent : y - p ∈ posTangentConeAt K p :=
+    sub_mem_posTangentConeAt_of_segment_subset (hK_conv.segment_subset hp hy)
+  have hderiv := ((hasFDerivAt_id p).const_sub x).norm_sq
+  have hnonneg :=
+    hmin.localize.hasFDerivWithinAt_nonneg hderiv.hasFDerivWithinAt htangent
+  have hxp : inner ℝ x (y - p) ≤ inner ℝ p (y - p) := by
+    simpa [smul_apply, ContinuousLinearMap.comp_apply] using hnonneg
+  rw [inner_sub_left]
+  exact sub_nonpos.mpr hxp
+
+/-- Metric projection onto a compact convex set is nonexpansive. -/
+theorem metricProjection_norm_sub_le
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+    (K : Set E) (hK_comp : IsCompact K) (hK_ne : K.Nonempty) (hK_conv : Convex ℝ K)
+    (x y : E) :
+    ‖metricProjection K hK_comp hK_ne x - metricProjection K hK_comp hK_ne y‖ ≤
+      ‖x - y‖ := by
+  let p := metricProjection K hK_comp hK_ne x
+  let q := metricProjection K hK_comp hK_ne y
+  have hp : p ∈ K := metricProjection_mem K hK_comp hK_ne x
+  have hq : q ∈ K := metricProjection_mem K hK_comp hK_ne y
+  have hx := nearest_inner_nonpos hK_conv hp
+    (metricProjection_isMinOn K hK_comp hK_ne x) hq
+  have hy := nearest_inner_nonpos hK_conv hq
+    (metricProjection_isMinOn K hK_comp hK_ne y) hp
+  have hx' : 0 ≤ inner ℝ (x - p) (p - q) := by
+    rw [show q - p = -(p - q) by abel, inner_neg_right] at hx
+    linarith
+  have hy' : inner ℝ (y - q) (p - q) ≤ 0 := hy
+  have hinner : ‖p - q‖ * ‖p - q‖ ≤ inner ℝ (x - y) (p - q) := by
+    rw [← real_inner_self_eq_norm_mul_norm]
+    rw [show x - y = (x - p) + (p - q) - (y - q) by abel]
+    nth_rewrite 2 [inner_sub_left]
+    rw [inner_add_left]
+    linarith
+  have hmul : ‖p - q‖ * ‖p - q‖ ≤ ‖x - y‖ * ‖p - q‖ :=
+    hinner.trans (real_inner_le_norm (x - y) (p - q))
+  change ‖p - q‖ ≤ ‖x - y‖
+  by_cases hpq : p = q
+  · simp [hpq]
+  · have hpq_pos : 0 < ‖p - q‖ := norm_pos_iff.mpr (sub_ne_zero.mpr hpq)
+    nlinarith
+
+theorem metricProjection_lipschitzWith
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+    (K : Set E) (hK_comp : IsCompact K) (hK_ne : K.Nonempty) (hK_conv : Convex ℝ K) :
+    LipschitzWith 1 (metricProjection K hK_comp hK_ne) := by
+  apply LipschitzWith.of_dist_le_mul
+  intro x y
+  simpa only [NNReal.coe_one, one_mul, dist_eq_norm] using
+    metricProjection_norm_sub_le K hK_comp hK_ne hK_conv x y
+
+theorem continuous_metricProjection
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+    (K : Set E) (hK_comp : IsCompact K) (hK_ne : K.Nonempty) (hK_conv : Convex ℝ K) :
+    Continuous (metricProjection K hK_comp hK_ne) :=
+  (metricProjection_lipschitzWith K hK_comp hK_ne hK_conv).continuous
+
+theorem metricProjection_eq_self
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+    {K : Set E} (hK_comp : IsCompact K) (hK_ne : K.Nonempty) (hK_conv : Convex ℝ K)
+    {x : E} (hx : x ∈ K) :
+    metricProjection K hK_comp hK_ne x = x := by
+  let p := metricProjection K hK_comp hK_ne x
+  have hp : p ∈ K := metricProjection_mem K hK_comp hK_ne x
+  have hinner : inner ℝ (x - p) (x - p) ≤ 0 :=
+    nearest_inner_nonpos hK_conv hp (metricProjection_isMinOn K hK_comp hK_ne x) hx
+  have hzero : x - p = 0 := real_inner_self_nonpos.mp hinner
+  exact (sub_eq_zero.mp hzero).symm
+
+end CompactConvex
+
+/-- Wolf Theorem 6.10 in a finite-dimensional real inner-product space. -/
+theorem fixedPoint_of_compact_convex
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
+    {K : Set E} (hK_ne : K.Nonempty) (hK_comp : IsCompact K) (hK_conv : Convex ℝ K)
+    {f : E → E} (hf_cont : ContinuousOn f K) (hf_maps : Set.MapsTo f K K) :
+    ∃ x ∈ K, f x = x := by
+  exact fixedPoint_of_compact_retract hK_comp
+    (CompactConvex.continuous_metricProjection K hK_comp hK_ne hK_conv)
+    (fun x _ => CompactConvex.metricProjection_mem K hK_comp hK_ne x)
+    (fun _ hx => CompactConvex.metricProjection_eq_self hK_comp hK_ne hK_conv hx)
+    hf_cont hf_maps
+
+/-- Wolf Theorem 6.10 in its printed form for a subset of `ℝⁿ`. -/
+theorem brouwer_fixedPoint_compactConvex
+    {n : ℕ} {S : Set (Fin n → ℝ)}
+    (hS_ne : S.Nonempty) (hS_comp : IsCompact S) (hS_conv : Convex ℝ S)
+    {T : (Fin n → ℝ) → (Fin n → ℝ)}
+    (hT_cont : ContinuousOn T S) (hT_maps : Set.MapsTo T S S) :
+    ∃ x ∈ S, T x = x := by
+  let e : EuclideanSpace ℝ (Fin n) ≃L[ℝ] (Fin n → ℝ) :=
+    EuclideanSpace.equiv (Fin n) ℝ
+  let S' : Set (EuclideanSpace ℝ (Fin n)) := e ⁻¹' S
+  let T' : EuclideanSpace ℝ (Fin n) → EuclideanSpace ℝ (Fin n) :=
+    fun x => e.symm (T (e x))
+  have hS'_ne : S'.Nonempty := by
+    obtain ⟨x, hx⟩ := hS_ne
+    exact ⟨e.symm x, by simpa [S'] using hx⟩
+  have hS'_comp : IsCompact S' := by
+    rw [show S' = e.symm '' S by
+      ext x
+      constructor
+      · intro hx
+        exact ⟨e x, hx, by simp⟩
+      · rintro ⟨y, hy, rfl⟩
+        simpa [S'] using hy]
+    exact hS_comp.image e.symm.continuous
+  have hS'_conv : Convex ℝ S' := by
+    exact hS_conv.linear_preimage e.toLinearMap
+  have he_maps : Set.MapsTo e S' S := by
+    intro x hx
+    exact hx
+  have hT'_cont : ContinuousOn T' S' := by
+    have hcomp : ContinuousOn (fun x => T (e x)) S' :=
+      hT_cont.comp e.continuous.continuousOn he_maps
+    exact e.symm.continuous.comp_continuousOn hcomp
+  have hT'_maps : Set.MapsTo T' S' S' := by
+    intro x hx
+    change e (e.symm (T (e x))) ∈ S
+    simpa using hT_maps hx
+  obtain ⟨x, hx, hfixed⟩ :=
+    fixedPoint_of_compact_convex hS'_ne hS'_comp hS'_conv hT'_cont hT'_maps
+  refine ⟨e x, hx, ?_⟩
+  apply e.symm.injective
+  simpa [T'] using hfixed

--- a/blueprint/src/chapter/ch07_qpf.tex
+++ b/blueprint/src/chapter/ch07_qpf.tex
@@ -855,17 +855,32 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \section{General Brouwer and stationary states}
 
-\begin{theorem}[Brouwer's fixed point theorem (simplex)]
-    \label{thm:brouwer_simplex}
-    Let $f\colon\Delta^n\to\Delta^n$ be a continuous map from the standard
-    $n$-simplex to itself. Then there exists $x\in\Delta^n$ such that
-    $f(x)=x$.
+\begin{theorem}[Brouwer's fixed point theorem]
+    \label{thm:brouwer_compact_convex}
+    \lean{brouwer_fixedPoint_compactConvex, fixedPoint_of_compact_convex}
+    \lean{CompactConvex.metricProjection, CompactConvex.metricProjection_mem}
+    \lean{CompactConvex.metricProjection_isMinOn, CompactConvex.nearest_inner_nonpos}
+    \lean{CompactConvex.metricProjection_norm_sub_le}
+    \lean{CompactConvex.metricProjection_lipschitzWith}
+    \lean{CompactConvex.continuous_metricProjection, CompactConvex.metricProjection_eq_self}
+    \leanok
+    Let $T$ be a continuous map from a nonempty, compact, convex set
+    $S\subset\mathbb{R}^n$ into itself. Then there is an $x\in S$ such that
+    $T(x)=x$.
 
-    % The general compact-convex form stated by \cite[Theorem~6.10]{Wolf2012Quantum}
-    % is not yet proved.  The simplex version and its extensions (products of
-    % simplices, closed cubes, compact retracts, density-matrix specialization)
-    % are formalized and suffice for all current applications.
+    This is \cite[Theorem~6.10]{Wolf2012Quantum}, including the case $n=0$.
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:brouwer_compact_retract}
+    Choose a nearest point in $S$ by minimizing squared distance. The
+    first-order variational inequality for this minimizer shows that the
+    metric projection is $1$-Lipschitz and is the identity on $S$. It is thus
+    a continuous retraction of the ambient Euclidean space onto $S$, so
+    Theorem~\ref{thm:brouwer_compact_retract} applies. Wolf states the theorem
+    without supplying a proof.
+\end{proof}
 
 \begin{theorem}[Stationary states --- nonlinear]\label{thm:stationary_states}
     \lean{IsStationaryMap.exists_stationaryState}

--- a/blueprint/src/chapter/ch07_qpf_supporting_results.tex
+++ b/blueprint/src/chapter/ch07_qpf_supporting_results.tex
@@ -65,6 +65,29 @@ convex domain and the limit argument used for channel fixed points.
     gives $\tr(E(\rho)) = \tr(\rho) = 1$.
 \end{proof}
 
+\begin{theorem}[Brouwer fixed point on compact convex sets]%
+    \label{thm:brouwer_compact_convex}
+    \lean{brouwer_fixedPoint_compactConvex, fixedPoint_of_compact_convex}
+    \lean{CompactConvex.metricProjection, CompactConvex.metricProjection_mem}
+    \lean{CompactConvex.metricProjection_isMinOn, CompactConvex.nearest_inner_nonpos}
+    \lean{CompactConvex.metricProjection_norm_sub_le}
+    \lean{CompactConvex.metricProjection_lipschitzWith}
+    \lean{CompactConvex.continuous_metricProjection, CompactConvex.metricProjection_eq_self}
+    \leanok
+    Let $S \subseteq \mathbb{R}^n$ be nonempty, compact, and convex. Every
+    continuous map $T : S \to S$ has a fixed point.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Choose a nearest point in $S$ by minimizing squared distance. The
+    first-order variational inequality for this minimizer shows that the
+    metric projection is $1$-Lipschitz and is the identity on $S$. It is thus
+    a continuous retraction of the ambient Euclidean space onto $S$, so the
+    compact-retract form of Brouwer's theorem applies. Wolf states the theorem
+    without supplying this proof.
+\end{proof}
+
 \begin{theorem}[Brouwer fixed point on density matrices]%
     \label{thm:brouwer_density_matrices}
     \lean{brouwer_fixedPoint_densityMatrices}

--- a/blueprint/src/chapter/ch07_qpf_supporting_results.tex
+++ b/blueprint/src/chapter/ch07_qpf_supporting_results.tex
@@ -65,34 +65,27 @@ convex domain and the limit argument used for channel fixed points.
     gives $\tr(E(\rho)) = \tr(\rho) = 1$.
 \end{proof}
 
-\begin{theorem}[Brouwer fixed point on compact convex sets]%
-    \label{thm:brouwer_compact_convex}
-    \lean{brouwer_fixedPoint_compactConvex, fixedPoint_of_compact_convex}
-    \lean{CompactConvex.metricProjection, CompactConvex.metricProjection_mem}
-    \lean{CompactConvex.metricProjection_isMinOn, CompactConvex.nearest_inner_nonpos}
-    \lean{CompactConvex.metricProjection_norm_sub_le}
-    \lean{CompactConvex.metricProjection_lipschitzWith}
-    \lean{CompactConvex.continuous_metricProjection, CompactConvex.metricProjection_eq_self}
+\begin{theorem}[Brouwer fixed point on compact retracts]%
+    \label{thm:brouwer_compact_retract}
+    \lean{fixedPoint_of_compact_retract, fixedPoint_of_compact_retract_fin}
+    \lean{exists_fixedPoint_closedCube, exists_fixedPoint_unitCube}
     \leanok
-    Let $S \subseteq \mathbb{R}^n$ be nonempty, compact, and convex. Every
-    continuous map $T : S \to S$ has a fixed point.
+    Let $K$ be a compact subset of a finite-dimensional real normed space
+    $E$. If there is a continuous retraction $r\colon E\to K$, then every
+    continuous map from $K$ to itself has a fixed point.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Choose a nearest point in $S$ by minimizing squared distance. The
-    first-order variational inequality for this minimizer shows that the
-    metric projection is $1$-Lipschitz and is the identity on $S$. It is thus
-    a continuous retraction of the ambient Euclidean space onto $S$, so the
-    compact-retract form of Brouwer's theorem applies. Wolf states the theorem
-    without supplying this proof.
+    Brouwer's theorem for finite products of simplices transfers to closed
+    cubes. After choosing linear coordinates on $E$, apply the fixed-point
+    theorem on a cube containing $K$ to the composite of the self-map with
+    the retraction. The zero-dimensional case is immediate.
 \end{proof}
 
 \begin{theorem}[Brouwer fixed point on density matrices]%
     \label{thm:brouwer_density_matrices}
     \lean{brouwer_fixedPoint_densityMatrices}
-    \lean{fixedPoint_of_compact_retract, fixedPoint_of_compact_retract_fin}
-    \lean{exists_fixedPoint_closedCube, exists_fixedPoint_unitCube}
     \leanok
     \uses{def:density_matrices, thm:density_compact}
     Let $D > 0$. Every continuous map from the compact convex set of
@@ -101,10 +94,10 @@ convex domain and the limit argument used for channel fixed points.
 
 \begin{proof}
     \leanok
-    The proof starts from Brouwer's theorem for products of simplices,
-    transfers it to closed cubes, and then to compact retracts of
-    finite-dimensional real normed spaces. The density-matrix set is
-    such a compact retract, using the explicit density retraction.
+    \uses{thm:brouwer_compact_retract}
+    The density-matrix set is a compact retract of its finite-dimensional
+    ambient real normed space, using the explicit density retraction. Apply
+    Theorem~\ref{thm:brouwer_compact_retract}.
 \end{proof}
 
 \begin{lemma}[Ces\`aro means remain density matrices]

--- a/docs/paper-gaps/wolf_brouwer_general_compact_convex.tex
+++ b/docs/paper-gaps/wolf_brouwer_general_compact_convex.tex
@@ -13,7 +13,7 @@
 
 \begin{document}
 \maketitle
-\gapnote{open-gap}{open}
+\gapnote{open-gap}{resolved}
 
 \section{The assertion}
 
@@ -29,62 +29,51 @@ lines~1143--1151.}
   \exists\, x \in S,\ T(x) = x.
 \end{align}
 
-\section{What is formalized}
+\section{Resolution}
 
 The vendored Gametheory library (LionSR/Brouwer) proves the Brouwer fixed-point
 theorem for the standard simplex~$\Delta^n$:
 \leanid{Brouwer}.
-TNLean extends this to products of simplices, closed cubes, and compact retracts
+QICLean extends this to products of simplices, closed cubes, and compact retracts
 of finite-dimensional real normed spaces.\footnote{Formal declarations:
 \leanid{exists\_fixedPoint\_closedCube} in
 \doclink{QICLean/Topology/BrouwerProduct},
 \leanid{fixedPoint\_of\_compact\_retract} in
 \doclink{QICLean/Topology/CompactRetractFixedPoint},
-and \leanid{brouwer\_fixedPoint\_densityMatrices} in
-\doclink{QICLean/Channel/FixedPoint/BrouwerDensityMatrices}.}  The density-matrix specialization
-is the only form used in the existing formalization of Wolf Theorem~6.11
-(Stationary states).
+and \leanid{fixedPoint\_of\_compact\_convex} and
+\leanid{brouwer\_fixedPoint\_compactConvex} in
+\doclink{QICLean/Topology/CompactConvexFixedPoint}.}
 
-\section{What is missing}
+The last two declarations now prove the coordinate-free theorem and Wolf's
+printed form for an arbitrary nonempty compact convex subset
+\(S \subset \mathbb{R}^n\), respectively.  The proof follows the metric-projection
+route previously identified in this note.  For each ambient point, compactness
+provides a minimizer of squared distance in~\(S\).  Convexity and the
+first-order variational inequality imply that the chosen projection is
+1-Lipschitz and restricts to the identity on~\(S\).  It therefore supplies the
+continuous retraction required by
+\leanid{fixedPoint\_of\_compact\_retract}.  The reusable projection declarations
+are \leanid{CompactConvex.metricProjection},
+\leanid{CompactConvex.nearest\_inner\_nonpos}, and
+\leanid{CompactConvex.metricProjection\_lipschitzWith}.
 
-The general statement with an \emph{arbitrary} nonempty compact convex subset
-\(S \subset \mathbb{R}^n\) is not yet proved.  Three natural routes would close
-this gap:
-
-\begin{enumerate}
-  \item \textbf{Metric projection.}  For a nonempty closed convex set~\(K\) in a
-    finite-dimensional Euclidean space, the nearest-point map
-    \(\operatorname{proj}_K(x) = \operatorname*{argmin}_{p \in K} \lVert x-p\rVert\) is unique,
-    1-Lipschitz, and restricts to the identity on~\(K\).  This provides the
-    retraction required by the existing retract-based fixed-point theorem.  The
-    existence, uniqueness, and continuity of the metric projection for convex
-    sets in Euclidean space is not yet in Mathlib.
-
-  \item \textbf{Convex-body homeomorphism.}  A nonempty compact convex~\(K\)
-    with nonempty interior in its affine hull is homeomorphic to the closed
-    unit ball, which is homeomorphic to a simplex.
-
-  \item \textbf{Triangulation.}  Refine \(K\) into a simplicial complex and
-    apply the Sperner-lemma / simplicial Brouwer argument directly (the route
-    taken by the Gametheory library for the standard simplex).
-\end{enumerate}
+Wolf supplies only the theorem statement at the cited location, so this route
+is recorded as the formal proof and is not attributed to the lecture notes.
 
 \section{Impact}
 
-The missing general statement does \emph{not} block the formalization of Wolf
+The former general-statement gap did \emph{not} block the formalization of Wolf
 Theorem~6.11 (Stationary states), Proposition~6.8 (Positive fixed-points), or
 Corollary~6.5 (spanning by stationary density matrices).  These results rely
 only on the density-matrix version of Brouwer, which is already proved.
-The general compact-convex Brouwer is not used anywhere in the current
-formalization.
+The density-matrix specialization remains the theorem used by those channel
+results; the general theorem is now available independently.
 
 \section{Verdict}
 
-\textbf{Open gap.}  The general compact-convex Brouwer theorem (Wolf's
-formulation) remains unformalized.  The simplex specialization and its
-extensions to closed cubes, compact retracts, and density matrices are formalized
-and suffice for the current applications.  The metric-projection route is the
-most natural starting point and would be reusable beyond this theorem.
+\textbf{Resolved.}  Wolf's general compact-convex statement is formalized as
+\leanid{brouwer\_fixedPoint\_compactConvex}.  The coordinate-free theorem and
+the reusable nonexpansive metric projection are formalized alongside it.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -901,8 +901,15 @@ In `QICLean.Channel.FixedPoint.Algebra`:
   — under the hypotheses of Theorem 6.12, the full adjoint fixed-point
   `*`-subalgebra coincides with the Kraus commutant.
 
-#### Wolf Theorem 6.10 (Brouwer's fixed point theorem)
+#### Wolf Theorem 6.10 (Brouwer's fixed point theorem) — FORMALIZED
 
+* `brouwer_fixedPoint_compactConvex` — `QICLean.Topology.CompactConvexFixedPoint`;
+  the printed statement for every nonempty compact convex
+  `S ⊆ Fin n → ℝ` and continuous self-map of `S`.
+* `fixedPoint_of_compact_convex` — coordinate-free form for finite-dimensional
+  real inner-product spaces.
+* `CompactConvex.metricProjection_lipschitzWith` — the reusable metric-projection
+  step: projection onto a nonempty compact convex set is 1-Lipschitz.
 * `brouwer_fixedPoint_densityMatrices` — `QICLean.Channel.FixedPoint.BrouwerDensityMatrices`
   (density-matrix specialization; kernel-checked).
 * `Brouwer (vendored Gametheory library)` — exact import citation: Brouwer for the
@@ -911,7 +918,7 @@ In `QICLean.Channel.FixedPoint.Algebra`:
   extends Brouwer to closed cubes.
 * `fixedPoint_of_compact_retract` — `QICLean.Topology.CompactRetractFixedPoint`;
   extends Brouwer to compact retracts of finite-dimensional real normed spaces.
-* The general compact-convex statement (Wolf's formulation) is not yet proved;
+* The former general compact-convex paper gap is resolved by metric projection;
   see `docs/paper-gaps/wolf_brouwer_general_compact_convex.tex`.
 
 #### Wolf Theorem 6.11 (Stationary states) — FORMALIZED


### PR DESCRIPTION
## Summary

- prove Wolf Theorem 6.10 in its printed form as `brouwer_fixedPoint_compactConvex` for every nonempty compact convex `S ⊆ Fin n → ℝ` and every continuous self-map of `S`;
- add the reusable coordinate-free theorem `fixedPoint_of_compact_convex` for finite-dimensional real inner-product spaces;
- construct metric projection from a squared-distance minimizer, prove its variational inequality and `1`-Lipschitz bound, and use it as the continuous retraction required by the existing compact-retract theorem;
- mark the former general compact-convex paper gap resolved and synchronize the Blueprint, coverage index, and generated topology aggregator.

## Source and proof boundary

Wolf states the theorem at `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1143–1151, but does not include a proof there. The formal proof follows the metric-projection route already documented in `docs/paper-gaps/wolf_brouwer_general_compact_convex.tex`; the note now records that route as the formal proof rather than attributing it to Wolf.

The source-level `T : S → S` is represented by an ambient map together with `ContinuousOn T S` and `Set.MapsTo T S S`. The exact `Fin n → ℝ` wrapper transfers through the continuous linear equivalence with Euclidean `L²` coordinates, so it does not assume the sup-norm function space itself carries an inner-product instance. The theorem also covers `n = 0`.

## Validation

- `lake build QICLean.Topology.CompactConvexFixedPoint QICLean.Topology -q --log-level=info`
- `lake exe lint_style --github`
- Blueprint–Lean sync after regeneration: 1971/1971, plus zero changed declarations missing Blueprint entries
- paper-gap reference check and focused `chktex`
- reader-facing prose check
- generated-import, oversized-file, and numbered-module policy checks
- `git diff --check origin/main...HEAD`
- `#print axioms` for the projection bound and both fixed-point theorems: only `propext`, `Classical.choice`, and `Quot.sound`

A full-root build was not run; the focused topology modules are the scoped local gate, and CI will run the repository-wide checks.

Closes #35
