### PR TITLE
feat(channel): exclude Schwarz transpose branch in Wolf Theorem 6.16

### DIFF
--- a/QICLean/Channel/Determinant.lean
+++ b/QICLean/Channel/Determinant.lean
@@ -65,6 +65,9 @@ The division follows the same organization as the earlier `Full/` and
   exact determinant of ordinary transposition in Wolf Theorem 6.1(3).
 * `ChannelDeterminant.Internal.wolfPositiveInvertibleMaps` — positivity of the
   inverse exactly for unitary conjugation and transpose-conjugation.
+* `ChannelDeterminant.Internal.wolfPositiveInvertibleSchwarzMaps` — the
+  Schwarz refinement used in Wolf Theorem 6.16, where the transpose branch is
+  excluded (and collapses to the unitary branch in dimension one).
 * `channelDet_norm_eq_one_iff_exists_unitaryChannel` — Wolf Theorem 6.1(2)
   for CPTP maps.
 * `IsKrausCP.channelDet_nonneg_of_choiRank_le_two` — nonnegativity for

--- a/QICLean/Channel/Determinant/PositiveInverse.lean
+++ b/QICLean/Channel/Determinant/PositiveInverse.lean
@@ -5,6 +5,7 @@ Authors: QICLean contributors
 -/
 import QICLean.Channel.Determinant.Composition
 import QICLean.Channel.Determinant.PositiveExtremality
+import QICLean.Channel.Schwarz.AbstractMultiplicativeDomain
 import QICLean.Channel.TransferMatrix
 
 /-!
@@ -20,6 +21,11 @@ The final classification is kept on Wolf's determinant route: determinant
 bounds for a map and its inverse force determinant modulus one, after which
 Wolf Theorem 6.1 supplies unitary conjugation or unitary conjugation after
 ordinary matrix transposition.
+
+The proof of Wolf Theorem 6.16 later applies this classification to its block
+maps.  There the Schwarz inequality excludes the transpose branch in matrix
+dimension at least two, while ordinary transposition is the identity in
+dimension one.
 
 ## References
 
@@ -252,5 +258,114 @@ theorem wolfPositiveInvertibleMaps [NeZero d]
       exact inverseOfBijective_unitaryChannel_isPositiveMap U hT
     · subst T
       exact inverseOfBijective_unitaryChannel_comp_transpose_isPositiveMap U hT
