### PR TITLE
Wolf Theorem 6.16: add unital Schwarz and Kronecker helpers

### DIFF
--- a/QICLean/Channel/PartialTrace.lean
+++ b/QICLean/Channel/PartialTrace.lean
@@ -62,6 +62,10 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
 * `Matrix.traceRight_kronecker`: `tr_B(A ⊗ B) = A • tr(B)`
 * `Matrix.traceLeft_one`: `tr_A(1) = d • 1`
 * `Matrix.traceRight_one`: `tr_B(1) = d' • 1`
+* `Matrix.PosSemidef.right_of_one_kronecker`: positivity of `1 ⊗ₖ B`
+  reflects to `B` when the identity factor is nonzero
+* `Matrix.kronecker_eq_one_of_left_trace_eq_one`: a trace-one left factor in
+  a Kronecker factorization of the identity is maximally mixed
 
 ## References
 
@@ -628,5 +632,53 @@ theorem traceRight_one :
   by_cases hij : i = j
   · simp [hij, Finset.sum_const, Finset.card_univ, Fintype.card_fin]
   · simp [hij]
+
+/-! ### Kronecker reflection and identity factors -/
+
+/-- Positive semidefiniteness of `1 ⊗ₖ B` reflects to the right factor when
+the identity factor is nonzero.
+
+This auxiliary fact supports Wolf Theorem 6.16's omitted scalar step and is
+not separately stated there. Source:
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1660--1663. -/
+theorem PosSemidef.right_of_one_kronecker {m d : ℕ} [NeZero m]
+    {B : Matrix (Fin d) (Fin d) ℂ}
+    (h : ((1 : Matrix (Fin m) (Fin m) ℂ) ⊗ₖ B).PosSemidef) :
+    B.PosSemidef := by
+  have hpartial := h.partialTraceLeft
+  rw [partialTraceLeft_kronecker, Matrix.trace_one, Fintype.card_fin] at hpartial
+  have hmpos : (0 : ℂ) < m := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne m)
+  have hrescaled := hpartial.smul (inv_pos.mpr hmpos).le
+  simpa only [smul_smul, inv_mul_cancel₀ (ne_of_gt hmpos), one_smul] using hrescaled
+
+/-- If a trace-one left factor tensored with `X` is the identity, then the
+left factor is maximally mixed and `X` is the compensating scalar identity.
+
+This auxiliary fact supports Wolf Theorem 6.16's omitted scalar step and is
+not separately stated there. Source:
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1660--1663. -/
+theorem kronecker_eq_one_of_left_trace_eq_one {m d : ℕ} [NeZero m] [NeZero d]
+    {sigma : Matrix (Fin m) (Fin m) ℂ}
+    {X : Matrix (Fin d) (Fin d) ℂ}
+    (hsigmaTrace : sigma.trace = 1) (h : sigma ⊗ₖ X = 1) :
+    sigma = (m : ℂ)⁻¹ • 1 ∧ X = (m : ℂ) • 1 := by
+  have hX : X = (m : ℂ) • 1 := by
+    have hleft := congrArg traceLeft h
+    rw [traceLeft_kronecker, hsigmaTrace, one_smul, traceLeft_one] at hleft
+    exact hleft
+  constructor
+  · have hright := congrArg traceRight h
+    rw [traceRight_kronecker, traceRight_one, hX, Matrix.trace_smul,
+      Matrix.trace_one, Fintype.card_fin] at hright
+    have hcancel : (d : ℂ) • ((m : ℂ) • sigma) = (d : ℂ) • 1 := by
+      simpa only [smul_smul, smul_eq_mul, mul_comm] using hright
+    have hdne : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+    have hmSigma : (m : ℂ) • sigma = 1 :=
+      smul_right_injective _ hdne hcancel
+    have hmne : (m : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne m)
+    have hrescaled := congrArg (fun Y ↦ (m : ℂ)⁻¹ • Y) hmSigma
+    simpa only [smul_smul, inv_mul_cancel₀ hmne, one_smul] using hrescaled
+  · exact hX
 
 end Matrix

--- a/QICLean/Channel/Schwarz.lean
+++ b/QICLean/Channel/Schwarz.lean
@@ -47,6 +47,7 @@ import QICLean.Channel.Schwarz.SupportRelativeEntropyGap
 import QICLean.Channel.Schwarz.SupportRelativeModular
 import QICLean.Channel.Schwarz.SupportResolvent
 import QICLean.Channel.Schwarz.SupportSourceDefect
