### PR TITLE
feat(channel): formalize corrected Collatz-Wielandt quantities

### DIFF
--- a/QICLean/Channel/Irreducible/CollatzWielandt.lean
+++ b/QICLean/Channel/Irreducible/CollatzWielandt.lean
@@ -16,8 +16,8 @@ density matrix `X` when `T X - a X ≥ 0`.  The feasible pairs form, after a
 uniform trace bound on `a`, a compact set.  Hence the lower value has a
 maximizer.
 
-The upper Collatz--Wielandt quantity is not introduced at this stage.  Wolf's
-proof first turns the lower maximizer into a positive-definite eigenvector by
+Wolf's proof does not use the upper Collatz--Wielandt quantity at this stage.
+It first turns the lower maximizer into a positive-definite eigenvector by
 Equation (6.31) and irreducibility; only then are the two global variational
 quantities identified.
 

--- a/QICLean/Channel/Irreducible/CollatzWielandt.lean
+++ b/QICLean/Channel/Irreducible/CollatzWielandt.lean
@@ -35,6 +35,163 @@ variable {D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
+/-- The real parameters in the set on the right-hand side of Wolf
+Equation (6.29), at local source lines 608--613. -/
+def lowerCollatzWielandtSet (T : Mat →ₗ[ℂ] Mat) (X : Mat) : Set ℝ :=
+  {a | (T X - (a : ℂ) • X).PosSemidef}
+
+/-- The real parameters in the set on the right-hand side of Wolf
+Equation (6.30), at local source lines 614--615. -/
+def upperCollatzWielandtSet (T : Mat →ₗ[ℂ] Mat) (X : Mat) : Set ℝ :=
+  {a | ((a : ℂ) • X - T X).PosSemidef}
+
+/-- Wolf's lower Collatz--Wielandt functional `r(X)` from Equation (6.29),
+valued in the extended reals.
+
+The extended value records the boundary at `X = 0` exactly: every real
+parameter is feasible there, so `r(0) = +∞`. -/
+noncomputable def lowerCollatzWielandtValue
+    (T : Mat →ₗ[ℂ] Mat) (X : Mat) : EReal :=
+  sSup ((fun a : ℝ => (a : EReal)) '' lowerCollatzWielandtSet T X)
+
+/-- Wolf's upper Collatz--Wielandt functional `tilde r(X)` from Equation
+(6.30), valued in the extended reals.
+
+If no real upper parameter exists, the infimum is `+∞`. At `X = 0`, every
+real parameter is feasible and the value is `-∞`. Thus neither boundary is
+represented by an arbitrary real. -/
+noncomputable def upperCollatzWielandtValue
+    (T : Mat →ₗ[ℂ] Mat) (X : Mat) : EReal :=
+  sInf ((fun a : ℝ => (a : EReal)) '' upperCollatzWielandtSet T X)
+
+/-- The corrected global lower Collatz--Wielandt quantity, after the
+trace-one normalization used by Wolf at local source lines 634--637. -/
+noncomputable def lowerCollatzWielandtGlobal
+    (T : Mat →ₗ[ℂ] Mat) : EReal :=
+  sSup (lowerCollatzWielandtValue T '' densityMatrices D)
+
+/-- The corrected global upper Collatz--Wielandt quantity, after the
+trace-one normalization used by Wolf at local source lines 634--637.
+
+This is an infimum, correcting the second supremum printed at source line
+618. -/
+noncomputable def upperCollatzWielandtGlobal
+    (T : Mat →ₗ[ℂ] Mat) : EReal :=
+  sInf (upperCollatzWielandtValue T '' densityMatrices D)
+
+/-- A lower parameter at a nonzero positive semidefinite matrix does not
+exceed an upper parameter at the same matrix. -/
+private theorem lowerCollatzWielandtSet_le_upperCollatzWielandtSet
+    (T : Mat →ₗ[ℂ] Mat) {X : Mat} {a b : ℝ}
+    (hX : X.PosSemidef) (hX_ne : X ≠ 0)
+    (ha : a ∈ lowerCollatzWielandtSet T X)
+    (hb : b ∈ upperCollatzWielandtSet T X) :
+    a ≤ b := by
+  have hsum := ha.add hb
+  have heq :
+      (T X - (a : ℂ) • X) + ((b : ℂ) • X - T X) =
+        (((b - a : ℝ) : ℂ) • X) := by
+    push_cast
+    module
+  rw [heq] at hsum
+  have htrace_nonneg := hsum.trace_nonneg
+  rw [Matrix.trace_smul, smul_eq_mul] at htrace_nonneg
+  have htrace_pos := hX.trace_pos_of_ne_zero hX_ne
+  have hprod_re_nonneg := (Complex.nonneg_iff.mp htrace_nonneg).1
+  have htrace_re_pos := (Complex.lt_def.mp htrace_pos).1
+  rw [Complex.mul_re] at hprod_re_nonneg
+  norm_num at hprod_re_nonneg
+  norm_num at htrace_re_pos
+  nlinarith
+
+/-- **Pointwise Collatz--Wielandt inequality.** For a nonzero positive
+semidefinite matrix, the functional in Wolf Equation (6.29) is at most the
+functional in Equation (6.30).
+
+This is the corrected pointwise order underlying Wolf Theorem 6.3. It does
+not assert pointwise equality for arbitrary positive semidefinite matrices. -/
+theorem lowerCollatzWielandtValue_le_upperCollatzWielandtValue
+    (T : Mat →ₗ[ℂ] Mat) {X : Mat}
+    (hX : X.PosSemidef) (hX_ne : X ≠ 0) :
+    lowerCollatzWielandtValue T X ≤ upperCollatzWielandtValue T X := by
+  rw [lowerCollatzWielandtValue, upperCollatzWielandtValue]
+  apply sSup_le
+  intro a ha
+  obtain ⟨a', ha', rfl⟩ := ha
+  apply le_sInf
+  intro b hb
+  obtain ⟨b', hb', rfl⟩ := hb
+  exact EReal.coe_le_coe_iff.mpr
+    (lowerCollatzWielandtSet_le_upperCollatzWielandtSet T hX hX_ne ha' hb')
+
+/-- **Equality at a positive eigenvector.** If `X ≥ 0` is nonzero and
+`T X = r X`, then both pointwise functionals in Wolf Equations (6.29)--(6.30)
+equal `r`.
+
+This is precisely the equality used at local source lines 649--651; no
+equality is claimed away from eigenvectors. -/
+theorem lower_and_upperCollatzWielandtValue_eq_of_eigenvector
+    (T : Mat →ₗ[ℂ] Mat) {X : Mat} {r : ℝ}
+    (hX : X.PosSemidef) (hX_ne : X ≠ 0)
+    (hEig : T X = (r : ℂ) • X) :
+    lowerCollatzWielandtValue T X = (r : EReal) ∧
+      upperCollatzWielandtValue T X = (r : EReal) := by
+  have hr_lower_set : r ∈ lowerCollatzWielandtSet T X := by
+    rw [lowerCollatzWielandtSet, Set.mem_ofPred_eq, hEig, sub_self]
+    exact Matrix.PosSemidef.zero
+  have hr_upper_set : r ∈ upperCollatzWielandtSet T X := by
+    rw [upperCollatzWielandtSet, Set.mem_ofPred_eq, hEig, sub_self]
+    exact Matrix.PosSemidef.zero
+  have hr_le_lower : (r : EReal) ≤ lowerCollatzWielandtValue T X := by
+    apply le_sSup
+    exact ⟨r, hr_lower_set, rfl⟩
+  have hupper_le_r : upperCollatzWielandtValue T X ≤ (r : EReal) := by
+    apply sInf_le
+    exact ⟨r, hr_upper_set, rfl⟩
+  have hlower_le_upper :=
+    lowerCollatzWielandtValue_le_upperCollatzWielandtValue T hX hX_ne
+  exact ⟨le_antisymm (hlower_le_upper.trans hupper_le_r) hr_le_lower,
+    le_antisymm hupper_le_r (hr_le_lower.trans hlower_le_upper)⟩
+
+/-- At the excluded point `X = 0`, Wolf's lower functional has the honest
+extended value `+∞`. -/
+theorem lowerCollatzWielandtValue_zero (T : Mat →ₗ[ℂ] Mat) :
+    lowerCollatzWielandtValue T 0 = ⊤ := by
+  have hset : lowerCollatzWielandtSet T 0 = Set.univ := by
+    ext a
+    change (T 0 - (a : ℂ) • (0 : Mat)).PosSemidef ↔ True
+    simp only [map_zero, smul_zero, sub_zero]
+    exact iff_true_intro Matrix.PosSemidef.zero
+  rw [lowerCollatzWielandtValue, hset, Set.image_univ]
+  rw [sSup_eq_top]
+  intro b hb
+  obtain ⟨a, hba, -⟩ := EReal.lt_iff_exists_real_btwn.mp hb
+  exact ⟨(a : EReal), ⟨a, rfl⟩, hba⟩
+
+/-- At the excluded point `X = 0`, Wolf's upper functional has the honest
+extended value `-∞`. -/
+theorem upperCollatzWielandtValue_zero (T : Mat →ₗ[ℂ] Mat) :
+    upperCollatzWielandtValue T 0 = ⊥ := by
+  have hset : upperCollatzWielandtSet T 0 = Set.univ := by
+    ext a
+    change ((a : ℂ) • (0 : Mat) - T 0).PosSemidef ↔ True
+    simp only [map_zero, smul_zero, sub_zero]
+    exact iff_true_intro Matrix.PosSemidef.zero
+  rw [upperCollatzWielandtValue, hset, Set.image_univ]
+  rw [sInf_eq_bot]
+  intro b hb
+  obtain ⟨a, -, hab⟩ := EReal.lt_iff_exists_real_btwn.mp hb
+  exact ⟨(a : EReal), ⟨a, rfl⟩, hab⟩
+
+/-- If no real parameter satisfies Wolf's upper inequality at `X`, then the
+upper pointwise functional has extended value `+∞`. -/
+theorem upperCollatzWielandtValue_eq_top_of_not_nonempty
+    (T : Mat →ₗ[ℂ] Mat) (X : Mat)
+    (h : ¬ (upperCollatzWielandtSet T X).Nonempty) :
+    upperCollatzWielandtValue T X = ⊤ := by
+  have hset : upperCollatzWielandtSet T X = ∅ := Set.not_nonempty_iff_eq_empty.mp h
+  simp [upperCollatzWielandtValue, hset]
+
 /-- A positive-definite weight has strictly positive trace pairing with every
 nonzero positive semidefinite matrix. -/
 private theorem trace_mul_pos_of_posDef_posSemidef_ne_zero
@@ -681,3 +838,80 @@ theorem exists_posDef_common_collatzWielandt_value_of_irreducible_positive
         T hT hIrr hrpos hX hX_eig hYa
   exact ⟨X, r, hXdensity, hr, hX, hX_eig, hLowerAtX, hUpperAtX,
     hLowerMax, hUpperMin⟩
+
+/-- **Wolf Theorem 6.3(1), pointwise-functional form.** For an irreducible
+positive map, Wolf's corrected global lower supremum and upper infimum are
+attained at the same positive-definite density-matrix eigenvector. Both
+extended-real values equal its eigenvalue.
+
+The proof uses the positive Perron pair obtained by Wolf's Equation (6.31),
+then applies the eigenvector equality at local source lines 649--651. -/
+theorem exists_posDef_collatzWielandt_extrema_of_irreducible_positive
+    [NeZero D]
+    (T : Mat →ₗ[ℂ] Mat) (hT : IsPositiveMap T) (hIrr : IsIrreducibleMap T) :
+    ∃ X : Mat, ∃ r : ℝ,
+      X ∈ densityMatrices D ∧ 0 ≤ r ∧ X.PosDef ∧
+        T X = (r : ℂ) • X ∧
+        lowerCollatzWielandtValue T X = (r : EReal) ∧
+        upperCollatzWielandtValue T X = (r : EReal) ∧
+        lowerCollatzWielandtGlobal T = (r : EReal) ∧
+        upperCollatzWielandtGlobal T = (r : EReal) := by
+  obtain ⟨X, r, hXdensity, hr, hX, hX_eig, -, -, hLowerMax, hUpperMin⟩ :=
+    exists_posDef_common_collatzWielandt_value_of_irreducible_positive T hT hIrr
+  have hX_ne : X ≠ 0 := by
+    intro hzero
+    have htrace := hXdensity.2
+    rw [hzero, Matrix.trace_zero] at htrace
+    norm_num at htrace
+  obtain ⟨hLowerAtX, hUpperAtX⟩ :=
+    lower_and_upperCollatzWielandtValue_eq_of_eigenvector
+      T hXdensity.1 hX_ne hX_eig
+  have hLowerBound : ∀ Y ∈ densityMatrices D,
+      lowerCollatzWielandtValue T Y ≤ (r : EReal) := by
+    intro Y hY
+    rw [lowerCollatzWielandtValue]
+    apply sSup_le
+    intro a ha
+    obtain ⟨a', ha', rfl⟩ := ha
+    exact EReal.coe_le_coe_iff.mpr (hLowerMax Y a' ⟨hY, ha'⟩)
+  have hUpperBound : ∀ Y ∈ densityMatrices D,
+      (r : EReal) ≤ upperCollatzWielandtValue T Y := by
+    intro Y hY
+    rw [upperCollatzWielandtValue]
+    apply le_sInf
+    intro a ha
+    obtain ⟨a', ha', rfl⟩ := ha
+    exact EReal.coe_le_coe_iff.mpr (hUpperMin Y a' ⟨hY, ha'⟩)
+  have hLowerGlobal : lowerCollatzWielandtGlobal T = (r : EReal) := by
+    apply le_antisymm
+    · rw [lowerCollatzWielandtGlobal]
+      apply sSup_le
+      intro a ha
+      obtain ⟨Y, hY, rfl⟩ := ha
+      exact hLowerBound Y hY
+    · rw [lowerCollatzWielandtGlobal]
+      apply le_sSup
+      exact ⟨X, hXdensity, hLowerAtX⟩
+  have hUpperGlobal : upperCollatzWielandtGlobal T = (r : EReal) := by
+    apply le_antisymm
+    · rw [upperCollatzWielandtGlobal]
+      apply sInf_le
+      exact ⟨X, hXdensity, hUpperAtX⟩
+    · rw [upperCollatzWielandtGlobal]
+      apply le_sInf
+      intro a ha
+      obtain ⟨Y, hY, rfl⟩ := ha
+      exact hUpperBound Y hY
+  exact ⟨X, r, hXdensity, hr, hX, hX_eig, hLowerAtX, hUpperAtX,
+    hLowerGlobal, hUpperGlobal⟩
+
+/-- **Corrected global Collatz--Wielandt equality.** For an irreducible
+positive map, the supremum of Wolf's lower pointwise functional over density
+matrices equals the infimum of the upper pointwise functional. -/
+theorem lowerCollatzWielandtGlobal_eq_upperCollatzWielandtGlobal
+    [NeZero D]
+    (T : Mat →ₗ[ℂ] Mat) (hT : IsPositiveMap T) (hIrr : IsIrreducibleMap T) :
+    lowerCollatzWielandtGlobal T = upperCollatzWielandtGlobal T := by
+  obtain ⟨-, r, -, -, -, -, -, -, hLower, hUpper⟩ :=
+    exists_posDef_collatzWielandt_extrema_of_irreducible_positive T hT hIrr
+  exact hLower.trans hUpper.symm

--- a/blueprint/src/chapter/ch07_qpf.tex
+++ b/blueprint/src/chapter/ch07_qpf.tex
@@ -931,6 +931,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{proof}\leanok
     \uses{thm:growth_pd_irred,
+        thm:collatz_wielandt_eigenvector,
         thm:trace_adjoint_irreducible_positive,
         thm:spectral_radius_pf_irred}
     First maximize the lower functional, in the order used by Wolf. On density
@@ -1003,7 +1004,8 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     second supremum and then states the reversed inequality
     $r\geq\widetilde r$. The valid statement proved here is the minimum of the
     upper feasible values, equal to the lower maximum by the trace-adjoint
-    argument above. No pointwise equality $r(Y)=\widetilde r(Y)$ is used.
+    argument above. No arbitrary pointwise equality
+    $r(Y)=\widetilde r(Y)$ is used.
 \end{proof}
 
 \begin{theorem}[Spectral radius from a positive-definite eigenvector]

--- a/blueprint/src/chapter/ch07_qpf.tex
+++ b/blueprint/src/chapter/ch07_qpf.tex
@@ -763,28 +763,107 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \section{The Collatz--Wielandt argument for irreducible positive maps}
 
-\begin{definition}[Lower and upper Collatz--Wielandt feasibility]
+\begin{definition}[Lower and upper Collatz--Wielandt quantities]
     \label{def:collatz_wielandt_feasible}
-    \lean{LowerCollatzWielandtFeasible, UpperCollatzWielandtFeasible}
+    \lean{lowerCollatzWielandtSet, upperCollatzWielandtSet,
+        lowerCollatzWielandtValue, upperCollatzWielandtValue,
+        lowerCollatzWielandtGlobal, upperCollatzWielandtGlobal,
+        LowerCollatzWielandtFeasible, UpperCollatzWielandtFeasible}
     \leanok
     \uses{def:density_matrices}
-    Let $T:\MN{D}\to\MN{D}$ be linear. A pair $(X,a)$ is lower feasible
-    for $a\in\R$ when
+    Let $T:\MN{D}\to\MN{D}$ be linear. For $X\in\MN{D}$ set
     \begin{align}
-        X&\geq0, & \tr X&=1,
-        & T(X)-aX&\geq0,
-        \label{eq:qpf_cw_lower_feasible}
+        L_T(X)
+        &:=\{a\in\R:T(X)-aX\geq0\},
+        &
+        U_T(X)
+        &:=\{a\in\R:aX-T(X)\geq0\},
+        \label{eq:qpf_cw_sets}\\
+        r_T(X)
+        &:=\sup L_T(X),
+        &
+        \widetilde r_T(X)
+        &:=\inf U_T(X),
+        \label{eq:qpf_cw_values}
     \end{align}
-    and is upper feasible when the first two conditions hold and
+    where the suprema and infima in~(\ref{eq:qpf_cw_values}) are taken in
+    $\overline{\R}$. These are
+    \cite[Equations~(6.29)--(6.30)]{Wolf2012Quantum}. The corrected global
+    quantities are
     \begin{align}
-        aX-T(X)&\geq0.
-        \label{eq:qpf_cw_upper_feasible}
+        r_T
+        &:=\sup_{X\geq0,\,\tr X=1}r_T(X),
+        &
+        \widetilde r_T
+        &:=\inf_{X\geq0,\,\tr X=1}\widetilde r_T(X).
+        \label{eq:qpf_cw_global_values}
     \end{align}
-    Thus the scalar ranges over all of $\R$, exactly as in the source. Under
-    the harmless normalization $\tr X=1$, these predicates express
-    $a\leq r(X)$ and $\widetilde r(X)\leq a$ for the functionals in
-    \cite[Equations~(6.29)--(6.30)]{Wolf2012Quantum}.
+    The trace-one condition is Wolf's homogeneous normalization from local
+    source lines~634--637. A pair $(X,a)$ is lower feasible when
+    $X\geq0$, $\tr X=1$, and $a\in L_T(X)$; it is upper feasible when the
+    first two conditions hold and $a\in U_T(X)$.
 \end{definition}
+
+\begin{theorem}[Boundary values of the pointwise quantities]
+    \label{thm:collatz_wielandt_boundaries}
+    \lean{lowerCollatzWielandtValue_zero,
+        upperCollatzWielandtValue_zero,
+        upperCollatzWielandtValue_eq_top_of_not_nonempty}
+    \leanok
+    \uses{def:collatz_wielandt_feasible}
+    For every linear map $T$,
+    $r_T(0)=+\infty$ and $\widetilde r_T(0)=-\infty$. If
+    $U_T(X)=\varnothing$, then $\widetilde r_T(X)=+\infty$.
+\end{theorem}
+
+\begin{proof}\leanok
+    At $X=0$, both sets in~(\ref{eq:qpf_cw_sets}) equal $\R$, whose supremum
+    and infimum in $\overline{\R}$ are respectively $+\infty$ and $-\infty$.
+    The infimum of the empty subset of $\overline{\R}$ is $+\infty$.
+\end{proof}
+
+\begin{theorem}[Pointwise Collatz--Wielandt inequality]
+    \label{thm:collatz_wielandt_pointwise_order}
+    \lean{lowerCollatzWielandtValue_le_upperCollatzWielandtValue}
+    \leanok
+    \uses{def:collatz_wielandt_feasible}
+    Let $X\geq0$ be nonzero. Then
+    \begin{align}
+        r_T(X)
+        &\leq\widetilde r_T(X).
+        \label{eq:qpf_cw_pointwise_order}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    If $a\in L_T(X)$ and $b\in U_T(X)$, adding the two positive
+    semidefinite residuals gives $(b-a)X\geq0$. Since $X\geq0$ is nonzero,
+    $\tr X>0$; taking traces therefore gives $a\leq b$. Taking the supremum
+    over $a$ and the infimum over $b$ proves
+    (\ref{eq:qpf_cw_pointwise_order}), including the cases in which either
+    set has an infinite extremum.
+\end{proof}
+
+\begin{theorem}[Collatz--Wielandt equality at a positive eigenvector]
+    \label{thm:collatz_wielandt_eigenvector}
+    \lean{lower_and_upperCollatzWielandtValue_eq_of_eigenvector}
+    \leanok
+    \uses{def:collatz_wielandt_feasible}
+    Let $X\geq0$ be nonzero and suppose $T(X)=aX$ for some $a\in\R$. Then
+    \begin{align}
+        r_T(X)
+        &=a=\widetilde r_T(X).
+        \label{eq:qpf_cw_eigenvector}
+    \end{align}
+    This is the pointwise equality used at local source lines~649--651.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:collatz_wielandt_pointwise_order}
+    The eigenvalue $a$ belongs to both sets in~(\ref{eq:qpf_cw_sets}). Hence
+    $a\leq r_T(X)\leq\widetilde r_T(X)\leq a$, where the middle inequality is
+    Theorem~\ref{thm:collatz_wielandt_pointwise_order}.
+\end{proof}
 
 \begin{theorem}[Irreducibility of the trace adjoint]
     \label{thm:trace_adjoint_irreducible_positive}
