### PR TITLE
feat(channel): classify Wolf positive invertible maps

### DIFF
--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -29,6 +29,7 @@ import QICLean.Channel.Determinant.Composition
 import QICLean.Channel.Determinant.HeisenbergDual
 import QICLean.Channel.Determinant.HilbertSchmidt
 import QICLean.Channel.Determinant.PositiveExtremality
+import QICLean.Channel.Determinant.PositiveInverse
 import QICLean.Channel.Determinant.UnitaryCharacterization
 import QICLean.Channel.DirectSumConditionalExpectation
 import QICLean.Channel.EnsembleEquivalence

--- a/QICLean/Channel/Determinant.lean
+++ b/QICLean/Channel/Determinant.lean
@@ -10,13 +10,14 @@ import QICLean.Channel.Determinant.Composition
 import QICLean.Channel.Determinant.HilbertSchmidt
 import QICLean.Channel.Determinant.HeisenbergDual
 import QICLean.Channel.Determinant.PositiveExtremality
+import QICLean.Channel.Determinant.PositiveInverse
 import QICLean.Channel.Determinant.UnitaryCharacterization
 
 /-!
 # Determinants of quantum channels
 
 Thin module assembling the determinant development for quantum channels from
-eight focused sub-modules.
+nine focused sub-modules.
 
 The division follows the same organization as the earlier `Full/` and
 `Growth/` developments:
@@ -37,6 +38,8 @@ The division follows the same organization as the earlier `Full/` and
 * `QICLean.Channel.Determinant.PositiveExtremality` — Wolf Theorem 6.1 for
   positive trace-preserving maps, including reality, saturation, and the
   transposition sign.
+* `QICLean.Channel.Determinant.PositiveInverse` — Wolf's positive-invertible-map
+  corollary, including trace preservation and positivity of the inverse.
 * `QICLean.Channel.Determinant.UnitaryCharacterization` — Wolf Theorem 6.1(2)
   for CPTP maps.
 
@@ -57,6 +60,8 @@ The division follows the same organization as the earlier `Full/` and
   — Wolf Theorem 6.1(2) for positive trace-preserving maps.
 * `ChannelDeterminant.Internal.channelDet_transposeLinearMapComplex` — the
   exact determinant of ordinary transposition in Wolf Theorem 6.1(3).
+* `ChannelDeterminant.Internal.wolfPositiveInvertibleMaps` — positivity of the
+  inverse exactly for unitary conjugation and transpose-conjugation.
 * `channelDet_norm_eq_one_iff_exists_unitaryChannel` — Wolf Theorem 6.1(2)
   for CPTP maps.
 * `norm_channelDet_le_choiPurity_rpow` — Wolf Eq. (6.27), the Choi bound

--- a/QICLean/Channel/Determinant/PositiveInverse.lean
+++ b/QICLean/Channel/Determinant/PositiveInverse.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: QICLean contributors
 -/
 import QICLean.Channel.Determinant.Composition
+import QICLean.Channel.Determinant.PositiveExtremality
 import QICLean.Channel.TransferMatrix
 
 /-!
@@ -165,5 +166,31 @@ theorem inverseOfBijective_unitaryChannel_comp_transpose_isPositiveMap
   simpa only [unitaryChannel, unitaryConjLM] using
     unitaryConjLM_comp_transpose_mapsPSDConeOnto
       (U : MatrixAlg d) (Matrix.UnitaryGroup.det_isUnit U)
