### PR TITLE
feat: prove unitary Schur triangularization

### DIFF
--- a/QICLean/Analysis.lean
+++ b/QICLean/Analysis.lean
@@ -87,6 +87,7 @@ import QICLean.Analysis.TwoProjectionCompression
 import QICLean.Analysis.TwoProjectionCompressionSpectrum
 import QICLean.Analysis.TwoProjectionDefectBlockSum
 import QICLean.Analysis.TwoProjectionReducedProjection
+import QICLean.Analysis.UnitarySchurTriangularization
 import QICLean.Analysis.UpperTriangularBound
 import QICLean.Analysis.WeightedCesaroMean
 import QICLean.Analysis.WeightedPositiveKernel

--- a/QICLean/Analysis/UnitarySchurTriangularization.lean
+++ b/QICLean/Analysis/UnitarySchurTriangularization.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import Mathlib.Analysis.Complex.Polynomial.Basic
+import Mathlib.Analysis.InnerProductSpace.Adjoint
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.LinearAlgebra.Eigenspace.Charpoly
+import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
+
+/-!
+# Unitary Schur triangularization
+
+This file develops the finite-dimensional complex Schur decomposition needed for
+Wolf's proof of Equation (8.111).  The construction is independent of quantum
+channels.
+
+The proof chooses an eigenvector of the adjoint as the final basis vector.  Its
+orthogonal complement is invariant under the original endomorphism, so induction
+on the dimension gives an orthonormal basis in which the endomorphism is upper
+triangular.  This formulation treats the zero-dimensional space directly.
+-/
+
+open Module
+open scoped ComplexConjugate InnerProductSpace Matrix
+
+namespace LinearMap
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+  [FiniteDimensional ℂ E]
+
+private theorem exists_orthonormalBasis_toMatrix_isUpperTriangular_aux
+    (n : ℕ) (hn : finrank ℂ E = n) (T : Module.End ℂ E) :
+    ∃ b : OrthonormalBasis (Fin n) ℂ E,
+      (LinearMap.toMatrix b.toBasis b.toBasis T).IsUpperTriangular := by
+  induction n using Nat.strong_induction_on generalizing E with
+  | h n ih =>
+      rcases n with _ | n
+      · let b := (stdOrthonormalBasis ℂ E).reindex (finCongr hn)
+        refine ⟨b, ?_⟩
+        intro i
+        exact Fin.elim0 i
+      · let _ : Nontrivial E := finrank_pos_iff.mp (by
+          rw [hn]
+          exact Nat.zero_lt_succ n)
+        obtain ⟨μ, hμ⟩ := Module.End.exists_eigenvalue T.adjoint
+        obtain ⟨v, hv⟩ := hμ.exists_hasEigenvector
+        have hv0 : v ≠ 0 := hv.2
+        let K : Submodule ℂ E := (ℂ ∙ v)ᗮ
+        have hK_invariant : ∀ x ∈ K, T x ∈ K := by
+          intro x hx
+          change x ∈ (ℂ ∙ v)ᗮ at hx
+          change T x ∈ (ℂ ∙ v)ᗮ
+          rw [Submodule.mem_orthogonal_singleton_iff_inner_left] at hx ⊢
+          rw [← T.adjoint_inner_right, hv.apply_eq_smul, inner_smul_right, hx, mul_zero]
+        let T_K : Module.End ℂ K := T.restrict hK_invariant
+        let _ : Fact (finrank ℂ E = n + 1) := ⟨hn⟩
+        have hKdim : finrank ℂ K = n := by
+          simpa [K] using Submodule.finrank_orthogonal_span_singleton (n := n) hv0
+        obtain ⟨bK, hbK⟩ := ih n (Nat.lt_succ_self n) hKdim T_K
+        let w : E := (‖v‖⁻¹ : ℂ) • v
+        let q : Fin (n + 1) → E := Fin.snoc (fun i ↦ (bK i : E)) w
+        have hw_norm : ‖w‖ = 1 := by
+          simpa [w] using norm_smul_inv_norm (𝕜 := ℂ) hv0
+        have hq : Orthonormal ℂ q := by
+          constructor
+          · intro i
+            cases i using Fin.lastCases with
+            | last => simpa [q] using hw_norm
+            | cast i =>
+                simp only [q, Fin.snoc_castSucc]
+                change ‖(bK i : E)‖ = 1
+                simpa only [Submodule.norm_coe] using bK.norm_eq_one i
+          · intro i j hij
+            cases i using Fin.lastCases with
+            | last =>
+                cases j using Fin.lastCases with
+                | last => exact (hij rfl).elim
+                | cast j =>
+                    have hj : ⟪v, (bK j : E)⟫_ℂ = 0 :=
+                      Submodule.mem_orthogonal_singleton_iff_inner_right.mp (bK j).property
+                    simp [q, w, inner_smul_left, hj]
+            | cast i =>
+                cases j using Fin.lastCases with
+                | last =>
+                    have hi : ⟪(bK i : E), v⟫_ℂ = 0 :=
+                      Submodule.mem_orthogonal_singleton_iff_inner_left.mp (bK i).property
+                    simp [q, w, inner_smul_right, hi]
+                | cast j =>
+                    have hij' : i ≠ j := by
+                      intro h
+                      apply hij
+                      exact congrArg Fin.castSucc h
+                    simpa [q] using bK.orthonormal.inner_eq_zero hij'
+        let b : OrthonormalBasis (Fin (n + 1)) ℂ E := OrthonormalBasis.mk hq <|
+          (hq.linearIndependent.span_eq_top_of_card_eq_finrank' (by simpa using hn.symm)).ge
+        have hbq : ∀ i, b i = q i := fun i ↦ by simp [b]
+        refine ⟨b, ?_⟩
+        intro i j hji
+        cases i using Fin.lastCases with
+        | last =>
+            cases j using Fin.lastCases with
+            | last => exact (lt_irrefl _ hji).elim
+            | cast j =>
+                rw [LinearMap.toMatrix_apply, b.coe_toBasis_repr_apply,
+                  OrthonormalBasis.repr_apply_apply, hbq]
+                rw [show b.toBasis j.castSucc = b j.castSucc from rfl, hbq]
+                have hTj : T (bK j : E) ∈ K := hK_invariant _ (bK j).property
+                have hinner : ⟪w, T (bK j : E)⟫_ℂ = 0 := by
+                  have : ⟪v, T (bK j : E)⟫_ℂ = 0 :=
+                    Submodule.mem_orthogonal_singleton_iff_inner_right.mp hTj
+                  simp [w, inner_smul_left, this]
+                simpa [q] using hinner
+        | cast i =>
+            cases j using Fin.lastCases with
+            | last => exact (not_lt_of_ge (Fin.le_last _) hji).elim
+            | cast j =>
+                have hji' : j < i := by simpa using hji
+                have hzero := hbK hji'
+                rw [LinearMap.toMatrix_apply, b.coe_toBasis_repr_apply,
+                  OrthonormalBasis.repr_apply_apply, hbq]
+                rw [show b.toBasis j.castSucc = b j.castSucc from rfl, hbq]
+                rw [LinearMap.toMatrix_apply, bK.coe_toBasis_repr_apply,
+                  OrthonormalBasis.repr_apply_apply] at hzero
+                simpa [q, T_K, LinearMap.restrict_apply] using hzero
+
+/-- A complex endomorphism admits an orthonormal basis in which its matrix is upper triangular.
+
+The proof is the finite-dimensional Schur induction.  It includes the case
+`finrank ℂ E = 0`; no nontriviality assumption on `E` is required. -/
+theorem exists_orthonormalBasis_toMatrix_isUpperTriangular (T : Module.End ℂ E) :
+    ∃ b : OrthonormalBasis (Fin (finrank ℂ E)) ℂ E,
+      (LinearMap.toMatrix b.toBasis b.toBasis T).IsUpperTriangular :=
+  exists_orthonormalBasis_toMatrix_isUpperTriangular_aux (finrank ℂ E) rfl T
+
+end LinearMap

--- a/QICLean/Analysis/UnitarySchurTriangularization.lean
+++ b/QICLean/Analysis/UnitarySchurTriangularization.lean
@@ -136,3 +136,74 @@ theorem exists_orthonormalBasis_toMatrix_isUpperTriangular (T : Module.End ℂ E
   exists_orthonormalBasis_toMatrix_isUpperTriangular_aux (finrank ℂ E) rfl T
 
 end LinearMap
+
+namespace Matrix
+
+/-- **Unitary Schur triangularization over the complex numbers.**
+
+For every complex square matrix `A`, there is a unitary matrix `U` and an upper-triangular
+matrix `R` such that `A = U * R * Uᴴ`.  The diagonal entries of `R` are exactly the eigenvalues
+of `A`, with the statement expressed using `A.toLin'`.  The result includes `m = 0`. -/
+theorem exists_unitary_schur_triangularization {m : ℕ}
+    (A : Matrix (Fin m) (Fin m) ℂ) :
+    ∃ (U : Matrix.unitaryGroup (Fin m) ℂ)
+        (R : Matrix (Fin m) (Fin m) ℂ),
+      R.IsUpperTriangular ∧
+      A = (U : Matrix (Fin m) (Fin m) ℂ) * R *
+        (U : Matrix (Fin m) (Fin m) ℂ)ᴴ ∧
+      (∀ z : ℂ, Module.End.HasEigenvalue A.toLin' z ↔ ∃ i : Fin m, R i i = z) := by
+  let T : Module.End ℂ (EuclideanSpace ℂ (Fin m)) := A.toLpLin 2 2
+  obtain ⟨b, hR⟩ := LinearMap.exists_orthonormalBasis_toMatrix_isUpperTriangular_aux
+    m (by simpa only [Fintype.card_fin] using
+      (finrank_euclideanSpace (𝕜 := ℂ) (ι := Fin m))) T
+  let e : OrthonormalBasis (Fin m) ℂ (EuclideanSpace ℂ (Fin m)) :=
+    EuclideanSpace.basisFun (Fin m) ℂ
+  let R : Matrix (Fin m) (Fin m) ℂ := LinearMap.toMatrix b.toBasis b.toBasis T
+  let U : Matrix.unitaryGroup (Fin m) ℂ :=
+    ⟨e.toBasis.toMatrix b.toBasis, e.toMatrix_orthonormalBasis_mem_unitary b⟩
+  refine ⟨U, R, hR, ?_, ?_⟩
+  · have hUstar : (U : Matrix (Fin m) (Fin m) ℂ)ᴴ = b.toBasis.toMatrix e := by
+      have hUb : (U : Matrix (Fin m) (Fin m) ℂ) * b.toBasis.toMatrix e = 1 := by
+        change e.toBasis.toMatrix b.toBasis * b.toBasis.toMatrix e.toBasis = 1
+        exact Module.Basis.toMatrix_mul_toMatrix_flip e.toBasis b.toBasis
+      have hunit : (U : Matrix (Fin m) (Fin m) ℂ)ᴴ *
+          (U : Matrix (Fin m) (Fin m) ℂ) = 1 := by
+        simpa only [← Matrix.star_eq_conjTranspose] using
+          (Matrix.mem_unitaryGroup_iff'.mp U.property)
+      calc
+        (U : Matrix (Fin m) (Fin m) ℂ)ᴴ =
+            (U : Matrix (Fin m) (Fin m) ℂ)ᴴ * 1 := (mul_one _).symm
+        _ = (U : Matrix (Fin m) (Fin m) ℂ)ᴴ *
+            ((U : Matrix (Fin m) (Fin m) ℂ) * b.toBasis.toMatrix e) := by rw [hUb]
+        _ = ((U : Matrix (Fin m) (Fin m) ℂ)ᴴ *
+            (U : Matrix (Fin m) (Fin m) ℂ)) * b.toBasis.toMatrix e :=
+              (mul_assoc _ _ _).symm
+        _ = b.toBasis.toMatrix e := by rw [hunit, one_mul]
+    rw [hUstar]
+    change A = e.toBasis.toMatrix b.toBasis * LinearMap.toMatrix b.toBasis b.toBasis T *
+      b.toBasis.toMatrix e.toBasis
+    have hchange :
+        e.toBasis.toMatrix b.toBasis * LinearMap.toMatrix b.toBasis b.toBasis T *
+            b.toBasis.toMatrix e.toBasis = LinearMap.toMatrix e.toBasis e.toBasis T :=
+      basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix
+        (b := e.toBasis) (b' := b.toBasis) (c := e.toBasis) (c' := b.toBasis) (f := T)
+    rw [hchange]
+    simp [T, e, EuclideanSpace.basisFun_toBasis, Matrix.toLpLin_eq_toLin]
+  · intro z
+    rw [Module.End.hasEigenvalue_iff_isRoot_charpoly, Matrix.charpoly_toLin']
+    have hAchar : T.charpoly = A.charpoly := by
+      simp [T, Matrix.toLpLin_eq_toLin, Matrix.charpoly_toLin]
+    have hRchar : R.charpoly = T.charpoly := LinearMap.charpoly_toMatrix T b.toBasis
+    rw [← hAchar, ← hRchar, Matrix.charpoly_of_isUpperTriangular R hR]
+    rw [Polynomial.isRoot_prod]
+    simp only [Finset.mem_univ, true_and, Polynomial.root_X_sub_C]
+
+-- The theorem includes the empty complex matrix without a `Nonempty (Fin m)` hypothesis.
+private example := exists_unitary_schur_triangularization
+  (0 : Matrix (Fin 0) (Fin 0) ℂ)
+
+-- The nilpotent two-dimensional Jordan block is a nonnormal test case.
+private example := exists_unitary_schur_triangularization
+  (!![0, 1; 0, 0] : Matrix (Fin 2) (Fin 2) ℂ)
+
+end Matrix

--- a/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_upper_triangular_power.tex
@@ -178,6 +178,37 @@
     the identity matrix has operator norm one because $D\ge1$.
 \end{proof}
 
+\begin{theorem}[Unitary Schur triangularization]
+    \label{thm:unitary_schur_triangularization}
+    \lean{LinearMap.exists_orthonormalBasis_toMatrix_isUpperTriangular,
+      Matrix.exists_unitary_schur_triangularization}
+    \leanok
+    For every $A\in M_D(\mathbb C)$, including $D=0$, there are a unitary
+    matrix $U$ and an upper-triangular matrix $R$ such that
+    \begin{align}
+      A=URU^\dagger.
+    \end{align}
+    Moreover, a complex number $z$ is an eigenvalue of $A$ if and only if
+    $R_{ii}=z$ for some $i$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    In positive dimension, choose an eigenvector of the adjoint of $A$ and
+    place its normalization last in an orthonormal basis.  Its orthogonal
+    complement is invariant under $A$.  Induction on that complement gives
+    an orthonormal basis in which the restricted matrix is upper triangular;
+    adjoining the normalized eigenvector therefore gives an upper-triangular
+    matrix $R$ for $A$.  The change of orthonormal basis is unitary and has
+    the displayed conjugation order.  The zero-dimensional case uses the
+    empty orthonormal basis.  Finally,
+    \begin{align}
+      \chi_A(X)=\chi_R(X)=\prod_i(X-R_{ii}),
+    \end{align}
+    so the roots of the characteristic polynomial are precisely the diagonal
+    entries of $R$.
+\end{proof}
+
 \begin{theorem}[Schur-form spectral-radius estimate]
     \label{thm:wolf_schur_form_spectral_radius_estimate}
     \lean{Matrix.wolf_eq_111_schur_form,
@@ -275,7 +306,8 @@
 \end{proof}
 
 % This lemma is only the algebraic first step in Wolf's proof of
-% Equation (8.111).  The channel-level estimate tracked in QICLean issue #300
-% remains pending on the unitary Schur triangularization tracked in issue
-% #383, as well as the source's bound on the strictly upper-triangular part.
+% Equation (8.111).  The generic unitary Schur triangularization is now
+% formalized above.  The channel-level estimate tracked in QICLean issue #300
+% remains pending on its specialization and the source's bound on the strictly
+% upper-triangular part.
 % There is deliberately no \leanok claim for the full asymptotic theorem here.


### PR DESCRIPTION
## Summary

- prove the finite-dimensional complex Schur theorem by induction on dimension, using an adjoint eigenvector as the last basis vector so that its orthogonal complement is invariant;
- package the orthonormal change of basis as a bundled unitary matrix and prove the exact column-vector identity `A = U * R * Uᴴ`;
- identify the eigenvalues of `A.toLin'` exactly with the diagonal entries of `R` through the characteristic polynomial of an upper-triangular matrix;
- treat the empty matrix explicitly and include a nonnormal nilpotent Jordan block as a focused example;
- add the corresponding Blueprint theorem immediately before the Schur-form estimate used in Wolf's route to Equation (8.111).

The adjoint-last induction is the upper-triangular form of the usual Schur argument: if `T† v = μv`, then `(ℂ v)ᗮ` is invariant under `T`. It avoids an arbitrary triangularizing basis and preserves the unitary similarity needed for norm estimates.

The module is channel-independent and imports no `QICLean.Channel` files. The full channel estimate in Equation (8.111) remains open in #300; this pull request supplies only its generic Schur prerequisite.

## Source correspondence

Wolf's source writes
`(T̂ - T̂_φ) = U (Λ + N) U†`, with `U` unitary, `Λ` diagonal, and `N` strictly upper triangular, in `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1299–1316. The theorem here supplies the generic unitary triangularization underlying that sentence. It does not identify the transfer-matrix specialization or claim the remaining bound on `N`.

## Verification

- `lake build QICLean.Analysis.UnitarySchurTriangularization QICLean.Analysis`
- `lake exe lint_style --github`
- `lake exe checkdecls blueprint/lean_decls`
- reader-facing prose, oversized-file, and numbered-module checks
- Blueprint declaration synchronization and changed-declaration reverse coverage
- `texra-blueprint paper-gaps check`
- ChkTeX with `blueprint/.chktexrc`
- complete 312-page LuaLaTeX Blueprint PDF build
- kernel axiom audit for both public theorems: only `propext`, `Classical.choice`, and `Quot.sound`
- hazard scan: no `sorry`, `admit`, new `axiom`, or `native_decide`

Closes #383.
Refs #300.
