### PR TITLE
Formalize Wolf Corollary 6.7 for positive maps

### DIFF
--- a/QICLean/Channel/FixedPoint.lean
+++ b/QICLean/Channel/FixedPoint.lean
@@ -10,6 +10,8 @@ Authors: QICLean contributors
 
 import QICLean.Channel.FixedPoint.AbstractAlgebra
 import QICLean.Channel.FixedPoint.AbstractCornerFixedPoints
+import QICLean.Channel.FixedPoint.AbstractMaximalRank
+import QICLean.Channel.FixedPoint.AbstractWeightedFixedPoints
 import QICLean.Channel.FixedPoint.Algebra
 import QICLean.Channel.FixedPoint.BlockForm
 import QICLean.Channel.FixedPoint.BrouwerDensityMatrices

--- a/QICLean/Channel/FixedPoint/AbstractMaximalRank.lean
+++ b/QICLean/Channel/FixedPoint/AbstractMaximalRank.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Analysis.MatrixSqrt
+import QICLean.Channel.FixedPoint.MaximalSupportBasic
+
+/-!
+# Maximum-rank stationary support for positive maps
+
+This file transfers the source-general maximal-support stationary point to
+every maximum-rank stationary density matrix.  No Kraus representation or
+complete positivity is used.
+
+The result is the support prerequisite in Wolf Corollary 6.7: for every
+maximum-rank stationary density matrix `rho`, every fixed point is supported
+on `supp(rho)`.
+-/
+
+open scoped Matrix Matrix.Norms.Frobenius ComplexOrder MatrixOrder Topology
+open Matrix
+
+noncomputable section
+
+namespace IsPositiveMap
+
+variable {D : Nat}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) Complex
+
+private theorem rank_stationaryProj {rho : Mat} (hrho : rho.PosSemidef) :
+    (Kraus.stationaryProj hrho).rank = rho.rank := by
+  have hrankRe :=
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).1.rank_eq_trace_re_of_idem
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).2
+  have htrace : (Kraus.stationaryProj hrho).trace = (rho.rank : Complex) := by
+    simpa [Kraus.stationaryProj] using hrho.supportProj_trace
+  rw [htrace] at hrankRe
+  exact_mod_cast hrankRe
+
+private theorem trace_stationaryProj {rho : Mat} (hrho : rho.PosSemidef) :
+    (Kraus.stationaryProj hrho).trace = (rho.rank : Complex) := by
+  simpa [Kraus.stationaryProj] using hrho.supportProj_trace
+
+/-- The support of every maximum-rank stationary density matrix carries the
+entire fixed-point space of a positive trace-preserving map.
+
+This is the exact `every maximum rank` support step used in Wolf Corollary
+6.7.  The proof compares the chosen matrix with the canonical maximal-support
+point through ranks of their support projections. -/
+theorem maximalSupport_of_maximalRank
+    {T : Mat →ₗ[Complex] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    {rho : Mat} (hrho : rho.PosSemidef) (hrhoFix : T rho = rho)
+    (hrhoMax : ∀ sigma : Mat, sigma.PosSemidef → sigma.trace = 1 →
+      T sigma = sigma → sigma.rank ≤ rho.rank) :
+    ∀ X : Mat, T X = X →
+      Kraus.stationaryProj hrho * X * Kraus.stationaryProj hrho = X := by
+  classical
+  let hbounded := hT.hasBoundedOrbits_of_tracePreserving hTP
+  let rho0 := LinearMap.meanErgodicProjection
+    (𝕜 := ℂ) (E := Matrix (Fin D) (Fin D) ℂ) T hbounded 1
+  obtain ⟨hrho0, hrho0Fix, hmax⟩ :
+      ∃ hrho0 : rho0.PosSemidef, T rho0 = rho0 ∧
+        ∀ X : Mat, T X = X →
+          Kraus.stationaryProj hrho0 * X * Kraus.stationaryProj hrho0 = X := by
+    simpa only [rho0, hbounded] using hT.exists_maximalSupport_fixedPoint hTP
+  set Q0 : Mat := Kraus.stationaryProj hrho0
+  set P : Mat := Kraus.stationaryProj hrho
+  have hQ0herm : Q0ᴴ = Q0 :=
+    (Kraus.isOrthogonalProjection_stationaryProj hrho0).1.eq
+  have hPherm : Pᴴ = P :=
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+  have hQ0idem : Q0 * Q0 = Q0 :=
+    (Kraus.isOrthogonalProjection_stationaryProj hrho0).2
+  have hPidem : P * P = P :=
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).2
+  rcases eq_or_ne rho0 0 with hrho0Zero | hrho0Ne
+  · have hQ0zero : Q0 = 0 := by
+      refine Matrix.ext_of_mulVec_single fun j ↦ ?_
+      rw [show Q0 = Kraus.stationaryProj hrho0 from rfl, Matrix.zero_mulVec]
+      exact hrho0.supportProj_mulVec_eq_zero_of_mulVec_eq_zero _ (by
+        rw [hrho0Zero, Matrix.zero_mulVec])
+    intro X hX
+    have hXzero : X = 0 := by
+      have h := hmax X hX
+      rw [hQ0zero] at h
+      simpa using h.symm
+    rw [hXzero, Matrix.mul_zero, Matrix.zero_mul]
+  · have hcNonneg : (0 : Complex) ≤ rho0.trace := hrho0.trace_nonneg
+    have hcNe : rho0.trace ≠ 0 := by
+      intro hzero
+      have hSstar : (CFC.sqrt rho0)ᴴ = CFC.sqrt rho0 :=
+        Matrix.conjTranspose_cfc_sqrt rho0
+      have hSS : CFC.sqrt rho0 * CFC.sqrt rho0 = rho0 :=
+        CFC.sqrt_mul_sqrt_self rho0 hrho0.nonneg
+      have htrace : ((CFC.sqrt rho0)ᴴ * CFC.sqrt rho0).trace = 0 := by
+        rw [hSstar, hSS]
+        exact hzero
+      have hsqrtZero : CFC.sqrt rho0 = 0 :=
+        Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp htrace
+      exact hrho0Ne (by rw [← hSS, hsqrtZero, Matrix.mul_zero])
+    have him : rho0.trace.im = 0 :=
+      ((Complex.nonneg_iff.mp hcNonneg).2).symm
+    have hreNonneg : 0 ≤ rho0.trace.re :=
+      (Complex.nonneg_iff.mp hcNonneg).1
+    have hreNe : rho0.trace.re ≠ 0 := by
+      intro h
+      exact hcNe (Complex.ext h him)
+    have htraceReal : rho0.trace = ((rho0.trace.re : Real) : Complex) :=
+      Complex.ext rfl (by simp [him])
+    let c : Real := (rho0.trace.re)⁻¹
+    have hcNonnegReal : 0 ≤ c := inv_nonneg.mpr hreNonneg
+    have hcNeReal : c ≠ 0 := inv_ne_zero hreNe
+    let sigma : Mat := ((c : Real) : Complex) • rho0
+    have hsigmaPsd : sigma.PosSemidef := by
+      have h := hrho0.conjTranspose_mul_mul_same
+        (((Real.sqrt c : Real) : Complex) • (1 : Mat))
+      have heq : (((Real.sqrt c : Real) : Complex) • (1 : Mat))ᴴ * rho0 *
+          (((Real.sqrt c : Real) : Complex) • (1 : Mat)) = sigma := by
+        rw [show sigma = ((c : Real) : Complex) • rho0 from rfl,
+          Matrix.conjTranspose_smul, Matrix.conjTranspose_one,
+          Matrix.smul_mul, Matrix.one_mul, Matrix.mul_smul, Matrix.mul_one,
+          smul_smul]
+        congr 1
+        rw [show star (((Real.sqrt c : Real) : Complex)) =
+          ((Real.sqrt c : Real) : Complex) by simp]
+        rw [← Complex.ofReal_mul, Real.mul_self_sqrt hcNonnegReal]
+      rw [← heq]
+      exact h
+    have hsigmaTrace : sigma.trace = 1 := by
+      rw [show sigma = ((c : Real) : Complex) • rho0 from rfl,
+        Matrix.trace_smul, htraceReal, smul_eq_mul, ← Complex.ofReal_mul,
+        inv_mul_cancel₀ hreNe, Complex.ofReal_one]
+    have hsigmaFix : T sigma = sigma := by
+      rw [show sigma = ((c : Real) : Complex) • rho0 from rfl,
+        T.map_smul, hrho0Fix]
+    have hsigmaRank : sigma.rank = rho0.rank := by
+      rw [show sigma = ((c : Real) : Complex) • rho0 from rfl,
+        Matrix.smul_eq_diagonal_mul]
+      refine Matrix.rank_mul_eq_right_of_det_ne_zero _ _ ?_
+      rw [Matrix.det_diagonal, Finset.prod_const]
+      exact pow_ne_zero _ (Complex.ofReal_ne_zero.mpr hcNeReal)
+    have hrankLower : rho0.rank ≤ rho.rank :=
+      hsigmaRank ▸ hrhoMax sigma hsigmaPsd hsigmaTrace hsigmaFix
+    have hQ0rhoQ0 : Q0 * rho * Q0 = rho := hmax rho hrhoFix
+    have hrankUpper : rho.rank ≤ rho0.rank := by
+      calc
+        rho.rank = (Q0 * rho * Q0).rank := by rw [hQ0rhoQ0]
+        _ ≤ (Q0 * rho).rank := Matrix.rank_mul_le_left _ _
+        _ ≤ Q0.rank := Matrix.rank_mul_le_left _ _
+        _ = rho0.rank := rank_stationaryProj hrho0
+    have hrankEq : rho.rank = rho0.rank :=
+      le_antisymm hrankUpper hrankLower
+    have hrhoQ0 : rho * Q0 = rho := by
+      conv_lhs => rw [← hQ0rhoQ0]
+      rw [Matrix.mul_assoc, Matrix.mul_assoc, hQ0idem, ← Matrix.mul_assoc]
+      exact hQ0rhoQ0
+    have hPQ0 : P * Q0 = P := by
+      have hsub : P * (1 - Q0) = 0 := by
+        refine Matrix.ext_of_mulVec_single fun j ↦ ?_
+        rw [Matrix.zero_mulVec, ← Matrix.mulVec_mulVec]
+        refine hrho.supportProj_mulVec_eq_zero_of_mulVec_eq_zero _ ?_
+        rw [Matrix.mulVec_mulVec,
+          show rho * (1 - Q0) = 0 by
+            rw [Matrix.mul_sub, Matrix.mul_one, hrhoQ0, sub_self],
+          Matrix.zero_mulVec]
+      rw [Matrix.mul_sub, Matrix.mul_one] at hsub
+      exact (sub_eq_zero.mp hsub).symm
+    have hQ0P : Q0 * P = P := by
+      have h := congrArg Matrix.conjTranspose hPQ0
+      rwa [Matrix.conjTranspose_mul, hQ0herm, hPherm] at h
+    have hR : (Q0 - P) * (Q0 - P) = Q0 - P := by
+      rw [mul_sub (Q0 - P) Q0 P, sub_mul Q0 P Q0,
+        sub_mul Q0 P P, hQ0idem, hPQ0, hQ0P, hPidem]
+      abel
+    have hRstar : (Q0 - P)ᴴ = Q0 - P := by
+      rw [Matrix.conjTranspose_sub, hQ0herm, hPherm]
+    have hRtrace : ((Q0 - P)ᴴ * (Q0 - P)).trace = 0 := by
+      rw [hRstar, hR, Matrix.trace_sub,
+        show Q0 = Kraus.stationaryProj hrho0 from rfl,
+        show P = Kraus.stationaryProj hrho from rfl,
+        trace_stationaryProj hrho0, trace_stationaryProj hrho,
+        hrankEq, sub_self]
+    have hPeq : P = Q0 := by
+      have h := Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp hRtrace
+      exact (sub_eq_zero.mp h).symm
+    intro X hX
+    rw [hPeq]
+    exact hmax X hX
+
+end IsPositiveMap