+
+/-- Ordinary matrix transposition is not a Schwarz map in matrix dimension at
+least two.
+
+For the matrix unit \(A=E_{01}\), the Schwarz defect of transposition is
+\(E_{11}-E_{00}\), whose \(00\)-entry is negative.
+
+Source: Wolf Theorem 6.16, proof line 1663 of
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`. -/
+theorem transposeLinearMapComplex_not_isSchwarzMap (hd : 2 ≤ d) :
+    ¬ IsSchwarzMap (Matrix.transposeLinearMapComplex (Fin d)) := by
+  classical
+  let i : Fin d := ⟨0, by omega⟩
+  let j : Fin d := ⟨1, by omega⟩
+  intro hSchwarz
+  have hDefect := hSchwarz (Matrix.single i j 1)
+  have hDiag := hDefect.diag_nonneg (i := i)
+  norm_num [Matrix.transposeLinearMapComplex, Matrix.single,
+    Matrix.conjTranspose, Matrix.mul_apply, i, j] at hDiag
+
+/-- Removing an outer unitary conjugation from a Schwarz map preserves the
+Schwarz property of the inner map.
+
+The proof conjugates the Schwarz defect back by \(U^\dagger\); this is the
+order-automorphism step used to show that unitary conjugation cannot repair
+the transpose defect in Wolf Theorem 6.16. -/
+theorem isSchwarzMap_of_unitaryChannel_comp
+    (U : Matrix.unitaryGroup (Fin d) ℂ) {E : MatrixEnd d}
+    (hE : IsSchwarzMap ((unitaryChannel U).comp E)) :
+    IsSchwarzMap E := by
+  have hStarU : (U : MatrixAlg d)ᴴ * U = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      Matrix.UnitaryGroup.star_mul_self U
+  have hCancel (X : MatrixAlg d) :
+      (U : MatrixAlg d)ᴴ * ((U : MatrixAlg d) * X) = X := by
+    rw [← Matrix.mul_assoc, hStarU, Matrix.one_mul]
+  intro A
+  have hDefect := hE A
+  have hBack := hDefect.conjTranspose_mul_mul_same (U : MatrixAlg d)
+  have hEq :
+      (U : MatrixAlg d)ᴴ *
+          (((unitaryChannel U).comp E) (Aᴴ * A) -
+            ((unitaryChannel U).comp E) Aᴴ *
+              ((unitaryChannel U).comp E) A) *
+          (U : MatrixAlg d) =
+        E (Aᴴ * A) - E Aᴴ * E A := by
+    simp only [LinearMap.comp_apply, unitaryChannel, LinearMap.coe_mk,
+      AddHom.coe_mk, Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_assoc,
+      hCancel, hStarU, Matrix.mul_one]
+  rw [hEq] at hBack
+  exact hBack
+
+/-- Unitary conjugation after ordinary transposition is not a Schwarz map in
+matrix dimension at least two.
+
+This is the standard-form branch excluded at Wolf Theorem 6.16, proof
+line 1663. -/
+theorem unitaryChannel_comp_transpose_not_isSchwarzMap (hd : 2 ≤ d)
+    (U : Matrix.unitaryGroup (Fin d) ℂ) :
+    ¬ IsSchwarzMap ((unitaryChannel U).comp
+      (Matrix.transposeLinearMapComplex (Fin d))) := by
+  intro hSchwarz
+  exact transposeLinearMapComplex_not_isSchwarzMap hd
+    (isSchwarzMap_of_unitaryChannel_comp U hSchwarz)
+
+/-- In matrix dimension one, ordinary transposition is the identity, so
+unitary conjugation after transposition collapses to the unitary branch.
+
+This packages the one-dimensional case tacitly included in Wolf Theorem 6.16,
+proof lines 1660--1663. -/
+theorem unitaryChannel_comp_transpose_fin_one
+    (U : Matrix.unitaryGroup (Fin 1) ℂ) :
+    (unitaryChannel U).comp (Matrix.transposeLinearMapComplex (Fin 1)) =
+      unitaryChannel U := by
+  apply LinearMap.ext
+  intro X
+  simp only [LinearMap.comp_apply]
+  congr 1
+  ext i j
+  rw [show i = j from Subsingleton.elim i j]
+  simp [Matrix.transposeLinearMapComplex]
+
+/-- **Wolf Theorem 6.16: the Schwarz condition excludes transposition.**
+
+A positive trace-preserving bijection with positive inverse that also
+satisfies the Schwarz inequality is unitary conjugation.  Wolf's positive
+invertible-map corollary gives unitary conjugation or unitary conjugation after
+ordinary transposition.  The latter is not Schwarz for \(d\geq 2\), and for
+\(d=1\) it is already the unitary branch.
+
+Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`,
+lines 1660--1663. -/
+theorem wolfPositiveInvertibleSchwarzMaps [NeZero d]
+    {T : MatrixEnd d} (hT : Function.Bijective T)
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (hInvPos : IsPositiveMap (inverseOfBijective T hT))
+    (hSchwarz : IsSchwarzMap T) :
+    ∃ U : Matrix.unitaryGroup (Fin d) ℂ, T = unitaryChannel U := by
+  obtain ⟨U, hUnitary | hTranspose⟩ :=
+    (wolfPositiveInvertibleMaps hT hPos hTP).mp hInvPos
+  · exact ⟨U, hUnitary⟩
+  · by_cases hdOne : d = 1
+    · subst d
+      rw [unitaryChannel_comp_transpose_fin_one] at hTranspose
+      exact ⟨U, hTranspose⟩
+    · have hdPos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
+      have hdTwo : 2 ≤ d := by omega
+      rw [hTranspose] at hSchwarz
+      exact (unitaryChannel_comp_transpose_not_isSchwarzMap hdTwo U hSchwarz).elim
 
 end ChannelDeterminant.Internal

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -553,6 +553,40 @@ $T^*$; the distinction and exact source lines are recorded in
 conditional data and do not assert that this existence theorem is already
 proved.
 
+\begin{theorem}[The Schwarz condition excludes matrix transpositions]
+    \label{thm:wolf_cycle_schwarz_excludes_transpose}
+    \lean{ChannelDeterminant.Internal.transposeLinearMapComplex_not_isSchwarzMap,
+        ChannelDeterminant.Internal.isSchwarzMap_of_unitaryChannel_comp,
+        ChannelDeterminant.Internal.unitaryChannel_comp_transpose_not_isSchwarzMap,
+        ChannelDeterminant.Internal.unitaryChannel_comp_transpose_fin_one,
+        ChannelDeterminant.Internal.wolfPositiveInvertibleSchwarzMaps}
+    \leanok
+    \uses{def:inverse_of_bijective_matrix_endomorphism,
+        def:positive_map, def:trace_preserving, def:unitary_channel,
+        def:abstract_schwarz_inequality}
+    Let $d>0$, and let $T:\MN{d}\to\MN{d}$ be a positive,
+    trace-preserving bijection whose inverse is positive. If $T$ satisfies the
+    Schwarz inequality in (\ref{eq:schwarz_abstract_inequality}), then there is
+    a unitary $U$ such that
+    \begin{align}
+        T(X)&=UXU^\dagger.
+    \end{align}
+    This is the final classification step at lines 1660--1663 of Wolf's proof
+    of Theorem~6.16.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:wolf_positive_invertible_maps}
+    The positive-invertible-map corollary gives either unitary conjugation or
+    $X\mapsto UX^{\mathsf T}U^\dagger$. For $d\geq 2$, take the matrix unit
+    $A=E_{01}$. The Schwarz defect of ordinary transposition is
+    $E_{11}-E_{00}$, which is not positive semidefinite. Conjugating a defect
+    by a unitary is an order automorphism, so the unitary-conjugated transpose
+    branch fails the same inequality. For $d=1$, ordinary transposition is the
+    identity and this alternative is already unitary conjugation.
+\end{proof}
+
 \begin{definition}[Block-permutation structure]
     \label{def:cycle_structure}
     \lean{CycleStructure}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -1383,6 +1383,23 @@ both `T` and `T*` are Schwarz.  No implication between these hypotheses is
 silently introduced, and the note does not claim that the theorem's conclusion
 is false under the single printed hypothesis.
 
