### PR TITLE
docs(wolf): resolve Theorem 6.16 Schwarz contract

### DIFF
--- a/QICLean/Channel/Peripheral/MultiCycleDecomposition.lean
+++ b/QICLean/Channel/Peripheral/MultiCycleDecomposition.lean
@@ -11,15 +11,18 @@ import Mathlib.Logic.Equiv.Fin.Rotate
 
 This file develops an explicit multi-cycle refinement of the
 block-permutation formalization developed in
-`TNLean.Channel.Peripheral.Cycles`, in the form needed for the
+`QICLean.Channel.Peripheral.Cycles`, in the form needed for the
 asymptotic-image side of
 Wolf, *Quantum Channels & Operations*, Theorem 6.16.
 
-Concretely, Wolf Theorem 6.16 describes the asymptotic dynamics of a general
-trace-preserving positive Schwarz map `T` as a permutation of Wedderburn
-blocks, with each block transported by a unitary.  Such a permutation may
-already be represented abstractly by the `CycleStructure` bundled data of
-`TNLean.Channel.Peripheral.Cycles`, whose underlying permutation `σ` is
+Concretely, Wolf Theorem 6.16 describes the asymptotic dynamics as a
+permutation of Wedderburn blocks, with each block transported by a unitary.
+Its printed proof uses the Schwarz inequality for both `T` and the trace
+adjoint of its recurrent projection; the corrected source-facing contract is
+recorded in `docs/paper-gaps/wolf_theorem6_16_schwarz_orientation.tex`.
+Such a permutation may already be represented abstractly by the
+`CycleStructure` bundled data of
+`QICLean.Channel.Peripheral.Cycles`, whose underlying permutation `σ` is
 allowed to have multiple disjoint cycles.  The present file refines that
 view by choosing an *explicit* cycle-index type `ι`, a per-cycle period
 `period : ι → ℕ`, and the corresponding projection families, stating the
@@ -27,12 +30,11 @@ disjoint-union-of-cycles structure as separate data.
 
 The corner-preservation proofs reuse the per-orbit proof pattern of
 `preserves_corner_pow_of_cyclic_decomp` from
-`TNLean.Channel.Peripheral.CyclicDecomposition`, adapted to the setting
+`QICLean.Channel.Peripheral.CyclicDecomposition`, adapted to the setting
 where the per-cycle projections do not sum to the identity.  The
-*existence direction* — that every TP positive Schwarz map admits such a
-decomposition on its asymptotic image — depends on Wolf Theorem 6.14
-(Wedderburn decomposition of the fixed-point algebra, issues #27/#360)
-and is left to future work.
+*existence direction* depends on Wolf Theorem 6.14 together with the
+remaining density-block classification and assembly lemmas, and is left to
+future work.
 
 ## Main definitions
 
@@ -77,7 +79,7 @@ element of the cycle-index type `ι` — together with:
   and `T (X * P c k) = T X * T (P c k)`.
 
 This refines the bundled permutation data of
-`TNLean.Channel.Peripheral.Cycles.CycleStructure`: a
+`QICLean.Channel.Peripheral.Cycles.CycleStructure`: a
 `MultiCycleDecomposition` chooses an explicit cycle-index type together
 with per-cycle periods and projection families for the underlying
 permutation structure, while `toCycleStructure` forgets that extra
@@ -86,9 +88,9 @@ organisation.
 In Wolf's Theorem 6.16, the cycle-index `ι` runs over the equivalence classes
 of Wedderburn blocks that share both a common multiplicity and a common
 period under the block permutation.  The existence of this data on the
-asymptotic image of an arbitrary TP positive Schwarz map depends on the
-Wedderburn decomposition of the fixed-point algebra (Wolf Theorem 6.14) and is
-deferred. -/
+asymptotic image under the corrected two-orientation Schwarz contract depends
+on the Wedderburn decomposition of the fixed-point algebra (Wolf Theorem 6.14)
+and is deferred. -/
 structure MultiCycleDecomposition.{u} (T : MatrixEnd D) where
   /-- Finite index type for the cycles. -/
   ι : Type u
@@ -303,10 +305,10 @@ projections are the flattened family; the cyclic action on the sigma
 index matches the per-cycle action on each `Fin (period c)`.
 
 This connects multi-cycle decompositions to the block-permutation theory:
-given a Wolf Theorem 6.16 Wedderburn-based existence result (currently blocked
-on issues #27/#360), the resulting `MultiCycleDecomposition` can be flattened
-to a `CycleStructure` for use with
-`TNLean.Channel.Peripheral.Cycles`. -/
+given a source-facing Wolf Theorem 6.16 Wedderburn-based existence result under
+the corrected Schwarz contract, the resulting `MultiCycleDecomposition` can be
+flattened to a `CycleStructure` for use with
+`QICLean.Channel.Peripheral.Cycles`. -/
 noncomputable def toCycleStructure (M : MultiCycleDecomposition T) :
     CycleStructure T :=
   CycleStructure.ofPermDecomp (T := T)

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -543,6 +543,16 @@ cycle decomposition of~\cite[Theorem~6.16]{Wolf2012Quantum}. The
 multi-cycle decomposition refines the single-cycle case to handle
 arbitrary peripheral periods.
 
+There is a source-contract correction at the existence boundary.  Wolf's
+proof uses the Schwarz inequality for $T$ to exclude the transpose branch,
+but invokes Theorem~6.14 on the recurrent projection $I$, whose printed
+hypothesis requires $I^*$ to be Schwarz.  Accordingly, the source-facing
+assembly follows the printed proof under Schwarz hypotheses for both $T$ and
+$T^*$; the distinction and exact source lines are recorded in
+\cite{gap:wolf_theorem6_16_schwarz_orientation}.  The definitions below are
+conditional data and do not assert that this existence theorem is already
+proved.
+
 \begin{definition}[Block-permutation structure]
     \label{def:cycle_structure}
     \lean{CycleStructure}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -321,3 +321,13 @@
   year        = {2026},
   note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_slater_attainment_conditions.pdf}},
 }
