### PR TITLE
feat(channel): formalize Wolf Theorem 6.8 equivalences

### DIFF
--- a/QICLean/Channel/WolfTheorem68.lean
+++ b/QICLean/Channel/WolfTheorem68.lean
@@ -5,16 +5,26 @@ Authors: TNLean contributors
 -/
 import QICLean.Channel.KrausIterateChoi
 import QICLean.Kraus.Wielandt.Primitivity.StronglyIrreducibleToFullWordSpan
+import QICLean.Kraus.Wielandt.Primitivity.VectorSpreadToPrimitive
+import Mathlib.Tactic.TFAE
 
 /-!
 # Wolf's primitive-channel criterion
 
-For a trace-preserving finite Kraus family, irreducibility together with
-primitivity implies eventual full word span. Equivalently, the Choi matrices of
-all sufficiently large powers of its Kraus map are positive definite. These are
-the implications from item 1 to items 3 and 4 of Wolf, Theorem 6.8, with
-irreducibility explicit because the project predicate `IsPrimitive` only
-controls the peripheral spectrum.
+For a trace-preserving finite Kraus family, Wolf, Theorem 6.8 identifies four
+equivalent forms of primitivity: irreducibility with trivial peripheral
+spectrum, eventual full vector spread, eventual full Kraus-word span, and
+eventual positive definiteness of the iterate Choi matrices. The same threshold
+works for the last two clauses; for minimal vector and word thresholds `n` and
+`q`, respectively, one has `n ≤ q`.
+
+The source calls the first clause simply "primitive" because its definition of
+primitivity includes irreducibility. Here it is represented by the conjunction
+`IsIrreducibleMap (mapLM K) ∧ IsPrimitive (mapLM K)`, since the project
+predicate `IsPrimitive` records only triviality of the peripheral spectrum.
+
+Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 829--833
+and 904--984.
 -/
 
 open scoped Matrix ComplexOrder
@@ -22,6 +32,60 @@ open scoped Matrix ComplexOrder
 namespace Kraus
 
 variable {r D : ℕ}
+
+/-- Starting at word length `n`, every nonzero vector has full Kraus-word
+spread. This is the explicit-threshold form of Wolf, Theorem 6.8(2). -/
+def HasFullVectorSpreadFrom
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ) (n : ℕ) : Prop :=
+  ∀ m, n ≤ m → ∀ φ : Fin D → ℂ, φ ≠ 0 → vectorSpreadSpan K φ m = ⊤
+
+/-- Starting at word length `q`, the degree-`m` Kraus words span the full
+matrix algebra. This is Wolf, Theorem 6.8(3). -/
+def HasFullWordSpanFrom
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ) (q : ℕ) : Prop :=
+  ∀ m, q ≤ m → wordSpan K m = ⊤
+
+/-- Starting at iterate `q`, every Choi matrix of a Kraus-map power is positive
+definite. This is Wolf, Theorem 6.8(4). -/
+def HasPosDefChoiFrom
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ) (q : ℕ) : Prop :=
+  ∀ m, q ≤ m →
+    (ChoiJamiolkowski.choiMatrix ((mapLM K) ^ m)).PosDef
+
+/-- Eventual full vector spread is equivalent to Wolf's explicit existence of
+a threshold `n` after which all lengths have full vector spread. -/
+theorem hasEventuallyFullVectorSpread_iff_exists_hasFullVectorSpreadFrom
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ) :
+    HasEventuallyFullVectorSpread K ↔ ∃ n, HasFullVectorSpreadFrom K n := by
+  constructor
+  · intro h
+    exact Filter.eventually_atTop.mp h
+  · rintro ⟨n, hn⟩
+    exact Filter.eventually_atTop.mpr ⟨n, hn⟩
+
+/-- Eventual full word span is equivalent to Wolf's explicit existence of a
+threshold `q` after which all word spans are the full matrix algebra. -/
+theorem hasEventuallyFullWordSpan_iff_exists_hasFullWordSpanFrom
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ) :
+    HasEventuallyFullWordSpan K ↔ ∃ q, HasFullWordSpanFrom K q := by
+  constructor
+  · intro h
+    exact Filter.eventually_atTop.mp h
+  · rintro ⟨q, hq⟩
+    exact Filter.eventually_atTop.mpr ⟨q, hq⟩
+
+/-- Eventual positive definiteness of iterate Choi matrices is equivalent to
+Wolf's explicit existence of a threshold `q` valid at every later iterate. -/
+theorem eventually_choiMatrix_mapLM_pow_posDef_iff_exists_hasPosDefChoiFrom
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ) :
+    (∀ᶠ m : ℕ in Filter.atTop,
+      (ChoiJamiolkowski.choiMatrix ((mapLM K) ^ m)).PosDef) ↔
+      ∃ q, HasPosDefChoiFrom K q := by
+  constructor
+  · intro h
+    exact Filter.eventually_atTop.mp h
+  · rintro ⟨q, hq⟩
+    exact Filter.eventually_atTop.mpr ⟨q, hq⟩
 
 /-- Wolf, Theorem 6.8, item 1 implies item 4: under trace preservation,
 irreducibility and primitivity force the Choi matrices of all sufficiently