--- a/QICLean/Channel/FixedPoint/AbstractWeightedFixedPoints.lean
+++ b/QICLean/Channel/FixedPoint/AbstractWeightedFixedPoints.lean
@@ -1,0 +1,737 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Analysis.MatrixSqrt
+import QICLean.Channel.DirectSumConditionalExpectation
+import QICLean.Channel.FixedPoint.AbstractCornerFixedPoints
+import QICLean.Channel.FixedPoint.AbstractMaximalRank
+import QICLean.Channel.FixedPoint.WeightedCornerFixedPoints
+import QICLean.Channel.FixedPoint.WolfTheorem614
+
+/-!
+# Weighted fixed points of positive maps
+
+This file formalizes the source-general form of Wolf Corollary 6.7.  Its
+multiplication argument follows the density-block description of Wolf
+Theorem 6.14: after weighting by a positive-definite stationary matrix, the
+blocks `sigma k tensor X k` become the coordinate right-factor algebra
+`1 tensor X k`.
+
+## Main declarations
+
+* `IsPositiveMap.weightedCornerFixedPointsStarSubalgebra` constructs the
+  support-correct weighted fixed-point star-algebra under Wolf's positive,
+  trace-preserving, and trace-adjoint Schwarz hypotheses.
+* `IsPositiveMap.mem_weightedCornerFixedPointsStarSubalgebra_iff_inverseSandwich`
+  identifies its carrier with the support-inverse-square-root conjugate of
+  the full fixed-point space at every maximum-rank stationary density.
+* `IsPositiveMap.wolfCorollary67` states Wolf Corollary 6.7 with its printed
+  hypotheses and its quantification over every maximum-rank stationary
+  density matrix.
+
+## Reference
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.7;
+  local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`,
+  lines 1497--1510.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+noncomputable section
+
+namespace IsPositiveMap
+
+variable {D : Nat}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) Complex
+
+/-- Multiplication closure in the full-support step of Wolf Corollary 6.7.
+
+The proof uses the density blocks from Wolf Theorem 6.14.  If the fixed
+matrices have blocks `sigma k tensor A k` and `sigma k tensor B k`, while the
+positive-definite stationary matrix has blocks `sigma k tensor R k`, then
+their weighted product has blocks
+`sigma k tensor (A k * (R k)^{-1} * B k)` and is therefore fixed. -/
+theorem weightedFixed_mul_of_posDef
+    {T : Mat →ₗ[Complex] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {rho : Mat} (hrho : rho.PosDef) (hrhoFix : T rho = rho)
+    {Y1 Y2 : Mat}
+    (hY1 : T (CFC.sqrt rho * Y1 * CFC.sqrt rho) =
+      CFC.sqrt rho * Y1 * CFC.sqrt rho)
+    (hY2 : T (CFC.sqrt rho * Y2 * CFC.sqrt rho) =
+      CFC.sqrt rho * Y2 * CFC.sqrt rho) :
+    T (CFC.sqrt rho * (Y1 * Y2) * CFC.sqrt rho) =
+      CFC.sqrt rho * (Y1 * Y2) * CFC.sqrt rho := by
+  classical
+  let S : Mat := CFC.sqrt rho
+  let A1 : Mat := S * Y1 * S
+  let A2 : Mat := S * Y2 * S
+  obtain ⟨K, d, m, e, U, sigma, hU, hd, hm, hsigmaPsd, hsigmaTrace, _, hfixed⟩ :=
+    hT.exists_block_densities_of_meanErgodicProjection
+      hTP hSchwarz hrho hrhoFix
+  obtain ⟨R, hRcoord⟩ := (hfixed rho).mp hrhoFix
+  obtain ⟨X1, hX1coord⟩ := (hfixed A1).mp (by simpa [A1, S] using hY1)
+  obtain ⟨X2, hX2coord⟩ := (hfixed A2).mp (by simpa [A2, S] using hY2)
+  let Phi := Matrix.unitaryReindexLinearEquiv e U hU
+  have hPhiR : Phi rho =
+      Matrix.blockDiagonal' (fun k ↦ sigma k ⊗ₖ R k) := by
+    rw [Matrix.unitaryReindexLinearEquiv_apply, hRcoord]
+    ext i j
+    simp
+  have hPhiX1 : Phi A1 =
+      Matrix.blockDiagonal' (fun k ↦ sigma k ⊗ₖ X1 k) := by
+    rw [Matrix.unitaryReindexLinearEquiv_apply, hX1coord]
+    ext i j
+    simp
+  have hPhiX2 : Phi A2 =
+      Matrix.blockDiagonal' (fun k ↦ sigma k ⊗ₖ X2 k) := by
+    rw [Matrix.unitaryReindexLinearEquiv_apply, hX2coord]
+    ext i j
+    simp
+  let Uunitary : unitary (Matrix (Fin D) (Fin D) Complex) := ⟨U, hU⟩
+  have hUunit : IsUnit U := ⟨Unitary.toUnits Uunitary, rfl⟩
+  have hconjRho : (star U * rho * U).PosDef := by
+    simpa only [star_eq_conjTranspose] using
+      hrho.conjTranspose_mul_mul_same
+        (Matrix.mulVec_injective_iff_isUnit.mpr hUunit)
+  have hPhiRPosDef : (Phi rho).PosDef := by
+    rw [Matrix.unitaryReindexLinearEquiv_apply]
+    exact hconjRho.submatrix e.injective
+  have hblocksPosDef :
+      (Matrix.blockDiagonal' (fun k ↦ sigma k ⊗ₖ R k)).PosDef := by
+    rwa [hPhiR] at hPhiRPosDef
+  have hblockPosDef : ∀ k, (sigma k ⊗ₖ R k).PosDef := by
+    intro k
+    have hprincipal := hblocksPosDef.submatrix
+      (e := fun i ↦ ⟨k, i⟩)
+      (fun _ _ hij ↦ eq_of_heq (Sigma.mk.inj_iff.mp hij).2)
+    have heq :
+        (Matrix.blockDiagonal' (fun j ↦ sigma j ⊗ₖ R j)).submatrix
+            (fun i ↦ ⟨k, i⟩) (fun i ↦ ⟨k, i⟩) =
+          sigma k ⊗ₖ R k := by
+      ext i j
+      exact Matrix.blockDiagonal'_apply_eq
+        (fun q ↦ sigma q ⊗ₖ R q) k i j
+    rwa [heq] at hprincipal
+  have hRPosDef : ∀ k, (R k).PosDef := by
+    intro k
+    let _ : Nonempty (Fin (m k)) := Fin.pos_iff_nonempty.mp (hm k)
+    have hpartial := (hblockPosDef k).partialTraceLeft
+    simpa only [Matrix.partialTraceLeft_kronecker, hsigmaTrace k, one_smul]
+      using hpartial
+  have hsigmaPosDef : ∀ k, (sigma k).PosDef := by
+    intro k
+    let _ : Nonempty (Fin (m k)) := Fin.pos_iff_nonempty.mp (hm k)
+    let _ : Nonempty (Fin (d k)) := Fin.pos_iff_nonempty.mp (hd k)
+    exact (hblockPosDef k).left_of_kronecker_of_trace_eq_one (hsigmaTrace k)
+  let blockR := Matrix.blockDiagonal' (fun k ↦ sigma k ⊗ₖ R k)
+  let blockRInv := Matrix.blockDiagonal'
+    (fun k ↦ (sigma k)⁻¹ ⊗ₖ (R k)⁻¹)
+  have hblockMulInv : blockR * blockRInv = 1 := by
+    rw [← Matrix.blockDiagonal'_mul]
+    have hfamily :
+        (fun k ↦ (sigma k ⊗ₖ R k) * ((sigma k)⁻¹ ⊗ₖ (R k)⁻¹)) =
+          (1 : ∀ k, Matrix (Fin (m k) × Fin (d k))
+            (Fin (m k) × Fin (d k)) Complex) := by
+      funext k
+      rw [← Matrix.mul_kronecker_mul,
+        Matrix.mul_nonsing_inv _
+          ((Matrix.isUnit_iff_isUnit_det _).mp (hsigmaPosDef k).isUnit),
+        Matrix.mul_nonsing_inv _
+          ((Matrix.isUnit_iff_isUnit_det _).mp (hRPosDef k).isUnit),
+        Matrix.one_kronecker_one]
+      rfl
+    rw [hfamily]
+    exact Matrix.blockDiagonal'_one
+  have hblockInv : blockR⁻¹ = blockRInv :=
+    Matrix.inv_eq_right_inv hblockMulInv
+  have hrhoDet : IsUnit rho.det :=
+    (Matrix.isUnit_iff_isUnit_det rho).mp hrho.isUnit
+  have hPhiInv : Phi rho⁻¹ = (Phi rho)⁻¹ := by
+    symm
+    apply Matrix.inv_eq_right_inv
+    rw [← Matrix.unitaryReindexLinearEquiv_mul,
+      Matrix.mul_nonsing_inv rho hrhoDet,
+      Matrix.unitaryReindexLinearEquiv_one]
+  let C : Mat := A1 * rho⁻¹ * A2
+  have hPhiC : Phi C = Matrix.blockDiagonal'
+      (fun k ↦ sigma k ⊗ₖ (X1 k * (R k)⁻¹ * X2 k)) := by
+    dsimp only [C]
+    rw [Matrix.unitaryReindexLinearEquiv_mul,
+      Matrix.unitaryReindexLinearEquiv_mul,
+      hPhiX1, hPhiInv, hPhiR, hblockInv, hPhiX2]
+    dsimp only [blockRInv]
+    rw [← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+    congr 1
+    funext k
+    rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+      Matrix.mul_nonsing_inv _
+        ((Matrix.isUnit_iff_isUnit_det _).mp (hsigmaPosDef k).isUnit),
+      Matrix.one_mul]
+  have hCfix : T C = C := by
+    apply (hfixed C).mpr
+    refine ⟨fun k ↦ X1 k * (R k)⁻¹ * X2 k, ?_⟩
+    calc
+      star U * C * U = Matrix.reindex e e (Phi C) := by
+        rw [Matrix.unitaryReindexLinearEquiv_apply]
+        ext i j
+        simp
+      _ = Matrix.reindex e e (Matrix.blockDiagonal'
+          (fun k ↦ sigma k ⊗ₖ (X1 k * (R k)⁻¹ * X2 k))) := by
+        rw [hPhiC]
+  have hSdet : IsUnit S.det := by
+    simpa only [S] using hrho.isUnit_det_cfc_sqrt
+  have hSS : S * S = rho := by
+    simpa only [S] using CFC.sqrt_mul_sqrt_self rho hrho.posSemidef.nonneg
+  have hSmulInv : S * S⁻¹ = 1 := Matrix.mul_nonsing_inv S hSdet
+  have hSinvMul : S⁻¹ * S = 1 := Matrix.nonsing_inv_mul S hSdet
+  have hrhoInv : rho⁻¹ = S⁻¹ * S⁻¹ := by
+    apply Matrix.inv_eq_right_inv
+    calc
+      rho * (S⁻¹ * S⁻¹) = (S * S) * (S⁻¹ * S⁻¹) := by rw [hSS]
+      _ = S * (S * S⁻¹) * S⁻¹ := by simp only [Matrix.mul_assoc]
+      _ = S * 1 * S⁻¹ := congrArg (fun Z ↦ S * Z * S⁻¹) hSmulInv
+      _ = S * S⁻¹ := by rw [Matrix.mul_one]
+      _ = 1 := hSmulInv
+  have hCeq : C = S * (Y1 * Y2) * S := by
+    dsimp only [C, A1, A2]
+    calc
+      (S * Y1 * S) * rho⁻¹ * (S * Y2 * S) =
+          (S * Y1 * S) * (S⁻¹ * S⁻¹) * (S * Y2 * S) := by rw [hrhoInv]
+      _ = S * Y1 * (S * S⁻¹) * (S⁻¹ * S) * Y2 * S := by
+        simp only [Matrix.mul_assoc]
+      _ = S * Y1 * 1 * 1 * Y2 * S := by rw [hSmulInv, hSinvMul]
+      _ = S * (Y1 * Y2) * S := by simp only [Matrix.mul_one, Matrix.mul_assoc]
+  simpa only [S, ← hCeq] using hCfix
+
+/-- The source-general full-support weighted fixed points form a star
+subalgebra.  Multiplication is the density-block calculation in
+`weightedFixed_mul_of_posDef`; the other operations use only linearity and
+positivity of `T`. -/
+noncomputable def weightedFixedPointsStarSubalgebra
+    {T : Mat →ₗ[Complex] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {rho : Mat} (hrho : rho.PosDef) (hrhoFix : T rho = rho) :
+    StarSubalgebra Complex Mat where
+  carrier := {Y | T (CFC.sqrt rho * Y * CFC.sqrt rho) =
+    CFC.sqrt rho * Y * CFC.sqrt rho}
+  zero_mem' := by simp
+  add_mem' := by
+    intro X Y hX hY
+    change T (CFC.sqrt rho * X * CFC.sqrt rho) =
+      CFC.sqrt rho * X * CFC.sqrt rho at hX
+    change T (CFC.sqrt rho * Y * CFC.sqrt rho) =
+      CFC.sqrt rho * Y * CFC.sqrt rho at hY
+    change T (CFC.sqrt rho * (X + Y) * CFC.sqrt rho) =
+      CFC.sqrt rho * (X + Y) * CFC.sqrt rho
+    rw [Matrix.mul_add, Matrix.add_mul, T.map_add, hX, hY]
+  one_mem' := by
+    change T (CFC.sqrt rho * (1 : Mat) * CFC.sqrt rho) =
+      CFC.sqrt rho * (1 : Mat) * CFC.sqrt rho
+    rw [Matrix.mul_one, CFC.sqrt_mul_sqrt_self rho hrho.posSemidef.nonneg]
+    exact hrhoFix
+  mul_mem' := weightedFixed_mul_of_posDef hT hTP hSchwarz hrho hrhoFix
+  algebraMap_mem' := by
+    intro c
+    change T (CFC.sqrt rho * algebraMap Complex Mat c * CFC.sqrt rho) =
+      CFC.sqrt rho * algebraMap Complex Mat c * CFC.sqrt rho
+    rw [Algebra.algebraMap_eq_smul_one, Matrix.mul_smul, Matrix.smul_mul,
+      Matrix.mul_one, CFC.sqrt_mul_sqrt_self rho hrho.posSemidef.nonneg,
+      T.map_smul, hrhoFix]
+  star_mem' := by
+    intro Y hY
+    change T (CFC.sqrt rho * Y * CFC.sqrt rho) =
+      CFC.sqrt rho * Y * CFC.sqrt rho at hY
+    change T (CFC.sqrt rho * star Y * CFC.sqrt rho) =
+      CFC.sqrt rho * star Y * CFC.sqrt rho
+    have hSstar : (CFC.sqrt rho)ᴴ = CFC.sqrt rho :=
+      Matrix.conjTranspose_cfc_sqrt rho
+    have hconj : CFC.sqrt rho * star Y * CFC.sqrt rho =
+        (CFC.sqrt rho * Y * CFC.sqrt rho)ᴴ := by
+      simp only [star_eq_conjTranspose, Matrix.conjTranspose_mul,
+        hSstar, Matrix.mul_assoc]
+    rw [hconj, hT.map_conjTranspose, hY]
+
+/-- Membership in the source-general full-support weighted fixed-point
+star-subalgebra is Wolf's displayed fixed-point condition. -/
+@[simp] theorem mem_weightedFixedPointsStarSubalgebra
+    {T : Mat →ₗ[Complex] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {rho : Mat} (hrho : rho.PosDef) (hrhoFix : T rho = rho) (Y : Mat) :
+    Y ∈ weightedFixedPointsStarSubalgebra hT hTP hSchwarz hrho hrhoFix ↔
+      T (CFC.sqrt rho * Y * CFC.sqrt rho) =
+        CFC.sqrt rho * Y * CFC.sqrt rho :=
+  Iff.rfl
+
+/-- Multiplication closure after taking the inverse square root on the support
+of a possibly singular stationary matrix.  The map is compressed to that
+support, `weightedFixed_mul_of_posDef` applies there by the density-block route
+of Theorem 6.14, and the result is extended back by zero. -/
+private theorem weightedCornerFixed_mul
+    {T : Mat →ₗ[Complex] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {rho : Mat} (hrho : rho.PosSemidef) (hrhoFix : T rho = rho)
+    {Y1 Y2 : Mat}
+    (hY1mem : Kraus.stationaryProj hrho * Y1 * Kraus.stationaryProj hrho = Y1)
+    (hY2mem : Kraus.stationaryProj hrho * Y2 * Kraus.stationaryProj hrho = Y2)
+    (hY1 : T (CFC.sqrt rho * Y1 * CFC.sqrt rho) =
+      CFC.sqrt rho * Y1 * CFC.sqrt rho)
+    (hY2 : T (CFC.sqrt rho * Y2 * CFC.sqrt rho) =
+      CFC.sqrt rho * Y2 * CFC.sqrt rho) :
+    T (CFC.sqrt rho * (Y1 * Y2) * CFC.sqrt rho) =
+      CFC.sqrt rho * (Y1 * Y2) * CFC.sqrt rho := by
+  classical
+  let Q : Mat := Kraus.stationaryProj hrho
+  obtain ⟨n, V, hV, hVrange⟩ :=
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).exists_range_isometry
+  let T' : Matrix (Fin n) (Fin n) Complex →ₗ[Complex]
+      Matrix (Fin n) (Fin n) Complex := stationarySupportCompression T V
+  have hT'pos : IsPositiveMap T' :=
+    stationarySupportCompression_isPositiveMap hT V
+  have hT'tp : IsTracePreservingMap T' :=
+    stationarySupportCompression_isTracePreservingMap
+      hT hTP hrho hrhoFix V hV hVrange
+  have hT'Schwarz : IsSchwarzMap (Matrix.traceAdjointMap T') := by
+    simpa only [T'] using
+      hSchwarz.traceAdjointMap_stationarySupportCompression hT V hV
+  let sigma : Matrix (Fin n) (Fin n) Complex := Vᴴ * rho * V
+  have hsigmaPosDef : sigma.PosDef := by
+    have h := Matrix.PosSemidef.compression_on_support_posDef
+      (D := D) (ρ := rho) hrho (k := n) (V := Vᴴ)
+      (by simpa [Matrix.conjTranspose_conjTranspose] using hV)
+      (by simpa [Q, Kraus.stationaryProj,
+        Matrix.conjTranspose_conjTranspose] using hVrange)
+    simpa [sigma, Matrix.conjTranspose_conjTranspose] using h
+  have hrhoSupport : Q * rho * Q = rho := by
+    simp only [Q]
+    rw [Kraus.stationaryProj_mul hrho, Kraus.mul_stationaryProj hrho]
+  have hsigmaFix : T' sigma = sigma := by
+    change Vᴴ * T (V * (Vᴴ * rho * V) * Vᴴ) * V = Vᴴ * rho * V
+    rw [show V * (Vᴴ * rho * V) * Vᴴ = rho by
+      calc
+        V * (Vᴴ * rho * V) * Vᴴ = (V * Vᴴ) * rho * (V * Vᴴ) := by
+          simp only [Matrix.mul_assoc]
+        _ = Q * rho * Q := by rw [hVrange]
+        _ = rho := hrhoSupport,
+      hrhoFix]
+  have hsqrt : CFC.sqrt sigma = Vᴴ * CFC.sqrt rho * V := by
+    simpa only [sigma] using Kraus.cfc_sqrt_compression hrho hVrange
+  have hQidem : Q * Q = Q :=
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).2
+  have hQY1 : Q * Y1 = Y1 := by
+    conv_lhs => rw [← hY1mem]
+    rw [← Matrix.mul_assoc, ← Matrix.mul_assoc, hQidem]
+    exact hY1mem
+  have hY1Q : Y1 * Q = Y1 := by
+    conv_lhs => rw [← hY1mem]
+    rw [Matrix.mul_assoc, hQidem]
+    exact hY1mem
+  have hY2Q : Y2 * Q = Y2 := by
+    conv_lhs => rw [← hY2mem]
+    rw [Matrix.mul_assoc, hQidem]
+    exact hY2mem
+  have hprodmem : Q * (Y1 * Y2) * Q = Y1 * Y2 := by
+    calc
+      Q * (Y1 * Y2) * Q = (Q * Y1) * (Y2 * Q) := by
+        simp only [Matrix.mul_assoc]
+      _ = Y1 * Y2 := by rw [hQY1, hY2Q]
+  have htransport (Y : Mat) (hYmem : Q * Y * Q = Y) :
+      CFC.sqrt sigma * (Vᴴ * Y * V) * CFC.sqrt sigma =
+        Vᴴ * (CFC.sqrt rho * Y * CFC.sqrt rho) * V := by
+    rw [hsqrt]
+    calc
+      (Vᴴ * CFC.sqrt rho * V) * (Vᴴ * Y * V) *
+          (Vᴴ * CFC.sqrt rho * V) =
+          Vᴴ * (CFC.sqrt rho * ((V * Vᴴ) * Y * (V * Vᴴ)) *
+            CFC.sqrt rho) * V := by
+        simp only [Matrix.mul_assoc]
+      _ = Vᴴ * (CFC.sqrt rho * (Q * Y * Q) * CFC.sqrt rho) * V := by
+        rw [hVrange]
+      _ = Vᴴ * (CFC.sqrt rho * Y * CFC.sqrt rho) * V := by rw [hYmem]
+  have hcompressWeighted (Y : Mat) (hYmem : Q * Y * Q = Y)
+      (hYfix : T (CFC.sqrt rho * Y * CFC.sqrt rho) =
+        CFC.sqrt rho * Y * CFC.sqrt rho) :
+      T' (CFC.sqrt sigma * (Vᴴ * Y * V) * CFC.sqrt sigma) =
+        CFC.sqrt sigma * (Vᴴ * Y * V) * CFC.sqrt sigma := by
+    let W : Mat := CFC.sqrt rho * Y * CFC.sqrt rho
+    have hWmem : Q * W * Q = W := by
+      simpa only [Q, W] using Kraus.sqrt_conj_supported hrho Y
+    have hVWV : V * (Vᴴ * W * V) * Vᴴ = W := by
+      calc
+        V * (Vᴴ * W * V) * Vᴴ = (V * Vᴴ) * W * (V * Vᴴ) := by
+          simp only [Matrix.mul_assoc]
+        _ = Q * W * Q := by rw [hVrange]
+        _ = W := hWmem
+    rw [htransport Y hYmem]
+    change Vᴴ * T (V * (Vᴴ * W * V) * Vᴴ) * V = Vᴴ * W * V
+    rw [hVWV, show T W = W by simpa only [W] using hYfix]
+  have hcompressedMul := weightedFixed_mul_of_posDef
+    hT'pos hT'tp hT'Schwarz hsigmaPosDef hsigmaFix
+    (hcompressWeighted Y1 (by simpa only [Q] using hY1mem) hY1)
+    (hcompressWeighted Y2 (by simpa only [Q] using hY2mem) hY2)
+  have hcompressedProduct :
+      (Vᴴ * Y1 * V) * (Vᴴ * Y2 * V) = Vᴴ * (Y1 * Y2) * V := by
+    calc
+      (Vᴴ * Y1 * V) * (Vᴴ * Y2 * V) =
+          Vᴴ * (Y1 * (V * Vᴴ) * Y2) * V := by
+        simp only [Matrix.mul_assoc]
+      _ = Vᴴ * (Y1 * Q * Y2) * V := by rw [hVrange]
+      _ = Vᴴ * (Y1 * Y2) * V := by rw [hY1Q]
+  rw [hcompressedProduct, htransport (Y1 * Y2) hprodmem] at hcompressedMul
+  let W : Mat := CFC.sqrt rho * (Y1 * Y2) * CFC.sqrt rho
+  have hWmem : Q * W * Q = W := by
+    simpa only [Q, W] using Kraus.sqrt_conj_supported hrho (Y1 * Y2)
+  have hVWV : V * (Vᴴ * W * V) * Vᴴ = W := by
+    calc
+      V * (Vᴴ * W * V) * Vᴴ = (V * Vᴴ) * W * (V * Vᴴ) := by
+        simp only [Matrix.mul_assoc]
+      _ = Q * W * Q := by rw [hVrange]
+      _ = W := hWmem
+  calc
+    T W = T (V * (Vᴴ * W * V) * Vᴴ) := congrArg T hVWV.symm
+    _ = V * T' (Vᴴ * W * V) * Vᴴ :=
+      stationarySupportCompression_intertwine
+        hT hrho hrhoFix V hV hVrange (Vᴴ * W * V)
+    _ = V * (Vᴴ * W * V) * Vᴴ := by rw [hcompressedMul]
+    _ = W := hVWV
+
+/-- Weighted fixed points on the support of a stationary positive matrix form
+a star-subalgebra of the existing corner algebra.  This support-correct form
+includes the zero-support case: then the corner is the zero algebra. -/
+noncomputable def weightedCornerFixedPointsStarSubalgebra
+    {T : Mat →ₗ[Complex] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {rho : Mat} (hrho : rho.PosSemidef) (hrhoFix : T rho = rho) :
+    letI hQ : IsIdempotentElem (Kraus.stationaryProj hrho) :=
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).2
+    letI : Semiring hQ.Corner := instSemiringCorner _ hQ
+    letI : Algebra Complex hQ.Corner := MatrixCorner.instAlgebraComplexCorner hQ
+    letI : Star hQ.Corner := MatrixCorner.cornerStar hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    letI : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    letI : StarModule Complex hQ.Corner :=
+      MatrixCorner.cornerStarModuleComplex hQ
+        (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    StarSubalgebra Complex hQ.Corner :=
+  letI hQ : IsIdempotentElem (Kraus.stationaryProj hrho) :=
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).2
+  let _ : Semiring hQ.Corner := instSemiringCorner _ hQ
+  let _ : Algebra Complex hQ.Corner := MatrixCorner.instAlgebraComplexCorner hQ
+  let _ : Star hQ.Corner := MatrixCorner.cornerStar hQ
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+  let _ : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+  let _ : StarModule Complex hQ.Corner :=
+    MatrixCorner.cornerStarModuleComplex hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+  let Q : Mat := Kraus.stationaryProj hrho
+  have hSstar : (CFC.sqrt rho)ᴴ = CFC.sqrt rho :=
+    Matrix.conjTranspose_cfc_sqrt rho
+  have hSrhoS : CFC.sqrt rho * Q * CFC.sqrt rho = rho := by
+    simpa only [Q] using (show
+      CFC.sqrt rho * Kraus.stationaryProj hrho * CFC.sqrt rho = rho by
+        rw [Kraus.cfc_sqrt_mul_stationaryProj hrho,
+          CFC.sqrt_mul_sqrt_self rho hrho.nonneg])
+  { carrier := {Y : hQ.Corner |
+      T (CFC.sqrt rho * Y.1 * CFC.sqrt rho) =
+        CFC.sqrt rho * Y.1 * CFC.sqrt rho}
+    zero_mem' := by
+      change T (CFC.sqrt rho * (0 : Mat) * CFC.sqrt rho) =
+        CFC.sqrt rho * (0 : Mat) * CFC.sqrt rho
+      simp
+    add_mem' := by
+      intro X Y hX hY
+      change T (CFC.sqrt rho * (X.1 + Y.1) * CFC.sqrt rho) =
+        CFC.sqrt rho * (X.1 + Y.1) * CFC.sqrt rho
+      rw [Matrix.mul_add, Matrix.add_mul, T.map_add, hX, hY]
+    one_mem' := by
+      change T (CFC.sqrt rho * Q * CFC.sqrt rho) =
+        CFC.sqrt rho * Q * CFC.sqrt rho
+      rw [hSrhoS]
+      exact hrhoFix
+    mul_mem' := by
+      intro X Y hX hY
+      change T (CFC.sqrt rho * (X.1 * Y.1) * CFC.sqrt rho) =
+        CFC.sqrt rho * (X.1 * Y.1) * CFC.sqrt rho
+      have hXmem : Q * X.1 * Q = X.1 := by
+        obtain ⟨hL, hR⟩ := (Subsemigroup.mem_corner_iff hQ).mp X.2
+        rw [Matrix.mul_assoc, hR, hL]
+      have hYmem : Q * Y.1 * Q = Y.1 := by
+        obtain ⟨hL, hR⟩ := (Subsemigroup.mem_corner_iff hQ).mp Y.2
+        rw [Matrix.mul_assoc, hR, hL]
+      exact weightedCornerFixed_mul
+        hT hTP hSchwarz hrho hrhoFix hXmem hYmem hX hY
+    algebraMap_mem' := by
+      intro c
+      change T (CFC.sqrt rho * (c • Q) * CFC.sqrt rho) =
+        CFC.sqrt rho * (c • Q) * CFC.sqrt rho
+      have hsmul : CFC.sqrt rho * (c • Q) * CFC.sqrt rho = c • rho := by
+        rw [Matrix.mul_smul, Matrix.smul_mul, hSrhoS]
+      rw [hsmul, T.map_smul, hrhoFix]
+    star_mem' := by
+      intro Y hY
+      change T (CFC.sqrt rho * Y.1ᴴ * CFC.sqrt rho) =
+        CFC.sqrt rho * Y.1ᴴ * CFC.sqrt rho
+      have hconj : CFC.sqrt rho * Y.1ᴴ * CFC.sqrt rho =
+          (CFC.sqrt rho * Y.1 * CFC.sqrt rho)ᴴ := by
+        rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+          hSstar, Matrix.mul_assoc]
+      rw [hconj, hT.map_conjTranspose, hY] }
+
+/-- Membership in the support-correct source-general weighted fixed-point
+star-subalgebra is exactly the square-root sandwich fixed-point condition. -/
+@[simp] theorem mem_weightedCornerFixedPointsStarSubalgebra
+    {T : Mat →ₗ[Complex] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {rho : Mat} (hrho : rho.PosSemidef) (hrhoFix : T rho = rho)
+    (hQ : IsIdempotentElem (Kraus.stationaryProj hrho) :=
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).2)
+    (Y : hQ.Corner) :
+    letI : Semiring hQ.Corner := instSemiringCorner _ hQ
+    letI : Algebra Complex hQ.Corner := MatrixCorner.instAlgebraComplexCorner hQ
+    letI : Star hQ.Corner := MatrixCorner.cornerStar hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    letI : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    letI : StarModule Complex hQ.Corner :=
+      MatrixCorner.cornerStarModuleComplex hQ
+        (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    Y ∈ weightedCornerFixedPointsStarSubalgebra
+      hT hTP hSchwarz hrho hrhoFix ↔
+      T (CFC.sqrt rho * Y.1 * CFC.sqrt rho) =
+        CFC.sqrt rho * Y.1 * CFC.sqrt rho :=
+  Iff.rfl
+
+/-! ## Wolf Corollary 6.7: the displayed inverse-square-root set -/
+
+private theorem cfc_sqrt_mul_supportInvSqrt
+    {rho : Mat} (hrho : rho.PosSemidef) :
+    CFC.sqrt rho * hrho.supportInvSqrt = Kraus.stationaryProj hrho := by
+  have hsqrt : CFC.sqrt rho = hrho.isHermitian.cfc Real.sqrt := by
+    rw [CFC.sqrt_eq_real_sqrt rho hrho.nonneg, cfcₙ_eq_cfc,
+      hrho.isHermitian.cfc_eq]
+  simpa only [hsqrt, Kraus.stationaryProj] using
+    hrho.cfc_sqrt_mul_supportInvSqrt
+
+private theorem supportInvSqrt_mul_cfc_sqrt
+    {rho : Mat} (hrho : rho.PosSemidef) :
+    hrho.supportInvSqrt * CFC.sqrt rho = Kraus.stationaryProj hrho := by
+  have hsqrt : CFC.sqrt rho = hrho.isHermitian.cfc Real.sqrt := by
+    rw [CFC.sqrt_eq_real_sqrt rho hrho.nonneg, cfcₙ_eq_cfc,
+      hrho.isHermitian.cfc_eq]
+  simpa only [hsqrt, Kraus.stationaryProj] using
+    hrho.supportInvSqrt_mul_cfc_sqrt
+
+/-- On matrices supported by `rho`, conjugation by the support inverse square
+root is inverse to conjugation by the square root.  This is the auxiliary
+support identity used to identify Wolf's displayed set exactly. -/
+private theorem sqrt_conj_supportInvSqrt_conj_eq
+    {rho X : Mat} (hrho : rho.PosSemidef)
+    (hX : Kraus.stationaryProj hrho * X *
+      Kraus.stationaryProj hrho = X) :
+    CFC.sqrt rho * (hrho.supportInvSqrt * X * hrho.supportInvSqrt) *
+        CFC.sqrt rho = X := by
+  calc
+    CFC.sqrt rho * (hrho.supportInvSqrt * X * hrho.supportInvSqrt) *
+        CFC.sqrt rho =
+        (CFC.sqrt rho * hrho.supportInvSqrt) * X *
+          (hrho.supportInvSqrt * CFC.sqrt rho) := by
+            simp only [Matrix.mul_assoc]
+    _ = Kraus.stationaryProj hrho * X * Kraus.stationaryProj hrho := by
+      rw [cfc_sqrt_mul_supportInvSqrt hrho,
+        supportInvSqrt_mul_cfc_sqrt hrho]
+    _ = X := hX
+
+/-- Conversely, on the support corner, conjugation by the support inverse
+square root recovers the corner element from its square-root sandwich. -/
+private theorem supportInvSqrt_conj_sqrt_conj_eq
+    {rho Y : Mat} (hrho : rho.PosSemidef)
+    (hY : Kraus.stationaryProj hrho * Y *
+      Kraus.stationaryProj hrho = Y) :
+    hrho.supportInvSqrt * (CFC.sqrt rho * Y * CFC.sqrt rho) *
+        hrho.supportInvSqrt = Y := by
+  calc
+    hrho.supportInvSqrt * (CFC.sqrt rho * Y * CFC.sqrt rho) *
+        hrho.supportInvSqrt =
+        (hrho.supportInvSqrt * CFC.sqrt rho) * Y *
+          (CFC.sqrt rho * hrho.supportInvSqrt) := by
+            simp only [Matrix.mul_assoc]
+    _ = Kraus.stationaryProj hrho * Y * Kraus.stationaryProj hrho := by
+      rw [supportInvSqrt_mul_cfc_sqrt hrho,
+        cfc_sqrt_mul_supportInvSqrt hrho]
+    _ = Y := hY
+
+/-- A fixed point supported by `rho` is the square-root sandwich of its
+support-inverse-square-root conjugate.  This is source-general: it uses no
+Kraus representation or complete positivity. -/
+private theorem exists_weightedCorner_sqrt_eq_of_fixedPoint
+    {T : Mat →ₗ[Complex] Mat}
+    {rho : Mat} (hrho : rho.PosSemidef)
+    {X : Mat} (hXFix : T X = X)
+    (hXSupport : Kraus.stationaryProj hrho * X *
+      Kraus.stationaryProj hrho = X) :
+    ∃ Y : Mat,
+      Kraus.stationaryProj hrho * Y * Kraus.stationaryProj hrho = Y ∧
+      T (CFC.sqrt rho * Y * CFC.sqrt rho) =
+        CFC.sqrt rho * Y * CFC.sqrt rho ∧
+      CFC.sqrt rho * Y * CFC.sqrt rho = X := by
+  let Y := hrho.supportInvSqrt * X * hrho.supportInvSqrt
+  have hQInvLeft : Kraus.stationaryProj hrho * hrho.supportInvSqrt =
+      hrho.supportInvSqrt := by
+    simpa only [Kraus.stationaryProj] using
+      hrho.supportProj_mul_supportInvSqrt
+  have hInvQRight : hrho.supportInvSqrt * Kraus.stationaryProj hrho =
+      hrho.supportInvSqrt := by
+    simpa only [Kraus.stationaryProj] using
+      hrho.supportInvSqrt_mul_supportProj
+  have hYSupport : Kraus.stationaryProj hrho * Y *
+      Kraus.stationaryProj hrho = Y := by
+    dsimp only [Y]
+    calc
+      Kraus.stationaryProj hrho *
+          (hrho.supportInvSqrt * X * hrho.supportInvSqrt) *
+          Kraus.stationaryProj hrho =
+          (Kraus.stationaryProj hrho * hrho.supportInvSqrt) * X *
+            (hrho.supportInvSqrt * Kraus.stationaryProj hrho) := by
+              simp only [Matrix.mul_assoc]
+      _ = hrho.supportInvSqrt * X * hrho.supportInvSqrt := by
+        rw [hQInvLeft, hInvQRight]
+  have hSandwich : CFC.sqrt rho * Y * CFC.sqrt rho = X := by
+    exact sqrt_conj_supportInvSqrt_conj_eq hrho hXSupport
+  exact ⟨Y, hYSupport, by rw [hSandwich]; exact hXFix, hSandwich⟩
+
+/-- At every maximum-rank stationary density, every fixed point is reached by
+the weighted support corner.  The `every maximum rank` premise is stated by
+quantifying an arbitrary `rho` whose rank bounds every stationary density. -/
+theorem exists_weightedCorner_sqrt_eq_of_maximalRank
+    {T : Mat →ₗ[Complex] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    {rho : Mat} (hrho : rho.PosSemidef) (hrhoFix : T rho = rho)
+    (hrhoMax : ∀ sigma : Mat, sigma.PosSemidef → sigma.trace = 1 →
+      T sigma = sigma → sigma.rank ≤ rho.rank)
+    {X : Mat} (hXFix : T X = X) :
+    ∃ Y : Mat,
+      Kraus.stationaryProj hrho * Y * Kraus.stationaryProj hrho = Y ∧
+      T (CFC.sqrt rho * Y * CFC.sqrt rho) =
+        CFC.sqrt rho * Y * CFC.sqrt rho ∧
+      CFC.sqrt rho * Y * CFC.sqrt rho = X :=
+  exists_weightedCorner_sqrt_eq_of_fixedPoint hrho hXFix
+    (hT.maximalSupport_of_maximalRank hTP hrho hrhoFix hrhoMax X hXFix)
+
+/-- Membership in the formal star-algebra is exactly membership in Wolf's
+displayed set
+`rho^(-1/2) {X | T X = X} rho^(-1/2)`, with the inverse square root
+totalized to zero off `supp(rho)`. -/
+theorem mem_weightedCornerFixedPointsStarSubalgebra_iff_inverseSandwich
+    {T : Mat →ₗ[Complex] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {rho : Mat} (hrho : rho.PosSemidef) (_hrhoTrace : rho.trace = 1)
+    (hrhoFix : T rho = rho)
+    (hrhoMax : ∀ sigma : Mat, sigma.PosSemidef → sigma.trace = 1 →
+      T sigma = sigma → sigma.rank ≤ rho.rank)
+    (hQ : IsIdempotentElem (Kraus.stationaryProj hrho) :=
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).2)
+    (Y : hQ.Corner) :
+    letI : Semiring hQ.Corner := instSemiringCorner _ hQ
+    letI : Algebra Complex hQ.Corner := MatrixCorner.instAlgebraComplexCorner hQ
+    letI : Star hQ.Corner := MatrixCorner.cornerStar hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    letI : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    letI : StarModule Complex hQ.Corner :=
+      MatrixCorner.cornerStarModuleComplex hQ
+        (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    Y ∈ weightedCornerFixedPointsStarSubalgebra
+        hT hTP hSchwarz hrho hrhoFix ↔
+      ∃ X : Mat, T X = X ∧
+        Y.1 = hrho.supportInvSqrt * X * hrho.supportInvSqrt := by
+  let _ : Semiring hQ.Corner := instSemiringCorner _ hQ
+  let _ : Algebra Complex hQ.Corner := MatrixCorner.instAlgebraComplexCorner hQ
+  let _ : Star hQ.Corner := MatrixCorner.cornerStar hQ
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+  let _ : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+  let _ : StarModule Complex hQ.Corner :=
+    MatrixCorner.cornerStarModuleComplex hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+  have hYSupport : Kraus.stationaryProj hrho * Y.1 *
+      Kraus.stationaryProj hrho = Y.1 := by
+    obtain ⟨hLeft, hRight⟩ := (Subsemigroup.mem_corner_iff hQ).mp Y.2
+    rw [Matrix.mul_assoc, hRight, hLeft]
+  constructor
+  · intro hYFixed
+    let X : Mat := CFC.sqrt rho * Y.1 * CFC.sqrt rho
+    refine ⟨X, ?_, ?_⟩
+    · have hYFixed' :=
+        (mem_weightedCornerFixedPointsStarSubalgebra
+          hT hTP hSchwarz hrho hrhoFix hQ Y).mp hYFixed
+      simpa only [X] using hYFixed'
+    · exact (supportInvSqrt_conj_sqrt_conj_eq hrho hYSupport).symm
+  · rintro ⟨X, hXFix, hYeq⟩
+    have hXSupport :=
+      hT.maximalSupport_of_maximalRank hTP hrho hrhoFix hrhoMax X hXFix
+    have hSandwich := sqrt_conj_supportInvSqrt_conj_eq hrho hXSupport
+    change T (CFC.sqrt rho * Y.1 * CFC.sqrt rho) =
+      CFC.sqrt rho * Y.1 * CFC.sqrt rho
+    rw [hYeq, hSandwich]
+    exact hXFix
+
+/-- **Wolf Corollary 6.7.** Let `T` be positive and trace preserving, with
+Schwarz trace adjoint.  For every maximum-rank stationary density `rho`, the
+support-inverse-square-root conjugate of the fixed-point space is a
+star-algebra.  The returned carrier is identified exactly with Wolf's
+displayed set; no ambient invertibility of `rho` is assumed. -/
+theorem wolfCorollary67
+    {T : Mat →ₗ[Complex] Mat} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {rho : Mat} (hrho : rho.PosSemidef) (hrhoTrace : rho.trace = 1)
+    (hrhoFix : T rho = rho)
+    (hrhoMax : ∀ sigma : Mat, sigma.PosSemidef → sigma.trace = 1 →
+      T sigma = sigma → sigma.rank ≤ rho.rank) :
+    letI hQ : IsIdempotentElem (Kraus.stationaryProj hrho) :=
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).2
+    letI : Semiring hQ.Corner := instSemiringCorner _ hQ
+    letI : Algebra Complex hQ.Corner := MatrixCorner.instAlgebraComplexCorner hQ
+    letI : Star hQ.Corner := MatrixCorner.cornerStar hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    letI : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    letI : StarModule Complex hQ.Corner :=
+      MatrixCorner.cornerStarModuleComplex hQ
+        (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+    ∃ A : StarSubalgebra Complex hQ.Corner,
+      ∀ Y : hQ.Corner, Y ∈ A ↔
+        ∃ X : Mat, T X = X ∧
+          Y.1 = hrho.supportInvSqrt * X * hrho.supportInvSqrt := by
+  let hQ : IsIdempotentElem (Kraus.stationaryProj hrho) :=
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).2
+  let _ : Semiring hQ.Corner := instSemiringCorner _ hQ
+  let _ : Algebra Complex hQ.Corner := MatrixCorner.instAlgebraComplexCorner hQ
+  let _ : Star hQ.Corner := MatrixCorner.cornerStar hQ
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+  let _ : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+    (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+  let _ : StarModule Complex hQ.Corner :=
+    MatrixCorner.cornerStarModuleComplex hQ
+      (Kraus.isOrthogonalProjection_stationaryProj hrho).1.eq
+  refine ⟨weightedCornerFixedPointsStarSubalgebra
+    hT hTP hSchwarz hrho hrhoFix, ?_⟩
+  intro Y
+  exact mem_weightedCornerFixedPointsStarSubalgebra_iff_inverseSandwich
+    hT hTP hSchwarz hrho hrhoTrace hrhoFix hrhoMax hQ Y
+
+end IsPositiveMap

--- a/QICLean/Channel/FixedPoint/MaximalRank.lean
+++ b/QICLean/Channel/FixedPoint/MaximalRank.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import QICLean.Channel.FixedPoint.AbstractWeightedFixedPoints
 import QICLean.Channel.FixedPoint.MaximalSupport
 
 /-!
@@ -20,6 +21,11 @@ $\sqrt{\rho}$ maps the weighted corner carrier of
 such $\rho$, which realizes the conjugated set
 $\rho^{-1/2}\,\{X \mid T(X) = X\}\,\rho^{-1/2}$ of the corollary, with the inverse square
 root taken on the support of $\rho$.
+
+These declarations are compatibility specializations of the source-general
+`IsPositiveMap` results in `AbstractMaximalRank` and
+`AbstractWeightedFixedPoints`; the proofs below introduce no independent
+Kraus-specific route.
 
 The comparison with the constructed witness $\rho_0$ goes through the rank: the support
 projection of a positive semidefinite matrix has the same rank as the matrix, and its
@@ -88,118 +94,18 @@ theorem maximalSupport_of_maximalRank
     (hρ_max : ∀ σ : Mat, σ.PosSemidef → σ.trace = 1 → map K σ = σ → σ.rank ≤ ρ.rank) :
     ∀ X : Mat, map K X = X →
       stationaryProj hρ_psd * X * stationaryProj hρ_psd = X := by
-  classical
-  obtain ⟨ρ₀, hρ₀_psd, hρ₀_fix, hmax⟩ := exists_maximalSupport_fixedPoint K h_tp
-  set Q₀ : Mat := stationaryProj hρ₀_psd with hQ₀def
-  set P : Mat := stationaryProj hρ_psd with hPdef
-  have hQ₀herm : Q₀ᴴ = Q₀ := (isOrthogonalProjection_stationaryProj hρ₀_psd).1.eq
-  have hPherm : Pᴴ = P := (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
-  have hQ₀idem : Q₀ * Q₀ = Q₀ := (isOrthogonalProjection_stationaryProj hρ₀_psd).2
-  have hPidem : P * P = P := (isOrthogonalProjection_stationaryProj hρ_psd).2
-  rcases eq_or_ne ρ₀ 0 with hρ₀0 | hρ₀ne
-  · -- Degenerate case: every fixed point vanishes, and the claim is trivial.
-    have hQ₀0 : Q₀ = 0 := by
-      refine Matrix.ext_of_mulVec_single fun j => ?_
-      rw [hQ₀def, Matrix.zero_mulVec]
-      exact hρ₀_psd.supportProj_mulVec_eq_zero_of_mulVec_eq_zero _ (by
-        rw [hρ₀0, Matrix.zero_mulVec])
-    intro X hX
-    have hX0 : X = 0 := by
-      have h := hmax X hX
-      rw [hQ₀0] at h
-      simpa using h.symm
-    rw [hX0, Matrix.mul_zero, Matrix.zero_mul]
-  · -- The trace of the nonzero maximal witness is a nonzero nonnegative real number.
-    have hc_nonneg : (0 : ℂ) ≤ ρ₀.trace := hρ₀_psd.trace_nonneg
-    have hc_ne : ρ₀.trace ≠ 0 := by
-      intro h0
-      have hS_herm : (CFC.sqrt ρ₀)ᴴ = CFC.sqrt ρ₀ :=
-        Matrix.conjTranspose_cfc_sqrt ρ₀
-      have hSS : CFC.sqrt ρ₀ * CFC.sqrt ρ₀ = ρ₀ :=
-        CFC.sqrt_mul_sqrt_self ρ₀ hρ₀_psd.nonneg
-      have htr : ((CFC.sqrt ρ₀)ᴴ * CFC.sqrt ρ₀).trace = 0 := by
-        rw [hS_herm, hSS]
-        exact h0
-      have hsq0 : CFC.sqrt ρ₀ = 0 :=
-        Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp htr
-      exact hρ₀ne (by rw [← hSS, hsq0, Matrix.mul_zero])
-    have him : ρ₀.trace.im = 0 := ((Complex.nonneg_iff.mp hc_nonneg).2).symm
-    have hre_nonneg : 0 ≤ ρ₀.trace.re := (Complex.nonneg_iff.mp hc_nonneg).1
-    have hre_ne : ρ₀.trace.re ≠ 0 := by
-      intro h
-      exact hc_ne (Complex.ext h him)
-    have htr_eq : ρ₀.trace = ((ρ₀.trace.re : ℝ) : ℂ) := by
-      exact Complex.ext rfl (by simp [him])
-    set c : ℝ := (ρ₀.trace.re)⁻¹ with hcdef
-    have hc_re_nonneg : 0 ≤ c := inv_nonneg.mpr hre_nonneg
-    have hc_re_ne : c ≠ 0 := inv_ne_zero hre_ne
-    -- The normalization of the maximal witness is a fixed-point density matrix.
-    set σ : Mat := ((c : ℝ) : ℂ) • ρ₀ with hσdef
-    have hσ_psd : σ.PosSemidef := by
-      have h := hρ₀_psd.conjTranspose_mul_mul_same
-        (((Real.sqrt c : ℝ) : ℂ) • (1 : Mat))
-      have heq : (((Real.sqrt c : ℝ) : ℂ) • (1 : Mat))ᴴ * ρ₀ *
-          (((Real.sqrt c : ℝ) : ℂ) • (1 : Mat)) = σ := by
-        rw [hσdef, Matrix.conjTranspose_smul, Matrix.conjTranspose_one,
-          Matrix.smul_mul, Matrix.one_mul, Matrix.mul_smul, Matrix.mul_one, smul_smul]
-        congr 1
-        rw [show star (((Real.sqrt c : ℝ) : ℂ)) = ((Real.sqrt c : ℝ) : ℂ) by simp]
-        rw [← Complex.ofReal_mul, Real.mul_self_sqrt hc_re_nonneg]
-      rw [← heq]
-      exact h
-    have hσ_tr : σ.trace = 1 := by
-      rw [hσdef, Matrix.trace_smul, htr_eq, smul_eq_mul, ← Complex.ofReal_mul,
-        inv_mul_cancel₀ hre_ne, Complex.ofReal_one]
-    have hσ_fix : map K σ = σ := by
-      rw [hσdef, map_smul, hρ₀_fix]
-    have hσ_rank : σ.rank = ρ₀.rank := by
-      rw [hσdef, Matrix.smul_eq_diagonal_mul]
-      refine Matrix.rank_mul_eq_right_of_det_ne_zero _ _ ?_
-      rw [Matrix.det_diagonal, Finset.prod_const]
-      exact pow_ne_zero _ (Complex.ofReal_ne_zero.mpr hc_re_ne)
-    -- The two ranks agree.
-    have h1 : ρ₀.rank ≤ ρ.rank := hσ_rank ▸ hρ_max σ hσ_psd hσ_tr hσ_fix
-    have hQ₀ρQ₀ : Q₀ * ρ * Q₀ = ρ := hmax ρ hρ_fix
-    have h2 : ρ.rank ≤ ρ₀.rank := by
-      calc ρ.rank = (Q₀ * ρ * Q₀).rank := by rw [hQ₀ρQ₀]
-        _ ≤ (Q₀ * ρ).rank := Matrix.rank_mul_le_left _ _
-        _ ≤ Q₀.rank := Matrix.rank_mul_le_left _ _
-        _ = ρ₀.rank := rank_stationaryProj hρ₀_psd
-    have hrank_eq : ρ.rank = ρ₀.rank := le_antisymm h2 h1
-    -- The support of `ρ` is contained in the support of the maximal witness.
-    have hρQ₀ : ρ * Q₀ = ρ := by
-      conv_lhs => rw [← hQ₀ρQ₀]
-      rw [Matrix.mul_assoc, Matrix.mul_assoc, hQ₀idem, ← Matrix.mul_assoc]
-      exact hQ₀ρQ₀
-    have hPQ₀ : P * Q₀ = P := by
-      have hsub : P * (1 - Q₀) = 0 := by
-        refine Matrix.ext_of_mulVec_single fun j => ?_
-        rw [Matrix.zero_mulVec, ← Matrix.mulVec_mulVec]
-        refine hρ_psd.supportProj_mulVec_eq_zero_of_mulVec_eq_zero _ ?_
-        rw [Matrix.mulVec_mulVec,
-          show ρ * (1 - Q₀) = 0 by rw [Matrix.mul_sub, Matrix.mul_one, hρQ₀, sub_self],
-          Matrix.zero_mulVec]
-      rw [Matrix.mul_sub, Matrix.mul_one] at hsub
-      exact (sub_eq_zero.mp hsub).symm
-    have hQ₀P : Q₀ * P = P := by
-      have h := congrArg Matrix.conjTranspose hPQ₀
-      rwa [Matrix.conjTranspose_mul, hQ₀herm, hPherm] at h
-    -- Two projections with equal traces, one absorbing the other, coincide.
-    have hR : (Q₀ - P) * (Q₀ - P) = Q₀ - P := by
-      rw [mul_sub (Q₀ - P) Q₀ P, sub_mul Q₀ P Q₀, sub_mul Q₀ P P,
-        hQ₀idem, hPQ₀, hQ₀P, hPidem]
-      abel
-    have hRH : (Q₀ - P)ᴴ = Q₀ - P := by
-      rw [Matrix.conjTranspose_sub, hQ₀herm, hPherm]
-    have hRtr : ((Q₀ - P)ᴴ * (Q₀ - P)).trace = 0 := by
-      rw [hRH, hR, Matrix.trace_sub, hQ₀def, hPdef, trace_stationaryProj hρ₀_psd,
-        trace_stationaryProj hρ_psd, hrank_eq, sub_self]
-    have hPeq : P = Q₀ := by
-      have h := Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp hRtr
-      exact (sub_eq_zero.mp h).symm
-    intro X hX
-    rw [hPeq]
-    exact hmax X hX
+  intro X hX
+  exact IsPositiveMap.maximalSupport_of_maximalRank
+    (isPositiveMap_mapLM K)
+    (isTracePreservingMap_mapLM_of_isTP K h_tp)
+    hρ_psd
+    (by simpa only [mapLM_apply] using hρ_fix)
+    (by
+      intro σ hσ hσTrace hσFix
+      exact hρ_max σ hσ hσTrace
+        (by simpa only [mapLM_apply] using hσFix))
+    X
+    (by simpa only [mapLM_apply] using hX)
 
 /-- **Conjugation by the square root at every fixed point of maximum rank.** Let $T$ be a
 trace-preserving Kraus map and let $\rho$ be a positive semidefinite fixed point of $T$
@@ -217,8 +123,17 @@ theorem exists_weightedCorner_sqrt_eq_of_maximalRank
     {X : Mat} (hX_fix : map K X = X) :
     ∃ Y : Mat, stationaryProj hρ_psd * Y * stationaryProj hρ_psd = Y ∧
       map K (CFC.sqrt ρ * Y * CFC.sqrt ρ) = CFC.sqrt ρ * Y * CFC.sqrt ρ ∧
-      CFC.sqrt ρ * Y * CFC.sqrt ρ = X :=
-  exists_weightedCorner_sqrt_eq_of_fixedPoint K h_tp hρ_psd hρ_fix hX_fix
-    (maximalSupport_of_maximalRank K h_tp hρ_psd hρ_fix hρ_max X hX_fix)
+      CFC.sqrt ρ * Y * CFC.sqrt ρ = X := by
+  simpa only [mapLM_apply] using
+    IsPositiveMap.exists_weightedCorner_sqrt_eq_of_maximalRank
+      (isPositiveMap_mapLM K)
+      (isTracePreservingMap_mapLM_of_isTP K h_tp)
+      hρ_psd
+      (by simpa only [mapLM_apply] using hρ_fix)
+      (by
+        intro σ hσ hσTrace hσFix
+        exact hρ_max σ hσ hσTrace
+          (by simpa only [mapLM_apply] using hσFix))
+      (by simpa only [mapLM_apply] using hX_fix)
 
 end Kraus

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -211,6 +211,88 @@
     Theorem~\ref{thm:maximal_support_compression_density_blocks}.
 \end{proof}
 
+\begin{theorem}[Weighted fixed points on stationary support]%
+    \label{thm:abstract_weighted_corner_fixed_points}
+    \lean{IsPositiveMap.weightedFixed_mul_of_posDef,
+        IsPositiveMap.weightedFixedPointsStarSubalgebra,
+        IsPositiveMap.mem_weightedFixedPointsStarSubalgebra,
+        IsPositiveMap.weightedCornerFixedPointsStarSubalgebra,
+        IsPositiveMap.mem_weightedCornerFixedPointsStarSubalgebra}
+    \leanok
+    \uses{thm:wolf_6_14, thm:compression_on_support_posDef}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, suppose that
+    $T^*$ satisfies the Schwarz inequality, and let $\rho\succeq0$ satisfy
+    $T(\rho)=\rho$.  With $Q=\supp(\rho)$, the set
+    \begin{align}
+        \left\{Y\in Q\MN{D}Q\;\middle|\;
+          T\!\left(\sqrt{\rho}\,Y\sqrt{\rho}\right)
+          =\sqrt{\rho}\,Y\sqrt{\rho}\right\}
+        \label{eq:spectral_weighted_corner_fixed_points}
+    \end{align}
+    is a $*$-subalgebra of the corner algebra $Q\MN{D}Q$.
+    No invertibility of $\rho$ on the ambient space is assumed.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:wolf_6_14, thm:compression_on_support_posDef}
+    Compress to $\supp(\rho)$, where $\rho$ is positive definite.  In the
+    density-block coordinates of Theorem~\ref{thm:wolf_6_14}, write fixed
+    points as
+    $\bigoplus_k\sigma_k\otimes X_k$ and the compressed $\rho$ as
+    $\bigoplus_k\sigma_k\otimes R_k$, with $\sigma_k,R_k>0$.  The weighted
+    product of two fixed blocks is
+    \begin{align}
+        (\sigma_k\otimes X_k)
+        (\sigma_k^{-1}\otimes R_k^{-1})
+        (\sigma_k\otimes Z_k)
+        &=\sigma_k\otimes(X_kR_k^{-1}Z_k),
+        \notag
+    \end{align}
+    hence is fixed.  This proves multiplication closure of
+    (\ref{eq:spectral_weighted_corner_fixed_points}); linearity, positivity,
+    and $T(\rho)=\rho$ give the remaining algebra and adjoint operations.
+    Extending the compressed result by zero gives the stated corner algebra.
+    If the support is zero, that corner is the zero algebra, so the boundary
+    case is included without an ambient inverse.
+\end{proof}
+
+\begin{theorem}[Weighted fixed-point star-algebra]%
+    \label{thm:wolf_corollary_6_7}
+    \lean{IsPositiveMap.wolfCorollary67,
+        IsPositiveMap.mem_weightedCornerFixedPointsStarSubalgebra_iff_inverseSandwich}
+    \leanok
+    \uses{thm:abstract_weighted_corner_fixed_points,
+        thm:maximalSupport_of_maximalRank}
+    Let $T:\MN{D}\to\MN{D}$ be a trace-preserving, positive, linear map for
+    which $T^*$ satisfies the Schwarz inequality.  For every density matrix
+    $\rho$ which is a maximum-rank fixed point of $T$, the set
+    \begin{align}
+        \rho^{-1/2}\Fix(T)\rho^{-1/2}
+        \label{eq:spectral_wolf_corollary_6_7}
+    \end{align}
+    is a $*$-algebra, with the inverse taken on $\supp(\rho)$.
+    This is \cite[Corollary~6.7]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:wolf_6_14, thm:abstract_weighted_corner_fixed_points,
+        thm:maximalSupport_of_maximalRank}
+    Theorem~\ref{thm:maximalSupport_of_maximalRank} applies to the arbitrary
+    maximum-rank stationary density $\rho$, so every $X\in\Fix(T)$ satisfies
+    $QXQ=X$ for $Q=\supp(\rho)$.  The support identities
+    \begin{align}
+        \sqrt{\rho}\,\rho^{-1/2}=Q,
+        &\qquad
+        \rho^{-1/2}\sqrt{\rho}=Q
+        \notag
+    \end{align}
+    show in both directions that the carrier in
+    (\ref{eq:spectral_weighted_corner_fixed_points}) is exactly the set in
+    (\ref{eq:spectral_wolf_corollary_6_7}).  Its multiplication closure is
+    the density-block calculation from Theorem~\ref{thm:wolf_6_14} recorded
+    above, so this is Wolf's route rather than a separate Kraus argument.
+\end{proof}
+
 \begin{theorem}[Conjugation by the square root at a fixed point of maximal support]%
     \label{thm:maximalSupport_weightedCorner}
     \lean{Kraus.exists_maximalSupport_weightedCorner_sqrt_eq}
@@ -305,10 +387,11 @@ support projection.
 \begin{theorem}[The support of a fixed point of maximum rank carries every fixed
         point]%
     \label{thm:maximalSupport_of_maximalRank}
-    \lean{Kraus.maximalSupport_of_maximalRank}
+    \lean{IsPositiveMap.maximalSupport_of_maximalRank,
+        Kraus.maximalSupport_of_maximalRank}
     \leanok
-    \uses{def:tp_kraus, def:support_proj}
-    Let $T(X)=\sum_iK_iXK_i^\dagger$ be trace-preserving and let
+    \uses{def:support_proj}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, and let
     $\rho\succeq0$ be a fixed point of $T$ whose rank bounds the rank of
     every fixed-point density matrix:
     $\rank\sigma\leq\rank\rho$ for every $\sigma\succeq0$ with
@@ -367,10 +450,11 @@ support projection.
 
 \begin{theorem}[Conjugation by the square root at every fixed point of maximum rank]%
     \label{thm:weightedCorner_sqrt_eq_of_maximalRank}
-    \lean{Kraus.exists_weightedCorner_sqrt_eq_of_maximalRank}
+    \lean{IsPositiveMap.exists_weightedCorner_sqrt_eq_of_maximalRank,
+        Kraus.exists_weightedCorner_sqrt_eq_of_maximalRank}
     \leanok
-    \uses{def:tp_kraus, def:support_proj}
-    Let $T(X)=\sum_iK_iXK_i^\dagger$ be trace-preserving and let
+    \uses{def:support_proj}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, and let
     $\rho\succeq0$ be a fixed point of $T$ whose rank bounds the rank of
     every fixed-point density matrix. Then every fixed point $X$ of $T$
     arises as $X=\sqrt{\rho}\,Y\sqrt{\rho}$ for a corner-supported $Y$ with
@@ -397,6 +481,12 @@ the conjugated fixed-point set
     \notag
 \end{align}
 of Corollary~6.7 of~\cite{Wolf2012Quantum}.
+
+The declarations \texttt{Kraus.maximalSupport\_of\_maximalRank} and
+\texttt{Kraus.exists\_weightedCorner\_sqrt\_eq\_of\_maximalRank} retain the
+former finite-Kraus interfaces as compatibility wrappers around the two
+source-general results above; they do not introduce a second proof route or
+stronger source-facing hypotheses.
 
 \section{Further irreducibility and primitivity equivalences}
 

--- a/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
+++ b/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
@@ -6,9 +6,9 @@
 
 \input{command}
 
-\title{Corner-Support Restriction in the Weighted Fixed-Point Star-Algebra}
+\title{Wolf Corollary 6.7: Source-General Resolution Record}
 \author{}
-\date{2026-07-12}
+\date{2026-08-24}
 
 \begin{document}
 \maketitle
@@ -32,70 +32,55 @@ support of the maximum-rank fixed point, so conjugation by $\rho^{-1/2}$ loses n
 
 \section{The formalization}
 
-Two layers are established, both for a Kraus map (the completely positive case of the
-Schwarz hypothesis, as in the other results of this section).
+The source-general implementation is in
+\leanid{QICLean/Channel/FixedPoint/AbstractWeightedFixedPoints.lean}.  It assumes exactly
+that $T$ is positive and trace preserving and that its trace adjoint is Schwarz; it does
+not assume a Kraus representation or complete positivity.
 
-For an \emph{arbitrary} positive semidefinite fixed point $\rho$ with support
-projection $Q$ (\leanid{Kraus.weightedCornerFixedPointsStarSubalgebra} and
-\leanid{Kraus.exists\_weightedCorner\_sqrt\_eq\_of\_fixedPoint} in
-\leanid{QICLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean}), the set
+For an arbitrary positive semidefinite fixed point $\rho$ with support projection $Q$,
+\leanid{IsPositiveMap.weightedCornerFixedPointsStarSubalgebra} proves that
 \[
-    \rho^{-1/2}\,\{X \mid T(X) = X,\ Q X Q = X\}\,\rho^{-1/2}
+    \left\{Y\in QM_D(\mathbb C)Q\mid
+      T(\sqrt\rho\,Y\sqrt\rho)=\sqrt\rho\,Y\sqrt\rho\right\}
 \]
-is a $*$-subalgebra of the corner algebra $Q M_D(\mathbb{C}) Q$; for a non-maximal
-$\rho$ the conjugated set is restricted to the fixed points supported on the support
-of $\rho$. The positive definite case without any support restriction is
-\leanid{Kraus.weightedFixedPointsStarSubalgebra}.
-
-At a fixed point of maximal support the restriction disappears
-(\leanid{Kraus.exists\_maximalSupport\_weightedCorner\_sqrt\_eq} in
-\leanid{QICLean/Channel/FixedPoint/MaximalSupport.lean}): there is a positive
-semidefinite fixed point $\rho_0$ at which the conjugated set is
+is a $*$-subalgebra of $QM_D(\mathbb C)Q$.  Its multiplication proof follows Wolf's
+Theorem~6.14 density blocks.  On the support sector, fixed blocks are
+$\sigma_k\otimes X_k$ and $\rho$ has blocks $\sigma_k\otimes R_k$ with both density
+factors positive definite.  The weighted product remains fixed because
 \[
-    \rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2},
+  (\sigma_k\otimes X_k)(\sigma_k^{-1}\otimes R_k^{-1})
+  (\sigma_k\otimes Z_k)
+  =\sigma_k\otimes(X_kR_k^{-1}Z_k).
 \]
-the set of the corollary, with the inverse square root taken on the support of
-$\rho_0$.
+This is the factor-swapped form of Wolf's
+$\mathcal M_{d_k}\otimes\rho_k$ notation, as already recorded for the formalized
+Theorem~6.14.
 
-\section{The maximal-support property}
+The every-maximum-rank step is source-general as well.
+\leanid{IsPositiveMap.maximalSupport\_of\_maximalRank} in
+\leanid{QICLean/Channel/FixedPoint/AbstractMaximalRank.lean} takes an arbitrary positive
+semidefinite fixed point whose rank bounds the rank of every stationary density and
+proves $QXQ=X$ for every fixed point $X$.  It compares that arbitrary choice with
+$T_\infty(\mathbf 1)$, rather than replacing Wolf's quantifier by the canonical witness.
 
-The removal of the restriction rests on the maximal-support property
-(\leanid{Kraus.exists\_maximalSupport\_fixedPoint}): there is a positive semidefinite
-fixed point $\rho_0$ whose support projection $Q_0$ satisfies $Q_0 X Q_0 = X$ for every
-fixed point $X$. The witness is the sum of the positive parts of the Hermitian and
-anti-Hermitian components of a basis $X_0, \ldots, X_{m-1}$ of the fixed-point space
-(the reference instead takes the image of the identity under the projection onto the
-fixed-point space). Writing
-$H_{1,j} = X_j + X_j^{\dagger}$ and $H_{2,j} = i(X_j - X_j^{\dagger})$ for the fixed
-Hermitian components and $H_{k,j} = P^{+}_{k,j} - P^{-}_{k,j}$ for their positive parts
-(\leanid{IsChannel.posSemidef\_parts\_of\_hermitian\_fixedPoint}), the witness
-\begin{align*}
-    \rho_0 &= \sum_{j=0}^{m-1}
-        \bigl(P^{+}_{1,j} + P^{-}_{1,j} + P^{+}_{2,j} + P^{-}_{2,j}\bigr)
-\end{align*}
-dominates every summand in the Loewner order, domination transfers the support
-(\leanid{Kraus.stationaryProj\_absorb\_of\_le}, from
-$0 \preceq (\mathbf 1-Q_0)P(\mathbf 1-Q_0) \preceq (\mathbf 1-Q_0)\rho_0(\mathbf 1-Q_0) = 0$),
-and linearity extends the absorption from the parts to every fixed point.
+Finally,
+\leanid{IsPositiveMap.mem\_weightedCornerFixedPointsStarSubalgebra\_iff\_inverseSandwich}
+identifies the formal carrier in both directions with
+$\rho^{-1/2}\mathcal F_T\rho^{-1/2}$.  The inverse square root is the functional-calculus
+inverse on $\supp(\rho)$ and zero on its kernel.  The support identities
+$\sqrt\rho\,\rho^{-1/2}=Q=\rho^{-1/2}\sqrt\rho$ give the equality without an ambient
+invertibility assumption.  The generic construction also includes zero support as the
+zero corner algebra; the source theorem's density hypothesis, of course, has trace one.
 
 \section{Verdict}
 
-The restriction is eliminated. The maximal-support property holds at the constructed
-witness (\leanid{Kraus.exists\_maximalSupport\_fixedPoint}), and the transfer to every
-maximum-rank fixed point is
-\leanid{Kraus.maximalSupport\_of\_maximalRank} in
-\leanid{QICLean/Channel/FixedPoint/MaximalRank.lean}: for any positive semidefinite fixed
-point $\rho$ whose rank bounds the rank of every fixed-point density matrix, the support
-projection of $\rho$ carries every fixed point, because the support projection of a
-positive semidefinite matrix has the rank of the matrix and its trace is that rank, so
-the two support projections have equal traces, one absorbs the other, and they coincide.
-The conjugated set $\rho^{-1/2}\,\{X \mid T(X) = X\}\,\rho^{-1/2}$ of the corollary is
-realized at every such $\rho$
-(\leanid{Kraus.exists\_weightedCorner\_sqrt\_eq\_of\_maximalRank}), with the inverse
-square root taken on the support of $\rho$. Unit trace of $\rho$ itself is not needed for
-the conclusion and is not assumed; the maximality hypothesis quantifies over fixed-point
-density matrices, as in the source. The remaining scope convention is the Kraus
-(completely positive) case of the source's Schwarz hypothesis, shared by the other
-formalized results of the section.
+The former Kraus-only scope restriction is eliminated.
+\leanid{IsPositiveMap.wolfCorollary67} states the printed corollary for a positive
+trace-preserving linear map with Schwarz trace adjoint and for every maximum-rank
+stationary density matrix, and it returns a star-algebra whose carrier is exactly Wolf's
+displayed inverse-square-root set.  The older declarations in the
+\texttt{Kraus} namespace remain compatibility specializations; the maximum-rank and
+surjectivity declarations delegate to the source-general proofs rather than furnishing
+a parallel route.
 
 \end{document}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -1167,67 +1167,47 @@ problem: one must still prove the channel hypotheses for those maps on the
 whole direct-sum algebras.  This remaining boundary is recorded in
 `https://sirui-lu.com/TNLean/paper-gaps/cpsv16_vertical_sector_invertibility.pdf`.
 