+
+@techreport{gap:wolf_theorem6_16_schwarz_orientation,
+  author      = {The {QICLean} contributors},
+  title       = {Wolf Theorem 6.16: The Two Schwarz Orientations in the Printed Proof},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_theorem6\_16\_schwarz\_orientation},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_theorem6_16_schwarz_orientation.pdf}},
+}

--- a/docs/paper-gaps/wolf_theorem6_16_schwarz_orientation.tex
+++ b/docs/paper-gaps/wolf_theorem6_16_schwarz_orientation.tex
@@ -1,0 +1,103 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Wolf Theorem~6.16: The Two Schwarz Orientations in the Printed Proof}
+\author{}
+\date{2026-08-24}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\section{The printed statement and the invoked theorem}
+
+Let $T:M_d(\mathbb C)\to M_d(\mathbb C)$ be positive and trace preserving,
+and write $T^*$ for its trace-pairing adjoint.  Wolf's Theorem~6.16 states
+that $T$ fulfils the Schwarz inequality and concludes that the peripheral
+space has the weighted matrix-block form in Equations~(6.66)--(6.67), with
+$T$ acting by the block permutation and unitary conjugations of
+Equation~(6.68) \cite[Theorem~6.16]{Wolf2012Quantum}.  The local source is
+\path{Notes/WolfNoteTexSource/ch06_spectral_properties.tex},
+lines~1592--1624.
+
+The proof identifies which map must satisfy the inequality.  It takes a
+subsequential limit
+\begin{align}
+  I=\lim_{i\to\infty} T^{n_i}
+  \notag
+\end{align}
+and says that $I$ remains Schwarz because this property is preserved under
+composition.  At the end it excludes matrix transposition because $T$, and
+therefore each induced block map $T_k$, is Schwarz.  Thus the proof uses the
+Schwarz inequality for $T$ itself; see local source lines~1626--1633 and
+1660--1663.
+
+For the weighted matrix-block form, however, the same proof identifies the
+peripheral space with $\operatorname{Fix}(I)$ and invokes Wolf's
+Theorem~6.14.  The hypothesis printed in Theorem~6.14 is that the
+trace adjoint of its trace-preserving map is Schwarz.  Applied to $I$, that
+hypothesis is
+\begin{align}
+  I^*(A^\dagger A)\succeq I^*(A^\dagger)I^*(A)
+  \qquad\text{for every }A\in M_d(\mathbb C).
+  \tag{required by Theorem 6.14}
+\end{align}
+The local source for this hypothesis is lines~1467--1474.  Schwarz closure
+for the powers of $T$ gives the corresponding inequality for $I$, not for
+$I^*$.  The printed proof supplies no step deriving the latter orientation.
+
+\section{Corrected proof contract}
+
+The minimal explicit correction that validates the proof as printed is to
+assume both Schwarz inequalities:
+\begin{align}
+  T(A^\dagger A)&\succeq T(A^\dagger)T(A),
+  \notag \\
+  T^*(A^\dagger A)&\succeq T^*(A^\dagger)T^*(A)
+  \qquad\text{for every }A\in M_d(\mathbb C).
+  \tag{corrected Theorem 6.16 contract}
+\end{align}
+The first is exactly the orientation used for the block dynamics and the
+transpose exclusion.  The second is stable under powers and finite-dimensional
+limits: since $(T^n)^*=(T^*)^n$, it supplies the Schwarz inequality for
+$I^*=\lim_{i\to\infty}(T^*)^{n_i}$.  Theorem~6.14 may then be applied to $I$
+with its literal printed hypothesis.
+
+This correction does not assert that the conclusion of Theorem~6.16 is false
+under the single printed Schwarz hypothesis.  A different proof could in
+principle derive the needed fixed-point structure.  It records instead the
+exact contract supported by Wolf's stated proof route.  In particular, a
+formal theorem following that route must not silently infer that the
+trace-pairing adjoint of an arbitrary Schwarz map is Schwarz.
+
+\section{Formalization boundary}
+
+The existing source-general fixed-point theorem has the literal
+Theorem~6.14 interface: positivity and trace preservation of a map $S$, and
+the Schwarz inequality for $S^*$.\footnote{Formal declaration:
+\leanid{IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero} in
+\doclink{QICLean/Channel/FixedPoint/WolfTheorem614}.}
+The source-facing Theorem~6.16 assembly will therefore expose both
+orientations.  Its recurrent-projection component may pass the second one to
+the fixed-point theorem, while its block-classification component retains the
+first one.  The remaining construction is tracked by \ghissue{40}; this
+contract audit is \ghissue{407}.
+
+\section{Conclusion}
+
+Wolf's printed proof uses two Schwarz orientations but states only the one for
+$T$.  Adding the Schwarz inequality for $T^*$ is a local hypothesis correction
+that makes the invocation of Theorem~6.14 valid without changing Wolf's
+terminology, block notation, or proof order.  Until a separately sourced
+derivation removes it, both orientations are the source-facing formal
+contract.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -1372,6 +1372,17 @@ clause 3.
 
 #### Wolf Theorem 6.16 (Structure of cycles) — PARTIALLY FORMALIZED
 