+
+/-- **Wolf Corollary: positive invertible maps.**
+
+For a positive trace-preserving bijection on a nonzero matrix algebra, the
+inverse is positive exactly for unitary conjugations and unitary conjugations
+after ordinary matrix transposition.  The forward direction follows Wolf's
+determinant argument: the determinant bounds for `T` and `T⁻¹`, together with
+multiplicativity, force `|det T| = 1`, so Wolf Theorem 6.1 applies. -/
+theorem wolfPositiveInvertibleMaps [NeZero d]
+    {T : MatrixEnd d} (hT : Function.Bijective T)
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    IsPositiveMap (inverseOfBijective T hT) ↔
+      ∃ U : Matrix.unitaryGroup (Fin d) ℂ,
+        T = unitaryChannel U ∨
+        T = (unitaryChannel U).comp
+          (Matrix.transposeLinearMapComplex (Fin d)) := by
+  constructor
+  · intro hInvPos
+    exact exists_unitary_or_transpose_of_channelDet_norm_eq_one hPos hTP
+      (channelDet_norm_eq_one_of_inverseOfBijective_isPositiveMap
+        hT hPos hTP hInvPos)
+  · rintro ⟨U, hTUnitary | hTTranspose⟩
+    · subst T
+      exact inverseOfBijective_unitaryChannel_isPositiveMap U hT
+    · subst T
+      exact inverseOfBijective_unitaryChannel_comp_transpose_isPositiveMap U hT
 
 end ChannelDeterminant.Internal

