### PR TITLE
feat(channel): add Wolf recurrent peripheral inverse

### DIFF
--- a/QICLean/Channel/Peripheral.lean
+++ b/QICLean/Channel/Peripheral.lean
@@ -29,6 +29,7 @@ import QICLean.Channel.Peripheral.JordanBlocks
 import QICLean.Channel.Peripheral.MultiCycleDecomposition
 import QICLean.Channel.Peripheral.PeriodicityRemoval
 import QICLean.Channel.Peripheral.Powers
+import QICLean.Channel.Peripheral.RecurrentInverse
 import QICLean.Channel.Peripheral.SchurAsymptoticConvergence
 import QICLean.Channel.Peripheral.SpectralProjection
 import QICLean.Channel.Peripheral.SpectralRadius

--- a/QICLean/Channel/Peripheral/RecurrentInverse.lean
+++ b/QICLean/Channel/Peripheral/RecurrentInverse.lean
@@ -1,0 +1,309 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Channel.Peripheral.AsymptoticImage
+import QICLean.Channel.Determinant.Bound
+import QICLean.Channel.Schwarz.Closure
+import QICLean.Channel.Schwarz.TwoPositive
+import Mathlib.Analysis.Normed.Operator.BanachSteinhaus
+
+/-!
+# The recurrent inverse on Wolf's asymptotic image
+
+In the proof of Wolf Theorem 6.16, a Dirichlet subsequence satisfies
+`T ^ (n i) → I`, and a further subsequence of the predecessor powers satisfies
+`T ^ (n i - 1) → S`.  Wolf writes this limit as `T⁻¹`, but uses it only on the
+asymptotic image `X_T`: the formal identities are
+
+`S.comp T = T.peripheralProjection` and
+`T.comp S = T.peripheralProjection`.
+
+This file follows that construction literally.  Pointwise boundedness of the
+powers is upgraded to operator-norm boundedness by Banach--Steinhaus; finite
+dimensional compactness then supplies the convergent predecessor subsequence.
+No global inverse and no alternative spectral inverse are introduced.
+
+The corrected source-facing Schwarz contract is also kept explicit.  Schwarz
+closure is applied separately to `T` and to `Matrix.traceAdjointMap T`; no
+implication between the two orientations is asserted.
+
+## Main results
+
+* `IsPositiveMap.exists_strictMono_tendsto_pow_peripheralProjection_and_predecessor`:
+  the shared recurrent subsequence and predecessor-power limit.
+* `IsPositiveMap.exists_peripheralRestrictedInverse`: the positive,
+  trace-preserving restricted inverse and its absorption/range identities.
+* `IsPositiveMap.peripheralProjection_isSchwarzMap` and
+  `IsPositiveMap.traceAdjointMap_peripheralProjection_isSchwarzMap`: the two
+  independent Schwarz orientations for the recurrent projection.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, proof of Theorem 6.16,
+  local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`,
+  lines 1626--1640.
+-/
+
+open Filter Matrix TNLean
+open scoped Topology TNOperatorSpace Matrix ComplexOrder MatrixOrder
+
+noncomputable section
+
+/-! ## Wolf's recurrent predecessor-power limit -/
+
+namespace IsPositiveMap
+
+variable {D : ℕ} [NeZero D]
+  {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+
+/-- **Wolf Theorem 6.16, recurrent predecessor-power construction.**
+
+For a positive trace-preserving `T`, there is one strictly increasing
+subsequence `n` and a matrix endomorphism `S` such that
+
+* `T ^ (n i) → T.peripheralProjection`, and
+* `T ^ (n i - 1) → S`
+
+in operator norm.  The first limit is the Dirichlet recurrent subsequence from
+Wolf Proposition 6.3.  Banach--Steinhaus and finite-dimensional compactness
+supply the predecessor limit used at local source lines 1629--1640. -/
+theorem exists_strictMono_tendsto_pow_peripheralProjection_and_predecessor
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    ∃ n : ℕ → ℕ, ∃ S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ),
+      StrictMono n ∧ 0 < n 0 ∧
+      Tendsto (fun i : ℕ ↦ endEquiv (T ^ n i)) atTop
+        (𝓝 (endEquiv T.peripheralProjection)) ∧
+      Tendsto (fun i : ℕ ↦ endEquiv (T ^ (n i - 1))) atTop
+        (𝓝 (endEquiv S)) := by
+  obtain ⟨n, hnmono, hn0, _hnpoint, hnclm⟩ :=
+    hPos.exists_strictMono_tendsto_pow_peripheralProjection_clm hTP
+  let U : ℕ → MatrixCLM (Fin D) := fun i ↦ endEquiv (T ^ (n i - 1))
+  have hb := hPos.hasBoundedOrbits_of_tracePreserving hTP
+  have hbU : Bornology.IsBounded (Set.range U) := by
+    let _ : CompleteSpace (Matrix (Fin D) (Fin D) ℂ) :=
+      FiniteDimensional.complete ℂ (Matrix (Fin D) (Fin D) ℂ)
+    obtain ⟨C, hC⟩ := banach_steinhaus (g := U) (fun X ↦ by
+      obtain ⟨CX, hCX⟩ := isBounded_iff_forall_norm_le.mp (hb X)
+      refine ⟨CX, fun i ↦ ?_⟩
+      change ‖(T ^ (n i - 1)) X‖ ≤ CX
+      simpa only [Module.End.coe_pow] using
+        hCX (T^[n i - 1] X) ⟨n i - 1, rfl⟩)
+    rw [isBounded_iff_forall_norm_le]
+    exact ⟨C, fun A hA ↦ by obtain ⟨i, rfl⟩ := hA; exact hC i⟩
+  let hFinite : FiniteDimensional ℂ (MatrixCLM (Fin D)) :=
+    (endEquiv (D := D)).toLinearEquiv.finiteDimensional
+  let hProper : ProperSpace (MatrixCLM (Fin D)) :=
+    @FiniteDimensional.proper ℂ _ (MatrixCLM (Fin D)) _ _ _ hFinite
+  let : ProperSpace (MatrixCLM (Fin D)) := hProper
+  obtain ⟨R, hR⟩ := hbU.subset_closedBall 0
+  obtain ⟨Sclm, _hSball, k, hkmono, hklim⟩ :=
+    (ProperSpace.isCompact_closedBall (0 : MatrixCLM (Fin D)) R).tendsto_subseq
+      (fun i ↦ hR ⟨i, rfl⟩)
+  let S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    (endEquiv (D := D)).symm Sclm
+  refine ⟨n ∘ k, S, hnmono.comp hkmono, ?_, ?_, ?_⟩
+  · exact hn0.trans_le (hnmono.monotone (Nat.zero_le (k 0)))
+  · exact hnclm.comp hkmono.tendsto_atTop
+  · change Tendsto (U ∘ k) atTop (𝓝 (endEquiv S))
+    have hES : endEquiv S = Sclm := by
+      simp only [S, AlgEquiv.apply_symm_apply]
+    rw [hES]
+    exact hklim
+
+/-- The recurrent/peripheral projection of a positive trace-preserving Schwarz
+map is Schwarz.  This transports only the Schwarz hypothesis for `T` through
+the recurrent powers; it makes no assertion about `Matrix.traceAdjointMap T`.
+
+Source: Wolf Theorem 6.16 proof, local source lines 1629--1633. -/
+theorem peripheralProjection_isSchwarzMap
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap T) : IsSchwarzMap T.peripheralProjection := by
+  obtain ⟨n, _hnmono, _hn0, _hnpoint, hnclm⟩ :=
+    hPos.exists_strictMono_tendsto_pow_peripheralProjection_clm hTP
+  let Mat := Matrix (Fin D) (Fin D) ℂ
+  have hP (X : Mat) : Tendsto (fun i : ℕ ↦ (T ^ n i) X) atTop
+      (𝓝 (T.peripheralProjection X)) :=
+    ((ContinuousLinearMap.apply ℂ Mat X).continuous.tendsto
+      (endEquiv T.peripheralProjection)).comp hnclm
+  exact IsSchwarzMap.of_tendsto (fun i ↦ hSchwarz.pow hPos (n i)) hP
+
+/-- Under the separate Schwarz hypothesis for `T*`, the trace-pairing adjoint
+of the recurrent/peripheral projection is Schwarz.  This is the orientation
+needed when Wolf applies Theorem 6.14 to the recurrent projection `I`.
+
+The proof uses `(T ^ n)* = (T*) ^ n` and transports the operator-norm recurrent
+limit through the trace-pairing adjoint.  It does not infer adjoint Schwarz
+from Schwarz for `T`.
+
+Source: Wolf Theorems 6.14 and 6.16, and the corrected contract recorded in
+`docs/paper-gaps/wolf_theorem6_16_schwarz_orientation.tex`. -/
+theorem traceAdjointMap_peripheralProjection_isSchwarzMap
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (hAdjointSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T)) :
+    IsSchwarzMap (Matrix.traceAdjointMap T.peripheralProjection) := by
+  obtain ⟨n, _hnmono, _hn0, _hnpoint, hnclm⟩ :=
+    hPos.exists_strictMono_tendsto_pow_peripheralProjection_clm hTP
+  let Mat := Matrix (Fin D) (Fin D) ℂ
+  have hP (X : Mat) : Tendsto (fun i : ℕ ↦ (T ^ n i) X) atTop
+      (𝓝 (T.peripheralProjection X)) :=
+    ((ContinuousLinearMap.apply ℂ Mat X).continuous.tendsto
+      (endEquiv T.peripheralProjection)).comp hnclm
+  have hAdjointPos : IsPositiveMap (Matrix.traceAdjointMap T) :=
+    hPos.traceAdjointMap
+  exact IsSchwarzMap.of_tendsto
+    (fun i ↦ by
+      rw [Matrix.traceAdjointMap_pow]
+      exact hAdjointSchwarz.pow hAdjointPos (n i))
+    (fun X ↦ Matrix.tendsto_traceAdjointMap hP X)
+
+private theorem recurrentPredecessor_properties
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    {n : ℕ → ℕ} {S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hnmono : StrictMono n) (hn0 : 0 < n 0)
+    (hnP : Tendsto (fun i : ℕ ↦ endEquiv (T ^ n i)) atTop
+      (𝓝 (endEquiv T.peripheralProjection)))
+    (hnS : Tendsto (fun i : ℕ ↦ endEquiv (T ^ (n i - 1))) atTop
+      (𝓝 (endEquiv S))) :
+    IsPositiveMap S ∧ IsTracePreservingMap S ∧
+      S.comp T = T.peripheralProjection ∧
+      T.comp S = T.peripheralProjection ∧
+      S.comp T.peripheralProjection = S ∧
+      T.peripheralProjection.comp S = S ∧
+      LinearMap.range S = LinearMap.range T.peripheralProjection := by
+  let Mat := Matrix (Fin D) (Fin D) ℂ
+  have hnpos (i : ℕ) : 0 < n i :=
+    hn0.trans_le (hnmono.monotone (Nat.zero_le i))
+  have hP (X : Mat) : Tendsto (fun i : ℕ ↦ (T ^ n i) X) atTop
+      (𝓝 (T.peripheralProjection X)) :=
+    ((ContinuousLinearMap.apply ℂ Mat X).continuous.tendsto
+      (endEquiv T.peripheralProjection)).comp hnP
+  have hS (X : Mat) : Tendsto (fun i : ℕ ↦ (T ^ (n i - 1)) X) atTop
+      (𝓝 (S X)) :=
+    ((ContinuousLinearMap.apply ℂ Mat X).continuous.tendsto (endEquiv S)).comp hnS
+  have hSpos : IsPositiveMap S :=
+    IsPositiveMap.of_tendsto (fun i ↦ hPos.pow (n i - 1)) hS
+  have hStp : IsTracePreservingMap S :=
+    IsTracePreservingMap.of_tendsto (fun i ↦ hTP.pow (n i - 1)) hS
+  have hST : S.comp T = T.peripheralProjection := by
+    apply LinearMap.ext
+    intro X
+    have hleft : Tendsto (fun i : ℕ ↦ (T ^ n i) X) atTop (𝓝 (S (T X))) :=
+      (hS (T X)).congr' (Filter.Eventually.of_forall fun i ↦ by
+        have hni : n i - 1 + 1 = n i := Nat.sub_add_cancel (hnpos i)
+        calc
+          (T ^ (n i - 1)) (T X) = ((T ^ (n i - 1)).comp T) X := rfl
+          _ = (T ^ (n i - 1 + 1)) X := by
+            rw [pow_succ, Module.End.mul_eq_comp]
+          _ = (T ^ n i) X := by rw [hni])
+    exact tendsto_nhds_unique hleft (hP X)
+  have hTS : T.comp S = T.peripheralProjection := by
+    apply LinearMap.ext
+    intro X
+    have hright0 : Tendsto (fun i : ℕ ↦ T ((T ^ (n i - 1)) X)) atTop
+        (𝓝 (T (S X))) :=
+      ((endEquiv T).continuous.tendsto (S X)).comp (hS X)
+    have hright : Tendsto (fun i : ℕ ↦ (T ^ n i) X) atTop (𝓝 (T (S X))) :=
+      hright0.congr' (Filter.Eventually.of_forall fun i ↦ by
+        have hni : n i - 1 + 1 = n i := Nat.sub_add_cancel (hnpos i)
+        calc
+          T ((T ^ (n i - 1)) X) = (T.comp (T ^ (n i - 1))) X := rfl
+          _ = (T ^ (n i - 1 + 1)) X := by
+            rw [pow_succ', Module.End.mul_eq_comp]
+          _ = (T ^ n i) X := by rw [hni])
+    exact tendsto_nhds_unique hright (hP X)
+  have hnPred : Tendsto (fun i : ℕ ↦ n i - 1) atTop atTop :=
+    (tendsto_sub_atTop_nat 1).comp hnmono.tendsto_atTop
+  have hEig : ∀ μ : ℂ, T.HasEigenvalue μ → ‖μ‖ ≤ 1 := fun μ hμ ↦
+    hPos.eigenvalue_norm_le_one_of_tracePreserving hTP μ hμ
+  have hSP : S.comp T.peripheralProjection = S := by
+    apply LinearMap.ext
+    intro X
+    change S (T.peripheralProjection X) = S X
+    have hzero : Tendsto
+        (fun i : ℕ ↦ (T ^ (n i - 1)) (X - T.peripheralProjection X)) atTop
+        (𝓝 0) :=
+      (T.tendsto_pow_apply_zero_of_mem_nonPeripheralSubspace hEig
+        (T.sub_peripheralProjection_mem X)).comp hnPred
+    have hsum := (hS (T.peripheralProjection X)).add hzero
+    have hsame : Tendsto (fun i : ℕ ↦ (T ^ (n i - 1)) X) atTop
+        (𝓝 (S (T.peripheralProjection X))) := by
+      simpa only [← map_add, add_sub_cancel, add_zero] using hsum
+    exact tendsto_nhds_unique hsame (hS X)
+  have hPS : T.peripheralProjection.comp S = S := by
+    apply LinearMap.ext
+    intro X
+    change T.peripheralProjection (S X) = S X
+    calc
+      T.peripheralProjection (S X) = S (T (S X)) :=
+        (LinearMap.congr_fun hST (S X)).symm
+      _ = S (T.peripheralProjection X) :=
+        congrArg S (LinearMap.congr_fun hTS X)
+      _ = S X := LinearMap.congr_fun hSP X
+  have hrange : LinearMap.range S = LinearMap.range T.peripheralProjection := by
+    apply le_antisymm
+    · rintro Y ⟨X, rfl⟩
+      exact ⟨S X, LinearMap.congr_fun hPS X⟩
+    · rintro Y ⟨X, rfl⟩
+      exact ⟨T X, LinearMap.congr_fun hST X⟩
+  exact ⟨hSpos, hStp, hST, hTS, hSP, hPS, hrange⟩
+
+/-- **Wolf Theorem 6.16, positive peripheral restricted inverse.**
+
+There is a positive trace-preserving map `S`, constructed as a limit of the
+predecessor powers `T ^ (n i - 1)`, which is a two-sided inverse for `T` on
+the asymptotic image.  The ambient identities have the peripheral projection
+on the right-hand side; in particular this theorem does not assert that `T`
+has a global inverse.  The absorption and range identities say precisely that
+`S` acts on the same peripheral/asymptotic image. -/
+theorem exists_peripheralRestrictedInverse
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    ∃ S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ),
+      IsPositiveMap S ∧ IsTracePreservingMap S ∧
+      S.comp T = T.peripheralProjection ∧
+      T.comp S = T.peripheralProjection ∧
+      S.comp T.peripheralProjection = S ∧
+      T.peripheralProjection.comp S = S ∧
+      LinearMap.range S = LinearMap.range T.peripheralProjection := by
+  obtain ⟨n, S, hnmono, hn0, hnP, hnS⟩ :=
+    hPos.exists_strictMono_tendsto_pow_peripheralProjection_and_predecessor hTP
+  exact ⟨S, hPos.recurrentPredecessor_properties hTP hnmono hn0 hnP hnS⟩
+
+end IsPositiveMap
+
+/-! ### Restricted inverse identities on the asymptotic image -/
+
+namespace Module.End
+
+variable {D : ℕ} {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+
+/-- If `S.comp T` is the peripheral projection, then `S (T X) = X` for
+every `X` in the asymptotic image. -/
+theorem peripheralRestrictedInverse_apply_map_of_mem_range
+    {S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hST : S.comp T = T.peripheralProjection) {X : Matrix (Fin D) (Fin D) ℂ}
+    (hX : X ∈ LinearMap.range T.peripheralProjection) :
+    S (T X) = X := by
+  have hPX : T.peripheralProjection X = X := by
+    rw [T.range_peripheralProjection] at hX
+    exact T.peripheralProjection_apply_of_mem hX
+  calc
+    S (T X) = T.peripheralProjection X := LinearMap.congr_fun hST X
+    _ = X := hPX
+
+/-- If `T.comp S` is the peripheral projection, then `T (S X) = X` for
+every `X` in the asymptotic image. -/
+theorem map_peripheralRestrictedInverse_apply_of_mem_range
+    {S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hTS : T.comp S = T.peripheralProjection) {X : Matrix (Fin D) (Fin D) ℂ}
+    (hX : X ∈ LinearMap.range T.peripheralProjection) :
+    T (S X) = X := by
+  have hPX : T.peripheralProjection X = X := by
+    rw [T.range_peripheralProjection] at hX
+    exact T.peripheralProjection_apply_of_mem hX
+  calc
+    T (S X) = T.peripheralProjection X := LinearMap.congr_fun hTS X
+    _ = X := hPX
+
+end Module.End

--- a/QICLean/Channel/Schwarz.lean
+++ b/QICLean/Channel/Schwarz.lean
@@ -12,6 +12,7 @@ import QICLean.Channel.Schwarz.AbstractMultiplicativeDomain
 import QICLean.Channel.Schwarz.AndoLieb
 import QICLean.Channel.Schwarz.Basic
 import QICLean.Channel.Schwarz.ChoiCompression
+import QICLean.Channel.Schwarz.Closure
 import QICLean.Channel.Schwarz.DiagonalJensen
 import QICLean.Channel.Schwarz.Douglas
 import QICLean.Channel.Schwarz.KadisonSchwarz

--- a/QICLean/Channel/Schwarz/Closure.lean
+++ b/QICLean/Channel/Schwarz/Closure.lean
@@ -1,0 +1,204 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Algebra.MatrixTracePairing
+import QICLean.Channel.Schwarz.AbstractMultiplicativeDomain
+
+/-!
+# Closure properties for positive, trace-preserving, and Schwarz maps
+
+This file collects the composition, power, and finite-dimensional pointwise
+limit closures used in Wolf's recurrent-projection argument.  It also records
+that trace-pairing adjoints commute with powers and pointwise limits.
+
+The Schwarz results are orientation-specific: applying them to a map and to
+its trace-pairing adjoint requires two separate Schwarz hypotheses.
+-/
+
+open Filter Matrix
+open scoped Topology TNOperatorSpace Matrix ComplexOrder MatrixOrder
+
+noncomputable section
+
+namespace IsPositiveMap
+
+variable {n : Type*} {S T : Module.End ℂ (Matrix n n ℂ)}
+
+/-- Positive matrix endomorphisms are closed under composition. -/
+theorem comp (hS : IsPositiveMap S) (hT : IsPositiveMap T) :
+    IsPositiveMap (S.comp T) := by
+  intro X hX
+  exact hS _ (hT X hX)
+
+/-- Every natural power of a positive matrix endomorphism is positive. -/
+theorem pow (hT : IsPositiveMap T) (m : ℕ) : IsPositiveMap (T ^ m) := by
+  induction m with
+  | zero =>
+      intro X hX
+      simpa using hX
+  | succ m ih =>
+      rw [pow_succ', Module.End.mul_eq_comp]
+      exact hT.comp ih
+
+/-- A pointwise finite-dimensional limit of positive matrix endomorphisms is
+positive. -/
+theorem of_tendsto
+    {E : ℕ → Module.End ℂ (Matrix n n ℂ)}
+    {S : Module.End ℂ (Matrix n n ℂ)}
+    (hE : ∀ i, IsPositiveMap (E i))
+    (hlim : ∀ X, Tendsto (fun i : ℕ ↦ E i X) atTop (𝓝 (S X))) :
+    IsPositiveMap S := by
+  intro X hX
+  exact Matrix.posSemidef_is_closed.mem_of_tendsto (hlim X)
+    (Filter.Eventually.of_forall fun i ↦ hE i X hX)
+
+end IsPositiveMap
+
+namespace IsTracePreservingMap
+
+variable {n : Type*} [Fintype n]
+  {S T : Module.End ℂ (Matrix n n ℂ)}
+
+/-- Trace-preserving matrix endomorphisms are closed under composition. -/
+theorem comp (hS : IsTracePreservingMap S) (hT : IsTracePreservingMap T) :
+    IsTracePreservingMap (S.comp T) := by
+  intro X
+  rw [LinearMap.comp_apply, hS, hT]
+
+/-- Every natural power of a trace-preserving matrix endomorphism is
+trace-preserving. -/
+theorem pow (hT : IsTracePreservingMap T) (m : ℕ) :
+    IsTracePreservingMap (T ^ m) := by
+  induction m with
+  | zero => simp [IsTracePreservingMap]
+  | succ m ih =>
+      rw [pow_succ', Module.End.mul_eq_comp]
+      exact hT.comp ih
+
+/-- A pointwise finite-dimensional limit of trace-preserving matrix
+endomorphisms is trace-preserving. -/
+theorem of_tendsto
+    {E : ℕ → Module.End ℂ (Matrix n n ℂ)}
+    {S : Module.End ℂ (Matrix n n ℂ)}
+    (hE : ∀ i, IsTracePreservingMap (E i))
+    (hlim : ∀ X, Tendsto (fun i : ℕ ↦ E i X) atTop (𝓝 (S X))) :
+    IsTracePreservingMap S := by
+  intro X
+  have htr : Tendsto (fun i : ℕ ↦ Matrix.trace (E i X)) atTop
+      (𝓝 (Matrix.trace (S X))) :=
+    ((Matrix.traceLinearMap n ℂ ℂ).continuous_of_finiteDimensional.tendsto
+      (S X)).comp (hlim X)
+  have hconst : (fun i : ℕ ↦ Matrix.trace (E i X)) = fun _ ↦ Matrix.trace X :=
+    funext fun i ↦ hE i X
+  rw [hconst] at htr
+  exact tendsto_nhds_unique htr tendsto_const_nhds
+
+end IsTracePreservingMap
+
+namespace IsSchwarzMap
+
+variable {n : Type*} [Fintype n]
+  {S T : Module.End ℂ (Matrix n n ℂ)}
+
+/-- Schwarz matrix endomorphisms are closed under composition when both maps
+are positive.  Positivity of the outer map transports the inner Schwarz
+defect; positivity of the inner map identifies `T(Aᴴ)` with `(T A)ᴴ`. -/
+theorem comp (hS : IsSchwarzMap S) (hT : IsSchwarzMap T)
+    (hSPos : IsPositiveMap S) (hTPos : IsPositiveMap T) :
+    IsSchwarzMap (S.comp T) := by
+  intro A
+  have hinner := hSPos _ (hT A)
+  have houter := hS (T A)
+  have heq :
+      (S.comp T) (Aᴴ * A) - (S.comp T) Aᴴ * (S.comp T) A =
+        S (T (Aᴴ * A) - T Aᴴ * T A) +
+          (S ((T A)ᴴ * T A) - S (T A)ᴴ * S (T A)) := by
+    simp only [LinearMap.comp_apply, map_sub, hTPos.map_conjTranspose]
+    module
+  rw [heq]
+  exact hinner.add houter
+
+/-- Every natural power of a positive Schwarz matrix endomorphism is
+Schwarz. -/
+theorem pow (hT : IsSchwarzMap T) (hTPos : IsPositiveMap T) (m : ℕ) :
+    IsSchwarzMap (T ^ m) := by
+  induction m with
+  | zero =>
+      intro A
+      simpa using (Matrix.PosSemidef.zero : (0 : Matrix n n ℂ).PosSemidef)
+  | succ m ih =>
+      rw [pow_succ', Module.End.mul_eq_comp]
+      exact hT.comp ih hTPos (hTPos.pow m)
+
+/-- A pointwise finite-dimensional limit of Schwarz matrix endomorphisms is
+Schwarz. -/
+theorem of_tendsto
+    {E : ℕ → Module.End ℂ (Matrix n n ℂ)}
+    {S : Module.End ℂ (Matrix n n ℂ)}
+    (hE : ∀ i, IsSchwarzMap (E i))
+    (hlim : ∀ X, Tendsto (fun i : ℕ ↦ E i X) atTop (𝓝 (S X))) :
+    IsSchwarzMap S := by
+  intro A
+  exact Matrix.posSemidef_is_closed.mem_of_tendsto
+    ((hlim (Aᴴ * A)).sub ((hlim Aᴴ).mul (hlim A)))
+    (Filter.Eventually.of_forall fun i ↦ hE i A)
+
+end IsSchwarzMap
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n]
+
+/-- The trace-pairing adjoint of the identity matrix endomorphism is the
+identity. -/
+theorem traceAdjointMap_id :
+    traceAdjointMap (LinearMap.id : Module.End ℂ (Matrix n n ℂ)) =
+      LinearMap.id := by
+  classical
+  apply LinearMap.ext
+  intro X
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro Y
+  rw [trace_traceAdjointMap_mul]
+  simp
+
+/-- The trace-pairing adjoint of a power is the corresponding power of the
+trace-pairing adjoint. -/
+theorem traceAdjointMap_pow (T : Module.End ℂ (Matrix n n ℂ)) (m : ℕ) :
+    traceAdjointMap (T ^ m) = (traceAdjointMap T) ^ m := by
+  classical
+  induction m with
+  | zero =>
+      simp only [pow_zero]
+      exact traceAdjointMap_id
+  | succ m ih =>
+      rw [pow_succ, Module.End.mul_eq_comp, traceAdjointMap_comp, ih,
+        pow_succ', Module.End.mul_eq_comp]
+
+/-- Pointwise convergence of matrix endomorphisms transports through the
+trace-pairing adjoint.  The proof uses the matrix-unit formula for the adjoint
+and finite-dimensional entrywise convergence. -/
+theorem tendsto_traceAdjointMap
+    {E : ℕ → Module.End ℂ (Matrix n n ℂ)}
+    {S : Module.End ℂ (Matrix n n ℂ)}
+    (hlim : ∀ X, Tendsto (fun i : ℕ ↦ E i X) atTop (𝓝 (S X)))
+    (X : Matrix n n ℂ) :
+    Tendsto (fun i : ℕ ↦ traceAdjointMap (E i) X) atTop
+      (𝓝 (traceAdjointMap S X)) := by
+  classical
+  change Tendsto
+    (fun i : ℕ ↦ fun a b ↦ traceAdjointMap (E i) X a b) atTop
+      (𝓝 (fun a b ↦ traceAdjointMap S X a b))
+  rw [tendsto_pi_nhds]
+  intro a
+  rw [tendsto_pi_nhds]
+  intro b
+  simp_rw [traceAdjointMap_apply_apply]
+  have hcont : Continuous (fun Y : Matrix n n ℂ ↦ Matrix.trace (X * Y)) :=
+    (Matrix.traceLinearMap n ℂ ℂ).continuous_of_finiteDimensional.comp
+      (continuous_const.mul continuous_id)
+  exact (hcont.tendsto _).comp (hlim (Matrix.single b a 1))
+
+end Matrix

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -549,9 +549,109 @@ but invokes Theorem~6.14 on the recurrent projection $I$, whose printed
 hypothesis requires $I^*$ to be Schwarz.  Accordingly, the source-facing
 assembly follows the printed proof under Schwarz hypotheses for both $T$ and
 $T^*$; the distinction and exact source lines are recorded in
-\cite{gap:wolf_theorem6_16_schwarz_orientation}.  The definitions below are
-conditional data and do not assert that this existence theorem is already
-proved.
+\cite{gap:wolf_theorem6_16_schwarz_orientation}.  The later block-structure
+definitions are conditional data and do not assert that the remaining
+classification theorem is already proved.
+
+\begin{lemma}[Closure under concatenation, powers, and limits]
+    \label{lem:positive_trace_schwarz_limit_closure}
+    \lean{IsPositiveMap.comp,
+        IsPositiveMap.pow,
+        IsPositiveMap.of_tendsto,
+        IsTracePreservingMap.comp,
+        IsTracePreservingMap.pow,
+        IsTracePreservingMap.of_tendsto,
+        IsSchwarzMap.comp,
+        IsSchwarzMap.pow,
+        IsSchwarzMap.of_tendsto,
+        Matrix.traceAdjointMap_id,
+        Matrix.traceAdjointMap_pow,
+        Matrix.tendsto_traceAdjointMap}
+    \leanok
+    \uses{def:positive_map,def:trace_preserving,
+        def:abstract_schwarz_inequality}
+    Positive and trace-preserving matrix endomorphisms are closed under
+    concatenation, natural powers, and finite-dimensional pointwise limits.
+    Positive Schwarz maps are closed under the same operations. Moreover,
+    the trace-pairing adjoint of the identity map is the identity map,
+    trace-pairing adjoints commute with natural powers, and pointwise
+    convergence passes to the trace-pairing adjoints.
+    Every assertion is orientation-specific: applying the Schwarz closure to
+    $T^*$ requires a Schwarz hypothesis for $T^*$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Positivity transports the Schwarz defect through the outer map, proving
+    concatenation closure; induction gives power closure. The cones of
+    positive semidefinite matrices are closed, so positivity and the Schwarz
+    inequality pass to finite-dimensional pointwise limits. Trace
+    preservation passes to limits by continuity of the trace. The adjoint
+    identities follow from the trace pairing and its matrix-unit formula.
+\end{proof}
+
+\begin{theorem}[Recurrent projection and inverse on the asymptotic image]
+    \label{thm:wolf_cycle_recurrent_peripheral_inverse}
+    \lean{IsPositiveMap.exists_strictMono_tendsto_pow_peripheralProjection_and_predecessor,
+        IsPositiveMap.peripheralProjection_isPositiveMap,
+        IsPositiveMap.peripheralProjection_isTracePreservingMap,
+        IsPositiveMap.peripheralProjection_isSchwarzMap,
+        IsPositiveMap.traceAdjointMap_peripheralProjection_isSchwarzMap,
+        IsPositiveMap.exists_peripheralRestrictedInverse,
+        Module.End.peripheralRestrictedInverse_apply_map_of_mem_range,
+        Module.End.map_peripheralRestrictedInverse_apply_of_mem_range}
+    \leanok
+    \uses{def:positive_map,def:trace_preserving,
+        def:abstract_schwarz_inequality,
+        def:peripheral_spectral_projections,
+        cor:peripheral_projection_channel,
+        thm:peripheral_asymptotic_image}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, with $D>0$,
+    and write $I=T_\phi$ for its recurrent/peripheral projection. There are
+    a strictly increasing sequence of positive integers $(n_i)$ and a
+    positive trace-preserving map $S$ such that
+    \begin{align}
+        T^{n_i}&\longrightarrow I, &
+        T^{n_i-1}&\longrightarrow S, \notag \\
+        S\circ T&=I, & T\circ S&=I, \notag \\
+        S\circ I&=S, & I\circ S&=S. \notag
+    \end{align}
+    The map $I$ is positive and trace preserving. Moreover, $S$ and $I$ have
+    the same range. Hence $S$ and $T$ are mutual inverses on
+    $\operatorname{ran}I=\mathcal{X}_T$; this is not a global inverse claim.
+    If $T$ is Schwarz, then $I$ is Schwarz. If, separately, $T^*$ is Schwarz,
+    then $I^*$ is Schwarz.
+
+    This is the recurrent-projection and positive-inverse step at lines
+    1629--1640 of the proof of~\cite[Theorem~6.16]{Wolf2012Quantum}, under the
+    corrected two-orientation contract used by that printed proof.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:positive_trace_schwarz_limit_closure,
+        thm:peripheral_projection_recurrent_subsequence,
+        lem:non_peripheral_pow_vanishing,
+        thm:peripheral_spectral_projection_properties}
+    Start with the Dirichlet subsequence for which $T^{n_i}\to I$. Positivity
+    and trace preservation give pointwise bounded forward orbits. The uniform
+    boundedness principle upgrades these to a common operator-norm bound for
+    the powers, and finite-dimensional compactness supplies a further
+    subsequence for which $T^{n_i-1}\to S$.
+
+    Since every $n_i$ is positive, composition on either side by $T$ turns
+    $T^{n_i-1}$ into $T^{n_i}$. Uniqueness of limits gives
+    $S\circ T=I=T\circ S$. Powers vanish on the non-peripheral complement;
+    passing this fact to the predecessor limit gives $S\circ I=S$, and the
+    two composition identities then give $I\circ S=S$. These absorption
+    identities imply $\operatorname{ran}S=\operatorname{ran}I$.
+
+    Positivity and trace preservation pass to $S$ through the same limit.
+    Schwarz closure under composition, powers, and finite-dimensional limits
+    gives the $I$ orientation from the hypothesis on $T$. The identity
+    $(T^n)^*=(T^*)^n$ gives the $I^*$ orientation separately from the
+    hypothesis on $T^*$; no adjoint-stability implication is used.
+\end{proof}
 
 \begin{theorem}[The Schwarz condition excludes matrix transpositions]
     \label{thm:wolf_cycle_schwarz_excludes_transpose}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -1383,6 +1383,26 @@ both `T` and `T*` are Schwarz.  No implication between these hypotheses is
 silently introduced, and the note does not claim that the theorem's conclusion
 is false under the single printed hypothesis.
 
+* The recurrent projection and positive inverse step at source lines
+  1629--1640 is formalized by:
+  - `IsPositiveMap.exists_strictMono_tendsto_pow_peripheralProjection_and_predecessor`,
+    which takes the existing Dirichlet subsequence `T^(n_i) → T_φ` and extracts
+    a further subsequence for which `T^(n_i - 1)` converges, using bounded
+    orbits, Banach--Steinhaus, and finite-dimensional compactness;
+  - `IsPositiveMap.exists_peripheralRestrictedInverse`, which packages the
+    limit `S` as positive and trace preserving with
+    `S.comp T = T.peripheralProjection`,
+    `T.comp S = T.peripheralProjection`, both absorption identities, and
+    `range S = range T.peripheralProjection`; this is an inverse only on
+    `X_T`, not a global inverse;
+  - `IsPositiveMap.peripheralProjection_isSchwarzMap` and
+    `IsPositiveMap.traceAdjointMap_peripheralProjection_isSchwarzMap`, which
+    transport the two Schwarz orientations independently and do not infer
+    Schwarz for `T*` from Schwarz for `T`;
+  - `Module.End.peripheralRestrictedInverse_apply_map_of_mem_range` and
+    `Module.End.map_peripheralRestrictedInverse_apply_of_mem_range`, which
+    state the two inverse identities on `range T.peripheralProjection = X_T`.
+
 * The final classification step at source lines 1660--1663 is formalized
   under exactly Wolf's positive, trace-preserving, positive-inverse, and
   Schwarz hypotheses:
@@ -1436,10 +1456,9 @@ is false under the single printed hypothesis.
   map for which both `T` and `T*` satisfy the Schwarz inequality admits a
   `MultiCycleDecomposition` on its asymptotic image, with the cycles coming
   from the now-formalized density-block decomposition of the fixed-point
-  space — still requires formalizing Schwarz closure and Wolf's positive
-  inverse on the recurrent image, deriving the density-block face permutation
-  and equal dimensions, and assembling the exact weighted Equations
-  (6.66)--(6.68). The conditional `CycleStructure` and
+  space — now requires deriving the density-block face permutation and equal
+  dimensions, and assembling the exact weighted Equations (6.66)--(6.68).
+  The conditional `CycleStructure` and
   `MultiCycleDecomposition` objects above are consumers of that theorem; they
   are not substitutes for the missing source-facing declaration.
 


### PR DESCRIPTION
## Summary

- add the composition, power, and pointwise-limit closure lemmas used by Wolf for positive, trace-preserving, and Schwarz maps
- extract a convergent predecessor-power subsequence from the same Dirichlet recurrent sequence and package its positive trace-preserving limit
- prove `S.comp T = T.peripheralProjection`, `T.comp S = T.peripheralProjection`, the two absorption identities, equal ranges, and the inverse identities restricted to the asymptotic image
- transport the Schwarz hypotheses for `T` and `T*` independently to the recurrent projection
- synchronize the generated aggregators, Blueprint dependency graph, and Wolf numbering coverage

## Source contract

This follows `Notes/WolfNoteTexSource/ch06_spectral_properties.tex` lines 1626--1640. Wolf writes the predecessor limit as `T⁻¹`, but the implementation exposes it only as an inverse on `range T.peripheralProjection = X_T`. It does not introduce a global inverse, a replacement spectral inverse, complete-positivity assumptions, or any of the later face-permutation/classification steps.

Banach--Steinhaus and finite-dimensional compactness supply the predecessor limit asserted by the source. They are recorded as the formal justification, not attributed to Wolf as a printed argument.

## Validation

- `lake build` (9,255 jobs)
- `lake exe lint_style`
- `lake exe checkdecls blueprint/lean_decls`
- import-aggregator generation/check/tests
- Lean file-policy, numbering, reader-prose, and diff checks
- Blueprint sync: 2,108/2,108
- `leanblueprint pdf` (321 pages)
- `texra-blueprint web`
- generated web render check: 30 pages, 27,909 typeset nodes
- axiom audit of all 18 new public declarations: only `propext`, `Classical.choice`, and `Quot.sound`
- independent exact-snapshot source/API/proof review: approved with no remaining blockers

Closes #408.