### PR TITLE
fix(docs): repair Wolf TeX notation builds

### DIFF
--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -1113,7 +1113,7 @@ This section states the existence theorems from
     formalized cone/rank/Wigner route of Wolf Proposition~3.6 gives
     $T(A)=YAY^\dagger$ or $T(A)=YA^{\mathsf T}Y^\dagger$ with $Y$
     invertible.  Trace preservation and nondegeneracy of the trace pairing
-    imply $Y^\dagger Y=\one$, so $Y$ is unitary.  Conversely, unitary
+    imply $Y^\dagger Y=\Id$, so $Y$ is unitary.  Conversely, unitary
     conjugation has determinant one, while transposition is an involution and
     hence has determinant of modulus one.
 \end{proof}

--- a/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
+++ b/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
@@ -67,7 +67,7 @@ Finally,
 \leanid{IsPositiveMap.mem\_weightedCornerFixedPointsStarSubalgebra\_iff\_inverseSandwich}
 identifies the formal carrier in both directions with
 $\rho^{-1/2}\mathcal F_T\rho^{-1/2}$.  The inverse square root is the functional-calculus
-inverse on $\supp(\rho)$ and zero on its kernel.  The support identities
+inverse on $\operatorname{supp}(\rho)$ and zero on its kernel.  The support identities
 $\sqrt\rho\,\rho^{-1/2}=Q=\rho^{-1/2}\sqrt\rho$ give the equality without an ambient
 invertibility assumption.  The generic construction also includes zero support as the
 zero corner algebra; the source theorem's density hypothesis, of course, has trace one.


### PR DESCRIPTION
## Summary

- expand the undefined `\supp` command in the Corollary 6.7 resolution note to `\operatorname{supp}`
- replace the undefined Blueprint-only `\one` command in the determinant proof with the established `\Id` macro
- keep both repairs local and mathematical content unchanged

## Source faithfulness

Wolf Corollary 6.7 uses support notation at `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1503--1509, and the Wolf preamble defines `\supp` as `\operatorname{supp}`. The standalone paper-gap note now uses that exact expansion.

Wolf source lines 351--407 use `\one`, whose source preamble expansion is `\mathbb{1}`. Blueprint `src/macros/common.tex` defines the established `\Id` macro with the same expansion, so the Blueprint repair uses its existing identity notation rather than introducing another command.

## Reproduced regressions

- focused paper-gap compilation failed at line 70 with undefined control sequence `\supp`
- full `leanblueprint pdf` failed in `ch03_channel_representations_normal_forms_and_determinant.tex` at the identity equation with undefined control sequence `\one`
- the post-#404 main run [32679912392](https://github.com/LionSR/QICLean/actions/runs/32679912392) failed solely in the all-paper-gap build on the Corollary 6.7 note, confirming this PR is the required landed-CI repair

## Validation

After rebasing onto exact `daba92beb0a7de737ad3e6c907ba8641f95a343f`:

- `leanblueprint pdf` (316-page PDF, including the #404 positive-inverse additions)
- strict `texra-blueprint web`
- `texra-blueprint --root . paper-gaps build` (all 41 notes)
- `texra-blueprint paper-gaps check` (38 referenced slugs)
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (2033 unique references / 2054 entries, 100 percent)
- full Blueprint `chktex`
- reader-facing prose check
- `git diff --check`
- exact-base `lake build QICLean` (9251 jobs) followed by `checkdecls` against this head generated 2033-entry declaration list

## Tracking

Follow-up document-build repairs to #400 / closed #392 and #401 / closed #394. This PR closes no leaf or tracking issue; chapter tracker #42 remains open.