### PR TITLE
Wolf Theorem 6.16: add connected pure-state face helpers

### DIFF
--- a/QICLean/Analysis/TraceNormContractionCoefficient.lean
+++ b/QICLean/Analysis/TraceNormContractionCoefficient.lean
@@ -35,6 +35,13 @@ variable {D D' : ℕ}
 def pureStateProj (ψ : Fin D → ℂ) : Matrix (Fin D) (Fin D) ℂ :=
   vecMulVec ψ (fun p => star (ψ p))
 
+/-- The rank-one projector depends continuously on its defining vector. -/
+theorem continuous_pureStateProj :
+    Continuous (pureStateProj (D := D)) := by
+  unfold pureStateProj
+  refine continuous_matrix fun i j => ?_
+  exact (continuous_apply i).mul (continuous_apply j).star
+
 /-- A vector has unit Euclidean norm, in the unbundled matrix-vector form. -/
 def IsUnitVector (ψ : Fin D → ℂ) : Prop :=
   (fun p => star (ψ p)) ⬝ᵥ ψ = 1

--- a/QICLean/Channel/Peripheral.lean
+++ b/QICLean/Channel/Peripheral.lean
@@ -29,6 +29,7 @@ import QICLean.Channel.Peripheral.JordanBlocks
 import QICLean.Channel.Peripheral.MultiCycleDecomposition
 import QICLean.Channel.Peripheral.PeriodicityRemoval
 import QICLean.Channel.Peripheral.Powers
+import QICLean.Channel.Peripheral.PureStateFace
 import QICLean.Channel.Peripheral.RecurrentInverse
 import QICLean.Channel.Peripheral.SchurAsymptoticConvergence
 import QICLean.Channel.Peripheral.SpectralProjection

--- a/QICLean/Channel/Peripheral/PureStateFace.lean
+++ b/QICLean/Channel/Peripheral/PureStateFace.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import Mathlib.Analysis.Normed.Module.Connected
+import QICLean.Analysis.TraceNormContractionCoefficient
+
+/-!
+# Connected rank-one pure-state faces
+
+This file supplies the topology used literally in Wolf's proof of Theorem 6.16,
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1648--1654.  Inside one
+full matrix block, pure states are rank-one projections.  Their unit-vector
+parametrization is path connected over `ℂ`, and its image under the continuous
+map `Matrix.pureStateProj` is therefore connected.
+
+The results here do not choose a target block, assume a block permutation, or
+compare block dimensions.  Those are conclusions for the later face-permutation
+argument, not hypotheses of these reusable helpers.
+
+## Main declarations
+
+* `Matrix.isPathConnected_unitVectors`
+* `Matrix.isConnected_pureStateProj_image`
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.16][Wolf2012QChannels]
+-/
+
+open scoped Matrix
+open Matrix
+
+noncomputable section
+
+namespace Matrix
+
+variable {D : ℕ}
+
+private theorem isUnitVector_euclideanEquiv_iff
+    (φ : EuclideanSpace ℂ (Fin D)) :
+    IsUnitVector (EuclideanSpace.equiv (Fin D) ℂ φ) ↔ ‖φ‖ = 1 := by
+  rw [IsUnitVector, dotProduct_comm]
+  change WithLp.ofLp φ ⬝ᵥ star (WithLp.ofLp φ) = 1 ↔ ‖φ‖ = 1
+  rw [← EuclideanSpace.inner_eq_star_dotProduct]
+  rw [inner_self_eq_norm_sq_to_K]
+  constructor
+  · intro h
+    have hsq : ‖φ‖ ^ 2 = 1 := by
+      rw [← Complex.ofReal_inj]
+      rw [Complex.ofReal_pow, Complex.ofReal_one]
+      exact h
+    nlinarith [norm_nonneg φ]
+  · intro h
+    norm_num [h]
+
+private theorem one_lt_rank_euclideanSpace (hD : 0 < D) :
+    1 < Module.rank ℝ (EuclideanSpace ℂ (Fin D)) := by
+  rw [rank_real_of_complex]
+  rw [← Module.finrank_eq_rank]
+  rw [finrank_euclideanSpace_fin]
+  have hnat : 1 < 2 * D := by omega
+  exact_mod_cast hnat
+
+/-- The complex unit vectors in a nonzero full matrix block form a path-connected set.
+
+The ambient function space carries the product topology used by the matrix API.  We
+transport Mathlib's path-connectedness theorem for the Euclidean unit sphere along
+`EuclideanSpace.equiv`; the defining dot-product equation for `IsUnitVector` is exactly
+the Euclidean norm-one equation. -/
+theorem isPathConnected_unitVectors (hD : 0 < D) :
+    IsPathConnected {ψ : Fin D → ℂ | IsUnitVector ψ} := by
+  let e := EuclideanSpace.equiv (Fin D) ℂ
+  have hpath : IsPathConnected
+      (Metric.sphere (0 : EuclideanSpace ℂ (Fin D)) 1) :=
+    isPathConnected_sphere (one_lt_rank_euclideanSpace hD) 0 (by positivity)
+  have himage : IsPathConnected
+      (e '' Metric.sphere (0 : EuclideanSpace ℂ (Fin D)) 1) :=
+    hpath.image e.continuous
+  have hset : e '' Metric.sphere (0 : EuclideanSpace ℂ (Fin D)) 1 =
+      {ψ : Fin D → ℂ | IsUnitVector ψ} := by
+    ext ψ
+    constructor
+    · rintro ⟨φ, hφ, rfl⟩
+      change IsUnitVector (e φ)
+      apply (isUnitVector_euclideanEquiv_iff φ).2
+      simpa only [Metric.mem_sphere, dist_zero_right] using hφ
+    · intro hψ
+      change IsUnitVector ψ at hψ
+      refine ⟨e.symm ψ, ?_, e.apply_symm_apply ψ⟩
+      rw [Metric.mem_sphere, dist_zero_right]
+      apply (isUnitVector_euclideanEquiv_iff (e.symm ψ)).1
+      have heq : (EuclideanSpace.equiv (Fin D) ℂ) (e.symm ψ) = ψ :=
+        e.apply_symm_apply ψ
+      rw [heq]
+      exact hψ
+  rw [← hset]
+  exact himage
+
+/-- The rank-one pure-state projections in a nonzero full matrix block form a connected set.
+
+This is the precise source-facing bridge used in Wolf's continuity step: it is the image
+of the connected unit-vector set under the existing continuous map `pureStateProj`. -/
+theorem isConnected_pureStateProj_image (hD : 0 < D) :
+    IsConnected (pureStateProj (D := D) ''
+      {ψ : Fin D → ℂ | IsUnitVector ψ}) :=
+  ((isPathConnected_unitVectors hD).image continuous_pureStateProj).isConnected
+
+end Matrix