--- a/QICLean/Channel/Determinant/PositiveInverse.lean
+++ b/QICLean/Channel/Determinant/PositiveInverse.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Channel.Determinant.Composition
+import QICLean.Channel.TransferMatrix
+
+/-!
+# Positive inverses of matrix maps
+
+This file develops the inverse-map interface needed for Wolf's corollary on
+positive invertible maps.  In particular, the inverse of a bijective
+trace-preserving map is trace preserving, and positivity of that inverse is
+equivalent to the original positive map carrying the positive-semidefinite
+cone onto itself.
+
+The final classification is kept on Wolf's determinant route: determinant
+bounds for a map and its inverse force determinant modulus one, after which
+Wolf Theorem 6.1 supplies unitary conjugation or unitary conjugation after
+ordinary matrix transposition.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.1.1][Wolf2012QChannels]
+
+## Tags
+
+positive map, inverse, trace preserving, determinant
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+
+variable {d : ℕ}
+
+namespace ChannelDeterminant.Internal
+
+local notation "MatrixAlg" => ChannelDeterminant.Internal.MatrixAlg
+local notation "MatrixEnd" => ChannelDeterminant.Internal.MatrixEnd
+
+/-- The inverse linear map of a bijective endomorphism of the matrix algebra. -/
+noncomputable def inverseOfBijective (T : MatrixEnd d)
+    (hT : Function.Bijective T) : MatrixEnd d :=
+  (LinearEquiv.ofBijective T hT).symm.toLinearMap
+
+@[simp]
+theorem apply_inverseOfBijective (T : MatrixEnd d)
+    (hT : Function.Bijective T) (X : MatrixAlg d) :
+    T (inverseOfBijective T hT X) = X := by
+  exact (LinearEquiv.ofBijective T hT).apply_symm_apply X
+
+@[simp]
+theorem inverseOfBijective_apply (T : MatrixEnd d)
+    (hT : Function.Bijective T) (X : MatrixAlg d) :
+    inverseOfBijective T hT (T X) = X := by
+  exact (LinearEquiv.ofBijective T hT).symm_apply_apply X
+
+@[simp]
+theorem comp_inverseOfBijective (T : MatrixEnd d)
+    (hT : Function.Bijective T) :
+    T.comp (inverseOfBijective T hT) = 1 := by
+  apply LinearMap.ext
+  intro X
+  exact apply_inverseOfBijective T hT X
+
+@[simp]
+theorem inverseOfBijective_comp (T : MatrixEnd d)
+    (hT : Function.Bijective T) :
+    (inverseOfBijective T hT).comp T = 1 := by
+  apply LinearMap.ext
+  intro X
+  exact inverseOfBijective_apply T hT X
+
+/-- The inverse of a bijective trace-preserving linear map is trace
+preserving.  This is the observation immediately following Wolf's positive
+invertible-map corollary. -/
+theorem inverseOfBijective_isTracePreservingMap
+    {T : MatrixEnd d} (hT : Function.Bijective T)
+    (hTP : IsTracePreservingMap T) :
+    IsTracePreservingMap (inverseOfBijective T hT) := by
+  intro X
+  have htrace := hTP (inverseOfBijective T hT X)
+  rw [apply_inverseOfBijective] at htrace
+  exact htrace.symm
+
+/-- A positive bijection with positive inverse maps the positive-semidefinite
+cone onto itself. -/
+theorem mapsPSDConeOnto_of_inverseOfBijective_isPositiveMap
+    {T : MatrixEnd d} (hT : Function.Bijective T)
+    (hPos : IsPositiveMap T)
+    (hInvPos : IsPositiveMap (inverseOfBijective T hT)) :
+    MapsPSDConeOnto T := by
+  refine ⟨hPos, ?_⟩
+  intro A hA
+  exact ⟨inverseOfBijective T hT A, hInvPos A hA,
+    apply_inverseOfBijective T hT A⟩
+
+/-- If a bijective linear map carries the positive-semidefinite cone onto
+itself, then its inverse is positive. -/
+theorem inverseOfBijective_isPositiveMap_of_mapsPSDConeOnto
+    {T : MatrixEnd d} (hT : Function.Bijective T)
+    (hCone : MapsPSDConeOnto T) :
+    IsPositiveMap (inverseOfBijective T hT) := by
+  intro A hA
+  obtain ⟨X, hX, hTX⟩ := hCone.2 A hA
+  have hInv : inverseOfBijective T hT A = X := by
+    apply hT.1
+    rw [apply_inverseOfBijective, hTX]
+  rwa [hInv]
+
+/-- For a positive bijection, positivity of the inverse is exactly
+surjectivity on the positive-semidefinite cone. -/
+theorem inverseOfBijective_isPositiveMap_iff_mapsPSDConeOnto
+    {T : MatrixEnd d} (hT : Function.Bijective T)
+    (hPos : IsPositiveMap T) :
+    IsPositiveMap (inverseOfBijective T hT) ↔ MapsPSDConeOnto T :=
+  ⟨mapsPSDConeOnto_of_inverseOfBijective_isPositiveMap hT hPos,
+    inverseOfBijective_isPositiveMap_of_mapsPSDConeOnto hT⟩
+
+/-- The determinant-bounds step in Wolf's positive-invertible-map
+corollary.  If a positive trace-preserving bijection has positive inverse,
+then both determinant moduli are at most one, while multiplicativity says
+their product is one. -/
+theorem channelDet_norm_eq_one_of_inverseOfBijective_isPositiveMap
+    {T : MatrixEnd d} (hT : Function.Bijective T)
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (hInvPos : IsPositiveMap (inverseOfBijective T hT)) :
+    ‖channelDet T‖ = 1 := by
+  have hInvTP : IsTracePreservingMap (inverseOfBijective T hT) :=
+    inverseOfBijective_isTracePreservingMap hT hTP
+  have hdetMul :
+      channelDet T * channelDet (inverseOfBijective T hT) = 1 := by
+    rw [← channelDet_comp, comp_inverseOfBijective, channelDet_id]
+  have hnormMul :
+      ‖channelDet T‖ * ‖channelDet (inverseOfBijective T hT)‖ = 1 := by
+    rw [← norm_mul, hdetMul, norm_one]
+  have hTle : ‖channelDet T‖ ≤ 1 :=
+    channelDet_norm_le_one_of_positive_tracePreserving hPos hTP
+  have hInvLe : ‖channelDet (inverseOfBijective T hT)‖ ≤ 1 :=
+    channelDet_norm_le_one_of_positive_tracePreserving hInvPos hInvTP
+  nlinarith [norm_nonneg (channelDet T),
+    norm_nonneg (channelDet (inverseOfBijective T hT))]
+
+/-- The inverse of a unitary conjugation is positive.  The proof uses the
+explicit cone-surjectivity witness for congruence by an invertible matrix. -/
+theorem inverseOfBijective_unitaryChannel_isPositiveMap
+    (U : Matrix.unitaryGroup (Fin d) ℂ)
+    (hU : Function.Bijective (unitaryChannel U)) :
+    IsPositiveMap (inverseOfBijective (unitaryChannel U) hU) := by
+  apply inverseOfBijective_isPositiveMap_of_mapsPSDConeOnto hU
+  simpa only [unitaryChannel, unitaryConjLM] using
+    unitaryConjLM_mapsPSDConeOnto (U : MatrixAlg d)
+      (Matrix.UnitaryGroup.det_isUnit U)
+
+/-- The inverse of unitary conjugation after ordinary transposition is
+positive.  This is Wolf's transpose branch, which must not be removed by
+strengthening the statement to complete positivity. -/
+theorem inverseOfBijective_unitaryChannel_comp_transpose_isPositiveMap
+    (U : Matrix.unitaryGroup (Fin d) ℂ)
+    (hU : Function.Bijective ((unitaryChannel U).comp
+      (Matrix.transposeLinearMapComplex (Fin d)))) :
+    IsPositiveMap (inverseOfBijective
+      ((unitaryChannel U).comp (Matrix.transposeLinearMapComplex (Fin d))) hU) := by
+  apply inverseOfBijective_isPositiveMap_of_mapsPSDConeOnto hU
+  simpa only [unitaryChannel, unitaryConjLM] using
+    unitaryConjLM_comp_transpose_mapsPSDConeOnto
+      (U : MatrixAlg d) (Matrix.UnitaryGroup.det_isUnit U)
+
+end ChannelDeterminant.Internal