+import QICLean.Channel.Schwarz.TracePreserving
 import QICLean.Channel.Schwarz.TwoPositive
 import QICLean.Channel.Schwarz.TwoVariable
 import QICLean.Channel.Schwarz.TwoVariableEquality

--- a/QICLean/Channel/Schwarz/TracePreserving.lean
+++ b/QICLean/Channel/Schwarz/TracePreserving.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Algebra.TracePurity
+import QICLean.Channel.Schwarz.AbstractMultiplicativeDomain
+
+/-!
+# Trace-preserving Schwarz maps are unital
+
+A positive trace-preserving endomorphism of a nonzero complex matrix algebra
+that satisfies the Schwarz inequality fixes the identity. This supplies one
+scalar-normalization prerequisite for Wolf's use of Schwarz maps at the end
+of the proof of Theorem 6.16.
+
+The proof uses no complete-positivity hypothesis.  Schwarz at the identity
+bounds the trace of `T(1) ^ 2` above by the dimension, while the Hermitian
+trace-square inequality bounds it below by the same value.  Its equality case
+then forces `T(1)` to be the identity.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+
+variable {D : ℕ}
+
+local notation "MatD" => Matrix (Fin D) (Fin D) ℂ
+
+/-- A positive trace-preserving Schwarz endomorphism of a nonzero complex
+matrix algebra is unital.
+
+This auxiliary fact supports the omitted scalar step in Wolf Theorem 6.16 and
+is not separately stated there. Source:
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1660--1663. -/
+theorem IsPositiveMap.map_one_eq_one_of_tracePreserving_of_isSchwarzMap
+    [NeZero D] {T : MatD →ₗ[ℂ] MatD}
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap T) : T 1 = 1 := by
+  let B : MatD := T 1
+  have hB : B.PosSemidef := hPos 1 Matrix.PosSemidef.one
+  have hDef : (B - B ^ 2).PosSemidef := by
+    simpa only [B, Matrix.conjTranspose_one, Matrix.one_mul, pow_two] using
+      hSchwarz (1 : MatD)
+  have hTraceB : B.trace = D := by
+    simpa only [B, Matrix.trace_one, Fintype.card_fin] using hTP (1 : MatD)
+  have hDefTrace : 0 ≤ (B - B ^ 2).trace.re :=
+    (Complex.nonneg_iff.mp hDef.trace_nonneg).1
+  have hTraceSqLe : (B ^ 2).trace.re ≤ D := by
+    simpa only [Matrix.trace_sub, Complex.sub_re, hTraceB, Complex.natCast_re,
+      sub_nonneg] using hDefTrace
+  have hDpos : (0 : ℝ) < D := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hPurity := hB.isHermitian.trace_re_sq_le_card_mul_trace_sq_re
+  have hTraceSqGe : (D : ℝ) ≤ (B ^ 2).trace.re := by
+    rw [hTraceB, Complex.natCast_re] at hPurity
+    nlinarith
+  have hTraceSq : (B ^ 2).trace.re = D := le_antisymm hTraceSqLe hTraceSqGe
+  have hPurityEq : B.trace.re ^ 2 = D * (B ^ 2).trace.re := by
+    rw [hTraceB, Complex.natCast_re, hTraceSq]
+    rw [pow_two]
+  obtain ⟨r, hBr⟩ :=
+    hB.isHermitian.trace_re_sq_eq_card_mul_trace_sq_re_iff.mp hPurityEq
+  have hTraceScalar := hTraceB
+  rw [hBr, Matrix.trace_smul, Matrix.trace_one, Fintype.card_fin] at hTraceScalar
+  have hTraceScalarRe := congrArg Complex.re hTraceScalar
+  simp only [smul_eq_mul, Complex.mul_re, Complex.ofReal_re,
+    Complex.natCast_re, Complex.ofReal_im, Complex.natCast_im, mul_zero,
+    sub_zero] at hTraceScalarRe
+  have hr : r = 1 := by
+    nlinarith
+  change B = 1
+  simp only [hBr, hr, Complex.ofReal_one, one_smul]

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -615,6 +615,38 @@ classification theorem is already proved.
     identities follow from the trace pairing and its matrix-unit formula.
 \end{proof}
 