--- a/QICLean/Channel/WolfProps.lean
+++ b/QICLean/Channel/WolfProps.lean
@@ -42,8 +42,9 @@ Wolf's *Quantum Channels & Operations: Guided Tour*:
   every rank-one self-outer-product ray is a scalar multiple of the identity.
 * `WolfProps.linearMap_eq_id_of_fixes_rankOne` — Proposition 2.3 (linear-algebra
   form): a linear map fixing every `vecMulVec v (star v)` is the identity.
-* `WolfProps.linearMap_eq_of_eq_on_rankOne` — two linear maps that agree on every
-  `vecMulVec v (star v)` are equal.
+* `WolfProps.linearMap_eq_of_eq_on_rankOne` — two linear maps from a full matrix
+  algebra into any complex module that agree on every `vecMulVec v (star v)`
+  are equal.
 * `WolfProps.channel_eq_id_of_fixes_pureStates` — Proposition 2.3 (channel form):
   a quantum channel fixing every pure-state projector is the identity.
 * `WolfProps.pureEnsembleDensity_eq_of_isometric_mixing` — Proposition 2.4
@@ -344,22 +345,44 @@ theorem linearMap_eq_id_of_fixes_rankOne
     simpa [Matrix.vecMulVec_apply, Pi.star_apply, i₀] using hii
   simpa [hc_one] using hc
 