@@ -35,5 +99,90 @@ theorem eventually_choiMatrix_mapLM_pow_posDef_of_isIrreducibleMap_of_isPrimitiv
       (ChoiJamiolkowski.choiMatrix ((mapLM K) ^ m)).PosDef :=
   (eventually_choiMatrix_mapLM_pow_posDef_iff_hasEventuallyFullWordSpan K).2
     (hasEventuallyFullWordSpan_of_isIrreducibleMap_of_isPrimitive K hTP hIrr hPrim)
+
+/-- Wolf, Theorem 6.8: for a trace-preserving finite Kraus family, the source's
+four characterizations of primitivity are equivalent. Clause 1 explicitly
+includes irreducibility because Wolf's definition of "primitive" includes it,
+whereas the project predicate `IsPrimitive` controls only the peripheral
+spectrum. Clauses 2--4 retain Wolf's quantifiers over every `m` beyond a single
+threshold. -/
+theorem wolf_theorem_6_8_tfae [NeZero D]
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ) (hTP : IsTP K) :
+    List.TFAE [
+      IsIrreducibleMap (mapLM K) ∧ IsPrimitive (mapLM K),
+      ∃ n, HasFullVectorSpreadFrom K n,
+      ∃ q, HasFullWordSpanFrom K q,
+      ∃ q, HasPosDefChoiFrom K q] := by
+  tfae_have h13 : 1 → 3 := by
+    rintro ⟨hIrr, hPrim⟩
+    exact (hasEventuallyFullWordSpan_iff_exists_hasFullWordSpanFrom K).mp
+      (hasEventuallyFullWordSpan_of_isIrreducibleMap_of_isPrimitive
+        K hTP hIrr hPrim)
+  tfae_have h34 : 3 ↔ 4 := by
+    constructor
+    · rintro ⟨q, hq⟩
+      refine ⟨q, fun m hqm ↦ ?_⟩
+      exact (choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top K m).mpr
+        (hq m hqm)
+    · rintro ⟨q, hq⟩
+      refine ⟨q, fun m hqm ↦ ?_⟩
+      exact (choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top K m).mp
+        (hq m hqm)
+  tfae_have h32 : 3 → 2 := by
+    rintro ⟨q, hq⟩
+    refine ⟨q, fun m hqm φ hφ ↦ ?_⟩
+    exact vectorSpreadSpan_eq_top_of_wordSpan_eq_top K (hq m hqm) φ hφ
+  tfae_have h21 : 2 → 1 := by
+    rintro ⟨n, hn⟩
+    have hn' := hn n le_rfl
+    exact ⟨isIrreducibleMap_mapLM_of_vectorSpreadSpan_eq_top K hn',
+      isPrimitive_mapLM_of_isTP_of_vectorSpreadSpan_eq_top K hTP hn'⟩
+  tfae_finish
+
+/-- Wolf, Theorem 6.8, final sentence: the same minimal threshold `q` works for
+full word span and positive-definite iterate Choi matrices, and the minimal
+full-vector-spread threshold `n` satisfies `n ≤ q`.
+
+The displayed minimality clauses make the source's phrase "chosen minimal"
+explicit. -/
+theorem wolf_theorem_6_8_minimal_indices [NeZero D]
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ) (hTP : IsTP K)
+    (hIrr : IsIrreducibleMap (mapLM K)) (hPrim : IsPrimitive (mapLM K)) :
+    ∃ n q,
+      HasFullVectorSpreadFrom K n ∧
+      HasFullWordSpanFrom K q ∧
+      HasPosDefChoiFrom K q ∧
+      (∀ n', HasFullVectorSpreadFrom K n' → n ≤ n') ∧
+      (∀ q', HasFullWordSpanFrom K q' → q ≤ q') ∧
+      (∀ q', HasPosDefChoiFrom K q' → q ≤ q') ∧
+      n ≤ q := by
+  classical
+  have hWord : ∃ q, HasFullWordSpanFrom K q :=
+    (hasEventuallyFullWordSpan_iff_exists_hasFullWordSpanFrom K).mp
+      (hasEventuallyFullWordSpan_of_isIrreducibleMap_of_isPrimitive
+        K hTP hIrr hPrim)
+  have hVector : ∃ n, HasFullVectorSpreadFrom K n := by
+    obtain ⟨q, hq⟩ := hWord
+    exact ⟨q, fun m hqm φ hφ ↦
+      vectorSpreadSpan_eq_top_of_wordSpan_eq_top K (hq m hqm) φ hφ⟩
+  let n := Nat.find hVector
+  let q := Nat.find hWord
+  have hn : HasFullVectorSpreadFrom K n := Nat.find_spec hVector
+  have hq : HasFullWordSpanFrom K q := Nat.find_spec hWord
+  have hqChoi : HasPosDefChoiFrom K q := fun m hqm ↦
+    (choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top K m).mpr (hq m hqm)
+  refine ⟨n, q, hn, hq, hqChoi, ?_, ?_, ?_, ?_⟩
+  · intro n' hn'
+    exact Nat.find_min' hVector hn'
+  · intro q' hq'
+    exact Nat.find_min' hWord hq'
+  · intro q' hq'
+    apply Nat.find_min' hWord
+    intro m hq'm
+    exact (choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top K m).mp
+      (hq' m hq'm)
+  · apply Nat.find_min' hVector
+    intro m hqm φ hφ
+    exact vectorSpreadSpan_eq_top_of_wordSpan_eq_top K (hq m hqm) φ hφ
 
 end Kraus

--- a/blueprint/src/chapter/ch03_channel_representations_kraus_iterate_choi.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_kraus_iterate_choi.tex
@@ -32,29 +32,6 @@ The empty product is the identity matrix.
     \cite[Theorem~6.8(2)]{Wolf2012Quantum}.
 \end{definition}
 
-\begin{definition}[Wolf's explicit eventual thresholds]
-    \label{def:wolf_6_8_explicit_thresholds}
-    \lean{Kraus.HasFullVectorSpreadFrom, Kraus.HasFullWordSpanFrom,
-        Kraus.HasPosDefChoiFrom}
-    \leanok
-    \uses{def:kraus_eventually_full_vector_spread,
-        def:kraus_eventually_full_word_span}
-    For $n,q\in\mathbb N$, write:
-    \begin{align}
-        V_n(K)&:\Longleftrightarrow
-          \forall m\geq n\ \forall\psi\neq0,\quad
-          H_m(K,\psi)=\C^D, \notag\\
-        W_q(K)&:\Longleftrightarrow
-          \forall m\geq q,\quad \mathcal S_m=\MN{D}, \notag\\
-        C_q(K)&:\Longleftrightarrow
-          \forall m\geq q,\quad \tau_{E^m}>0.
-        \notag
-    \end{align}
-    These definitions retain the universal quantifiers in items~2--4 of
-    \cite[Theorem~6.8]{Wolf2012Quantum}; they are the explicit-threshold
-    forms of the corresponding eventual predicates.
-\end{definition}
-
 \begin{theorem}[Full word span gives full vector spread]
     \label{thm:kraus_vector_spread_of_word_span}
     \lean{Kraus.vectorSpreadSpan_eq_top_of_wordSpan_eq_top}
@@ -211,57 +188,6 @@ The empty product is the identity matrix.
     $\mathcal S_m=\MN{D}$. Finally,
     Corollary~\ref{cor:kraus_iterate_eventual_choi_posdef} gives the Choi
     statement.
-\end{proof}
-
-\begin{theorem}[Completely positive primitive maps]
-    \label{thm:wolf_6_8_kraus_equivalences}
-    \lean{Kraus.hasEventuallyFullVectorSpread_iff_exists_hasFullVectorSpreadFrom,
-        Kraus.hasEventuallyFullWordSpan_iff_exists_hasFullWordSpanFrom,
-        Kraus.eventually_choiMatrix_mapLM_pow_posDef_iff_exists_hasPosDefChoiFrom,
-        Kraus.wolf_theorem_6_8_tfae,
-        Kraus.wolf_theorem_6_8_minimal_indices}
-    \leanok
-    \uses{def:wolf_6_8_explicit_thresholds,
-        thm:kraus_primitive_irreducible_eventual_span_choi,
-        thm:kraus_iterate_choi_posdef_iff_word_span,
-        thm:kraus_vector_spread_of_word_span,
-        thm:kraus_irreducible_from_spreading,
-        thm:kraus_primitive_from_tp_spreading}
-    Let $K$ be trace preserving, so its Kraus map $E$ is completely positive
-    and trace preserving. Then the following four statements are equivalent:
-    \begin{enumerate}
-        \item $E$ is irreducible and has trivial peripheral spectrum;
-        \item $V_n(K)$ holds for some $n\in\mathbb N$;
-        \item $W_q(K)$ holds for some $q\in\mathbb N$;
-        \item $C_q(K)$ holds for some $q\in\mathbb N$.
-    \end{enumerate}
-    The first clause is exactly the source's term ``primitive'': Wolf's
-    definition includes irreducibility, while the Lean predicate
-    \texttt{IsPrimitive} records triviality of the peripheral spectrum.
-    The admissible thresholds in clauses~3 and~4 coincide. Consequently one
-    common minimal $q$ works in both clauses, and if $n$ is minimal in
-    clause~2, then $n\leq q$. This is
-    \cite[Theorem~6.8]{Wolf2012Quantum}.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:kraus_primitive_irreducible_eventual_span_choi,
-        thm:kraus_iterate_choi_posdef_iff_word_span,
-        thm:kraus_vector_spread_of_word_span,
-        thm:kraus_irreducible_from_spreading,
-        thm:kraus_primitive_from_tp_spreading}
-    Irreducibility and the trivial peripheral spectrum give $W_q(K)$ for a
-    sufficiently large $q$. At each fixed length, vectorization identifies
-    the span of the Kraus words with the span generating the iterate Choi
-    matrix, so $W_q(K)\Longleftrightarrow C_q(K)$ with the same $q$.
-    Moreover, a full matrix word span acts transitively on every nonzero
-    vector, proving $W_q(K)\Rightarrow V_q(K)$. Conversely, evaluating
-    $V_n(K)$ at $m=n$ gives both irreducibility and trivial peripheral
-    spectrum by the fixed-length vector-spreading theorems. Thus the four
-    clauses are equivalent. Pointwise equivalence makes the sets of
-    admissible word and Choi thresholds identical. Since $q$ is itself an
-    admissible vector threshold, minimality gives $n\leq q$.
 \end{proof}
 
 \begin{theorem}[Eventual Choi positivity gives eventual vector spread]

--- a/blueprint/src/chapter/ch03_channel_representations_kraus_iterate_choi.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_kraus_iterate_choi.tex
@@ -32,6 +32,29 @@ The empty product is the identity matrix.
     \cite[Theorem~6.8(2)]{Wolf2012Quantum}.
 \end{definition}
 
+\begin{definition}[Wolf's explicit eventual thresholds]
+    \label{def:wolf_6_8_explicit_thresholds}
+    \lean{Kraus.HasFullVectorSpreadFrom, Kraus.HasFullWordSpanFrom,
+        Kraus.HasPosDefChoiFrom}
+    \leanok
+    \uses{def:kraus_eventually_full_vector_spread,
+        def:kraus_eventually_full_word_span}
+    For $n,q\in\mathbb N$, write:
+    \begin{align}
+        V_n(K)&:\Longleftrightarrow
+          \forall m\geq n\ \forall\psi\neq0,\quad
+          H_m(K,\psi)=\C^D, \notag\\
+        W_q(K)&:\Longleftrightarrow
+          \forall m\geq q,\quad \mathcal S_m=\MN{D}, \notag\\
+        C_q(K)&:\Longleftrightarrow
+          \forall m\geq q,\quad \tau_{E^m}>0.
+        \notag
+    \end{align}
+    These definitions retain the universal quantifiers in items~2--4 of
+    \cite[Theorem~6.8]{Wolf2012Quantum}; they are the explicit-threshold
+    forms of the corresponding eventual predicates.
+\end{definition}
+
 \begin{theorem}[Full word span gives full vector spread]
     \label{thm:kraus_vector_spread_of_word_span}
     \lean{Kraus.vectorSpreadSpan_eq_top_of_wordSpan_eq_top}
@@ -188,6 +211,57 @@ The empty product is the identity matrix.
     $\mathcal S_m=\MN{D}$. Finally,
     Corollary~\ref{cor:kraus_iterate_eventual_choi_posdef} gives the Choi
     statement.
+\end{proof}
+
+\begin{theorem}[Completely positive primitive maps]
+    \label{thm:wolf_6_8_kraus_equivalences}
+    \lean{Kraus.hasEventuallyFullVectorSpread_iff_exists_hasFullVectorSpreadFrom,
+        Kraus.hasEventuallyFullWordSpan_iff_exists_hasFullWordSpanFrom,
+        Kraus.eventually_choiMatrix_mapLM_pow_posDef_iff_exists_hasPosDefChoiFrom,
+        Kraus.wolf_theorem_6_8_tfae,
+        Kraus.wolf_theorem_6_8_minimal_indices}
+    \leanok
+    \uses{def:wolf_6_8_explicit_thresholds,
+        thm:kraus_primitive_irreducible_eventual_span_choi,
+        thm:kraus_iterate_choi_posdef_iff_word_span,
+        thm:kraus_vector_spread_of_word_span,
+        thm:kraus_irreducible_from_spreading,
+        thm:kraus_primitive_from_tp_spreading}
+    Let $K$ be trace preserving, so its Kraus map $E$ is completely positive
+    and trace preserving. Then the following four statements are equivalent:
+    \begin{enumerate}
+        \item $E$ is irreducible and has trivial peripheral spectrum;
+        \item $V_n(K)$ holds for some $n\in\mathbb N$;
+        \item $W_q(K)$ holds for some $q\in\mathbb N$;
+        \item $C_q(K)$ holds for some $q\in\mathbb N$.
+    \end{enumerate}
+    The first clause is exactly the source's term ``primitive'': Wolf's
+    definition includes irreducibility, while the Lean predicate
+    \texttt{IsPrimitive} records triviality of the peripheral spectrum.
+    The admissible thresholds in clauses~3 and~4 coincide. Consequently one
+    common minimal $q$ works in both clauses, and if $n$ is minimal in
+    clause~2, then $n\leq q$. This is
+    \cite[Theorem~6.8]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:kraus_primitive_irreducible_eventual_span_choi,
+        thm:kraus_iterate_choi_posdef_iff_word_span,
+        thm:kraus_vector_spread_of_word_span,
+        thm:kraus_irreducible_from_spreading,
+        thm:kraus_primitive_from_tp_spreading}
+    Irreducibility and the trivial peripheral spectrum give $W_q(K)$ for a
+    sufficiently large $q$. At each fixed length, vectorization identifies
+    the span of the Kraus words with the span generating the iterate Choi
+    matrix, so $W_q(K)\Longleftrightarrow C_q(K)$ with the same $q$.
+    Moreover, a full matrix word span acts transitively on every nonzero
+    vector, proving $W_q(K)\Rightarrow V_q(K)$. Conversely, evaluating
+    $V_n(K)$ at $m=n$ gives both irreducibility and trivial peripheral
+    spectrum by the fixed-length vector-spreading theorems. Thus the four
+    clauses are equivalent. Pointwise equivalence makes the sets of
+    admissible word and Choi thresholds identical. Since $q$ is itself an
+    admissible vector threshold, minimality gives $n\leq q$.
 \end{proof}
 
 \begin{theorem}[Eventual Choi positivity gives eventual vector spread]

--- a/blueprint/src/chapter/ch07_qpf.tex
+++ b/blueprint/src/chapter/ch07_qpf.tex
@@ -853,6 +853,118 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 
 
+\section{Completely positive primitive maps}
+
+Let $D\geq1$ and let $T:\MN{D}\to\MN{D}$ have the Kraus decomposition
+$T(X)=\sum_i K_iXK_i^\dagger$. Following Wolf, for $m\in\mathbb N$ let
+\begin{align}
+    K_m
+    :=\operatorname{span}\left\{
+        \prod_{k=1}^{m}K_{i_k}:i_1,\ldots,i_m
+      \right\},
+    \qquad
+    \tau_m
+    :=(T^m\otimes\operatorname{id}_D)
+      (\ketbra{\Omega}{\Omega}).
+    \notag
+\end{align}
+
+\begin{definition}[The three Kraus threshold clauses]
+    \label{def:wolf_6_8_explicit_thresholds}
+    \lean{Kraus.HasFullVectorSpreadFrom, Kraus.HasFullWordSpanFrom,
+        Kraus.HasPosDefChoiFrom}
+    \leanok
+    \uses{def:vector_spread_span, def:kraus_exact_word_span,
+        def:kraus_map, def:choi_matrix}
+    At a threshold $n$, the vector-spread clause says that, for every
+    $m\geq n$ and every nonzero $\psi\in\C^D$,
+    $K_m\ket{\psi}=\C^D$. At a threshold $q$, the word-span clause says
+    $K_m=\MN{D}$ for every $m\geq q$, while the Choi clause says
+    $\tau_m>0$ for every $m\geq q$.
+    These are the direct quantified clauses in
+    \cite[Theorem~6.8(2--4)]{Wolf2012Quantum}.
+\end{definition}
+
+\begin{theorem}[Eventual and explicit-threshold formulations]
+    \label{thm:wolf_6_8_eventual_thresholds}
+    \lean{Kraus.hasEventuallyFullVectorSpread_iff_exists_hasFullVectorSpreadFrom,
+        Kraus.hasEventuallyFullWordSpan_iff_exists_hasFullWordSpanFrom,
+        Kraus.eventually_choiMatrix_mapLM_pow_posDef_iff_exists_hasPosDefChoiFrom}
+    \leanok
+    \uses{def:wolf_6_8_explicit_thresholds,
+        def:kraus_eventually_full_vector_spread,
+        def:kraus_eventually_full_word_span}
+    Each assertion that the corresponding property holds for every
+    sufficiently large $m$ is equivalent to the existence of a threshold
+    with Wolf's explicit universal quantifier:
+    \begin{align}
+        &\bigl(\forall\text{ sufficiently large }m\ \forall\psi\neq0,
+          K_m\ket{\psi}=\C^D\bigr)
+          \Longleftrightarrow
+          \bigl(\exists n\ \forall m\geq n\ \forall\psi\neq0,
+          K_m\ket{\psi}=\C^D\bigr), \notag\\
+        &\bigl(\forall\text{ sufficiently large }m, K_m=\MN{D}\bigr)
+          \Longleftrightarrow
+          \bigl(\exists q\ \forall m\geq q, K_m=\MN{D}\bigr), \notag\\
+        &\bigl(\forall\text{ sufficiently large }m, \tau_m>0\bigr)
+          \Longleftrightarrow
+          \bigl(\exists q\ \forall m\geq q, \tau_m>0\bigr).
+          \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    In each case, ``for every sufficiently large $m$'' means exactly that
+    there is a lower threshold beyond which the property holds.
+\end{proof}
+
+\begin{theorem}[Completely positive primitive maps]
+    \label{thm:wolf_6_8_kraus_equivalences}
+    \lean{Kraus.wolf_theorem_6_8_tfae,
+        Kraus.wolf_theorem_6_8_minimal_indices}
+    \leanok
+    \uses{def:tp_kraus, def:irreducible_cp, def:primitive_channel,
+        def:wolf_6_8_explicit_thresholds}
+    Let $T:\MN{D}\to\MN{D}$ be completely positive and trace preserving,
+    with the Kraus decomposition above. Then the following are equivalent:
+    \begin{enumerate}
+        \item $T$ is primitive: it is irreducible and its peripheral spectrum
+              consists only of $1$;
+        \item there is an $n\in\mathbb N$ such that, for every $m\geq n$ and
+              every nonzero $\psi\in\C^D$, $K_m\ket{\psi}=\C^D$;
+        \item there is a $q\in\mathbb N$ such that
+              $K_m=\MN{D}$ for every $m\geq q$;
+        \item there is a $q\in\mathbb N$ such that
+              $\tau_m>0$ for every $m\geq q$.
+    \end{enumerate}
+    The thresholds in items~3 and~4 can be chosen equal. If $n$ and $q$ are
+    chosen minimal, then $n\leq q$. This is
+    \cite[Theorem~6.8]{Wolf2012Quantum}.
+    % The formal primitive clause is IsIrreducibleMap together with the
+    % project's spectral IsPrimitive predicate.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:wolf_6_8_eventual_thresholds,
+        thm:kraus_primitive_irreducible_eventual_span_choi,
+        thm:kraus_iterate_choi_posdef_iff_word_span,
+        thm:kraus_vector_spread_of_word_span,
+        thm:kraus_irreducible_from_spreading,
+        thm:kraus_primitive_from_tp_spreading}
+    Primitivity gives full $K_m$ for all sufficiently large $m$ by the
+    established positive-definite-fixed-point and nonperipheral-decay
+    argument. At every fixed length, vectorization identifies $K_m$ with the
+    span generating $\tau_m$, so items~3 and~4 are equivalent with the same
+    $q$. A full matrix word span sends every nonzero vector onto all of
+    $\C^D$, proving item~2 from item~3 at the same threshold;
+    conversely, evaluating item~2 at $m=n$ gives irreducibility and trivial
+    peripheral spectrum. Thus all four clauses are equivalent. The pointwise
+    word-span--Choi equivalence makes their admissible $q$-sets equal, and a
+    word threshold is also a vector threshold, so minimality gives $n\leq q$.
+\end{proof}
+
 \section{General Brouwer and stationary states}
 
 \begin{theorem}[Brouwer's fixed point theorem]

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -17,10 +17,10 @@ are consumed under their real names (`isIrreducibleMap_full_similarity`,
 library, so the wrapper theorems are noted below without a live Lean
 counterpart.
 
-The tensor-network-layer companion concordance (Wolf Chapter 6 sections
-formalized over Kraus-span primitivity, the quantum Wielandt inequality, and
-the assembled quantum Perron-Frobenius theorem) lives in the sibling TNLean
-project, not in this repository.
+The tensor-network-layer companion concordance (including the quantum
+Wielandt inequality and the assembled quantum Perron-Frobenius theorem) lives
+in the sibling TNLean project, not in this repository. The source-facing
+Kraus-span characterization of primitive channels is formalized here.
 
 ## Wolf Lecture Notes — Chapter 2: Representations
 
@@ -525,10 +525,9 @@ No new proofs are introduced here; this is a documentation-only index module.
 
 This module covers the sections of Wolf Chapter 6 whose formalization lives in
 the quantum-channel layer.  The sections formalized in the tensor-network layer
-— the Kraus-span primitivity characterizations (Theorem 6.8), the quantum
-Wielandt inequality (Theorem 6.9), the unique-fixed-point theorem for tensors
-with eventually full Kraus rank (Theorem 6.15), and the assembled quantum
-Perron–Frobenius theorem — are indexed in
+— the quantum Wielandt inequality (Theorem 6.9), the unique-fixed-point theorem
+for tensors with eventually full Kraus rank (Theorem 6.15), and the assembled
+quantum Perron–Frobenius theorem — are indexed in
 `TNLean.Wielandt.WolfChapter6TNIndex`.
 
 ---
@@ -808,8 +807,25 @@ tensor-network side; see `TNLean.Wielandt.WolfChapter6TNIndex`.
 
 #### Wolf Theorem 6.8 (CP primitive maps, Kraus span characterizations)
 
-Formalized in the tensor-network layer; indexed in
-`TNLean.Wielandt.WolfChapter6TNIndex`.
+**FORMALIZED** in `QICLean.Channel.WolfTheorem68`:
+
+* `Kraus.wolf_theorem_6_8_tfae` packages all four source clauses: Wolf
+  primitivity (represented by irreducibility together with the project's
+  spectral `IsPrimitive` predicate), full vector reachability for every
+  `m ≥ n`, full homogeneous Kraus-word span for every `m ≥ q`, and positive
+  definiteness of the Choi matrix of every power `m ≥ q`.
+* `Kraus.wolf_theorem_6_8_minimal_indices` chooses a single threshold `q`
+  minimal for both the word-span and Choi clauses, chooses the minimal vector
+  threshold `n`, and proves `n ≤ q`.
+* `Kraus.hasEventuallyFullVectorSpread_iff_exists_hasFullVectorSpreadFrom`,
+  `Kraus.hasEventuallyFullWordSpan_iff_exists_hasFullWordSpanFrom`, and
+  `Kraus.eventually_choiMatrix_mapLM_pow_posDef_iff_exists_hasPosDefChoiFrom`
+  identify the reusable eventual predicates with Wolf's explicitly quantified
+  threshold clauses.
+
+The Kraus-map presentation supplies complete positivity; trace preservation is
+an explicit hypothesis. No stronger CP-independent primitivity predicate is
+introduced.
 
 #### Wolf Theorem 6.9 (Quantum Wielandt inequality)
 


### PR DESCRIPTION
## Summary

- state Wolf, Theorem 6.8 with the source's four equivalent clauses for a trace-preserving finite Kraus family
- package the eventual vector-spread, exact-word-span, and Choi-positive-definite clauses in their explicit threshold form
- prove the source's final minimal-index comparison using one least threshold for clauses (3) and (4)
- place the source-facing theorem in the main QPF Blueprint chapter and keep the technical word/Choi bridge in the representation chapter

## Source correspondence

- `Notes/WolfNoteTexSource/chapter/ch06.tex`, Theorem 6.8, especially lines 829--833 and 904--984
- notation follows the source's `K_m` and `tau_m`; the Blueprint does not introduce parallel proof-only notation
- the Lean statement records the source convention that primitivity includes irreducibility, while the project's spectral `IsPrimitive` predicate supplies the peripheral-spectrum clause

## Validation

- `lake build QICLean.Channel.WolfTheorem68`
- `lake exe lint_style`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Blueprint reader-prose, paper-gap, import-aggregator, file-policy, numbering, and `chktex` checks reported green through the sync pipeline
- `git diff --check origin/main...HEAD`

Closes #64