@@ -818,7 +897,10 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \begin{theorem}[Spectral radius of irreducible positive maps]
     \label{thm:wolf_irreducible_positive_spectral_radius}
     \lean{exists_wolfTheorem63_of_irreducible_positive,
-        exists_wolfTheorem63_of_irreducible_positive_of_ne_zero}
+        exists_wolfTheorem63_of_irreducible_positive_of_ne_zero,
+        exists_posDef_common_collatzWielandt_value_of_irreducible_positive,
+        exists_posDef_collatzWielandt_extrema_of_irreducible_positive,
+        lowerCollatzWielandtGlobal_eq_upperCollatzWielandtGlobal}
     \leanok
     \uses{def:positive_map, def:irreducible_cp,
         def:collatz_wielandt_feasible}
@@ -902,9 +984,10 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
         \tag{6.33}\label{eq:qpf_cw_trace_pairing}
     \end{align}
     Since $\tr(X_0Y)>0$, this gives $\lambda=r$. Pairing $X_0$ instead with
-    the positive residual in~(\ref{eq:qpf_cw_upper_feasible}) shows that every
-    upper feasible value is at least $r$. Together with feasibility of the
-    Perron pair, this proves the corrected global maximum--minimum equality.
+    the upper residual $aY-T(Y)\geq0$ from~(\ref{eq:qpf_cw_sets}) shows that
+    every upper feasible value is at least $r$. Together with feasibility of
+    the Perron pair, this proves the corrected global maximum--minimum
+    equality.
 
     Finally set
     \begin{align}

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -391,7 +391,7 @@ The corrected Collatz--Wielandt pair is
 \end{equation}
 For an irreducible positive map, both extrema are attained at the same
 positive-definite eigenvector and are equal. Thus the second ``sup'' and the