-#### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED (Kraus case)
+#### Wolf Corollary 6.7 (weighted fixed-point star-algebra) — FORMALIZED
 
-In `QICLean.Channel.FixedPoint.Corollaries`:
+In `QICLean.Channel.FixedPoint.AbstractMaximalRank`:
 
-* `Kraus.rightCanonicalGauge` — the gauged family `ρ^{-1/2} K_i ρ^{1/2}`.
-* `Kraus.weightedFixedPointsStarSubalgebra` — if `T(ρ) = ρ` with `ρ > 0`,
-  then `ρ^{-1/2} Fix(T) ρ^{-1/2}` is a `StarSubalgebra`.
-* `Kraus.mem_weightedFixedPointsStarSubalgebra_iff` — membership is
-  equivalent to saying that `ρ^{1/2} X ρ^{1/2}` is fixed by the original map.
+* `IsPositiveMap.maximalSupport_of_maximalRank` — for a positive
+  trace-preserving map and every positive semidefinite fixed point `ρ` whose
+  rank bounds the rank of every stationary density matrix, the support
+  projection `Q` satisfies `Q X Q = X` for every fixed point `X`.  Thus the
+  quantifier is Wolf's arbitrary maximum-rank stationary density, not one
+  chosen canonical witness.
 
-In `QICLean.Channel.FixedPoint.WeightedCornerFixedPoints` (singular case, any
-positive semidefinite fixed point, restricted to corner-supported fixed
-points):
+In `QICLean.Channel.FixedPoint.AbstractWeightedFixedPoints`:
 