+The source-contract audit is resolved in
+`docs/paper-gaps/wolf_theorem6_16_schwarz_orientation.tex`.  The printed
+proof uses the Schwarz inequality for `T` itself when it excludes the
+transpose branch, but obtains Equation (6.66) by applying Theorem 6.14 to the
+recurrent projection `I`; that theorem requires the trace adjoint `I*` to be
+Schwarz.  Closure under powers and limits transports the two orientations
+separately.  Therefore the source-facing assembly will explicitly assume that
+both `T` and `T*` are Schwarz.  No implication between these hypotheses is
+silently introduced, and the note does not claim that the theorem's conclusion
+is false under the single printed hypothesis.
+
 * Reusable formalization for the permutation-of-blocks direction lives in
   `QICLean.Channel.Peripheral.CyclicDecomposition` and
   `QICLean.Channel.Peripheral.Cycles`:
@@ -1405,9 +1416,10 @@ clause 3.
     per-cycle cyclic shifts.
 
 * The remaining **existence direction** — that every trace-preserving positive
-  Schwarz map admits a `MultiCycleDecomposition` on its asymptotic image, with
-  the cycles coming from the now-formalized density-block decomposition of the
-  fixed-point space — is left to future work.
+  map for which both `T` and `T*` satisfy the Schwarz inequality admits a
+  `MultiCycleDecomposition` on its asymptotic image, with the cycles coming
+  from the now-formalized density-block decomposition of the fixed-point
+  space — is left to future work.
 
 ---
 


### PR DESCRIPTION
Closes #407.

## Source contract
- Audits `Notes/WolfNoteTexSource/ch06_spectral_properties.tex` at Theorems 6.14 and 6.16.
- Records the minimal explicit correction for the printed proof route: Schwarz for `T` is used by the transpose exclusion, while Schwarz for `T*` supplies the literal Theorem 6.14 hypothesis for the recurrent projection adjoint.
- Explicitly does not claim that the conclusion is false under the single printed hypothesis or invent a replacement proof.

## Changes
- Adds a resolved paper-gap note with exact source lines, Wolf notation, and the corrected two-orientation contract.
- Syncs the Blueprint and Wolf numbering coverage at the Theorem 6.16 existence boundary.
- Removes stale TNLean paths and obsolete issue references from the existing multi-cycle module documentation; no Lean declaration or proof changes.

## Validation
- `lake build QICLean.Channel.Peripheral.MultiCycleDecomposition`
- `lake build QICLean` (9,253 jobs)
- Blueprint sync: 2,083 / 2,083; reverse changed-declaration coverage clean
- `lake exe checkdecls blueprint/lean_decls`
- strict Blueprint web build and reader render: 30 pages, 27,747 typeset nodes
- full Blueprint PDF: 320 pages
- full paper-gap build; 40 referenced slugs resolve
- ChkTeX, style, import aggregators, module policies, reader-facing prose, and `git diff --check`