-displayed reversed inequality are a single local source error. Equality is
+displayed reversed inequality are two local source errors. Equality is
 not asserted pointwise for arbitrary $X$. In the extended-real formulation,
 $r(0)=+\infty$ and $\widetilde r(0)=-\infty$; for every nonzero $X\geq0$ one
 has $r(X)\leq\widetilde r(X)$, with equality at positive eigenvectors as used

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -368,8 +368,12 @@ the characteristic polynomial records the complete multiplicity data.
 The declarations
 \leanid{exists_wolfTheorem63_of_irreducible_positive} and
 \leanid{exists_wolfTheorem63_of_irreducible_positive_of_ne_zero} formalize
-Wolf Theorem~6.3 for arbitrary positive maps. The two corrections are
-documented in
+Wolf Theorem~6.3 for arbitrary positive maps. The declarations
+\leanid{lowerCollatzWielandtValue},
+\leanid{upperCollatzWielandtValue}, and
+\leanid{lowerCollatzWielandtGlobal\_eq\_upperCollatzWielandtGlobal}
+formalize the corrected pointwise and global quantities. The two corrections
+are documented in
 \path{docs/paper-gaps/wolf_thm6_3_positive_map_cp_scope.tex}.
 
 \paragraph{The global upper quantity.}
@@ -388,7 +392,10 @@ The corrected Collatz--Wielandt pair is
 For an irreducible positive map, both extrema are attained at the same
 positive-definite eigenvector and are equal. Thus the second ``sup'' and the
 displayed reversed inequality are a single local source error. Equality is