-* `Kraus.weightedCornerFixedPointsStarSubalgebra` — the corner elements `Y`
-  with `√ρ Y √ρ` fixed by the map form a star-subalgebra of the corner
-  algebra `Q M_D(ℂ) Q`, realizing `ρ^{-1/2} {X | T(X) = X, Q X Q = X} ρ^{-1/2}`
-  with the inverse square root taken on the support of `ρ`.
-* `Kraus.exists_weightedCorner_sqrt_eq_of_fixedPoint` — conjugation by `√ρ`
-  maps the carrier onto the corner-supported fixed points.
+* `IsPositiveMap.weightedFixed_mul_of_posDef` — multiplication closure in the
+  full-support case, proved through Wolf Theorem 6.14 density blocks:
+  `(σ_k ⊗ X_k)(σ_k⁻¹ ⊗ R_k⁻¹)(σ_k ⊗ Z_k)
+  = σ_k ⊗ (X_k R_k⁻¹ Z_k)`.
+* `IsPositiveMap.weightedCornerFixedPointsStarSubalgebra` — for a positive
+  trace-preserving `T` whose trace adjoint is Schwarz and any positive
+  semidefinite stationary `ρ`, the corner elements `Y` for which
+  `T (√ρ Y √ρ) = √ρ Y √ρ` form a `StarSubalgebra` of `Q M_D(ℂ) Q`.
+  Compression to `supp(ρ)` supplies the positive-definite density-block
+  calculation; zero support gives the zero corner algebra.
+* `IsPositiveMap.mem_weightedCornerFixedPointsStarSubalgebra_iff_inverseSandwich`
+  — at every maximum-rank stationary density, membership is equivalent to
+  the exact displayed condition
+  `Y = ρ⁻¹ᐟ² X ρ⁻¹ᐟ²` for some `X` with `T X = X`, where the inverse square
+  root is totalized to zero off `supp(ρ)`.
+* `IsPositiveMap.wolfCorollary67` — the source-facing result under exactly
+  Wolf's hypotheses: `T` is positive and trace preserving, `T*` is Schwarz,
+  and `ρ` is an arbitrary maximum-rank stationary density matrix.  It returns
+  the star-algebra together with the exact carrier equality above.
 