+\begin{theorem}[Unital Schwarz normalization and Kronecker reflection]
+    \label{thm:wolf_cycle_schwarz_unital_kronecker}
+    \lean{IsPositiveMap.map_one_eq_one_of_tracePreserving_of_isSchwarzMap,
+        Matrix.PosSemidef.right_of_one_kronecker,
+        Matrix.kronecker_eq_one_of_left_trace_eq_one}
+    \leanok
+    \uses{def:positive_map,def:trace_preserving,
+        def:abstract_schwarz_inequality}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, with $D>0$,
+    and suppose that $T$ is Schwarz. Then $T(\Id)=\Id$. For $m,d>0$,
+    positivity of $\Id_m\otimes B$ implies $B\succeq0$. If
+    $\tr(\sigma)=1$ and $\sigma\otimes X=\Id_{md}$, then
+    $\sigma=m^{-1}\Id_m$ and $X=m\Id_d$.
+
+    These auxiliary facts are needed before the matched-multiplicity comparison
+    and the transport of the ambient Schwarz defect to an individual weighted
+    full-matrix block map at source lines 1660--1663. They establish neither
+    remaining step; that source-facing assembly remains open. This is not a
+    modified-product argument.
+    % Tracking: GitHub issue #417.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Put $B=T(\Id)$. Positivity gives $B\succeq0$, Schwarz gives
+    $B-B^2\succeq0$, and trace preservation gives $\tr(B)=D$. The Hermitian
+    trace-square inequality and its equality case force $B=\Id$. Partial
+    trace and positive scalar rescaling reflect positivity from
+    $\Id_m\otimes B$. Taking both partial traces of
+    $\sigma\otimes X=\Id_{md}$ gives the remaining formulas.
+\end{proof}
+
 \begin{theorem}[Recurrent projection and inverse on the asymptotic image]
     \label{thm:wolf_cycle_recurrent_peripheral_inverse}
     \lean{IsPositiveMap.exists_strictMono_tendsto_pow_peripheralProjection_and_predecessor,

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -1418,6 +1418,25 @@ is false under the single printed hypothesis.
     any linear map out of a full matrix block by the existing polarization
     identity.
 
+* The following auxiliary normalization and tensor-factor facts are
+  prerequisites for the scalar/multiplicity comparison and block-Schwarz
+  transport at source lines 1660--1663:
+  - `IsPositiveMap.map_one_eq_one_of_tracePreserving_of_isSchwarzMap`, which
+    proves that a positive trace-preserving Schwarz endomorphism of a nonzero
+    full matrix algebra is unital, using the Hermitian trace-square equality
+    case rather than complete positivity;
+  - `Matrix.PosSemidef.right_of_one_kronecker`, which reflects positivity from
+    \(\Id_m\otimes B\) to \(B\) for \(m>0\) by partial trace and positive
+    scalar rescaling;
+  - `Matrix.kronecker_eq_one_of_left_trace_eq_one`, which uses both partial
+    traces to show that \(\tr(\sigma)=1\) and
+    \(\sigma\otimes X=\Id_{md}\) force
+    \(\sigma=m^{-1}\Id_m\) and \(X=m\Id_d\).
+  These helpers neither compare the matched block multiplicities nor transport
+  the ambient Schwarz defect to the individual weighted full-matrix block
+  maps. That remaining source-facing assembly is tracked by #417. No
+  modified-product proof or complete-positivity hypothesis is introduced here.
+
 * The final classification step at source lines 1660--1663 is formalized
   under exactly Wolf's positive, trace-preserving, positive-inverse, and
   Schwarz hypotheses:


### PR DESCRIPTION
## Summary

- prove that a positive trace-preserving Schwarz endomorphism of a nonzero complex matrix algebra fixes the identity
- reflect positive semidefiniteness from an identity Kronecker factor to the other factor
- recover the maximally mixed left factor and compensating scalar identity from a trace-one Kronecker factorization of the identity
- synchronize the compiled boundary with the Blueprint and Wolf numbering coverage

## Source contract

These are the generic normalization prerequisites for Wolf Theorem 6.16, proof lines 1660--1663. They do not assert the still-open matched-multiplicity comparison or transport of the ambient Schwarz defect to a weighted block map; that source-facing assembly remains #417. The proofs use the direct trace-purity and partial-trace route, without complete positivity, Kraus data, or a modified product.

## Validation

- focused Lean builds
- full lake build: 9,258 jobs
- style lint, checkdecls, import-aggregator check, diff check, and chktex
- Blueprint synchronization and reader-prose checks
- axiom audit of all three declarations: only propext, Classical.choice, and Quot.sound
- independent exact-SHA review at 34ca72e3d5fdb630138b27364af7aa869ae4425a: approved

Closes #419.