-not asserted pointwise for arbitrary $X$.
+not asserted pointwise for arbitrary $X$. In the extended-real formulation,
+$r(0)=+\infty$ and $\widetilde r(0)=-\infty$; for every nonzero $X\geq0$ one
+has $r(X)\leq\widetilde r(X)$, with equality at positive eigenvectors as used
+at local source lines~649--651.
 
 \paragraph{The one-dimensional zero map.}
 The theorem assumes only that $T:\MN{D}\to\MN{D}$ is irreducible and positive,

--- a/docs/paper-gaps/wolf_thm6_3_positive_map_cp_scope.tex
+++ b/docs/paper-gaps/wolf_thm6_3_positive_map_cp_scope.tex
@@ -106,8 +106,22 @@ $T(X)-aX\geq0$ and $bX-T(X)\geq0$ give respectively
   \widetilde r(X)&=\max\{3,3/2\}=3.
 \end{align}
 Equality at a positive eigenvector is sufficient for the theorem. The
-standalone pointwise and extended-value development tracked separately does
-not enter this proof.
+declarations
+\leanid{lowerCollatzWielandtValue} and
+\leanid{upperCollatzWielandtValue} formalize the two pointwise functionals in
+the extended reals. They record the excluded zero boundary exactly:
+\begin{align}
+  r(0)&=+\infty,&
+  \widetilde r(0)&=-\infty.
+\end{align}
+If the upper defining set is empty, its infimum is $+\infty$. For every
+nonzero $X\geq0$ the declaration
+\leanid{lowerCollatzWielandtValue\_le\_upperCollatzWielandtValue} proves the
+correct pointwise order $r(X)\leq\widetilde r(X)$, while
+\leanid{lower\_and\_upperCollatzWielandtValue\_eq\_of\_eigenvector} proves
+equality at every positive eigenvector. Thus the formal statement matches
+exactly the use at local source lines~649--651 without asserting the false
+arbitrary pointwise equality.
 
 \section{Source-faithful proof route}
 