-In `QICLean.Channel.FixedPoint.MaximalSupportBasic` (the maximal-support property
-for arbitrary positive trace-preserving maps):
-
-* `Kraus.stationaryProj_absorb_of_le` — for positive semidefinite $P \preceq \rho$
-  the support projection of $\rho$ absorbs $P$.
-* `IsPositiveMap.exists_maximalSupport_fixedPoint` — for an arbitrary positive
-  trace-preserving map, the fixed point $T_\infty(\mathbf 1)$ has support carrying every
-  fixed point, as in Wolf Proposition 6.9.
-
-In `QICLean.Channel.FixedPoint.MaximalSupport` (the Kraus specialization and
-the removal of the corner restriction):
-
-* `Kraus.exists_maximalSupport_fixedPoint` — a positive semidefinite fixed point
-  $\rho_0$ whose
-  support projection $Q_0$ satisfies $Q_0 X Q_0 = X$ for every fixed point $X$.
-* `Kraus.exists_maximalSupport_weightedCorner_sqrt_eq` — at $\rho_0$, conjugation
-  by $\sqrt{\rho_0}$ maps the corner carrier onto the full fixed-point set,
-  realizing $\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2}$ without a support
-  restriction.
-
-In `QICLean.Channel.FixedPoint.MaximalRank` (the transfer to every fixed point
-of maximum rank):
-
-* `Kraus.rank_stationaryProj`, `Kraus.trace_stationaryProj` — the support
-  projection of a positive semidefinite matrix has the rank of the matrix,
-  and its trace is that rank.
-* `Kraus.maximalSupport_of_maximalRank` — if the rank of a positive
-  semidefinite fixed point $\rho$ bounds the rank of every fixed-point
-  density matrix, its support projection $Q$ satisfies $Q X Q = X$ for every
-  fixed point $X$.
-* `Kraus.exists_weightedCorner_sqrt_eq_of_maximalRank` — at every such
-  $\rho$, conjugation by $\sqrt{\rho}$ maps the corner carrier onto the full
-  fixed-point set, realizing $\rho^{-1/2}\,\{X \mid T(X) = X\}\,\rho^{-1/2}$
-  with the inverse square root taken on the support of $\rho$.
-
-The scope is the Kraus (completely positive) case of the source's Schwarz
-hypothesis, as recorded for the other results of this section; the source's
-maximum-rank fixed-point density matrix satisfies the rank hypothesis, with
-unit trace of $\rho$ itself not needed for the conclusion
-(see `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`).
+The earlier declarations in `QICLean.Channel.FixedPoint.Corollaries`,
+`WeightedCornerFixedPoints`, `MaximalSupport`, and `MaximalRank` remain
+finite-Kraus compatibility specializations.  In particular,
+`Kraus.maximalSupport_of_maximalRank` and
+`Kraus.exists_weightedCorner_sqrt_eq_of_maximalRank` now delegate to the
+source-general declarations rather than maintaining a second proof route.
+The former scope restriction is resolved in
+`docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`.
 
 #### Conditional expectation used in Wolf Theorem 6.14 — FORMALIZED
 