--- a/QICLean/Channel/Determinant/PositiveInverse.lean
+++ b/QICLean/Channel/Determinant/PositiveInverse.lean
@@ -74,7 +74,9 @@ theorem inverseOfBijective_comp (T : MatrixEnd d)
 
 /-- The inverse of a bijective trace-preserving linear map is trace
 preserving.  This is the observation immediately following Wolf's positive
-invertible-map corollary. -/
+invertible-map corollary.
+
+Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 423--426. -/
 theorem inverseOfBijective_isTracePreservingMap
     {T : MatrixEnd d} (hT : Function.Bijective T)
     (hTP : IsTracePreservingMap T) :
@@ -229,7 +231,9 @@ For a positive trace-preserving bijection on a nonzero matrix algebra, the
 inverse is positive exactly for unitary conjugations and unitary conjugations
 after ordinary matrix transposition.  The forward direction follows Wolf's
 determinant argument: the determinant bounds for `T` and `T⁻¹`, together with
-multiplicativity, force `|det T| = 1`, so Wolf Theorem 6.1 applies. -/
+multiplicativity, force `|det T| = 1`, so Wolf Theorem 6.1 applies.
+
+Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 416--426. -/
 theorem wolfPositiveInvertibleMaps [NeZero d]
     {T : MatrixEnd d} (hT : Function.Bijective T)
     (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :

--- a/QICLean/Channel/Determinant/PositiveInverse.lean
+++ b/QICLean/Channel/Determinant/PositiveInverse.lean
@@ -142,16 +142,72 @@ theorem channelDet_norm_eq_one_of_inverseOfBijective_isPositiveMap
   nlinarith [norm_nonneg (channelDet T),
     norm_nonneg (channelDet (inverseOfBijective T hT))]
 
+private theorem unitaryChannel_comp_inv
+    (U : Matrix.unitaryGroup (Fin d) ℂ) :
+    (unitaryChannel U).comp (unitaryChannel U⁻¹) = 1 := by
+  have hUUInv : (U : MatrixAlg d) * (U⁻¹ : Matrix.unitaryGroup (Fin d) ℂ) = 1 :=
+    congrArg Subtype.val (mul_inv_cancel U)
+  have hUInvStarUStar :
+      ((U⁻¹ : Matrix.unitaryGroup (Fin d) ℂ) : MatrixAlg d)ᴴ *
+          (U : MatrixAlg d)ᴴ = 1 := by
+    rw [← Matrix.conjTranspose_mul, hUUInv, Matrix.conjTranspose_one]
+  apply LinearMap.ext
+  intro X
+  change (U : MatrixAlg d) *
+      (((U⁻¹ : Matrix.unitaryGroup (Fin d) ℂ) : MatrixAlg d) * X *
+        ((U⁻¹ : Matrix.unitaryGroup (Fin d) ℂ) : MatrixAlg d)ᴴ) *
+      (U : MatrixAlg d)ᴴ = X
+  rw [show (U : MatrixAlg d) *
+      (((U⁻¹ : Matrix.unitaryGroup (Fin d) ℂ) : MatrixAlg d) * X *
+        ((U⁻¹ : Matrix.unitaryGroup (Fin d) ℂ) : MatrixAlg d)ᴴ) *
+      (U : MatrixAlg d)ᴴ =
+        ((U : MatrixAlg d) *
+          ((U⁻¹ : Matrix.unitaryGroup (Fin d) ℂ) : MatrixAlg d)) * X *
+          (((U⁻¹ : Matrix.unitaryGroup (Fin d) ℂ) : MatrixAlg d)ᴴ *
+            (U : MatrixAlg d)ᴴ) by simp only [Matrix.mul_assoc],
+    hUUInv, hUInvStarUStar, Matrix.one_mul, Matrix.mul_one]
+
+/-- The inverse of unitary conjugation is conjugation by the inverse unitary. -/
+theorem inverseOfBijective_unitaryChannel
+    (U : Matrix.unitaryGroup (Fin d) ℂ)
+    (hU : Function.Bijective (unitaryChannel U)) :
+    inverseOfBijective (unitaryChannel U) hU = unitaryChannel U⁻¹ := by
+  apply LinearMap.ext
+  intro X
+  apply hU.1
+  rw [apply_inverseOfBijective]
+  symm
+  simpa only [LinearMap.comp_apply, Module.End.one_apply] using
+    LinearMap.congr_fun (unitaryChannel_comp_inv U) X
+
+/-- The inverse of `Ad U` after ordinary transposition is ordinary
+transposition after `Ad U⁻¹`; the reversed composition order is essential. -/
+theorem inverseOfBijective_unitaryChannel_comp_transpose
+    (U : Matrix.unitaryGroup (Fin d) ℂ)
+    (hU : Function.Bijective ((unitaryChannel U).comp
+      (Matrix.transposeLinearMapComplex (Fin d)))) :
+    inverseOfBijective
+        ((unitaryChannel U).comp (Matrix.transposeLinearMapComplex (Fin d))) hU =
+      (Matrix.transposeLinearMapComplex (Fin d)).comp (unitaryChannel U⁻¹) := by
+  apply LinearMap.ext
+  intro X
+  apply hU.1
+  rw [apply_inverseOfBijective]
+  have hInv := LinearMap.congr_fun (unitaryChannel_comp_inv U) X
+  symm
+  change unitaryChannel U
+    (((unitaryChannel U⁻¹ X)ᵀ)ᵀ) = X
+  simpa only [Matrix.transpose_transpose, LinearMap.comp_apply,
+    Module.End.one_apply] using hInv
+
 /-- The inverse of a unitary conjugation is positive.  The proof uses the
-explicit cone-surjectivity witness for congruence by an invertible matrix. -/
+explicit inverse standard form. -/
 theorem inverseOfBijective_unitaryChannel_isPositiveMap
     (U : Matrix.unitaryGroup (Fin d) ℂ)
     (hU : Function.Bijective (unitaryChannel U)) :
     IsPositiveMap (inverseOfBijective (unitaryChannel U) hU) := by
-  apply inverseOfBijective_isPositiveMap_of_mapsPSDConeOnto hU
-  simpa only [unitaryChannel, unitaryConjLM] using
-    unitaryConjLM_mapsPSDConeOnto (U : MatrixAlg d)
-      (Matrix.UnitaryGroup.det_isUnit U)
+  rw [inverseOfBijective_unitaryChannel U hU]
+  exact unitaryChannel_isPositiveMap U⁻¹
 
 /-- The inverse of unitary conjugation after ordinary transposition is
 positive.  This is Wolf's transpose branch, which must not be removed by
@@ -162,10 +218,10 @@ theorem inverseOfBijective_unitaryChannel_comp_transpose_isPositiveMap
       (Matrix.transposeLinearMapComplex (Fin d)))) :
     IsPositiveMap (inverseOfBijective
       ((unitaryChannel U).comp (Matrix.transposeLinearMapComplex (Fin d))) hU) := by