@@ -142,6 +156,8 @@ formalized for arbitrary positive maps. The one-dimensional zero-map boundary
 requires either the corrected conclusion $r\geq0$ or the explicit hypothesis
 $T\neq0$ for the printed $r>0$ form. The second global extremum at
 lines~617--619 is an infimum, not a supremum, and the accompanying printed
-inequality is correspondingly invalid.
+inequality is correspondingly invalid. The pointwise functionals now use
+extended values, their zero and empty-set boundaries are explicit, and their
+equality is asserted only at positive eigenvectors.
 
 \end{document}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -798,15 +798,27 @@ The headline declarations are in
 
 They package the four source conclusions in order:
 
-1. `LowerCollatzWielandtFeasible` and `UpperCollatzWielandtFeasible` encode
-   Equations (6.29)–(6.30) on density matrices, with the scalar ranging over
-   all real numbers as in the source.
+1. `lowerCollatzWielandtSet` and `upperCollatzWielandtSet` are the two sets in
+   Equations (6.29)–(6.30), and `lowerCollatzWielandtValue` and
+   `upperCollatzWielandtValue` take their extended-real supremum and infimum.
+   The zero boundary is explicit: the values are respectively `⊤` and `⊥`;
+   an empty upper set has value `⊤`.
+   `lowerCollatzWielandtValue_le_upperCollatzWielandtValue` proves the corrected
+   pointwise order for every nonzero positive semidefinite matrix, and
+   `lower_and_upperCollatzWielandtValue_eq_of_eigenvector` proves equality at
+   positive eigenvectors, exactly as used at source lines 649–651.
+   `LowerCollatzWielandtFeasible` and `UpperCollatzWielandtFeasible` encode the
+   corresponding trace-one pairs, with the scalar ranging over all real
+   numbers as in the source.
    `exists_lowerCollatzWielandt_maximizer` constructs the lower maximizer
    first. `idPlus_pow_apply_map_sub_smul` is Equation (6.31), and
    `exists_posDef_eigenvector_of_irreducible_positive` uses it with Wolf
    Theorem 6.2 to obtain a positive-definite eigenvector. After that,
    `exists_posDef_common_collatzWielandt_value_of_irreducible_positive`