-/-- Two complex-linear matrix maps are equal if they agree on every rank-one
-self-outer-product `vecMulVec v (star v)`. -/
+/-- Two complex-linear maps from a full matrix algebra into an arbitrary complex module
+are equal if they agree on every rank-one self-outer-product `vecMulVec v (star v)`.
+
+Polarization first extends the hypothesis to all outer products `vecMulVec u (star v)`;
+the standard matrix units are scaled outer products, so linearity finishes the proof. -/
 theorem linearMap_eq_of_eq_on_rankOne
-    (T S : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    {E : Type*} [AddCommGroup E] [Module ℂ E]
+    (T S : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] E)
     (h : ∀ v : Fin D → ℂ,
       T (Matrix.vecMulVec v (star v)) = S (Matrix.vecMulVec v (star v))) :
     T = S := by
-  have hfix : T - S + LinearMap.id = LinearMap.id :=
-    linearMap_eq_id_of_fixes_rankOne (T - S + LinearMap.id) fun v ↦ by
-      simp only [LinearMap.add_apply, LinearMap.sub_apply, LinearMap.id_apply, h v,
-        sub_self, zero_add]
+  have houter (u v : Fin D → ℂ) :
+      T (Matrix.vecMulVec u (star v)) = S (Matrix.vecMulVec u (star v)) := by
+    have hpol := vecMulVec_star_eq_polarization u v
+    have hT := congrArg T hpol
+    have hS := congrArg S hpol
+    simp only [map_smul, map_sub, map_add, h] at hT hS
+    have h4 : (4 : ℂ) • T (Matrix.vecMulVec u (star v)) =
+        (4 : ℂ) • S (Matrix.vecMulVec u (star v)) := hT.trans hS.symm
+    exact smul_right_injective E (by norm_num : (4 : ℂ) ≠ 0) h4
   apply LinearMap.ext
   intro X
-  have hX := LinearMap.congr_fun hfix X
-  simpa only [LinearMap.add_apply, LinearMap.sub_apply, LinearMap.id_apply,
-    add_eq_right, sub_eq_zero] using hX
+  refine Matrix.induction_on' X ?_ ?_ ?_
+  · simp
+  · intro p q hp hq
+    simp only [map_add, hp, hq]
+  · intro i j x
+    have hstar : star (Pi.single j (1 : ℂ)) =
+        (Pi.single j (1 : ℂ) : Fin D → ℂ) := by
+      ext k
+      simp [Pi.single_apply, Pi.star_apply]
+    have hsingle : (Matrix.single i j x : Matrix (Fin D) (Fin D) ℂ) =
+        x • Matrix.vecMulVec (Pi.single i 1) (star (Pi.single j 1)) := by
+      rw [hstar]
+      rw [← Matrix.single_eq_single_vecMulVec_single (i := i) (j := j)]
+      ext p q
+      simp [Matrix.single_apply]
+    rw [hsingle, map_smul, map_smul, houter]
 
 /-- **Proposition 2.3 (Wolf), pure-state form**: any linear map (in particular any
 quantum channel) leaving every pure-state projector `vecMulVec v (star v)`

--- a/blueprint/src/chapter/ch03_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_choi_and_kraus.tex
@@ -582,7 +582,8 @@ The next three corollaries support channel decompositions and correspond to
     \label{thm:linearMap_eq_of_eq_on_rankOne}
     \lean{WolfProps.linearMap_eq_of_eq_on_rankOne}
     \leanok
-    Let $T,S:\MN{D}\to\MN{D}$ be complex-linear maps. If
+    Let $E$ be a complex vector space and let
+    $T,S:\MN{D}\to E$ be complex-linear maps. If
     \begin{align}
         T(\ketbra{v}{v})=S(\ketbra{v}{v})
     \end{align}