+* The final classification step at source lines 1660--1663 is formalized
+  under exactly Wolf's positive, trace-preserving, positive-inverse, and
+  Schwarz hypotheses:
+  - `ChannelDeterminant.Internal.transposeLinearMapComplex_not_isSchwarzMap`
+    uses the matrix unit \(E_{01}\), whose transpose Schwarz defect is
+    \(E_{11}-E_{00}\), to rule out ordinary transposition for \(d\geq 2\).
+  - `ChannelDeterminant.Internal.isSchwarzMap_of_unitaryChannel_comp` proves
+    that an outer unitary conjugation cannot repair a Schwarz defect.
+  - `ChannelDeterminant.Internal.unitaryChannel_comp_transpose_not_isSchwarzMap`
+    excludes Wolf's unitary-conjugation-after-transposition standard form.
+  - `ChannelDeterminant.Internal.unitaryChannel_comp_transpose_fin_one`
+    records that the transpose branch collapses to unitary conjugation for
+    \(d=1\).
+  - `ChannelDeterminant.Internal.wolfPositiveInvertibleSchwarzMaps` combines
+    those facts with the completed positive-invertible-map corollary, without
+    assuming complete positivity.
+
 * Reusable formalization for the permutation-of-blocks direction lives in
   `QICLean.Channel.Peripheral.CyclicDecomposition` and
   `QICLean.Channel.Peripheral.Cycles`:
@@ -1419,7 +1436,12 @@ is false under the single printed hypothesis.
   map for which both `T` and `T*` satisfy the Schwarz inequality admits a
   `MultiCycleDecomposition` on its asymptotic image, with the cycles coming
   from the now-formalized density-block decomposition of the fixed-point
-  space — is left to future work.
+  space — still requires formalizing Schwarz closure and Wolf's positive
+  inverse on the recurrent image, deriving the density-block face permutation
+  and equal dimensions, and assembling the exact weighted Equations
+  (6.66)--(6.68). The conditional `CycleStructure` and
+  `MultiCycleDecomposition` objects above are consumers of that theorem; they
+  are not substitutes for the missing source-facing declaration.
 
 ---
 


### PR DESCRIPTION
## Source

Wolf, Quantum Channels & Operations, Chapter 6, proof of Theorem 6.16, local source lines 1660--1663. Wolf classifies each positive trace-preserving block map with positive inverse as either matrix transposition or unitary conjugation, then rules out transposition by the Schwarz requirement.

## What this proves

- ordinary matrix transposition is not IsSchwarzMap for d >= 2, using A = E_01 and the exact defect E_11 - E_00;
- an outer unitary conjugation can be removed from a Schwarz inequality by conjugating its defect back, so Ad_U after transposition also fails Schwarz;
- for d = 1, transposition is the identity, so the nominal transpose alternative already is the unitary branch;
- ChannelDeterminant.Internal.wolfPositiveInvertibleSchwarzMaps combines these facts with the landed Wolf positive-invertible-map classification under exactly positivity, trace preservation, bijectivity, positive inverse, and Schwarz.

No complete-positivity or Kraus hypothesis is introduced.

The Blueprint now records this precise Theorem 6.16 proof step, and Chapter 6 coverage keeps the remaining source-contract, recurrent-inverse, block-face, and Equations (6.66)--(6.68) work explicitly open.

## Validation

- lake build QICLean.Channel.Determinant.PositiveInverse
- lake build QICLean.Channel.Determinant
- lake build QICLean (9253 jobs)
- lake exe lint_style
- lake exe checkdecls blueprint/lean_decls (2052 unique references)
- blueprint_lean_sync.py --ci (2073 / 2073 theorem-like entries)
- reverse Blueprint coverage: no changed declaration missing a Blueprint entry
- axiom audit for all five new declarations: only propext, Classical.choice, Quot.sound
- reader-facing prose check
- focused chktex
- texra-blueprint paper-gaps check (39 slugs)
- texra-blueprint web
- leanblueprint pdf (319 pages)
- git diff --check

Closes #410.
Parent tracker: #40.