-   identifies the global lower maximum with the global upper minimum.
+   identifies the global lower maximum with the global upper minimum, while
+   `exists_posDef_collatzWielandt_extrema_of_irreducible_positive` and
+   `lowerCollatzWielandtGlobal_eq_upperCollatzWielandtGlobal` state the same
+   conclusion for the corrected pointwise functionals.
 2. `eigenspace_eq_span_of_irreducible_positive` and
    `finrank_eigenspace_eq_one_of_irreducible_positive` formalize Equation
    (6.32): the ordinary complex eigenspace at `r` is one-dimensional. This is


### PR DESCRIPTION
Closes #34.

## Source correction

Wolf, Chapter 6, Eqs. (6.29)--(6.30) and the proof of Theorem 6.3 (source lines 608--651) motivate lower and upper Collatz--Wielandt quantities. The printed paragraph has a second supremum where the upper quantity must be an infimum, and its displayed inequality is reversed. Equality is not true for an arbitrary positive semidefinite test matrix; the source only obtains equality at the positive Perron eigenvector.

## Formalization

- define pointwise lower and upper feasible sets and their `EReal` supremum/infimum, including honest zero and empty-set boundaries;
- prove the corrected pointwise lower-bound/upper-bound inequality by the source's positive residual and trace argument;
- prove equality at nonzero positive semidefinite eigenvectors, matching source lines 649--651;
- define density-normalized global extrema and prove their equality using the positive-definite Perron witness landed for #33;
- synchronize the Blueprint, Wolf erratum, Theorem 6.3 scope note, and Wolf numbering coverage.

The theorem remains at the source-faithful irreducible positive-map scope; it does not add CP or trace-preserving assumptions, and it does not assert the false arbitrary pointwise equality.

## Validation

Validated on exact base `ce291b877066197dd0be5f5ae7958322e7d0b515`:

- `lake build QICLean.Channel.Irreducible.CollatzWielandt`
- `lake build QICLean`
- public theorem `#print axioms` audit (only `propext`, `Classical.choice`, and `Quot.sound`)
- Blueprint declaration sync: 2083/2083 entries, including reverse changed-declaration coverage
- `lake exe checkdecls blueprint/lean_decls`
- `lake exe lint_style`
- import-aggregator, numbered-theorem, oversized-file, reader-prose, forbidden-token, and Lean-policy gates
- full `leanblueprint pdf` (320 pages)
- all 41 paper-gap note builds plus the policy document, `paper-gaps check`, and full `chktex`
- `git diff --check`