@@ -590,10 +591,10 @@ The next three corollaries support channel decompositions and correspond to
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:linearMap_eq_id_of_fixes_rankOne}
-    The map $T-S+\id$ fixes every matrix $\ketbra{v}{v}$, so
-    Theorem~\ref{thm:linearMap_eq_id_of_fixes_rankOne} gives
-    $T-S+\id=\id$. Hence $T=S$.
+    Polarization expresses every outer product $\ketbra{u}{v}$ as a
+    complex linear combination of four self-outer-products. Thus $T$
+    and $S$ agree on all outer products, in particular on every matrix
+    unit. Linearity then gives $T=S$ on all of $\MN{D}$.
 \end{proof}
 
 \begin{definition}[Pure-state ensemble density]

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -536,6 +536,31 @@ Theorem~6.2 appears in Theorem~\ref{thm:wolf_6_2_item_3}.
     large level in one direction and applying upward closure in the other.
 \end{proof}
 
+\begin{theorem}[Connected rank-one pure-state locus in a full matrix block]
+    \label{thm:wolf_connected_pure_state_proj_image}
+    \lean{Matrix.continuous_pureStateProj,
+        Matrix.isPathConnected_unitVectors,
+        Matrix.isConnected_pureStateProj_image}
+    \leanok
+    Let $d>0$. The map
+    \begin{align}
+        \psi\longmapsto\ketbra{\psi}{\psi}
+        \qquad(\psi\in\C^d)
+        \notag
+    \end{align}
+    is continuous. Its unit-vector domain is path connected, and hence
+    the set of rank-one pure-state projections in $\MN{d}$ is connected.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The complex unit sphere is a real sphere in a Euclidean space of
+    dimension $2d>1$, hence it is path connected. Under Euclidean
+    coordinates it is exactly the set of vectors $\psi$ satisfying
+    $\langle\psi,\psi\rangle=1$. The rank-one projector depends
+    continuously on $\psi$, so its image is connected.
+\end{proof}
+
 \section{Multi-cycle block-permutation structure}
 
 This section develops the block-permutation structure underlying the

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -1403,6 +1403,21 @@ is false under the single printed hypothesis.
     `Module.End.map_peripheralRestrictedInverse_apply_of_mem_range`, which
     state the two inverse identities on `range T.peripheralProjection = X_T`.
 
+* The literal continuity ingredients from source lines 1648--1654 are
+  formalized without assuming a target block or a block classification:
+  - `Matrix.continuous_pureStateProj` proves continuity of the map
+    sending psi to its rank-one self-projector.
+  - `Matrix.isPathConnected_unitVectors` transports Mathlib's
+    path-connected complex Euclidean unit sphere to the existing matrix-vector
+    `IsUnitVector` API.
+  - `Matrix.isConnected_pureStateProj_image` proves that the rank-one
+    pure-state projections in a nonzero full matrix block form a connected
+    set.
+  - `WolfProps.linearMap_eq_of_eq_on_rankOne` now has arbitrary
+    complex-module codomain, so agreement on rank-one projectors determines
+    any linear map out of a full matrix block by the existing polarization
+    identity.
+
 * The final classification step at source lines 1660--1663 is formalized
   under exactly Wolf's positive, trace-preserving, positive-inverse, and
   Schwarz hypotheses:


### PR DESCRIPTION
## Summary

- expose continuity of the existing rank-one pure-state projector
- transport path-connectedness of the nonzero complex unit sphere into the existing matrix-vector coordinates
- prove the corresponding pure-projector image is connected
- generalize rank-one polarization extensionality to linear maps with any complex-module codomain
- synchronize the Blueprint and Wolf numbering coverage

## Source contract

This follows `Notes/WolfNoteTexSource/ch06_spectral_properties.tex` lines 1648--1654: continuity makes the target block independent of the rank-one state. It adds only the topology and polarization helpers needed for that literal step. It does not choose a target block, assume a permutation, compare block dimensions, or invoke an alternate classification route.

## Validation

- `lake build QICLean` (9,256 jobs)
- focused module, Peripheral aggregator, and known-consumer builds
- `lake exe lint_style --github`
- import-aggregator generation/check and 9 generator tests
- module-policy, hotspot, size, numbering, reader-prose, paper-gap, diff, and `chktex` checks
- Blueprint sync: 2,111/2,111; zero changed declarations missing
- Blueprint web render: 30 pages, 27,936 typeset nodes
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`
- independent exact-SHA review: approved with no remaining findings

Closes #416.