-  apply inverseOfBijective_isPositiveMap_of_mapsPSDConeOnto hU
-  simpa only [unitaryChannel, unitaryConjLM] using
-    unitaryConjLM_comp_transpose_mapsPSDConeOnto
-      (U : MatrixAlg d) (Matrix.UnitaryGroup.det_isUnit U)
+  rw [inverseOfBijective_unitaryChannel_comp_transpose U hU]
+  intro X hX
+  exact Matrix.transposeLinearMapComplex_isPositiveMap _
+    (unitaryChannel_isPositiveMap U⁻¹ X hX)
 
 /-- **Wolf Corollary: positive invertible maps.**
 

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -1226,7 +1226,8 @@ This section states the existence theorems from
         ChannelDeterminant.Internal.channelDet_norm_eq_one_of_inverseOfBijective_isPositiveMap}
     \leanok
     \uses{def:inverse_of_bijective_matrix_endomorphism,
-        thm:channelDet_norm_le_one, thm:channelDet_comp}
+        def:positive_map, def:trace_preserving,
+        def:maps_psd_cone_onto, def:channel_det}
     The inverse of a bijective trace-preserving linear map is trace preserving.
     If $T$ is positive, then $T^{-1}$ is positive exactly when $T$ maps the
     positive-semidefinite cone onto itself.  If both maps are positive and
