### PR TITLE
chore: ignore generated paper-gap PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ blueprint/lean_decls
 blueprint/src/web.paux
 blueprint/src/*.xdv
 blueprint/src/Packages/__pycache__/
+/docs/paper-gaps/*.pdf
 
 # Local scratch / experiments
 Scratch/


### PR DESCRIPTION
Summary:
- ignore PDFs generated by `texra-blueprint --root . paper-gaps build`
- keep the rule scoped to `docs/paper-gaps/*.pdf` so tracked Wolf/source PDFs and paper-gap TeX inputs are unaffected

Validation:
- `texra-blueprint --root . paper-gaps build` (42 generated PDFs, all ignored)
- `texra-blueprint --root . paper-gaps check` (39 referenced slugs)
- `lake exe lint_style`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/generate_import_aggregators.py --check`
- `git diff --check`
- clean worktree after the full paper-gap build