### PR TITLE
feat(algebra): prove corrected Kramers degeneracy theorem

### DIFF
--- a/QICLean/Algebra.lean
+++ b/QICLean/Algebra.lean
@@ -24,6 +24,7 @@ import QICLean.Algebra.HermitianSpectrumPerturbation
 import QICLean.Algebra.HermitianSpectrumPreserver
 import QICLean.Algebra.HermitianTracePower
 import QICLean.Algebra.HermitianUnitaryConjugacy
+import QICLean.Algebra.KramersDegeneracy
 import QICLean.Algebra.KroneckerFactorPositivity
 import QICLean.Algebra.MatrixAux
 import QICLean.Algebra.MatrixCongruence

--- a/QICLean/Algebra/KramersDegeneracy.lean
+++ b/QICLean/Algebra/KramersDegeneracy.lean
@@ -1,0 +1,335 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import Mathlib.Analysis.Matrix.Spectrum
+import Mathlib.Analysis.Normed.Operator.LinearIsometry
+import Mathlib.LinearAlgebra.Dimension.Finite
+import Mathlib.LinearAlgebra.Eigenspace.Matrix
+import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
+import Mathlib.LinearAlgebra.Matrix.DotProduct
+
+/-!
+# Kramers degeneracy
+
+Wolf, *Quantum Channels & Operations*, Chapter 3, proves Kramers' theorem: a Hermitian
+operator $H$ commuting with an antiunitary $T$ of square $-1$ has every eigenvalue at
+least two-fold degenerate
+(`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines 498–521).  Wolf
+reduces the statement to matrices: writing $T = \Gamma V$ with $\Gamma$ complex
+conjugation and $V$ unitary, the commutation $[H, T] = 0$ becomes
+$H V^\dagger = V^\dagger H^T$ and the condition $T^2 = -1$ becomes antisymmetry
+$V^T = -V$ (lines 500–501).
+
+The subsequent "Kramers' theorem II" (lines 527–530) relaxes the unitary to a general
+antisymmetric intertwiner $A \neq 0$ with $H A = A H^T$ and claims the same global
+degeneracy.  As printed that claim is false: with
+$H = \operatorname{diag}(0, 1, 1)$ and $A$ the standard symplectic unit of the
+$1$-eigenspace one has $H A = A H^T$ and $A^T = -A \neq 0$, yet the eigenvalue $0$ is
+simple, because the partner vector $A \overline\psi$ of the $0$-eigenvector vanishes.
+The correct statement is conditional: $A \overline\psi$ is always an eigenvector of $H$
+for the same eigenvalue and is always orthogonal to $\psi$, so the eigenvalue is
+degenerate *whenever the partner is nonzero*; a global conclusion follows when $A$ is
+injective, e.g. invertible.  The counterexample and the corrected statements are
+recorded in `docs/paper-gaps/wolf_ch3_kramers_theorem_ii.tex`.
+
+Degeneracy is expressed as `2 ≤ Module.finrank ℂ (Module.End.eigenspace H.toLin' μ)`.
+Wolf's proof exhibits two orthogonal eigenvectors for the same eigenvalue, so the
+eigenspace dimension is the invariant his argument bounds; the geometric multiplicity
+of a Hermitian matrix also agrees with the algebraic one, so nothing is lost against
+the phrase "two-fold degenerate".
+
+## Main results
+
+* `Matrix.dotProduct_mulVec_self_eq_zero_of_transpose_eq_neg`: the quadratic form of an
+  antisymmetric complex matrix vanishes identically.
+* `Matrix.two_le_finrank_eigenspace_of_linearIndependent_pair`: two independent
+  eigenvectors for one eigenvalue bound the eigenspace dimension below by two.
+* `Matrix.IsHermitian.transpose_mulVec_star_of_mulVec_eq_smul`: the conjugate of a
+  `μ`-eigenvector of a Hermitian matrix is a `μ`-eigenvector of its transpose.
+* `Matrix.IsHermitian.mulVec_star_intertwiner_of_mul_eq_mul_transpose`: eigenvector
+  transport across an antisymmetric intertwiner — the partner `A *ᵥ star ψ` is again a
+  `μ`-eigenvector.
+* `Matrix.IsHermitian.two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero`:
+  the corrected conditional Kramers theorem II.
+* `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_isUnit`: the
+  invertible-`A` global corollary.
+* `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_unitary`: Kramers'
+  theorem in Wolf's matrix form, recovered as the unitary case of the corrected
+  theorem II.
+* `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antiunitary`: Kramers' theorem with
+  Wolf's printed antiunitary hypotheses.
+
+## References
+
+* Wolf, *Quantum Channels & Operations*, Chapter 3, Kramers' theorem and Kramers'
+  theorem II (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`,
+  lines 498–530).
+-/
+
+open scoped ComplexOrder Matrix
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n]
+
+/-- The quadratic form of an antisymmetric complex matrix vanishes: if `Mᵀ = -M`, then
+`x ⬝ᵥ M *ᵥ x = 0` for every vector `x`.  This is the mechanism behind the orthogonality
+step of Kramers' theorem (Wolf ch03, equations (3.29)–(3.30), lines 512–520 of
+`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`). -/
+theorem dotProduct_mulVec_self_eq_zero_of_transpose_eq_neg {M : Matrix n n ℂ}
+    (hM : Mᵀ = -M) (x : n → ℂ) : x ⬝ᵥ M *ᵥ x = 0 := by
+  have hself : x ⬝ᵥ M *ᵥ x = -(x ⬝ᵥ M *ᵥ x) := by
+    calc x ⬝ᵥ M *ᵥ x = x ᵥ* M ⬝ᵥ x := Matrix.dotProduct_mulVec x M x
+      _ = Mᵀ *ᵥ x ⬝ᵥ x := by rw [Matrix.mulVec_transpose]
+      _ = (-M) *ᵥ x ⬝ᵥ x := by rw [hM]
+      _ = -(M *ᵥ x ⬝ᵥ x) := by rw [Matrix.neg_mulVec, neg_dotProduct]
+      _ = -(x ⬝ᵥ M *ᵥ x) := by rw [dotProduct_comm]
+  have htwo : (2 : ℂ) * (x ⬝ᵥ M *ᵥ x) = 0 := by linear_combination hself
+  simpa using htwo
+
+omit [Fintype n] in
+/-- The conjugate transpose of an antisymmetric complex matrix is again antisymmetric:
+`Vᴴᵀ = -Vᴴ` whenever `Vᵀ = -V`. -/
+theorem transpose_conjTranspose_eq_neg_of_transpose_eq_neg {V : Matrix n n ℂ}
+    (hV : Vᵀ = -V) : Vᴴᵀ = -Vᴴ := by
+  rw [← Matrix.conjTranspose_transpose_eq_transpose_conjTranspose, hV,
+    Matrix.conjTranspose_neg]
+
+/-- Two nonzero orthogonal vectors are linearly independent. -/
+private theorem linearIndependent_pair_of_dotProduct_star_eq_zero {u v : n → ℂ} (hu : u ≠ 0)
+    (hv : v ≠ 0) (huv : star u ⬝ᵥ v = 0) : LinearIndependent ℂ ![u, v] := by
+  rw [LinearIndependent.pair_iff' hu]
+  intro a hav
+  refine hv ?_
+  have hself : star u ⬝ᵥ u ≠ 0 := fun h => hu (dotProduct_star_self_eq_zero.mp h)
+  have ha : a * (star u ⬝ᵥ u) = 0 := by
+    have h : star u ⬝ᵥ (a • u) = 0 := by rw [hav]; exact huv
+    rwa [dotProduct_smul, smul_eq_mul] at h
+  rw [← hav, (mul_eq_zero.mp ha).resolve_right hself, zero_smul]
+
+/-- The partner vector `A *ᵥ star ψ` of an antisymmetric intertwiner is orthogonal to
+`ψ`: `star ψ ⬝ᵥ (A *ᵥ star ψ) = 0`.  This is Wolf's orthogonality calculation
+(equations (3.29)–(3.30), ch03 lines 512–520) with `A` in place of `V†`. -/
+theorem dotProduct_star_mulVec_star_eq_zero_of_transpose_eq_neg {A : Matrix n n ℂ}
+    (hA : Aᵀ = -A) (ψ : n → ℂ) : star ψ ⬝ᵥ A *ᵥ star ψ = 0 :=
+  dotProduct_mulVec_self_eq_zero_of_transpose_eq_neg hA (star ψ)
+
+variable [DecidableEq n]
+
+/-- Two linearly independent eigenvectors of `A` for the same eigenvalue `μ` force the
+eigenspace of `μ` to have dimension at least two. -/
+theorem two_le_finrank_eigenspace_of_linearIndependent_pair {A : Matrix n n ℂ} {μ : ℂ}
+    {u v : n → ℂ} (hu : A *ᵥ u = μ • u) (hv : A *ᵥ v = μ • v)
+    (hLI : LinearIndependent ℂ ![u, v]) :
+    2 ≤ Module.finrank ℂ (Module.End.eigenspace (Matrix.toLin' A) μ) := by
+  have hmem : ∀ i : Fin 2, ![u, v] i ∈ Module.End.eigenspace (Matrix.toLin' A) μ := by
+    intro i
+    fin_cases i <;> rw [Module.End.mem_eigenspace_iff, Matrix.toLin'_apply] <;>
+      simpa using ‹_›
+  have hLIsub : LinearIndependent ℂ fun i : Fin 2 => (⟨![u, v] i, hmem i⟩ :
+      Module.End.eigenspace (Matrix.toLin' A) μ) :=
+    LinearIndependent.of_comp (Module.End.eigenspace (Matrix.toLin' A) μ).subtype hLI
+  simpa using hLIsub.fintype_card_le_finrank
+
+end Matrix
+
+namespace Matrix.IsHermitian
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- Every eigenvalue of a Hermitian matrix is fixed by complex conjugation. -/
+private theorem conj_eq_self_of_hasEigenvalue {H : Matrix n n ℂ} (hH : H.IsHermitian) {μ : ℂ}
+    (hμ : Module.End.HasEigenvalue (Matrix.toLin' H) μ) : (starRingEnd ℂ) μ = μ := by
+  have hspec : μ ∈ spectrum ℂ H := by
+    rw [← Matrix.spectrum_toLin']
+    exact Module.End.hasEigenvalue_iff_mem_spectrum.mp hμ
+  rw [hH.spectrum_eq_image_range] at hspec
+  obtain ⟨r, -, rfl⟩ := hspec
+  simp
+
+omit [DecidableEq n] in
+/-- The entrywise conjugate of a `μ`-eigenvector of a Hermitian matrix `H` is a
+`μ`-eigenvector of the transpose `Hᵀ`, provided `μ` is real (which Hermiticity of `H`
+forces, see `Matrix.IsHermitian.conj_eq_self_of_hasEigenvalue`).  This is the middle
+step of Wolf's calculation `H *ᵥ (Vᴴ *ᵥ star ψ) = Vᴴ *ᵥ (Hᵀ *ᵥ star ψ) =
+λ • (Vᴴ *ᵥ star ψ)` (ch03 line 509),
+factored out so it can be reused with a general intertwiner. -/
+theorem transpose_mulVec_star_of_mulVec_eq_smul {H : Matrix n n ℂ} (hH : H.IsHermitian)
+    {μ : ℂ} {ψ : n → ℂ} (hψ : H *ᵥ ψ = μ • ψ) (hμ : (starRingEnd ℂ) μ = μ) :
+    Hᵀ *ᵥ star ψ = μ • star ψ := by
+  rw [Matrix.mulVec_transpose, ← hH.eq, ← Matrix.star_mulVec, hψ]
+  ext i
+  simp [Pi.star_apply, hμ]
+
+omit [DecidableEq n] in
+/-- **Eigenvector transport across an antisymmetric intertwiner** (Wolf ch03 line 509
+with `A` in place of `V†`): if `H` is Hermitian, `H * A = A * Hᵀ`, and `ψ` is a
+`μ`-eigenvector of `H` with `μ` real, then the partner `A *ᵥ star ψ` is again a
+`μ`-eigenvector: `H *ᵥ (A *ᵥ star ψ) = μ • (A *ᵥ star ψ)`. -/
+theorem mulVec_star_intertwiner_of_mul_eq_mul_transpose {H A : Matrix n n ℂ}
+    (hH : H.IsHermitian) (hHA : H * A = A * Hᵀ) {μ : ℂ} {ψ : n → ℂ}
+    (hψ : H *ᵥ ψ = μ • ψ) (hμ : (starRingEnd ℂ) μ = μ) :
+    H *ᵥ (A *ᵥ star ψ) = μ • (A *ᵥ star ψ) := by
+  rw [Matrix.mulVec_mulVec, hHA, ← Matrix.mulVec_mulVec,
+    hH.transpose_mulVec_star_of_mulVec_eq_smul hψ hμ, Matrix.mulVec_smul]
+
+/-- **Kramers' theorem II, corrected conditional form** (Wolf ch03 lines 527–530).
+
+Let `H` be Hermitian and let `A` be an antisymmetric intertwiner, `Aᵀ = -A` with
+`H * A = A * Hᵀ`.  If `ψ` is a `μ`-eigenvector of `H` whose partner `A *ᵥ star ψ` is
+nonzero, then the eigenspace of `μ` is at least two-dimensional: `ψ` and its partner
+are orthogonal eigenvectors for the same eigenvalue.
+
+Wolf's printed statement assumes only `A ≠ 0` and concludes that *every* eigenvalue of
+`H` is at least two-fold degenerate.  That global form is false, because the partner
+`A *ᵥ star ψ` of a particular eigenvector can vanish; the nonvanishing hypothesis below
+is exactly what Wolf's calculation needs and cannot be dropped (the eigenvalue `0` of
+`H = diag (0, 1, 1)` with `A` the symplectic unit of the `1`-eigenspace is simple — see
+the paper-gap note).
+
+**Local fix (Wolf ch03, lines 527–530):** the nonvanishing hypothesis
+`A *ᵥ star ψ ≠ 0` is added to the printed statement.  Counterexample and corrected
+statement: `docs/paper-gaps/wolf_ch3_kramers_theorem_ii.tex`. -/
+theorem two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero {H A : Matrix n n ℂ}
+    (hH : H.IsHermitian) (hHA : H * A = A * Hᵀ) (hAanti : Aᵀ = -A)
+    {μ : ℂ} {ψ : n → ℂ} (hψ : H *ᵥ ψ = μ • ψ) (hψne : ψ ≠ 0)
+    (hAψ : A *ᵥ star ψ ≠ 0) :
+    2 ≤ Module.finrank ℂ (Module.End.eigenspace (Matrix.toLin' H) μ) := by
+  have hμev : Module.End.HasEigenvalue (Matrix.toLin' H) μ :=
+    Module.End.hasEigenvalue_of_hasEigenvector <| Module.End.hasEigenvector_iff.mpr
+      ⟨Module.End.mem_eigenspace_iff.mpr (by rw [Matrix.toLin'_apply]; exact hψ), hψne⟩
+  have hconj : (starRingEnd ℂ) μ = μ := conj_eq_self_of_hasEigenvalue hH hμev
+  have hφ : H *ᵥ (A *ᵥ star ψ) = μ • (A *ᵥ star ψ) :=
+    hH.mulVec_star_intertwiner_of_mul_eq_mul_transpose hHA hψ hconj
+  have horth : star ψ ⬝ᵥ A *ᵥ star ψ = 0 :=
+    Matrix.dotProduct_star_mulVec_star_eq_zero_of_transpose_eq_neg hAanti ψ
+  exact Matrix.two_le_finrank_eigenspace_of_linearIndependent_pair hψ hφ
+    (Matrix.linearIndependent_pair_of_dotProduct_star_eq_zero hψne hAψ horth)
+
+/-- **Kramers' theorem II for an invertible antisymmetric intertwiner** (corrected
+global form of Wolf ch03 lines 527–530): if `H` is Hermitian and `A` is an invertible
+antisymmetric matrix with `H * A = A * Hᵀ`, then every eigenvalue of `H` is at least
+two-fold degenerate.
+
+Invertibility makes the partner `A *ᵥ star ψ` of every eigenvector nonzero, so the
+corrected conditional theorem applies to every eigenvalue.  Over `ℂ` an antisymmetric
+matrix can be invertible only in even dimension (`Aᵀ = -A` gives
+`det A = (-1)^n det A`), matching Wolf's remark (lines 523–525) that antisymmetric
+unitaries exist only in even dimensions.
+
+**Local fix (Wolf ch03, lines 527–530):** the printed hypothesis `A ≠ 0` is
+strengthened to invertibility of `A`, a convenient uniform hypothesis under which
+Wolf's calculation closes for every eigenvalue at once.  Documented in
+`docs/paper-gaps/wolf_ch3_kramers_theorem_ii.tex`. -/
+theorem two_le_finrank_eigenspace_of_antisymmetric_isUnit {H A : Matrix n n ℂ}
+    (hH : H.IsHermitian) (hAunit : IsUnit A) (hHA : H * A = A * Hᵀ) (hAanti : Aᵀ = -A)
+    {μ : ℂ} (hμ : Module.End.HasEigenvalue (Matrix.toLin' H) μ) :
+    2 ≤ Module.finrank ℂ (Module.End.eigenspace (Matrix.toLin' H) μ) := by
+  obtain ⟨ψ, hψmem, hψne⟩ := hμ.exists_hasEigenvector
+  have hψ : H *ᵥ ψ = μ • ψ := by
+    have h := Module.End.mem_eigenspace_iff.mp hψmem
+    rwa [Matrix.toLin'_apply] at h
+  have hAψ : A *ᵥ star ψ ≠ 0 := by
+    intro hzero
+    obtain ⟨u, hu⟩ := hAunit
+    have hid : (↑u⁻¹ : Matrix n n ℂ) * A = 1 := by rw [← hu, Units.inv_mul]
+    have hstarψ : star ψ = 0 := by
+      have h := congrArg (fun w : n → ℂ => (↑u⁻¹ : Matrix n n ℂ) *ᵥ w) hzero
+      rwa [Matrix.mulVec_zero, Matrix.mulVec_mulVec, hid, Matrix.one_mulVec] at h
+    exact hψne (by simpa using congrArg star hstarψ)
+  exact hH.two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero hHA hAanti
+    hψ hψne hAψ
+
+/-- **Kramers' theorem** (Wolf, *Quantum Channels & Operations*, ch03 line 503), in
+Wolf's own matrix reduction of the antiunitary statement.
+
+Wolf states the theorem for a Hermitian $H$ and an antiunitary $T$ with $[H, T] = 0$ and
+$T^2 = -1$, and immediately rewrites both hypotheses in matrix terms: with $T = \Gamma V$
+for $\Gamma$ complex conjugation and $V$ unitary, commutation is
+$H V^\dagger = V^\dagger H^T$ and $T^2 = -1$ is antisymmetry $V^T = -V$ (lines 500–501).
+Those two matrix identities, together with $V^\dagger V = 1$, are the hypotheses below,
+so the statement is Wolf's with the antiunitary rewritten exactly as he rewrites it; no
+further hypothesis is imposed.
+
+"At least two-fold degenerate" is `2 ≤ Module.finrank ℂ (Module.End.eigenspace H.toLin' μ)`:
+Wolf's proof produces a second eigenvector orthogonal to the first, so the eigenspace
+dimension is what the argument bounds.
+
+The relation to the corrected Kramers theorem II is direct: this is the case
+`A = Vᴴ` of `two_le_finrank_eigenspace_of_antisymmetric_isUnit`, where `Vᴴ` is
+antisymmetric because `V` is, and invertible because `V` is unitary.  Wolf's proof is
+exactly this specialization: from $H \psi = \mu \psi$ the partner
+$\varphi = V^\dagger \overline{\psi}$ is nonzero by unitarity, satisfies
+$H \varphi = \mu \varphi$ by transport, and is orthogonal to $\psi$ because the
+quadratic form of the antisymmetric matrix $V^\dagger$ vanishes. -/
+theorem two_le_finrank_eigenspace_of_antisymmetric_unitary {H V : Matrix n n ℂ}
+    (hH : H.IsHermitian) (hVunit : Vᴴ * V = 1) (hHV : H * Vᴴ = Vᴴ * Hᵀ) (hVanti : Vᵀ = -V)
+    {μ : ℂ} (hμ : Module.End.HasEigenvalue (Matrix.toLin' H) μ) :
+    2 ≤ Module.finrank ℂ (Module.End.eigenspace (Matrix.toLin' H) μ) :=
+  hH.two_le_finrank_eigenspace_of_antisymmetric_isUnit
+    (isUnit_iff_exists.mpr ⟨V, hVunit, mul_eq_one_comm.mp hVunit⟩) hHV
+    (Matrix.transpose_conjTranspose_eq_neg_of_transpose_eq_neg hVanti) hμ
+
+/-- **Kramers' theorem** in Wolf's printed antiunitary form (ch03 lines 503–505).
+
+Let $H$ be Hermitian and let $T$ be antiunitary. If $H$ commutes with $T$ and
+$T^2=-\Id$, then every eigenspace of $H$ has dimension at least two. Here
+antiunitarity is represented by a conjugate-linear isometric equivalence; the two
+operator identities are stated pointwise, without choosing a matrix factorization
+of $T$.
+
+Indeed, if $H\psi=\mu\psi$, then Hermiticity makes $\mu$ real and commutation gives
+$H(T\psi)=\mu T\psi$. The vectors $\psi$ and $T\psi$ are independent: a relation
+$T\psi=a\psi$ would imply $-\psi=T^2\psi=\overline a a\psi$, contradicting
+$\overline a a=|a|^2\geq 0$.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 3, Kramers' theorem;
+`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines 500–505. -/
+theorem two_le_finrank_eigenspace_of_antiunitary
+    {H : Matrix n n ℂ} (hH : H.IsHermitian)
+    (T : (n → ℂ) ≃ₗᵢ⋆[ℂ] (n → ℂ))
+    (hcomm : ∀ ψ, H *ᵥ T ψ = T (H *ᵥ ψ))
+    (hsq : ∀ ψ, T (T ψ) = -ψ)
+    {μ : ℂ} (hμ : Module.End.HasEigenvalue (Matrix.toLin' H) μ) :
+    2 ≤ Module.finrank ℂ (Module.End.eigenspace (Matrix.toLin' H) μ) := by
+  obtain ⟨ψ, hψmem, hψne⟩ := hμ.exists_hasEigenvector
+  have hψ : H *ᵥ ψ = μ • ψ := by
+    have := Module.End.mem_eigenspace_iff.mp hψmem
+    rwa [Matrix.toLin'_apply] at this
+  have hconj : star μ = μ := by
+    simpa using conj_eq_self_of_hasEigenvalue hH hμ
+  let φ : n → ℂ := T ψ
+  have hφ : H *ᵥ φ = μ • φ := by
+    calc
+      H *ᵥ φ = T (H *ᵥ ψ) := hcomm ψ
+      _ = T (μ • ψ) := by rw [hψ]
+      _ = star μ • φ := T.map_smulₛₗ μ ψ
+      _ = μ • φ := by rw [hconj]
+  have hφne : φ ≠ 0 := by
+    intro hzero
+    apply hψne
+    exact T.injective (by simpa [φ] using hzero)
+  have hLI : LinearIndependent ℂ ![ψ, φ] := by
+    rw [LinearIndependent.pair_iff' hψne]
+    intro a ha
+    have hscalar : star a * a = -1 := by
+      apply smul_left_injective ℂ hψne
+      calc
+        (star a * a) • ψ = star a • a • ψ := by rw [smul_smul]
+        _ = star a • φ := by rw [ha]
+        _ = T (a • ψ) := by
+          simpa [φ] using (T.map_smulₛₗ a ψ).symm
+        _ = T φ := by rw [ha]
+        _ = -ψ := hsq ψ
+        _ = (-1 : ℂ) • ψ := by simp
+    have hnormSq : (Complex.normSq a : ℂ) = -1 := by
+      rw [Complex.normSq_eq_conj_mul_self]
+      exact hscalar
+    have hre := congrArg Complex.re hnormSq
+    norm_num at hre
+    exact (not_lt_of_ge (Complex.normSq_nonneg a)) (by linarith)
+  exact Matrix.two_le_finrank_eigenspace_of_linearIndependent_pair hψ hφ hLI
+
+end Matrix.IsHermitian

--- a/QICLean/Algebra/KramersDegeneracy.lean
+++ b/QICLean/Algebra/KramersDegeneracy.lean
@@ -25,9 +25,10 @@ $V^T = -V$ (lines 500–501).
 The subsequent "Kramers' theorem II" (Wolf Thm 3.2, lines 527–530) relaxes the
 unitary to a general antisymmetric intertwiner $A \neq 0$ with $H A = A H^T$ and
 claims the same global degeneracy.  As printed that claim is false: with
-$H = \operatorname{diag}(0, 1, 1)$ and $A$ the standard symplectic unit of the
-$1$-eigenspace one has $H A = A H^T$ and $A^T = -A \neq 0$, yet the eigenvalue $0$ is
-simple, because the partner vector $A \overline\psi$ of the $0$-eigenvector vanishes.
+$H = \operatorname{diag}(0, 1, 1)$ and $A$ the standard antisymmetric unit
+$[[0,1],[-1,0]]$ of the $1$-eigenspace one has $H A = A H^T$ and $A^T = -A \neq 0$,
+yet the eigenvalue $0$ is simple, because the partner vector $A \overline\psi$ of
+the $0$-eigenvector vanishes.
 The correct statement is conditional: $A \overline\psi$ is always an eigenvector of $H$
 for the same eigenvalue and is always orthogonal to $\psi$, so the eigenvalue is
 degenerate *whenever the partner is nonzero*; a global conclusion follows when $A$ is
@@ -153,9 +154,9 @@ omit [DecidableEq n] in
 /-- The entrywise conjugate of a `μ`-eigenvector of a Hermitian matrix `H` is a
 `μ`-eigenvector of the transpose `Hᵀ`, provided `μ` is real (which Hermiticity of `H`
 forces, see `Matrix.IsHermitian.conj_eq_self_of_hasEigenvalue`).  This is the middle
-step of Wolf's calculation `H *ᵥ (Vᴴ *ᵥ star ψ) = Vᴴ *ᵥ (Hᵀ *ᵥ star ψ) =
-λ • (Vᴴ *ᵥ star ψ)` (ch03 line 509),
-factored out so it can be reused with a general intertwiner. -/
+step of Wolf's ch03-line-509 calculation
+`H *ᵥ (Vᴴ *ᵥ star ψ) = Vᴴ *ᵥ (Hᵀ *ᵥ star ψ) = λ • (Vᴴ *ᵥ star ψ)`, factored out so it
+can be reused with a general intertwiner. -/
 theorem transpose_mulVec_star_of_mulVec_eq_smul {H : Matrix n n ℂ} (hH : H.IsHermitian)
     {μ : ℂ} {ψ : n → ℂ} (hψ : H *ᵥ ψ = μ • ψ) (hμ : (starRingEnd ℂ) μ = μ) :
     Hᵀ *ᵥ star ψ = μ • star ψ := by
@@ -187,8 +188,8 @@ Wolf's printed Theorem 3.2 assumes only `A ≠ 0` and concludes that *every* eig
 `H` is at least two-fold degenerate.  That global form is false, because the partner
 `A *ᵥ star ψ` of a particular eigenvector can vanish; the nonvanishing hypothesis below
 is exactly what Wolf's calculation needs and cannot be dropped (the eigenvalue `0` of
-`H = diag (0, 1, 1)` with `A` the symplectic unit of the `1`-eigenspace is simple — see
-the paper-gap note).
+`H = diag (0, 1, 1)` with `A` the antisymmetric unit of the `1`-eigenspace is simple —
+see the paper-gap note).
 
 **Local fix (Wolf ch03, lines 527–530):** the nonvanishing hypothesis
 `A *ᵥ star ψ ≠ 0` is added to the printed statement.  Counterexample and corrected
@@ -211,9 +212,8 @@ theorem two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero {H A : Matr
 
 /-- **Kramers' theorem II for an invertible antisymmetric intertwiner** (corrected
 global form of Wolf Thm 3.2, ch03 lines 527–530): if `H` is Hermitian and `A` is an
-invertible
-antisymmetric matrix with `H * A = A * Hᵀ`, then every eigenvalue of `H` is at least
-two-fold degenerate.
+invertible antisymmetric matrix with `H * A = A * Hᵀ`, then every eigenvalue of `H`
+is at least two-fold degenerate.
 
 Invertibility makes the partner `A *ᵥ star ψ` of every eigenvector nonzero, so the
 corrected conditional theorem applies to every eigenvalue.  Over `ℂ` an antisymmetric

--- a/QICLean/Algebra/KramersDegeneracy.lean
+++ b/QICLean/Algebra/KramersDegeneracy.lean
@@ -15,16 +15,16 @@ import Mathlib.LinearAlgebra.Matrix.DotProduct
 
 Wolf, *Quantum Channels & Operations*, Chapter 3, proves Kramers' theorem: a Hermitian
 operator $H$ commuting with an antiunitary $T$ of square $-1$ has every eigenvalue at
-least two-fold degenerate
-(`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines 498–521).  Wolf
+least two-fold degenerate (Wolf Thm 3.1,
+`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines 498–521).  Wolf
 reduces the statement to matrices: writing $T = \Gamma V$ with $\Gamma$ complex
 conjugation and $V$ unitary, the commutation $[H, T] = 0$ becomes
 $H V^\dagger = V^\dagger H^T$ and the condition $T^2 = -1$ becomes antisymmetry
 $V^T = -V$ (lines 500–501).
 
-The subsequent "Kramers' theorem II" (lines 527–530) relaxes the unitary to a general
-antisymmetric intertwiner $A \neq 0$ with $H A = A H^T$ and claims the same global
-degeneracy.  As printed that claim is false: with
+The subsequent "Kramers' theorem II" (Wolf Thm 3.2, lines 527–530) relaxes the
+unitary to a general antisymmetric intertwiner $A \neq 0$ with $H A = A H^T$ and
+claims the same global degeneracy.  As printed that claim is false: with
 $H = \operatorname{diag}(0, 1, 1)$ and $A$ the standard symplectic unit of the
 $1$-eigenspace one has $H A = A H^T$ and $A^T = -A \neq 0$, yet the eigenvalue $0$ is
 simple, because the partner vector $A \overline\psi$ of the $0$-eigenvector vanishes.
@@ -55,17 +55,17 @@ the phrase "two-fold degenerate".
   the corrected conditional Kramers theorem II.
 * `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_isUnit`: the
   invertible-`A` global corollary.
-* `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_unitary`: Kramers'
-  theorem in Wolf's matrix form, recovered as the unitary case of the corrected
-  theorem II.
+* `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_unitary`: the
+  matrix form of Kramers' theorem, recovered as the unitary case of the corrected
+  intertwiner theorem.
 * `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antiunitary`: Kramers' theorem with
   Wolf's printed antiunitary hypotheses.
 
 ## References
 
-* Wolf, *Quantum Channels & Operations*, Chapter 3, Kramers' theorem and Kramers'
-  theorem II (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`,
-  lines 498–530).
+* Wolf, *Quantum Channels & Operations*, Chapter 3, Theorem 3.1 (Kramers' theorem)
+  and Theorem 3.2 (Kramers' theorem II),
+  `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines 498–530.
 -/
 
 open scoped ComplexOrder Matrix
@@ -175,14 +175,15 @@ theorem mulVec_star_intertwiner_of_mul_eq_mul_transpose {H A : Matrix n n ℂ}
   rw [Matrix.mulVec_mulVec, hHA, ← Matrix.mulVec_mulVec,
     hH.transpose_mulVec_star_of_mulVec_eq_smul hψ hμ, Matrix.mulVec_smul]
 
-/-- **Kramers' theorem II, corrected conditional form** (Wolf ch03 lines 527–530).
+/-- **Kramers' theorem II, corrected conditional form** (Wolf Thm 3.2, ch03 lines
+527–530).
 
 Let `H` be Hermitian and let `A` be an antisymmetric intertwiner, `Aᵀ = -A` with
 `H * A = A * Hᵀ`.  If `ψ` is a `μ`-eigenvector of `H` whose partner `A *ᵥ star ψ` is
 nonzero, then the eigenspace of `μ` is at least two-dimensional: `ψ` and its partner
 are orthogonal eigenvectors for the same eigenvalue.
 
-Wolf's printed statement assumes only `A ≠ 0` and concludes that *every* eigenvalue of
+Wolf's printed Theorem 3.2 assumes only `A ≠ 0` and concludes that *every* eigenvalue of
 `H` is at least two-fold degenerate.  That global form is false, because the partner
 `A *ᵥ star ψ` of a particular eigenvector can vanish; the nonvanishing hypothesis below
 is exactly what Wolf's calculation needs and cannot be dropped (the eigenvalue `0` of
@@ -209,7 +210,8 @@ theorem two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero {H A : Matr
     (Matrix.linearIndependent_pair_of_dotProduct_star_eq_zero hψne hAψ horth)
 
 /-- **Kramers' theorem II for an invertible antisymmetric intertwiner** (corrected
-global form of Wolf ch03 lines 527–530): if `H` is Hermitian and `A` is an invertible
+global form of Wolf Thm 3.2, ch03 lines 527–530): if `H` is Hermitian and `A` is an
+invertible
 antisymmetric matrix with `H * A = A * Hᵀ`, then every eigenvalue of `H` is at least
 two-fold degenerate.
 
@@ -242,8 +244,8 @@ theorem two_le_finrank_eigenspace_of_antisymmetric_isUnit {H A : Matrix n n ℂ}
   exact hH.two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero hHA hAanti
     hψ hψne hAψ
 
-/-- **Kramers' theorem** (Wolf, *Quantum Channels & Operations*, ch03 line 503), in
-Wolf's own matrix reduction of the antiunitary statement.
+/-- **Kramers' theorem** (Wolf, *Quantum Channels & Operations*, Thm 3.1, ch03
+lines 503–506), in Wolf's own matrix reduction of the antiunitary statement.
 
 Wolf states the theorem for a Hermitian $H$ and an antiunitary $T$ with $[H, T] = 0$ and
 $T^2 = -1$, and immediately rewrites both hypotheses in matrix terms: with $T = \Gamma V$
@@ -272,7 +274,8 @@ theorem two_le_finrank_eigenspace_of_antisymmetric_unitary {H V : Matrix n n ℂ
     (isUnit_iff_exists.mpr ⟨V, hVunit, mul_eq_one_comm.mp hVunit⟩) hHV
     (Matrix.transpose_conjTranspose_eq_neg_of_transpose_eq_neg hVanti) hμ
 
-/-- **Kramers' theorem** in Wolf's printed antiunitary form (ch03 lines 503–505).
+/-- **Kramers' theorem** in Wolf's printed antiunitary form (Thm 3.1, ch03 lines
+503–505).
 
 Let $H$ be Hermitian and let $T$ be antiunitary. If $H$ commutes with $T$ and
 $T^2=-\Id$, then every eigenspace of $H$ has dimension at least two. Here

--- a/blueprint/src/chapter/ch04_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp.tex
@@ -18,6 +18,4 @@ forced by an anti-unitary symmetry of square $-\Id$.
 \input{chapter/ch04_positive_not_cp_choi_and_decomposable_maps}
 \input{chapter/ch04_positive_not_cp_ppt_and_separable_states}
 \input{chapter/ch04_positive_not_cp_schmidt_number_and_entanglement}
-% ch25_positive_not_cp_kramers_degeneracy.tex stays in TNLean (its item
-% resolves to a TN-side Lean declaration per the boundary report); see
-% interface_edges.md.
+\input{chapter/ch04_positive_not_cp_kramers_degeneracy}

--- a/blueprint/src/chapter/ch04_positive_not_cp_kramers_degeneracy.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_kramers_degeneracy.tex
@@ -1,0 +1,166 @@
+\section{Kramers degeneracy}
+\label{sec:kramers_degeneracy}
+
+An anti-unitary symmetry of square $-\Id$ forces every eigenvalue of a
+commuting Hermitian operator to be at least two-fold degenerate.  This section
+formalizes Kramers' theorem together with its antisymmetric-intertwiner
+relaxation, whose printed form requires a correction
+\cite[Chapter~3]{Wolf2012Quantum}.
+
+\begin{lemma}[Independent eigenvectors give degeneracy]
+    \label{lem:eigenspace_dim_of_independent_pair}
+    \lean{Matrix.two_le_finrank_eigenspace_of_linearIndependent_pair}
+    \leanok
+    If two linearly independent vectors are eigenvectors of $M\in\MN{D}$ for the
+    same eigenvalue $\lambda$, then the eigenspace of $\lambda$ has dimension at
+    least two.
+\end{lemma}
+
+\begin{proof}\leanok
+    The two vectors span a two-dimensional subspace of the eigenspace.
+\end{proof}
+
+\begin{theorem}[Kramers' theorem]
+    \label{thm:kramers_degeneracy}
+    \lean{Matrix.IsHermitian.two_le_finrank_eigenspace_of_antiunitary}
+    \leanok
+    Let $H\in\MN{D}$ be Hermitian and let $T$ be an anti-unitary operator with
+    $[H,T]=0$ and $T^2=-\Id$.  Then every eigenvalue of $H$ is at least
+    two-fold degenerate
+    \cite[Chapter~3, Theorem~3.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:eigenspace_dim_of_independent_pair}
+    Let $H\ket{\psi}=\lambda\ket{\psi}$ with $\ket{\psi}\neq 0$.  Hermiticity
+    gives $\lambda\in\R$, while commutation and anti-linearity give
+    \begin{align}
+        H T\ket{\psi}
+         & =T H\ket{\psi}
+        =T\bigl(\lambda\ket{\psi}\bigr)
+        =\overline\lambda T\ket{\psi}
+        =\lambda T\ket{\psi}.
+    \end{align}
+    Antiunitarity makes $T\ket{\psi}$ nonzero.  These two eigenvectors are
+    linearly independent: if $T\ket{\psi}=a\ket{\psi}$, then
+    \begin{align}
+        -\ket{\psi}=T^2\ket{\psi}
+        =T\bigl(a\ket{\psi}\bigr)
+        =\overline a a\ket{\psi},
+    \end{align}
+    which is impossible because $\overline a a=|a|^2\geq0$.  Hence the
+    eigenspace of $\lambda$ has dimension at least two by
+    Lemma~\ref{lem:eigenspace_dim_of_independent_pair}.
+\end{proof}
+
+Writing $T=\Gamma V$ with $\Gamma$ complex conjugation and $V$ unitary, the
+hypotheses of Theorem~\ref{thm:kramers_degeneracy} become
+$HV^\dagger=V^\dagger H^T$ and $V^T=-V$.  Wolf then relaxes the unitary to a
+general antisymmetric intertwiner.  The two calculations behind the theorem
+survive the relaxation verbatim; only the nonvanishing of the second
+eigenvector does not (Remark~\ref{rem:kramers_ii_counterexample}).
+
+\begin{lemma}[The partner eigenvector]
+    \label{lem:kramers_partner}
+    \lean{Matrix.IsHermitian.transpose_mulVec_star_of_mulVec_eq_smul,
+        Matrix.IsHermitian.mulVec_star_intertwiner_of_mul_eq_mul_transpose,
+        Matrix.dotProduct_star_mulVec_star_eq_zero_of_transpose_eq_neg,
+        Matrix.dotProduct_mulVec_self_eq_zero_of_transpose_eq_neg}
+    \leanok
+    Let $H\in\MN{D}$ be Hermitian and let $A\in\MN{D}$ satisfy $HA=AH^{T}$ and
+    $A^{T}=-A$.  If $H\ket{\psi}=\lambda\ket{\psi}$, then the partner vector
+    $A\ket{\overline\psi}$ is again a $\lambda$-eigenvector of $H$ and is
+    orthogonal to $\ket{\psi}$:
+    \begin{align}
+        H\,A\ket{\overline\psi}       & =\lambda\,A\ket{\overline\psi}, \\
+        \braket{\psi}{A\overline\psi} & =0.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Hermiticity of $H$ makes $\lambda$ real, so conjugating the eigenvalue
+    equation gives $H^{T}\ket{\overline\psi}=\lambda\ket{\overline\psi}$, and
+    the intertwining relation yields
+    $H\,A\ket{\overline\psi}=AH^{T}\ket{\overline\psi}
+        =\lambda\,A\ket{\overline\psi}$.  For the orthogonality, antisymmetry makes
+    the quadratic form of $A$ its own negative:
+    $\braket{\psi}{A\overline\psi}=-\braket{\psi}{A\overline\psi}$.
+\end{proof}
+
+\begin{remark}
+    \label{rem:kramers_ii_counterexample}
+    Wolf prints this relaxation with the hypothesis $A\neq0$ alone and
+    concludes that every eigenvalue of $H$ is at least two-fold degenerate
+    \cite[Chapter~3, Theorem~3.2]{Wolf2012Quantum}.  As printed this is
+    false.  On $\C^3$ with basis indexed by $0,1,2$, take
+    \begin{align}
+        H=\operatorname{diag}(0,1,1),\qquad
+        A=
+        \begin{pmatrix}
+            0 & 0  & 0 \\
+            0 & 0  & 1 \\
+            0 & -1 & 0
+        \end{pmatrix}.
+    \end{align}
+    Then $H$ is Hermitian, $A^{T}=-A\neq0$, and $HA=AH^{T}=A$, but the
+    eigenvalue $0$ is simple: its eigenvector $\ket{e_0}$ has vanishing partner
+    $A\ket{\overline{e_0}}=Ae_0=0$, so Lemma~\ref{lem:kramers_partner} supplies
+    no second eigenvector.  The correct conditional statement is
+    Theorem~\ref{thm:kramers_ii_nonvanishing}.
+\end{remark}
+
+\begin{theorem}[Kramers' theorem for an antisymmetric intertwiner]
+    \label{thm:kramers_ii_nonvanishing}
+    \lean{Matrix.IsHermitian.two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero}
+    \leanok
+    Let $H\in\MN{D}$ be Hermitian and let $A\in\MN{D}$ satisfy $HA=AH^{T}$ and
+    $A^{T}=-A$.  If $\ket{\psi}\neq0$ satisfies
+    $H\ket{\psi}=\lambda\ket{\psi}$ and the partner does not vanish,
+    $A\ket{\overline\psi}\neq0$, then the eigenspace of $\lambda$ has dimension
+    at least two.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:kramers_partner, lem:eigenspace_dim_of_independent_pair}
+    By Lemma~\ref{lem:kramers_partner}, $\ket{\psi}$ and
+    $A\ket{\overline\psi}$ are nonzero orthogonal eigenvectors for the same
+    eigenvalue $\lambda$, hence linearly independent, and
+    Lemma~\ref{lem:eigenspace_dim_of_independent_pair} gives the dimension
+    bound.
+\end{proof}
+
+\begin{corollary}[Invertible intertwiner]
+    \label{cor:kramers_ii_invertible}
+    \lean{Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_isUnit}
+    \leanok
+    Let $H\in\MN{D}$ be Hermitian and let $A\in\MN{D}$ be invertible with
+    $HA=AH^{T}$ and $A^{T}=-A$.  Then every eigenvalue of $H$ is at least
+    two-fold degenerate.
+\end{corollary}
+
+\begin{proof}\leanok
+    \uses{thm:kramers_ii_nonvanishing}
+    If $H\ket{\psi}=\lambda\ket{\psi}$ with $\ket{\psi}\neq0$, invertibility
+    of $A$ gives $A\ket{\overline\psi}\neq0$, so
+    Theorem~\ref{thm:kramers_ii_nonvanishing} applies.  An antisymmetric
+    invertible matrix exists only in even dimensions, since
+    $\det A=\det A^{T}=(-1)^{D}\det A$.
+\end{proof}
+
+\begin{corollary}[Kramers' theorem, matrix form]
+    \label{cor:kramers_matrix_form}
+    \lean{Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_unitary,
+        Matrix.transpose_conjTranspose_eq_neg_of_transpose_eq_neg}
+    \leanok
+    Let $H,V\in\MN{D}$ with $H$ Hermitian, $V$ unitary,
+    $HV^{\dagger}=V^{\dagger}H^{T}$, and $V^{T}=-V$.  Then every eigenvalue of
+    $H$ is at least two-fold degenerate.
+\end{corollary}
+
+\begin{proof}\leanok
+    \uses{cor:kramers_ii_invertible}
+    This is Corollary~\ref{cor:kramers_ii_invertible} at $A=V^{\dagger}$: the
+    adjoint of $V$ is antisymmetric because $V$ is, and invertible because $V$
+    is unitary.  This is Wolf's own proof of
+    Theorem~\ref{thm:kramers_degeneracy} read through the matrix reduction.
+\end{proof}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -31,9 +31,7 @@
 %                                          no-information-without-disturbance
 %                                          sections, folded in as this
 %                                          chapter's opening material)
-%   Ch.3  Positive, but not completely -> ch04_positive_not_cp_* (except
-%                                          kramers_degeneracy, which stays
-%                                          in TNLean)
+%   Ch.3  Positive, but not completely -> ch04_positive_not_cp_*
 %   Ch.4  Convex Structure             -> ch04_convex_structure
 %   Ch.5  Operator Inequalities        -> ch05_schwarz_* (including the
 %                                          former auxiliary chapter's

--- a/docs/paper-gaps/wolf_ch3_kramers_theorem_ii.tex
+++ b/docs/paper-gaps/wolf_ch3_kramers_theorem_ii.tex
@@ -1,0 +1,140 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Nonvanishing Partner in Wolf's Kramers Theorem~II}
+\author{}
+\date{2026-08-24}
+
+\begin{document}
+\maketitle
+\gapnote{false-source}{resolved}
+
+\section{The assertion}
+
+Wolf's Kramers theorem~II states:\footnote{\cite[Chapter~3, Theorem~3.2
+(``Kramer's theorem~II'')]{Wolf2012Quantum}; local source
+\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex},
+lines~527--530.  Tracked in \ghissue{17}.}
+\begin{align}
+  \left.
+  \begin{minipage}{0.82\linewidth}
+  Let $H$ be Hermitian and $HA=AH^{T}$ for some anti-symmetric $A\neq 0$.
+  Then each eigenvalue of $H$ is at least two-fold degenerate.
+  \end{minipage}
+  \right\}
+  \tag{\path{Wolf ch03, lines 527--530}}
+\end{align}
+The theorem is offered as a relaxation of the first Kramers theorem
+(\cite[Chapter~3, Theorem~3.1]{Wolf2012Quantum}), which
+treats a Hermitian $H$ commuting with an anti-unitary $T$ of square $-\Id$:
+writing $T=\Gamma V$ with $\Gamma$ complex conjugation and $V$ unitary, the
+hypotheses become $HV^{\dagger}=V^{\dagger}H^{T}$ and $V^{T}=-V$, and the
+printed text adds that ``the restriction on the required symmetry in the
+theorem can be relaxed as the same proof shows.''\footnote{Local source,
+lines~498--501 (the matrix reduction) and lines~523--525 (the relaxation
+claim).}
+
+\section{The point at issue}
+
+The proof in question produces, for every eigenvector
+$H\ket{\psi}=\lambda\ket{\psi}$, the partner vector $A\ket{\overline\psi}$ and
+argues that the two vectors are orthogonal eigenvectors for the same
+eigenvalue.  Both calculation steps survive the relaxation:
+\begin{align}
+  H\,A\ket{\overline\psi}
+  =A H^{T}\ket{\overline\psi}
+  =\lambda\,A\ket{\overline\psi},
+  \qquad
+  \braket{\psi}{A\overline\psi}=0,
+\end{align}
+the first because Hermiticity makes $\lambda$ real and
+$H^{T}\ket{\overline\psi}=\overline{H\ket{\psi}}$, the second because the
+quadratic form of an anti-symmetric matrix is its own negative.  What does
+\emph{not} survive is the nondegeneracy step.  In the first theorem the
+partner is $V^{\dagger}\ket{\overline\psi}$ with $V$ unitary, hence nonzero;
+for a general anti-symmetric $A\neq 0$ the vector $\ket{\overline\psi}$ may lie
+in the kernel of $A$, and then the partner vanishes and the orthogonality
+statement is vacuous.
+
+Concretely, on $\C^{3}$ take
+\begin{align}
+  H=\operatorname{diag}(0,1,1),
+  \qquad
+  A=
+  \begin{pmatrix}
+    0&0&0\\
+    0&0&1\\
+    0&-1&0
+  \end{pmatrix}.
+\end{align}
+Then $H=H^{\dagger}$, $A^{T}=-A$, $A\neq 0$, and $HA=AH^{T}=A$, since the
+nontrivial rows and columns of $A$ sit entirely inside the $1$-eigenspace of
+$H$.  The eigenvalue $0$ of $H$ is simple, with eigenvector $e_{1}$, and the
+partner vanishes: $A\overline{e_{1}}=Ae_{1}=0$.  So the printed conclusion
+fails while every printed hypothesis holds.
+
+\section{The corrected statement}
+
+The calculation above proves the conditional statement: the eigenvalue
+$\lambda$ of an eigenvector $\ket{\psi}$ is at least two-fold degenerate
+\emph{whenever the partner is nonzero},
+\begin{align}
+  A\ket{\overline\psi}\neq 0
+  \Longrightarrow
+  \dim\ker(H-\lambda)\ge 2,
+\end{align}
+because $\ket{\psi}$ and $A\ket{\overline\psi}$ are then two orthogonal,
+hence linearly independent, eigenvectors for $\lambda$.  A hypothesis-free
+global conclusion therefore requires $A$ to be injective, so that
+$\ket{\psi}\neq 0$ implies $A\ket{\overline\psi}\neq 0$: if the
+anti-symmetric intertwiner $A$ is invertible, then every eigenvalue of $H$ is
+at least two-fold degenerate.  Over $\C$ an anti-symmetric matrix can be
+invertible only in even dimensions, since
+$\det A=\det A^{T}=(-1)^{d}\det A$; this matches the observation printed next
+to the first theorem that anti-symmetric unitaries exist only in even
+dimensions.\footnote{Local source, lines~523--524.}
+
+The first Kramers theorem is exactly the invertible case: for $T=\Gamma V$
+the choice $A=V^{\dagger}$ is anti-symmetric (because $V^{T}=-V$) and
+invertible (because $V$ is unitary), so the corrected theorem~II specializes
+to theorem~I, with Wolf's own proof.
+
+\section{The formalization}
+
+The corrected development lives in
+\doclink{QICLean/Algebra/KramersDegeneracy}.\footnote{Transport:
+\leanid{Matrix.IsHermitian.mulVec_star_intertwiner_of_mul_eq_mul_transpose};
+orthogonality:
+\leanid{Matrix.dotProduct_star_mulVec_star_eq_zero_of_transpose_eq_neg};
+conditional theorem:
+\leanid{Matrix.IsHermitian.two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero};
+invertible global corollary:
+\leanid{Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_isUnit};
+theorem~I in matrix form, derived as the case $A=V^{\dagger}$:
+\leanid{Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_unitary};
+theorem~I with the printed anti-unitary hypotheses:
+\leanid{Matrix.IsHermitian.two_le_finrank_eigenspace_of_antiunitary}.}
+Degeneracy is recorded as $2\le\dim$ of the eigenspace; for a Hermitian
+matrix the geometric and algebraic multiplicities agree, so nothing is lost
+against the printed phrase ``two-fold degenerate''.  The false printed
+statement itself is deliberately not formalized.
+
+\section{Conclusion}
+
+Kramers theorem~II as printed is false; the hypothesis $A\neq0$ is
+insufficient because the partner $A\ket{\overline\psi}$ can vanish.  The
+correct local conclusion holds under the exact nonvanishing condition
+$A\ket{\overline\psi}\neq0$, and the global conclusion holds when $A$ is
+invertible.  This is a genuine source error, resolved by the corrected
+statements above.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -95,6 +95,49 @@ This is a genuine source error. The unrestricted printed converse should not
 be claimed as formalized; the formal theorem proves the corrected,
 trace-nonnegative statement.
 
+\section{The missing nonvanishing condition in Kramers' theorem~II}
+\label{sec:kramers-ii}
+
+\paragraph{Formalization trigger.}
+The corrected theorem is formalized as
+\leanid{Matrix.IsHermitian.two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero}
+(conditional form) and
+\leanid{Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_isUnit}
+(invertible intertwiner) in \doclink{QICLean/Algebra/KramersDegeneracy}; the
+first Kramers theorem is recovered there as the unitary special case. The
+source error is documented in
+\path{docs/paper-gaps/wolf_ch3_kramers_theorem_ii.tex}.
+
+\paragraph{Printed source and its role.}
+After Kramers' theorem (a Hermitian $H$ commuting with an anti-unitary $T$,
+$T^{2}=-\Id$, has all eigenvalues at least two-fold degenerate), Wolf prints
+``Kramer's theorem II'': if $H$ is Hermitian and $HA=AH^{T}$ for some
+anti-symmetric $A\neq 0$, then each eigenvalue of $H$ is at least two-fold
+degenerate, ``as the same proof shows.''  The local source is
+\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex},
+lines~527--530, with the matrix reduction at lines~500--501.
+
+\paragraph{Correction.}
+The proof transports an eigenvector $\ket\psi$ of eigenvalue $\lambda$ to the
+partner $A\ket{\overline\psi}$, which is again a $\lambda$-eigenvector and is
+orthogonal to $\ket\psi$; both steps survive for a general anti-symmetric
+intertwiner.  The degeneracy follows only when the partner is nonzero, and
+that is an extra condition: the correct local statement concludes
+$\dim\ker(H-\lambda)\ge 2$ from $A\ket{\overline\psi}\neq 0$, and a global
+conclusion requires $A$ injective.  The corrected theorem therefore assumes
+$A$ invertible and concludes that every eigenvalue of $H$ is at least
+two-fold degenerate.
+
+\paragraph{Why the correction is necessary.}
+On $\C^{3}$, $H=\operatorname{diag}(0,1,1)$ and the anti-symmetric unit of
+the $1$-eigenspace satisfy $HA=AH^{T}=A$ with $A\neq 0$, but the eigenvalue
+$0$ is simple: the partner $Ae_{1}$ of its eigenvector vanishes.
+
+\paragraph{Classification.}
+This is a genuine source error.  Theorem~I is unaffected: it is the case
+$A=V^{\dagger}$ of the corrected theorem, where unitarity supplies exactly the
+missing nonvanishing.
+
 \section{The false converse for Pauli-block truncation}
 \label{sec:pauli-block-truncation}
 

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -509,6 +509,40 @@ so that the cited formal statements are available from the main project import.
   recorded in
   `docs/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.tex`.
 
+### Section 3.3 Transposition and time reversal
+
+#### Wolf Theorem 3.1 (Kramers' theorem) — FORMALIZED
+
+- `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antiunitary` — the printed
+  antiunitary statement: `[H,T] = 0` and `T² = -1` for Hermitian `H` and
+  antiunitary `T` imply every eigenvalue is at least two-fold degenerate ✓
+  (in `QICLean/Algebra/KramersDegeneracy.lean`)
+- `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_unitary` —
+  Wolf's matrix reduction `T = ΓV` of the same theorem: `H` Hermitian,
+  `Vᴴ * V = 1`, `H * Vᴴ = Vᴴ * Hᵀ`, `Vᵀ = -V` ✓ — proved as the unitary
+  special case `A = Vᴴ` of the corrected Theorem 3.2 below
+
+#### Wolf Theorem 3.2 (Kramers' theorem II) — FALSE AS PRINTED; CORRECTED FORM FORMALIZED
+
+- The printed statement (`H` Hermitian, `Aᵀ = -A ≠ 0`, `H * A = A * Hᵀ` ⟹
+  every eigenvalue at least two-fold degenerate) is false: the partner
+  `A *ᵥ star ψ` of an eigenvector can vanish. The counterexample
+  (`H = diag(0,1,1)`, `A` the antisymmetric unit of the `1`-eigenspace) and
+  the corrected statements are recorded in
+  `docs/paper-gaps/wolf_ch3_kramers_theorem_ii.tex`; the false printed form
+  is deliberately not formalized.
+- `Matrix.IsHermitian.transpose_mulVec_star_of_mulVec_eq_smul` and
+  `Matrix.IsHermitian.mulVec_star_intertwiner_of_mul_eq_mul_transpose` —
+  eigenvector transport: `A *ᵥ star ψ` is again a `μ`-eigenvector ✓
+- `Matrix.dotProduct_star_mulVec_star_eq_zero_of_transpose_eq_neg` —
+  orthogonality `star ψ ⬝ᵥ (A *ᵥ star ψ) = 0` ✓
+- `Matrix.IsHermitian.two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero`
+  — corrected conditional form: the eigenspace of `μ` has dimension `≥ 2`
+  whenever the partner `A *ᵥ star ψ` is nonzero ✓
+- `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_isUnit` —
+  invertible-`A` global corollary: if `A` is invertible, every eigenvalue of
+  `H` is at least two-fold degenerate ✓
+
 ---
 
 ## Wolf Chapter 6 — Spectral Properties: Public Theorem Index


### PR DESCRIPTION
Closes #17

## Source contract

Wolf, *Quantum Channels & Operations*, Chapter 3 (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`):

- **Theorem 3.1 (Kramers' theorem), lines 503–506 — valid.** If $[H,T]=0$ and $T^2=-1$ for Hermitian $H$ and anti-unitary $T$, then each eigenvalue of $H$ is at least two-fold degenerate. Matrix reduction (lines 500–501): $T=\Gamma V$ gives $HV^\dagger=V^\dagger H^T$ and $V^T=-V$.
- **Theorem 3.2 (Kramers' theorem II), lines 527–530 — false as printed.** It assumes only $HA=AH^T$, $A^T=-A$, $A\neq 0$, and concludes every eigenvalue of $H$ is at least two-fold degenerate. Counterexample on $\mathbb C^3$: $H=\operatorname{diag}(0,1,1)$, $A=\begin{pmatrix}0&0&0\\0&0&1\\0&-1&0\end{pmatrix}$. Then $HA=AH^T=A$, $A^T=-A\neq0$, but the eigenvalue $0$ is simple: the partner $A\overline{e_1}=0$ vanishes.
- **Corrected statement** (issue #17): if $H\psi=\lambda\psi$ then $H(A\overline\psi)=\lambda A\overline\psi$ and $\langle\psi,A\overline\psi\rangle=0$, so $\lambda$ is degenerate **whenever $A\overline\psi\neq0$**; every eigenvalue is at least two-fold degenerate when $A$ is injective/invertible. The false printed form is deliberately not formalized.

Erratum: `docs/paper-gaps/wolf_ch3_kramers_theorem_ii.tex` (`false-source`, resolved), also registered in `docs/paper-gaps/wolf_lecture_notes_errata.tex`. The corrected declarations carry `**Local fix (Wolf ch03, lines 527–530):**` markers.

## Proof route

New module `QICLean/Algebra/KramersDegeneracy.lean` (Mathlib-only, Algebra layer; no Channel imports, per the dependency-direction constraint):

1. `Matrix.dotProduct_mulVec_self_eq_zero_of_transpose_eq_neg` — skew quadratic form vanishes (Wolf's (3.29)–(3.30) mechanism, ch03 lines 512–520); specialized to the partner as `Matrix.dotProduct_star_mulVec_star_eq_zero_of_transpose_eq_neg`.
2. `Matrix.IsHermitian.transpose_mulVec_star_of_mulVec_eq_smul` — the conjugated eigenvector solves the transpose equation (line 509's middle step).
3. `Matrix.IsHermitian.mulVec_star_intertwiner_of_mul_eq_mul_transpose` — eigenvector transport: $H(A\overline\psi)=AH^T\overline\psi=\lambda A\overline\psi$.
4. `Matrix.IsHermitian.two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero` — corrected conditional Theorem 3.2 under the exact nonvanishing hypothesis $A\overline\psi\neq0$.
5. `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_isUnit` — invertible-$A$ global corollary (`IsUnit` in the square finite-dimensional API, per the issue's ownership audit).
6. Theorem 3.1 in matrix form (`..._of_antisymmetric_unitary`) is derived as the case $A=V^\dagger$ of the corrected Theorem 3.2 — the issue's requested relation between the two theorems — and in the printed antiunitary form (`..._of_antiunitary`), preserving the exact hypotheses and conclusion.

The antiunitary form and the generic linear-algebra lemmas are the reviewed declarations moved verbatim from `TNLean/Algebra/KramersDegeneracy.lean` (LionSR/TNLean#6306) into QICLean, per the repository-ownership direction in the issue discussion. **Coordinated TNLean follow-up (not in this PR):** TNLean should delete its duplicate module and pick up these declarations via its QICLean pin bump.

## Blueprint

New section "Kramers degeneracy" closing chapter `ch04_positive_not_cp` (Wolf ch. 3): the antiunitary theorem, the partner-eigenvector lemma, the corrected conditional theorem, the invertible and matrix-form corollaries, and a remark displaying the counterexample. All entries carry `\lean{...}` + `\leanok`; proofs carry `\leanok` + `\uses{...}` matching the actual call graph. `docs/wolf_numbering_coverage.md` records Thm 3.1 formalized and Thm 3.2 false-as-printed with the corrected form formalized.

## Verification

- `lake env lean QICLean/Algebra/KramersDegeneracy.lean` — clean; `lake build QICLean` — clean (rebased on 9351bc2).
- `#print axioms` on all ten new declarations: only `propext`, `Classical.choice`, `Quot.sound`. No `sorry`/`admit`/`native_decide`/`unsafeCast`/new axioms (grep clean).
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` — current (regenerated, committed).
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` + `lake exe checkdecls blueprint/lean_decls` — all declarations resolve; `--ci` sync check in sync (10/10 for the new chapter); `--warn-missing-blueprint` on the changed Lean file — no missing entries.
- `lake exe lint_style` — clean; `python3 scripts/test_lean_file_policies.py -v` — 16 tests OK; `check_reader_facing_prose.py --diff-base origin/main --ci` — clean.
- `texra-blueprint --root . paper-gaps build` (all notes compile to PDF) and `paper-gaps check` — pass; `chktex` clean on the new chapter; `latexindent -l blueprint/latexindent.yaml` — clean.
- `texra-blueprint web` — full blueprint web build succeeds with no ERROR lines.