@@ -1234,6 +1235,7 @@ This section states the existence theorems from
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:channelDet_norm_le_one, thm:channelDet_comp}
     For $X=T^{-1}(Y)$, trace preservation of $T$ gives
     $\tr(T^{-1}(Y))=\tr(Y)$.  Positivity of the inverse is equivalent to
     positivity of the unique preimage of every positive-semidefinite matrix.
@@ -1249,7 +1251,8 @@ This section states the existence theorems from
         ChannelDeterminant.Internal.inverseOfBijective_unitaryChannel_isPositiveMap,
         ChannelDeterminant.Internal.inverseOfBijective_unitaryChannel_comp_transpose_isPositiveMap}
     \leanok
-    \uses{def:inverse_of_bijective_matrix_endomorphism, def:unitary_channel}
+    \uses{def:inverse_of_bijective_matrix_endomorphism, def:unitary_channel,
+        def:positive_map}
     For a unitary $U$, the inverse of $A\mapsto UAU^\dagger$ is conjugation
     by $U^{-1}$.  The inverse of
     $A\mapsto UA^{\mathsf T}U^\dagger$ is ordinary transposition after
@@ -1258,6 +1261,7 @@ This section states the existence theorems from
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:transpose_positive_trace_preserving}
     Compose the displayed maps directly, using involutivity of ordinary
     transposition.  Unitary conjugation, transposition, and their compositions
     preserve the positive-semidefinite cone.
@@ -1267,9 +1271,8 @@ This section states the existence theorems from
     \label{thm:wolf_positive_invertible_maps}
     \lean{ChannelDeterminant.Internal.wolfPositiveInvertibleMaps}
     \leanok
-    \uses{thm:positive_inverse_preliminaries,
-        thm:positive_inverse_standard_forms,
-        thm:channelDet_norm_eq_one_iff_positive_tp}
+    \uses{def:inverse_of_bijective_matrix_endomorphism,
+        def:positive_map, def:trace_preserving, def:unitary_channel}
     Let $D>0$, and let $T:\MN{D}\to\MN{D}$ be positive, trace preserving,
     and bijective.  Then $T^{-1}$ is positive if and only if there is a
     unitary $U$ for which

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -1204,6 +1204,95 @@ This section states the existence theorems from
     classification remains reusable.
 \end{proof}
 