### PR DESCRIPTION
## Summary

- formalize Wolf Corollary 6.7 for a positive trace-preserving linear map whose trace adjoint is Schwarz
- quantify an arbitrary maximum-rank stationary density and identify the corner carrier exactly with the support-inverse-square-root set
- make the existing finite-Kraus maximum-rank declarations compatibility wrappers over the source-general proofs
- place the result beside Theorem 6.14 in the main Blueprint and resolve the former Kraus-only gap/coverage text

## Source and proof route

This follows `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1497--1510. Multiplication uses the formalized Theorem 6.14 density blocks and the modified product visible in those blocks:

`(sigma_k tensor X_k) (sigma_k^-1 tensor R_k^-1) (sigma_k tensor Z_k) = sigma_k tensor (X_k R_k^-1 Z_k)`.

Maximum-rank support is transferred from the canonical maximal-support point to every maximum-rank stationary density. The identities `sqrt(rho) rho^(-1/2) = Q = rho^(-1/2) sqrt(rho)` then prove both directions of the exact displayed-set membership theorem, with the inverse totalized to zero off `supp(rho)`. The zero-support construction is the zero corner algebra; the source-facing density theorem retains trace one.

## Validation

- `lake exe cache get`
- focused builds: `QICLean.Channel.FixedPoint.AbstractMaximalRank`, `AbstractWeightedFixedPoints`, `MaximalRank`, and `QICLean.Channel.FixedPoint`
- `lake exe lint_style --github`
- `#print axioms` for nine source-general and compatibility declarations: only `propext`, `Classical.choice`, and `Quot.sound`
- Blueprint sync: 1998 Lean references / 2019 theorem-like entries, 100 percent; reverse changed-declaration coverage has zero missing entries
- reader-facing prose, paper-gap references, chktex, import-aggregator, oversized-file, numbered-module, forbidden-token, and diff checks

Local `lake exe checkdecls blueprint/lean_decls` was not claimed: it imports the broad root module, and the worktree did not have `QICLean.olean`; a broad local build was intentionally not started. The full CI build runs that gate.

Closes #392