+\begin{definition}[Inverse of a bijective matrix endomorphism]
+    \label{def:inverse_of_bijective_matrix_endomorphism}
+    \lean{ChannelDeterminant.Internal.inverseOfBijective,
+        ChannelDeterminant.Internal.apply_inverseOfBijective,
+        ChannelDeterminant.Internal.inverseOfBijective_apply,
+        ChannelDeterminant.Internal.comp_inverseOfBijective,
+        ChannelDeterminant.Internal.inverseOfBijective_comp}
+    \leanok
+    Let $T:\MN{D}\to\MN{D}$ be a bijective complex-linear map.  Write
+    $T^{-1}$ for the inverse linear map supplied by the associated linear
+    equivalence; it is both a left and a right inverse of $T$.
+\end{definition}
+
+\begin{theorem}[Trace preservation and positivity of the inverse]
+    \label{thm:positive_inverse_preliminaries}
+    \lean{ChannelDeterminant.Internal.inverseOfBijective_isTracePreservingMap,
+        ChannelDeterminant.Internal.mapsPSDConeOnto_of_inverseOfBijective_isPositiveMap,
+        ChannelDeterminant.Internal.inverseOfBijective_isPositiveMap_of_mapsPSDConeOnto,
+        ChannelDeterminant.Internal.inverseOfBijective_isPositiveMap_iff_mapsPSDConeOnto,
+        ChannelDeterminant.Internal.channelDet_norm_eq_one_of_inverseOfBijective_isPositiveMap}
+    \leanok
+    \uses{def:inverse_of_bijective_matrix_endomorphism,
+        thm:channelDet_norm_le_one, thm:channelDet_comp}
+    The inverse of a bijective trace-preserving linear map is trace preserving.
+    If $T$ is positive, then $T^{-1}$ is positive exactly when $T$ maps the
+    positive-semidefinite cone onto itself.  If both maps are positive and
+    trace preserving, then $|\det T|=1$.
+\end{theorem}
+
+\begin{proof}\leanok
+    For $X=T^{-1}(Y)$, trace preservation of $T$ gives
+    $\tr(T^{-1}(Y))=\tr(Y)$.  Positivity of the inverse is equivalent to
+    positivity of the unique preimage of every positive-semidefinite matrix.
+    Finally,
+    $\det(T)\det(T^{-1})=1$, while the determinant bound places both moduli
+    at most one, so both moduli equal one.
+\end{proof}
+
+\begin{theorem}[Explicit inverses of the standard forms]
+    \label{thm:positive_inverse_standard_forms}
+    \lean{ChannelDeterminant.Internal.inverseOfBijective_unitaryChannel,
+        ChannelDeterminant.Internal.inverseOfBijective_unitaryChannel_comp_transpose,
+        ChannelDeterminant.Internal.inverseOfBijective_unitaryChannel_isPositiveMap,
+        ChannelDeterminant.Internal.inverseOfBijective_unitaryChannel_comp_transpose_isPositiveMap}
+    \leanok
+    \uses{def:inverse_of_bijective_matrix_endomorphism, def:unitary_channel}
+    For a unitary $U$, the inverse of $A\mapsto UAU^\dagger$ is conjugation
+    by $U^{-1}$.  The inverse of
+    $A\mapsto UA^{\mathsf T}U^\dagger$ is ordinary transposition after
+    conjugation by $U^{-1}$.  Both inverse maps are positive; the reversed
+    composition order in the transpose branch is essential.
+\end{theorem}
+
+\begin{proof}\leanok
+    Compose the displayed maps directly, using involutivity of ordinary
+    transposition.  Unitary conjugation, transposition, and their compositions
+    preserve the positive-semidefinite cone.
+\end{proof}
+
+\begin{theorem}[Positive invertible maps]
+    \label{thm:wolf_positive_invertible_maps}
+    \lean{ChannelDeterminant.Internal.wolfPositiveInvertibleMaps}
+    \leanok
+    \uses{thm:positive_inverse_preliminaries,
+        thm:positive_inverse_standard_forms,
+        thm:channelDet_norm_eq_one_iff_positive_tp}
+    Let $D>0$, and let $T:\MN{D}\to\MN{D}$ be positive, trace preserving,
+    and bijective.  Then $T^{-1}$ is positive if and only if there is a
+    unitary $U$ for which
+    \begin{align}
+        T(A)=UAU^\dagger
+        \qquad\text{or}\qquad
+        T(A)=UA^{\mathsf T}U^\dagger.
+    \end{align}
+    This is the corollary ``Positive invertible maps'' following
+    \cite[Theorem~6.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:positive_inverse_preliminaries,
+        thm:positive_inverse_standard_forms,
+        thm:channelDet_norm_eq_one_iff_positive_tp}
+    If $T^{-1}$ is positive, it is automatically trace preserving and the
+    determinant bounds for $T$ and $T^{-1}$ force $|\det T|=1$.  Apply the
+    source-general determinant-saturation classification.  Conversely, use
+    the explicit positive inverse of each standard form above.  This is
+    exactly Wolf's determinant route and retains the transpose branch.
+\end{proof}
+
 \begin{theorem}[Determinant one iff the channel is unitary]
     \label{thm:channelDet_norm_eq_one_iff_unitary}
     \lean{channelDet_norm_eq_one_iff_exists_unitaryChannel}\leanok

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -611,6 +611,28 @@ replaces `|det T₂| = 1` by Wolf's geometric alternative "unitary conjugation
 or matrix transposition".  The declarations here deliberately retain the
 algebraic equality split as a reusable separate theorem.
 
+#### Wolf Corollary "Positive invertible maps" — FORMALIZED
+
+* `ChannelDeterminant.Internal.inverseOfBijective_isTracePreservingMap` — the
+  source's observation that the inverse of a bijective trace-preserving linear
+  map is automatically trace preserving.
+* `ChannelDeterminant.Internal.channelDet_norm_eq_one_of_inverseOfBijective_isPositiveMap`
+  — if a positive trace-preserving bijection and its inverse are positive, the
+  determinant bounds and multiplicativity force `|det T| = 1`.
+* `ChannelDeterminant.Internal.inverseOfBijective_unitaryChannel` and
+  `ChannelDeterminant.Internal.inverseOfBijective_unitaryChannel_comp_transpose`
+  — the explicit inverses of the two standard forms, with the correct reversed
+  composition order in the transpose branch.
+* `ChannelDeterminant.Internal.wolfPositiveInvertibleMaps` — for positive
+  matrix dimension, the inverse of a positive trace-preserving bijection is
+  positive exactly when the map is unitary conjugation or unitary conjugation
+  after ordinary transposition.
+
+The forward implication follows Wolf's determinant route and consumes the
+source-general saturation theorem above.  The converse uses the explicit
+positive inverse of each standard form; it does not strengthen the hypotheses
+to complete positivity and therefore retains Wolf's transpose branch.
+
 
 #### Wolf Lemma 6.1 (Dirichlet's simultaneous approximation) — FORMALIZED
 


### PR DESCRIPTION
## Summary

- formalize the inverse linear map of a bijective matrix endomorphism and its left/right inverse laws
- prove Wolf's observation that the inverse of a bijective trace-preserving map is trace preserving, and characterize positivity of the inverse by surjectivity on the positive-semidefinite cone
- follow Wolf's determinant argument to classify positive inverses as unitary conjugations or unitary conjugations after ordinary matrix transposition
- make the inverse and positivity of both standard forms explicit, including the reversed composition order in the transpose branch
- synchronize the determinant aggregators, Blueprint, and Wolf numbering coverage

## Source route

This follows `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 416--426. If `T` and `T⁻¹` are positive and trace preserving, Wolf's determinant bounds and multiplicativity give `|det T| = 1`. The source-general positive-map extremality theorem then supplies unitary conjugation or unitary conjugation after ordinary transposition. Conversely, the inverse of each standard form is written explicitly and proved positive.

The theorem deliberately assumes positivity rather than complete positivity, so Wolf's transpose branch is retained. `[NeZero d]` states the positive-dimension boundary explicitly, and bijectivity supplies the inverse rather than treating it as a partial operation.

## Validation

- `lake build QICLean.Channel.Determinant.PositiveInverse QICLean.Channel.Determinant QICLean.Channel`
- `lake build QICLean` (9,251 jobs)
- `lake exe lint_style --github`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- reverse Blueprint coverage check: zero changed declarations missing
- reader-facing prose, generated-import, oversized-file, numbered-module, and diff checks
- source contains no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`
- `#print axioms` for all public declarations reports only `propext`, `Classical.choice`, and `Quot.sound`

Closes #395
Refs #38
