### PR TITLE
feat(channel): assemble Wolf density-block face permutation

### DIFF
--- a/QICLean/Channel/Peripheral.lean
+++ b/QICLean/Channel/Peripheral.lean
@@ -23,6 +23,7 @@ import QICLean.Channel.Peripheral.CyclicDecomposition.LetterShift
 import QICLean.Channel.Peripheral.CyclicDecomposition.PeripheralUnitary
 import QICLean.Channel.Peripheral.CyclicDecomposition.Primitivity
 import QICLean.Channel.Peripheral.CyclicGroupKraus
+import QICLean.Channel.Peripheral.DensityBlockCoordinates
 import QICLean.Channel.Peripheral.GroupStructure
 import QICLean.Channel.Peripheral.IrreducibleChannel
 import QICLean.Channel.Peripheral.JordanBlocks

--- a/QICLean/Channel/Peripheral.lean
+++ b/QICLean/Channel/Peripheral.lean
@@ -24,6 +24,7 @@ import QICLean.Channel.Peripheral.CyclicDecomposition.PeripheralUnitary
 import QICLean.Channel.Peripheral.CyclicDecomposition.Primitivity
 import QICLean.Channel.Peripheral.CyclicGroupKraus
 import QICLean.Channel.Peripheral.DensityBlockCoordinates
+import QICLean.Channel.Peripheral.DensityBlockDynamics
 import QICLean.Channel.Peripheral.DirectSumFacePermutation
 import QICLean.Channel.Peripheral.GroupStructure
 import QICLean.Channel.Peripheral.IrreducibleChannel

--- a/QICLean/Channel/Peripheral.lean
+++ b/QICLean/Channel/Peripheral.lean
@@ -24,6 +24,7 @@ import QICLean.Channel.Peripheral.CyclicDecomposition.PeripheralUnitary
 import QICLean.Channel.Peripheral.CyclicDecomposition.Primitivity
 import QICLean.Channel.Peripheral.CyclicGroupKraus
 import QICLean.Channel.Peripheral.DensityBlockCoordinates
+import QICLean.Channel.Peripheral.DirectSumFacePermutation
 import QICLean.Channel.Peripheral.GroupStructure
 import QICLean.Channel.Peripheral.IrreducibleChannel
 import QICLean.Channel.Peripheral.JordanBlocks

--- a/QICLean/Channel/Peripheral.lean
+++ b/QICLean/Channel/Peripheral.lean
@@ -25,6 +25,7 @@ import QICLean.Channel.Peripheral.CyclicDecomposition.Primitivity
 import QICLean.Channel.Peripheral.CyclicGroupKraus
 import QICLean.Channel.Peripheral.DensityBlockCoordinates
 import QICLean.Channel.Peripheral.DensityBlockDynamics
+import QICLean.Channel.Peripheral.DensityBlockFacePermutation
 import QICLean.Channel.Peripheral.DirectSumFacePermutation
 import QICLean.Channel.Peripheral.GroupStructure
 import QICLean.Channel.Peripheral.IrreducibleChannel

--- a/QICLean/Channel/Peripheral/DensityBlockCoordinates.lean
+++ b/QICLean/Channel/Peripheral/DensityBlockCoordinates.lean
@@ -1,0 +1,407 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Algebra.TraceReindex
+import QICLean.Channel.FixedPoint.ExtremeDensityStates
+import QICLean.Channel.FixedPoint.WolfTheorem614
+
+/-!
+# Density-block coordinates on the peripheral image
+
+This file packages the coordinate maps used in the proof of Wolf's Theorem 6.16.
+The fixed-point description from `IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero`
+has one zero summand and nonzero summands of the form `sigma k ⊗ X k`.  The embedding below
+uses exactly those witnesses.  Its left inverse removes the zero summand, compresses to each
+diagonal block, and takes the partial trace over the density factor.
+
+The formal factor order is the one established by the fixed-point theorem: `sigma k ⊗ X k`,
+whereas Wolf writes the full-matrix factor first.  No second block decomposition is introduced.
+
+## Main declarations
+
+* `Matrix.densityBlockWithZeroEmbedding`
+* `Matrix.densityBlockWithZeroCompression`
+* `Matrix.densityBlockWithZeroCompression_embedding`
+
+## Reference
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.16;
+  local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1641--1659.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder BigOperators Kronecker
+
+noncomputable section
+
+namespace Matrix
+
+private noncomputable def densityBlockTensorEmbedding
+    {K : ℕ} {d m : Fin K → ℕ}
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ) :
+    (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ) where
+  toFun X k := sigma k ⊗ₖ X k
+  map_add' X Y := by
+    funext k
+    exact Matrix.kronecker_add (sigma k) (X k) (Y k)
+  map_smul' c X := by
+    funext k
+    exact Matrix.kronecker_smul c (sigma k) (X k)
+
+private noncomputable def zeroBottomRightEmbedding
+    {D n : ℕ} :
+    Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ]
+      Matrix (Fin (D - n) ⊕ Fin n) (Fin (D - n) ⊕ Fin n) ℂ where
+  toFun A := Matrix.fromBlocks 0 0 0 A
+  map_add' A B := by
+    ext i j
+    rcases i with i | i <;> rcases j with j | j <;> simp
+  map_smul' c A := by
+    ext i j
+    rcases i with i | i <;> rcases j with j | j <;> simp
+
+private theorem trace_zeroBottomRightEmbedding
+    {D n : ℕ} (A : Matrix (Fin n) (Fin n) ℂ) :
+    Matrix.trace (Matrix.fromBlocks
+      (0 : Matrix (Fin (D - n)) (Fin (D - n)) ℂ) 0 0 A) = Matrix.trace A := by
+  rw [Matrix.trace]
+  rw [Fintype.sum_sum_type]
+  simp [Matrix.trace, Matrix.diag]
+
+private noncomputable def bottomRightCompression
+    {D n : ℕ} :
+    Matrix (Fin (D - n) ⊕ Fin n) (Fin (D - n) ⊕ Fin n) ℂ →ₗ[ℂ]
+      Matrix (Fin n) (Fin n) ℂ where
+  toFun A := A.toBlocks₂₂
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+private noncomputable def densityBlockFamilyCompression
+    {K : ℕ} {d m : Fin K → ℕ} :
+    Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+        ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ →ₗ[ℂ]
+      (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) where
+  toFun A k := Matrix.partialTraceLeft
+    (Matrix.directSumBlockCompression (m := m) (d := d) k A)
+  map_add' A B := by
+    funext k i j
+    simp only [Matrix.partialTraceLeft_apply, map_add, Matrix.add_apply, Pi.add_apply,
+      Finset.sum_add_distrib]
+  map_smul' c A := by
+    funext k i j
+    simp only [Matrix.partialTraceLeft_apply, map_smul, Matrix.smul_apply, Pi.smul_apply,
+      RingHom.id_apply, smul_eq_mul, Finset.mul_sum]
+
+/-- Embed a family of full-matrix factors into the zero-extended density-block space
+provided by Wolf Theorem 6.14.
+
+The value at `X` is
+`U * reindex e₀ e₀ (fromBlocks 0 0 0 (reindex e e (blockDiagonal' (sigma ⊗ X)))) * U†`.
+The use of `sigma k ⊗ X k` follows QICLean's established factor order. -/
+noncomputable def densityBlockWithZeroEmbedding
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ) :
+    (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) →ₗ[ℂ]
+      Matrix (Fin D) (Fin D) ℂ :=
+  (Matrix.unitaryReindexLinearEquiv e₀ U hU).symm.toLinearMap.comp
+    (zeroBottomRightEmbedding.comp
+      ((Matrix.reindexLinearEquiv ℂ ℂ e e).toLinearMap.comp
+        (Matrix.directSumDiagonalEmbedding.comp
+          (densityBlockTensorEmbedding sigma))))
+
+@[simp]
+theorem densityBlockWithZeroEmbedding_apply
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    densityBlockWithZeroEmbedding e e₀ U hU sigma X =
+      U * Matrix.reindex e₀ e₀
+        (Matrix.fromBlocks 0 0 0
+          (Matrix.reindex e e
+            (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))) * star U := by
+  simp [densityBlockWithZeroEmbedding, zeroBottomRightEmbedding,
+    densityBlockTensorEmbedding, Matrix.unitaryReindexLinearEquiv_symm_apply]
+
+/-- Recover the full-matrix factors from Wolf's zero-extended density-block coordinates.
+
+After changing to the unitary coordinates, this retains the bottom-right nonzero summand,
+undoes its reindexing, compresses to each diagonal block, and traces over `Fin (m k)`. -/
+noncomputable def densityBlockWithZeroCompression
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :=
+  densityBlockFamilyCompression.comp
+    ((Matrix.reindexLinearEquiv ℂ ℂ e.symm e.symm).toLinearMap.comp
+      (bottomRightCompression.comp
+        (Matrix.unitaryReindexLinearEquiv e₀ U hU).toLinearMap))
+
+@[simp]
+theorem densityBlockWithZeroCompression_apply
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (B : Matrix (Fin D) (Fin D) ℂ) (k : Fin K) :
+    densityBlockWithZeroCompression e e₀ U hU B k =
+      Matrix.partialTraceLeft
+        (Matrix.directSumBlockCompression (m := m) (d := d) k
+          (Matrix.reindex e.symm e.symm
+            (Matrix.unitaryReindexLinearEquiv e₀ U hU B).toBlocks₂₂)) := by
+  rfl
+
+/-- Taking density-block coordinates after embedding recovers the original family when
+the fixed density factors have trace one. -/
+@[simp]
+theorem densityBlockWithZeroCompression_embedding
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    densityBlockWithZeroCompression e e₀ U hU
+        (densityBlockWithZeroEmbedding e e₀ U hU sigma X) = X := by
+  let Phi := Matrix.unitaryReindexLinearEquiv e₀ U hU
+  let A : Matrix (Fin (D - n) ⊕ Fin n) (Fin (D - n) ⊕ Fin n) ℂ :=
+    Matrix.fromBlocks 0 0 0
+      (Matrix.reindex e e
+        (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))
+  have hcoord : Phi (densityBlockWithZeroEmbedding e e₀ U hU sigma X) = A := by
+    change Phi (Phi.symm A) = A
+    exact Phi.apply_symm_apply A
+  funext k
+  rw [densityBlockWithZeroCompression_apply, hcoord]
+  simp [A, Matrix.partialTraceLeft_kronecker, hsigmaTrace]
+
+/-- Density-block compression preserves positive semidefiniteness componentwise. -/
+theorem densityBlockWithZeroCompression_posSemidef
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    {B : Matrix (Fin D) (Fin D) ℂ} (hB : B.PosSemidef) :
+    ∀ k, (densityBlockWithZeroCompression e e₀ U hU B k).PosSemidef := by
+  intro k
+  rw [densityBlockWithZeroCompression_apply]
+  apply Matrix.PosSemidef.partialTraceLeft
+  apply Matrix.directSumBlockCompression_isPositiveMap k
+  have hcoord : (Matrix.unitaryReindexLinearEquiv e₀ U hU B).PosSemidef :=
+    Matrix.unitaryReindexLinearEquiv_posSemidef e₀ U hU hB
+  have hbottom : (Matrix.unitaryReindexLinearEquiv e₀ U hU B).toBlocks₂₂.PosSemidef := by
+    exact hcoord.submatrix Sum.inr
+  simpa only [Matrix.reindex_apply, Equiv.symm_symm,
+    Matrix.posSemidef_submatrix_equiv] using hbottom
+
+/-- Embedding componentwise positive-semidefinite full-matrix factors gives a positive
+semidefinite ambient matrix. -/
+theorem densityBlockWithZeroEmbedding_posSemidef
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigma : ∀ k, (sigma k).PosSemidef)
+    {X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ}
+    (hX : ∀ k, (X k).PosSemidef) :
+    (densityBlockWithZeroEmbedding e e₀ U hU sigma X).PosSemidef := by
+  let Phi := Matrix.unitaryReindexLinearEquiv e₀ U hU
+  let A : Matrix (Fin (D - n) ⊕ Fin n) (Fin (D - n) ⊕ Fin n) ℂ :=
+    Matrix.fromBlocks 0 0 0
+      (Matrix.reindex e e
+        (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))
+  change (Phi.symm A).PosSemidef
+  apply Matrix.unitaryReindexLinearEquiv_symm_posSemidef e₀ U hU
+  apply Matrix.PosSemidef.fromBlocks_diag Matrix.PosSemidef.zero
+  have hblocks :
+      (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k).PosSemidef :=
+    (Matrix.blockDiagonal'_posSemidef_iff
+      (fun k ↦ sigma k ⊗ₖ X k)).2 fun k ↦ (hsigma k).kronecker (hX k)
+  simpa only [Matrix.reindex_apply, Matrix.posSemidef_submatrix_equiv] using hblocks
+
+/-- Positive semidefiniteness in density-block coordinates is exactly componentwise
+positive semidefiniteness of the full-matrix factors. -/
+theorem densityBlockWithZeroEmbedding_posSemidef_iff
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigma : ∀ k, (sigma k).PosSemidef)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    (densityBlockWithZeroEmbedding e e₀ U hU sigma X).PosSemidef ↔
+      ∀ k, (X k).PosSemidef := by
+  constructor
+  · intro hX
+    have hcompressed := densityBlockWithZeroCompression_posSemidef
+      e e₀ U hU hX
+    simpa only [densityBlockWithZeroCompression_embedding
+      e e₀ U hU sigma hsigmaTrace X] using hcompressed
+  · exact densityBlockWithZeroEmbedding_posSemidef e e₀ U hU sigma hsigma
+
+/-- The ambient trace of an embedded density-block family is the sum of the traces of
+its full-matrix factors. -/
+theorem trace_densityBlockWithZeroEmbedding
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    (densityBlockWithZeroEmbedding e e₀ U hU sigma X).trace =
+      ∑ k, (X k).trace := by
+  rw [densityBlockWithZeroEmbedding_apply]
+  have hUleft : star U * U = 1 := Matrix.mem_unitaryGroup_iff'.mp hU
+  let A : Matrix (Fin n) (Fin n) ℂ :=
+    Matrix.reindex e e
+      (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k)
+  change Matrix.trace
+    (U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U) =
+      ∑ k, (X k).trace
+  calc
+    Matrix.trace
+        (U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U) =
+        Matrix.trace
+          (star U * (U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A))) :=
+      Matrix.trace_mul_comm _ _
+    _ = Matrix.trace
+        ((star U * U) * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A)) := by
+      rw [← Matrix.mul_assoc]
+    _ = Matrix.trace (Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A)) := by
+      rw [hUleft, Matrix.one_mul]
+    _ = Matrix.trace (Matrix.fromBlocks 0 0 0 A) := Matrix.trace_reindex e₀ _
+    _ = Matrix.trace A := trace_zeroBottomRightEmbedding A
+    _ = Matrix.trace
+        (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k) := Matrix.trace_reindex e _
+    _ = ∑ k, Matrix.trace (sigma k ⊗ₖ X k) := Matrix.trace_blockDiagonal' _
+    _ = ∑ k, (X k).trace := by
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [Matrix.trace_kronecker, hsigmaTrace, one_mul]
+
+/-- The trace-one positive cone in density-block coordinates is exactly the direct-sum
+density-state space used for Wolf's relative extreme points. -/
+theorem densityBlockWithZeroEmbedding_mem_densityMatrices_iff
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigma : ∀ k, (sigma k).PosSemidef)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    densityBlockWithZeroEmbedding e e₀ U hU sigma X ∈ densityMatrices D ↔
+      X ∈ directSumDensityMatrices d := by
+  simp only [mem_densityMatrices, Matrix.mem_directSumDensityMatrices,
+    densityBlockWithZeroEmbedding_posSemidef_iff e e₀ U hU sigma hsigma hsigmaTrace X,
+    trace_densityBlockWithZeroEmbedding e e₀ U hU sigma hsigmaTrace X]
+
+/-- Every encoded density-block family is fixed under the coordinate equation supplied by
+`IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero`. -/
+theorem densityBlockWithZeroEmbedding_fixed
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    {P : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hfixed : ∀ B, P B = B ↔
+      ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+        star U * B * U = Matrix.reindex e₀ e₀
+          (Matrix.fromBlocks 0 0 0
+            (Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))))
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    P (densityBlockWithZeroEmbedding e e₀ U hU sigma X) =
+      densityBlockWithZeroEmbedding e e₀ U hU sigma X := by
+  apply (hfixed _).mpr
+  refine ⟨X, ?_⟩
+  rw [densityBlockWithZeroEmbedding_apply]
+  have hUleft : star U * U = 1 := Matrix.mem_unitaryGroup_iff'.mp hU
+  calc
+    star U *
+          (U * Matrix.reindex e₀ e₀
+            (Matrix.fromBlocks 0 0 0
+              (Matrix.reindex e e
+                (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))) * star U) * U =
+        (star U * U) * Matrix.reindex e₀ e₀
+          (Matrix.fromBlocks 0 0 0
+            (Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))) * (star U * U) := by
+      simp only [Matrix.mul_assoc]
+    _ = Matrix.reindex e₀ e₀
+        (Matrix.fromBlocks 0 0 0
+          (Matrix.reindex e e
+            (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))) := by
+      rw [hUleft]
+      simp
+
+/-- Encoding the compressed coordinates of a fixed point reconstructs that fixed point.
+
+The hypothesis is exactly the fixed-point equation returned by
+`IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero`; in particular, this theorem
+does not introduce a second decomposition or strengthen the fixed-point contract. -/
+theorem densityBlockWithZeroEmbedding_compression_of_fixed
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    {P : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hfixed : ∀ B, P B = B ↔
+      ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+        star U * B * U = Matrix.reindex e₀ e₀
+          (Matrix.fromBlocks 0 0 0
+            (Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))))
+    {B : Matrix (Fin D) (Fin D) ℂ} (hB : P B = B) :
+    densityBlockWithZeroEmbedding e e₀ U hU sigma
+        (densityBlockWithZeroCompression e e₀ U hU B) = B := by
+  obtain ⟨X, hBcoord⟩ := (hfixed B).mp hB
+  let A : Matrix (Fin n) (Fin n) ℂ :=
+    Matrix.reindex e e
+      (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k)
+  have hcoord : Matrix.unitaryReindexLinearEquiv e₀ U hU B =
+      Matrix.fromBlocks 0 0 0 A := by
+    rw [Matrix.unitaryReindexLinearEquiv_apply, hBcoord]
+    simp [A]
+  have hcompression : densityBlockWithZeroCompression e e₀ U hU B = X := by
+    funext k
+    rw [densityBlockWithZeroCompression_apply, hcoord]
+    simp [A, Matrix.partialTraceLeft_kronecker, hsigmaTrace]
+  rw [hcompression, densityBlockWithZeroEmbedding_apply]
+  rw [← hBcoord]
+  have hUright : U * star U = 1 := Matrix.mem_unitaryGroup_iff.mp hU
+  calc
+    U * (star U * B * U) * star U =
+        (U * star U) * B * (U * star U) := by
+      simp only [Matrix.mul_assoc]
+    _ = B := by rw [hUright]; simp
+
+end Matrix

--- a/QICLean/Channel/Peripheral/DensityBlockDynamics.lean
+++ b/QICLean/Channel/Peripheral/DensityBlockDynamics.lean
@@ -1,0 +1,355 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Channel.FixedPoint.TraceNonincreasingDirectSum
+import QICLean.Channel.Peripheral.DensityBlockCoordinates
+import QICLean.Channel.Peripheral.RecurrentInverse
+
+/-!
+# Dynamics in Wolf's density-block coordinates
+
+This file transports the positive trace-preserving dynamics on Wolf's asymptotic
+image to the full-matrix factors in the density-block coordinates supplied by
+`IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero`.
+
+For the embedding `E` and compression `R` defined in
+`QICLean.Channel.Peripheral.DensityBlockCoordinates`, the transported map is
+
+`Abar = R.comp (A.comp E)`.
+
+Applied to `A = T` and to the recurrent restricted inverse `A = S` from
+`IsPositiveMap.exists_peripheralRestrictedInverse`, this gives Wolf's maps on the
+direct sum of the full matrix factors.  The formal factor order remains
+`sigma k ⊗ X k`, the reverse of Wolf's displayed tensor order and the convention
+already fixed by the density-block theorem.
+
+The results below establish only the transport needed for Wolf Theorem 6.16,
+lines 1641--1659: exact intertwining with `E`, mutual inverse identities,
+positivity, and preservation of the sum of the block traces.  They do not assert a
+global inverse for `T`, equality of multiplicity dimensions, a CP/Kraus
+classification, or the later unitary/transpose alternative.
+
+## Reference
+
+* M. M. Wolf, *Quantum Channels & Operations: Guided Tour*, proof of Theorem 6.16;
+  local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`,
+  lines 1637--1659.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder BigOperators Kronecker
+
+noncomputable section
+
+namespace Matrix
+
+/-- Transport an ambient matrix endomorphism to Wolf's full-matrix density-block
+coordinates by first encoding, then applying the ambient map, and finally compressing. -/
+noncomputable def densityBlockDynamics
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (A : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) :
+    Module.End ℂ (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :=
+  (densityBlockWithZeroCompression e e₀ U hU).comp
+    (A.comp (densityBlockWithZeroEmbedding e e₀ U hU sigma))
+
+@[simp]
+theorem densityBlockDynamics_apply
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (A : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    densityBlockDynamics e e₀ U hU sigma A X =
+      densityBlockWithZeroCompression e e₀ U hU
+        (A (densityBlockWithZeroEmbedding e e₀ U hU sigma X)) :=
+  rfl
+
+/-- Encoding after the transported action of `T` is exactly the ambient action of
+`T` on encoded coordinates.  The proof uses only that the encoded family is fixed
+by `T.peripheralProjection` and that the peripheral projection commutes with `T`. -/
+theorem densityBlockWithZeroEmbedding_densityBlockDynamics
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hfixed : ∀ B, T.peripheralProjection B = B ↔
+      ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+        star U * B * U = Matrix.reindex e₀ e₀
+          (Matrix.fromBlocks 0 0 0
+            (Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))))
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    densityBlockWithZeroEmbedding e e₀ U hU sigma
+        (densityBlockDynamics e e₀ U hU sigma T X) =
+      T (densityBlockWithZeroEmbedding e e₀ U hU sigma X) := by
+  apply densityBlockWithZeroEmbedding_compression_of_fixed
+    e e₀ U hU sigma hsigmaTrace hfixed
+  calc
+    T.peripheralProjection
+          (T (densityBlockWithZeroEmbedding e e₀ U hU sigma X)) =
+        T (T.peripheralProjection
+          (densityBlockWithZeroEmbedding e e₀ U hU sigma X)) :=
+      LinearMap.congr_fun T.peripheralProjection_comp _
+    _ = T (densityBlockWithZeroEmbedding e e₀ U hU sigma X) := by
+      rw [densityBlockWithZeroEmbedding_fixed e e₀ U hU sigma hfixed]
+
+/-- Encoding after the transported recurrent restricted inverse `S` is exactly
+the ambient action of `S` on encoded coordinates.  The absorption identity
+`T.peripheralProjection.comp S = S` is the precise replacement for a nonexistent
+global inverse. -/
+theorem densityBlockWithZeroEmbedding_densityBlockRestrictedInverse
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    {T S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hfixed : ∀ B, T.peripheralProjection B = B ↔
+      ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+        star U * B * U = Matrix.reindex e₀ e₀
+          (Matrix.fromBlocks 0 0 0
+            (Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))))
+    (hPS : T.peripheralProjection.comp S = S)
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    densityBlockWithZeroEmbedding e e₀ U hU sigma
+        (densityBlockDynamics e e₀ U hU sigma S X) =
+      S (densityBlockWithZeroEmbedding e e₀ U hU sigma X) := by
+  apply densityBlockWithZeroEmbedding_compression_of_fixed
+    e e₀ U hU sigma hsigmaTrace hfixed
+  exact LinearMap.congr_fun hPS _
+
+/-- On density-block coordinates, the recurrent restricted inverse is a left
+inverse for the transported action of `T`.  The ambient identity used is exactly
+`S.comp T = T.peripheralProjection`, not a global inverse equation. -/
+theorem densityBlockRestrictedInverse_comp_densityBlockDynamics
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    {T S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hfixed : ∀ B, T.peripheralProjection B = B ↔
+      ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+        star U * B * U = Matrix.reindex e₀ e₀
+          (Matrix.fromBlocks 0 0 0
+            (Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))))
+    (hST : S.comp T = T.peripheralProjection) :
+    (densityBlockDynamics e e₀ U hU sigma S).comp
+        (densityBlockDynamics e e₀ U hU sigma T) = LinearMap.id := by
+  apply LinearMap.ext
+  intro X
+  change densityBlockWithZeroCompression e e₀ U hU
+      (S (densityBlockWithZeroEmbedding e e₀ U hU sigma
+        (densityBlockDynamics e e₀ U hU sigma T X))) = X
+  rw [densityBlockWithZeroEmbedding_densityBlockDynamics
+    e e₀ U hU sigma hsigmaTrace hfixed X]
+  rw [show S (T (densityBlockWithZeroEmbedding e e₀ U hU sigma X)) =
+      T.peripheralProjection
+        (densityBlockWithZeroEmbedding e e₀ U hU sigma X) from
+    LinearMap.congr_fun hST _]
+  rw [densityBlockWithZeroEmbedding_fixed e e₀ U hU sigma hfixed]
+  exact densityBlockWithZeroCompression_embedding
+    e e₀ U hU sigma hsigmaTrace X
+
+/-- On density-block coordinates, the transported action of `T` is a left
+inverse for the recurrent restricted inverse.  The proof uses the second
+restricted identity `T.comp S = T.peripheralProjection` together with the
+absorption identity that keeps the image of `S` inside the asymptotic image. -/
+theorem densityBlockDynamics_comp_densityBlockRestrictedInverse
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    {T S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hfixed : ∀ B, T.peripheralProjection B = B ↔
+      ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+        star U * B * U = Matrix.reindex e₀ e₀
+          (Matrix.fromBlocks 0 0 0
+            (Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))))
+    (hTS : T.comp S = T.peripheralProjection)
+    (hPS : T.peripheralProjection.comp S = S) :
+    (densityBlockDynamics e e₀ U hU sigma T).comp
+        (densityBlockDynamics e e₀ U hU sigma S) = LinearMap.id := by
+  apply LinearMap.ext
+  intro X
+  change densityBlockWithZeroCompression e e₀ U hU
+      (T (densityBlockWithZeroEmbedding e e₀ U hU sigma
+        (densityBlockDynamics e e₀ U hU sigma S X))) = X
+  rw [densityBlockWithZeroEmbedding_densityBlockRestrictedInverse
+    e e₀ U hU sigma hsigmaTrace hfixed hPS X]
+  rw [show T (S (densityBlockWithZeroEmbedding e e₀ U hU sigma X)) =
+      T.peripheralProjection
+        (densityBlockWithZeroEmbedding e e₀ U hU sigma X) from
+    LinearMap.congr_fun hTS _]
+  rw [densityBlockWithZeroEmbedding_fixed e e₀ U hU sigma hfixed]
+  exact densityBlockWithZeroCompression_embedding
+    e e₀ U hU sigma hsigmaTrace X
+
+/-- Positivity of an ambient map descends to positivity on every full-matrix
+factor in Wolf's density-block coordinates. -/
+theorem densityBlockDynamics_isPositiveDirectSumMap
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigma : ∀ k, (sigma k).PosSemidef)
+    {A : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hA : IsPositiveMap A) :
+    IsPositiveDirectSumMap (densityBlockDynamics e e₀ U hU sigma A) := by
+  intro X hX k
+  apply densityBlockWithZeroCompression_posSemidef e e₀ U hU
+  exact hA _
+    (densityBlockWithZeroEmbedding_posSemidef
+      e e₀ U hU sigma hsigma hX)
+
+/-- Trace preservation of an ambient map descends to preservation of the total
+trace of the full-matrix factors whenever its transported action intertwines
+with the density-block embedding. -/
+theorem densityBlockDynamics_isTracePreservingBetweenDirectSums
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    {A : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hA : IsTracePreservingMap A)
+    (hencode : ∀ X,
+      densityBlockWithZeroEmbedding e e₀ U hU sigma
+          (densityBlockDynamics e e₀ U hU sigma A X) =
+        A (densityBlockWithZeroEmbedding e e₀ U hU sigma X)) :
+    IsTracePreservingBetweenDirectSums
+      (densityBlockDynamics e e₀ U hU sigma A) := by
+  intro X
+  calc
+    ∑ k, (densityBlockDynamics e e₀ U hU sigma A X k).trace =
+        (densityBlockWithZeroEmbedding e e₀ U hU sigma
+          (densityBlockDynamics e e₀ U hU sigma A X)).trace :=
+      (trace_densityBlockWithZeroEmbedding
+        e e₀ U hU sigma hsigmaTrace _).symm
+    _ = (A (densityBlockWithZeroEmbedding e e₀ U hU sigma X)).trace := by
+      rw [hencode X]
+    _ = (densityBlockWithZeroEmbedding e e₀ U hU sigma X).trace := hA _
+    _ = ∑ k, (X k).trace :=
+      trace_densityBlockWithZeroEmbedding e e₀ U hU sigma hsigmaTrace X
+
+end Matrix
+
+open Matrix
+
+namespace IsPositiveMap
+
+/-- **Wolf Theorem 6.16, density-block dynamics package.**
+
+For a positive trace-preserving map whose trace adjoint is Schwarz, choose the
+zero-extended density-block coordinates of
+`IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero` for
+`T.peripheralProjection`, and choose the recurrent restricted inverse `S` of
+`IsPositiveMap.exists_peripheralRestrictedInverse`.  In the exact witness order
+of the fixed-point theorem, this produces the transported maps
+
+`Tbar = R.comp (T.comp E)` and `Sbar = R.comp (S.comp E)`.
+
+They intertwine with the ambient maps under `E`, are mutually inverse on the
+direct sum, are positive, and preserve the total trace.  These are precisely
+the hypotheses consumed by the subsequent pure-state face-permutation argument
+at Wolf Theorem 6.16, lines 1641--1659.  The conclusion is restricted to the
+asymptotic-image coordinates and does not assert that `T` has a global inverse. -/
+theorem exists_peripheralDensityBlockDynamics
+    {D : ℕ} [NeZero D]
+    {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hPos : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hAdjointSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T)) :
+    ∃ (n K : ℕ) (d m : Fin K → ℕ)
+      (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+      (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+      (U : Matrix (Fin D) (Fin D) ℂ)
+      (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+      (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+      (S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)),
+      (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ k, (sigma k).PosDef) ∧ (∀ k, (sigma k).trace = 1) ∧
+        (∀ B, T.peripheralProjection B = B ↔
+          ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+            star U * B * U = Matrix.reindex e₀ e₀
+              (Matrix.fromBlocks 0 0 0
+                (Matrix.reindex e e
+                  (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k)))) ∧
+        IsPositiveMap S ∧ IsTracePreservingMap S ∧
+        (let Tbar := Matrix.densityBlockDynamics e e₀ U hU sigma T
+         let Sbar := Matrix.densityBlockDynamics e e₀ U hU sigma S
+         (∀ X, Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma (Tbar X) =
+            T (Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma X)) ∧
+         (∀ X, Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma (Sbar X) =
+            S (Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma X)) ∧
+         Sbar.comp Tbar = LinearMap.id ∧
+         Tbar.comp Sbar = LinearMap.id ∧
+         Matrix.IsPositiveDirectSumMap Tbar ∧
+         Matrix.IsPositiveDirectSumMap Sbar ∧
+         Matrix.IsTracePreservingBetweenDirectSums Tbar ∧
+         Matrix.IsTracePreservingBetweenDirectSums Sbar) := by
+  have hPPos : IsPositiveMap T.peripheralProjection :=
+    hPos.peripheralProjection_isPositiveMap hTP
+  have hPTP : IsTracePreservingMap T.peripheralProjection :=
+    hPos.peripheralProjection_isTracePreservingMap hTP
+  have hPAdjointSchwarz :
+      IsSchwarzMap (Matrix.traceAdjointMap T.peripheralProjection) :=
+    hPos.traceAdjointMap_peripheralProjection_isSchwarzMap hTP hAdjointSchwarz
+  obtain ⟨n, K, d, m, e, e₀, U, sigma, hU, hd, hm, hsigma,
+      hsigmaTrace, hfixed⟩ :=
+    hPPos.exists_fixedPoints_densityBlocks_with_zero hPTP hPAdjointSchwarz
+  obtain ⟨S, hSPos, hSTP, hST, hTS, _hSP, hPS, _hRange⟩ :=
+    hPos.exists_peripheralRestrictedInverse hTP
+  refine ⟨n, K, d, m, e, e₀, U, sigma, hU, S, hd, hm, hsigma,
+    hsigmaTrace, hfixed, hSPos, hSTP, ?_⟩
+  dsimp only
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · exact Matrix.densityBlockWithZeroEmbedding_densityBlockDynamics
+      e e₀ U hU sigma hsigmaTrace hfixed
+  · exact Matrix.densityBlockWithZeroEmbedding_densityBlockRestrictedInverse
+      e e₀ U hU sigma hsigmaTrace hfixed hPS
+  · exact Matrix.densityBlockRestrictedInverse_comp_densityBlockDynamics
+      e e₀ U hU sigma hsigmaTrace hfixed hST
+  · exact Matrix.densityBlockDynamics_comp_densityBlockRestrictedInverse
+      e e₀ U hU sigma hsigmaTrace hfixed hTS hPS
+  · exact Matrix.densityBlockDynamics_isPositiveDirectSumMap
+      e e₀ U hU sigma (fun k ↦ (hsigma k).posSemidef) hPos
+  · exact Matrix.densityBlockDynamics_isPositiveDirectSumMap
+      e e₀ U hU sigma (fun k ↦ (hsigma k).posSemidef) hSPos
+  · exact Matrix.densityBlockDynamics_isTracePreservingBetweenDirectSums
+      e e₀ U hU sigma hsigmaTrace hTP
+        (Matrix.densityBlockWithZeroEmbedding_densityBlockDynamics
+          e e₀ U hU sigma hsigmaTrace hfixed)
+  · exact Matrix.densityBlockDynamics_isTracePreservingBetweenDirectSums
+      e e₀ U hU sigma hsigmaTrace hSTP
+        (Matrix.densityBlockWithZeroEmbedding_densityBlockRestrictedInverse
+          e e₀ U hU sigma hsigmaTrace hfixed hPS)
+
+end IsPositiveMap

--- a/QICLean/Channel/Peripheral/DensityBlockFacePermutation.lean
+++ b/QICLean/Channel/Peripheral/DensityBlockFacePermutation.lean
@@ -1,0 +1,204 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Channel.Peripheral.DensityBlockDynamics
+import QICLean.Channel.Peripheral.DirectSumFacePermutation
+
+/-!
+# Wolf's permutation of density-block pure-state faces
+
+This file assembles the density-block coordinates of Wolf Theorem 6.14, the
+positive trace-preserving recurrent inverse on the asymptotic image, and Wolf's
+extreme-state/continuity argument from the proof of Theorem 6.16.  It covers
+exactly the source step at
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1641--1659.
+
+The formal coordinates use `sigma k ⊗ X k`, the tensor-factor order fixed by
+`IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero`.  The resulting
+equivalence sends a source block to its target block.  Its inverse is Wolf's
+output-to-input permutation `pi` in the displayed formula at lines 1656--1659.
+
+This is an intentionally partial boundary of Theorem 6.16.  It proves equality
+only of the full-matrix dimensions `d`, not of the multiplicity dimensions `m`.
+Transport of the ordinary Schwarz inequality to the matched block maps,
+comparison of multiplicities, exclusion of the transpose alternative in the
+assembled density-block coordinates, and Equation (6.68) remain separate
+follow-up work.  No CP/Kraus or ring-ideal classification is used.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder BigOperators Kronecker
+
+noncomputable section
+
+namespace Matrix
+
+variable {iota kappa : Type*}
+variable [Finite iota] [DecidableEq iota]
+variable [Finite kappa] [DecidableEq kappa]
+variable {d : iota → ℕ} {e : kappa → ℕ}
+variable [∀ i, NeZero (d i)] [∀ j, NeZero (e j)]
+
+omit [∀ i, NeZero (d i)] [∀ j, NeZero (e j)] in
+/-- The full-family form of the forward block action.  At output block `j`,
+the input is read from `F.blockEquiv.symm j`, which is Wolf's permutation `pi`. -/
+theorem DirectSumFacePermutation.map_apply
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S)
+    (X : ∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) (j : kappa) :
+    T X j = directSumBlockMap T (F.blockEquiv.symm j) j
+      (X (F.blockEquiv.symm j)) := by
+  classical
+  let := Fintype.ofFinite iota
+  let := Fintype.ofFinite kappa
+  calc
+    T X j = T (∑ i, Pi.single i (X i)) j := by
+      rw [Finset.univ_sum_single]
+    _ = (∑ i, T (Pi.single i (X i))) j := by rw [map_sum]
+    _ = ∑ i, T (Pi.single i (X i)) j := by rw [Finset.sum_apply]
+    _ = ∑ i, (Pi.single (F.blockEquiv i)
+        (directSumBlockMap T i (F.blockEquiv i) (X i)) :
+          ∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) j := by
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [F.map_single]
+    _ = directSumBlockMap T (F.blockEquiv.symm j) j
+        (X (F.blockEquiv.symm j)) := by
+      rw [Finset.sum_eq_single (F.blockEquiv.symm j)]
+      · rw [F.blockEquiv.apply_symm_apply, Pi.single_eq_same]
+      · intro i _ hi
+        rw [Pi.single_eq_of_ne]
+        intro hji
+        apply hi
+        apply F.blockEquiv.injective
+        rw [Equiv.apply_symm_apply]
+        exact hji.symm
+      · simp
+
+omit [∀ i, NeZero (d i)] [∀ j, NeZero (e j)] in
+/-- The full-family form of the inverse block action. -/
+theorem DirectSumFacePermutation.inverse_apply
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S)
+    (Y : ∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) (i : iota) :
+    S Y i = directSumBlockMap S (F.blockEquiv i) i (Y (F.blockEquiv i)) := by
+  classical
+  let := Fintype.ofFinite iota
+  let := Fintype.ofFinite kappa
+  calc
+    S Y i = S (∑ j, Pi.single j (Y j)) i := by
+      rw [Finset.univ_sum_single]
+    _ = (∑ j, S (Pi.single j (Y j))) i := by rw [map_sum]
+    _ = ∑ j, S (Pi.single j (Y j)) i := by rw [Finset.sum_apply]
+    _ = ∑ j, (Pi.single (F.blockEquiv.symm j)
+        (directSumBlockMap S j (F.blockEquiv.symm j) (Y j)) :
+          ∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) i := by
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [F.inverse_map_single]
+    _ = directSumBlockMap S (F.blockEquiv i) i (Y (F.blockEquiv i)) := by
+      rw [Finset.sum_eq_single (F.blockEquiv i)]
+      · rw [F.blockEquiv.symm_apply_apply, Pi.single_eq_same]
+      · intro j _ hj
+        rw [Pi.single_eq_of_ne]
+        intro hij
+        apply hj
+        apply F.blockEquiv.symm.injective
+        rw [Equiv.symm_apply_apply]
+        exact hij.symm
+      · simp
+
+end Matrix
+
+open Matrix
+
+namespace IsPositiveMap
+
+/-- **Wolf Theorem 6.16, permutation of density-block pure-state faces.**
+
+Under the trace-adjoint Schwarz hypothesis needed to apply Wolf Theorem 6.14
+to the recurrent projection, the asymptotic-image coordinates carry mutually
+inverse positive trace-preserving maps `Tbar` and `Sbar`.  Their relative pure
+states determine a source-to-target block equivalence.  If `tau` denotes that
+equivalence, then `tau.symm` is Wolf's output-to-input permutation `pi`:
+the output block `j` depends only on the input block `pi j`.
+
+The returned `DirectSumFacePermutation` exposes the matched block maps, their
+single-block and full-family actions, positivity, ordinary trace preservation,
+two-sided inverse identities, and `d i = d (tau i)`.  No equality involving
+the multiplicities `m` is asserted.  The ordinary Schwarz transport and the
+later unitary/transpose classification are deliberately outside this theorem. -/
+theorem exists_peripheralDensityBlockFacePermutation
+    {D : ℕ} [NeZero D]
+    {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hPos : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hAdjointSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T)) :
+    ∃ (n K : ℕ) (d m : Fin K → ℕ)
+      (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+      (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+      (U : Matrix (Fin D) (Fin D) ℂ)
+      (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+      (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+      (S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)),
+      (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ k, (sigma k).PosDef) ∧ (∀ k, (sigma k).trace = 1) ∧
+        (∀ B, T.peripheralProjection B = B ↔
+          ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+            star U * B * U = Matrix.reindex e₀ e₀
+              (Matrix.fromBlocks 0 0 0
+                (Matrix.reindex e e
+                  (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k)))) ∧
+        IsPositiveMap S ∧ IsTracePreservingMap S ∧
+        (let Tbar := Matrix.densityBlockDynamics e e₀ U hU sigma T
+         let Sbar := Matrix.densityBlockDynamics e e₀ U hU sigma S
+         (∀ X, Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma (Tbar X) =
+            T (Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma X)) ∧
+         (∀ X, Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma (Sbar X) =
+            S (Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma X)) ∧
+         Sbar.comp Tbar = LinearMap.id ∧
+         Tbar.comp Sbar = LinearMap.id ∧
+         Matrix.IsPositiveDirectSumMap Tbar ∧
+         Matrix.IsPositiveDirectSumMap Sbar ∧
+         Matrix.IsTracePreservingBetweenDirectSums Tbar ∧
+         Matrix.IsTracePreservingBetweenDirectSums Sbar ∧
+         ∃ F : Matrix.DirectSumFacePermutation Tbar Sbar,
+           let pi := F.blockEquiv.symm
+           (∀ X j, Tbar X j = Matrix.directSumBlockMap Tbar (pi j) j (X (pi j))) ∧
+           (∀ Y i, Sbar Y i =
+             Matrix.directSumBlockMap Sbar (pi.symm i) i (Y (pi.symm i))) ∧
+           ∀ j, d (pi j) = d j) := by
+  obtain ⟨n, K, d, m, e, e₀, U, sigma, hU, S, hd, hm, hsigma,
+      hsigmaTrace, hfixed, hSPos, hSTP, hDynamics⟩ :=
+    hPos.exists_peripheralDensityBlockDynamics hTP hAdjointSchwarz
+  dsimp only at hDynamics
+  rcases hDynamics with
+    ⟨hTencode, hSencode, hST, hTS, hTPos, hSbarPos, hTTP, hSTPbar⟩
+  let Tbar := Matrix.densityBlockDynamics e e₀ U hU sigma T
+  let Sbar := Matrix.densityBlockDynamics e e₀ U hU sigma S
+  let : ∀ k, NeZero (d k) := fun k ↦ ⟨Nat.ne_of_gt (hd k)⟩
+  have hTBetween : Matrix.IsPositiveBetweenDirectSums Tbar := by
+    exact hTPos
+  have hSBetween : Matrix.IsPositiveBetweenDirectSums Sbar := by
+    exact hSbarPos
+  obtain ⟨F⟩ := Matrix.exists_directSumFacePermutation_of_mutualInverse
+    hTBetween hSBetween hTTP hSTPbar hST hTS
+  have hDimension : ∀ j, d (F.blockEquiv.symm j) = d j := by
+    intro j
+    simpa only [Equiv.apply_symm_apply] using
+      F.dimension_eq (F.blockEquiv.symm j)
+  refine ⟨n, K, d, m, e, e₀, U, sigma, hU, S, hd, hm, hsigma,
+    hsigmaTrace, hfixed, hSPos, hSTP, ?_⟩
+  dsimp only
+  refine ⟨hTencode, hSencode, hST, hTS, hTPos, hSbarPos,
+    hTTP, hSTPbar, F, ?_⟩
+  exact ⟨F.map_apply, F.inverse_apply, hDimension⟩
+
+end IsPositiveMap

--- a/QICLean/Channel/Peripheral/DirectSumFacePermutation.lean
+++ b/QICLean/Channel/Peripheral/DirectSumFacePermutation.lean
@@ -1,0 +1,523 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Channel.FixedPoint.ExtremeDensityStates
+import QICLean.Channel.FixedPoint.TraceNonincreasingDirectSum
+import QICLean.Channel.Peripheral.PureStateFace
+import QICLean.Channel.Wigner.ProjectivePureState
+
+/-!
+# Permutation of pure-state faces in finite matrix direct sums
+
+This module follows the extreme-state and continuity argument in Wolf's proof
+of Theorem 6.16, lines 1641--1659. Mutually inverse positive
+trace-preserving maps between finite direct sums preserve relative pure states.
+Connectedness makes the target summand independent of the pure state inside a
+fixed source summand, and the inverse map then gives a permutation of summands
+with equal full-matrix dimensions.
+
+Only the full-matrix dimensions are compared here. No multiplicity dimension,
+complete-positivity hypothesis, Kraus representation, or classification of
+the induced block maps is used.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder BigOperators
+
+noncomputable section
+
+namespace Matrix
+
+variable {ι κ : Type*}
+variable [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
+variable {d : ι → ℕ} {e : κ → ℕ}
+variable [∀ i, NeZero (d i)] [∀ j, NeZero (e j)]
+
+/-- Positivity for a linear map between two finite direct sums of full matrix
+algebras. -/
+def IsPositiveBetweenDirectSums
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)) : Prop :=
+  ∀ A, (∀ i, (A i).PosSemidef) → ∀ j, (T A j).PosSemidef
+
+/-- The component from source block `i` to target block `j` of a linear map
+between finite matrix direct sums. -/
+def directSumBlockMap
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ))
+    (i : ι) (j : κ) :
+    Matrix (Fin (d i)) (Fin (d i)) ℂ →ₗ[ℂ]
+      Matrix (Fin (e j)) (Fin (e j)) ℂ where
+  toFun X := T (Pi.single i X) j
+  map_add' X Y := by
+    simp only [Pi.single_add, map_add, Pi.add_apply]
+  map_smul' c X := by
+    simp only [Pi.single_smul, map_smul, Pi.smul_apply, RingHom.id_apply]
+
+omit [DecidableEq ι] [DecidableEq κ]
+    [∀ i, NeZero (d i)] [∀ j, NeZero (e j)] in
+/-- A positive total-trace-preserving map sends direct-sum density states to
+direct-sum density states. -/
+theorem IsPositiveBetweenDirectSums.mapsTo_directSumDensityMatrices
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    (hT : IsPositiveBetweenDirectSums T)
+    (hTP : IsTracePreservingBetweenDirectSums T) :
+    Set.MapsTo T (directSumDensityMatrices d) (directSumDensityMatrices e) := by
+  intro A hA
+  exact ⟨hT A hA.1, (hTP A).trans hA.2⟩
+
+omit [DecidableEq ι] [DecidableEq κ]
+    [∀ i, NeZero (d i)] [∀ j, NeZero (e j)] in
+/-- Mutually inverse positive trace-preserving maps preserve relative pure
+states in the forward direction. -/
+theorem mapsTo_extremePoints_directSumDensityMatrices_of_mutualInverse
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (hT : IsPositiveBetweenDirectSums T)
+    (hS : IsPositiveBetweenDirectSums S)
+    (hTTP : IsTracePreservingBetweenDirectSums T)
+    (hSTP : IsTracePreservingBetweenDirectSums S)
+    (hST : S.comp T = LinearMap.id)
+    (hTS : T.comp S = LinearMap.id) :
+    Set.MapsTo T
+      (Set.extremePoints ℝ (directSumDensityMatrices d))
+      (Set.extremePoints ℝ (directSumDensityMatrices e)) := by
+  intro P hP
+  refine mem_extremePoints_iff_left.mpr ?_
+  refine ⟨hT.mapsTo_directSumDensityMatrices hTTP hP.1, ?_⟩
+  intro A hA B hB hsegment
+  have hSA : S A ∈ directSumDensityMatrices d :=
+    hS.mapsTo_directSumDensityMatrices hSTP hA
+  have hSB : S B ∈ directSumDensityMatrices d :=
+    hS.mapsTo_directSumDensityMatrices hSTP hB
+  rcases hsegment with ⟨a, b, ha, hb, hab, hcombo⟩
+  have hsegmentS : P ∈ openSegment ℝ (S A) (S B) := by
+    refine ⟨a, b, ha, hb, hab, ?_⟩
+    have hcomboC : (a : ℂ) • A + (b : ℂ) • B = T P := by
+      simpa only [Complex.coe_smul] using hcombo
+    calc
+      a • S A + b • S B = (a : ℂ) • S A + (b : ℂ) • S B := by
+        simp only [Complex.coe_smul]
+      _ = S ((a : ℂ) • A + (b : ℂ) • B) := by
+        rw [map_add, map_smul, map_smul]
+      _ = S (T P) := congrArg S hcomboC
+      _ = P := LinearMap.congr_fun hST P
+  have hSAeq : S A = P := hP.2 hSA hSB hsegmentS
+  calc
+    A = T (S A) := (LinearMap.congr_fun hTS A).symm
+    _ = T P := congrArg T hSAeq
+
+omit [∀ i, NeZero (d i)] [∀ j, NeZero (e j)] in
+private theorem exists_targetBlock_of_rankOne
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    (hT : Set.MapsTo T
+      (Set.extremePoints ℝ (directSumDensityMatrices d))
+      (Set.extremePoints ℝ (directSumDensityMatrices e)))
+    (i : ι) {P : Matrix (Fin (d i)) (Fin (d i)) ℂ}
+    (hP : IsRankOneOrthogonalProjection P) :
+    ∃ j Q, IsRankOneOrthogonalProjection Q ∧
+      T (Pi.single i P) = Pi.single j Q := by
+  have hout := hT
+    ((mem_extremePoints_directSumDensityMatrices_iff (d := d)).mpr
+      ⟨i, P, hP, rfl⟩)
+  exact (mem_extremePoints_directSumDensityMatrices_iff (d := e)).mp hout
+
+omit [∀ j, NeZero (e j)] in
+private theorem exists_targetBlock_assignment
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    (hT : Set.MapsTo T
+      (Set.extremePoints ℝ (directSumDensityMatrices d))
+      (Set.extremePoints ℝ (directSumDensityMatrices e))) :
+    ∃ τ : ι → κ, ∀ i P, IsRankOneOrthogonalProjection P →
+      ∃ Q, IsRankOneOrthogonalProjection Q ∧
+        T (Pi.single i P) = Pi.single (τ i) Q := by
+  classical
+  have hassignment : ∀ i, ∃ j, ∀ P, IsRankOneOrthogonalProjection P →
+      ∃ Q, IsRankOneOrthogonalProjection Q ∧
+        T (Pi.single i P) = Pi.single j Q := by
+    intro i
+    let C : Set (Matrix (Fin (d i)) (Fin (d i)) ℂ) :=
+      pureStateProj '' {psi : Fin (d i) → ℂ | IsUnitVector psi}
+    have hC : IsConnected C := isConnected_pureStateProj_image (NeZero.pos (d i))
+    obtain ⟨P₀, hP₀⟩ := hC.nonempty
+    rcases hP₀ with ⟨psi₀, hpsi₀, rfl⟩
+    have hproj₀ : IsRankOneOrthogonalProjection (pureStateProj psi₀) :=
+      hpsi₀.isRankOneOrthogonalProjection_pureStateProj
+    obtain ⟨j₀, Q₀, hQ₀, hout₀⟩ := exists_targetBlock_of_rankOne hT i hproj₀
+    refine ⟨j₀, ?_⟩
+    intro P hP
+    obtain ⟨psi, hpsi, hpsiP⟩ :=
+      IsRankOneOrthogonalProjection.exists_isUnitVector_pureStateProj hP
+    subst P
+    obtain ⟨j, Q, hQ, hout⟩ := exists_targetBlock_of_rankOne hT i
+      hpsi.isRankOneOrthogonalProjection_pureStateProj
+    have hfContinuous : Continuous (fun X : Matrix (Fin (d i)) (Fin (d i)) ℂ ↦
+        (T (Pi.single i X) j₀).trace.re) :=
+      Complex.continuous_re.comp
+        ((directSumBlockMap T i j₀).continuous_of_finiteDimensional.matrix_trace)
+    have hfMapsTo : Set.MapsTo
+        (fun X : Matrix (Fin (d i)) (Fin (d i)) ℂ ↦
+          (T (Pi.single i X) j₀).trace.re)
+        C ({0, 1} : Set ℝ) := by
+      rintro X ⟨phi, hphi, rfl⟩
+      obtain ⟨l, R, hR, houtR⟩ := exists_targetBlock_of_rankOne hT i
+        hphi.isRankOneOrthogonalProjection_pureStateProj
+      change (T (Pi.single i (pureStateProj phi)) j₀).trace.re ∈ ({0, 1} : Set ℝ)
+      by_cases hl : j₀ = l
+      · subst l
+        rw [houtR, Pi.single_eq_same]
+        simp [IsRankOneOrthogonalProjection.mem_densityMatrices hR |>.2]
+      · rw [houtR, Pi.single_eq_of_ne hl]
+        simp
+    have hfEq := hC.isPreconnected.constant_of_mapsTo
+      (Set.toFinite ({0, 1} : Set ℝ)).isDiscrete hfContinuous.continuousOn hfMapsTo
+      ⟨psi, hpsi, rfl⟩ ⟨psi₀, hpsi₀, rfl⟩
+    have hf₀ : (T (Pi.single i (pureStateProj psi₀)) j₀).trace.re = 1 := by
+      rw [hout₀, Pi.single_eq_same]
+      simp [IsRankOneOrthogonalProjection.mem_densityMatrices hQ₀ |>.2]
+    have hf : (T (Pi.single i (pureStateProj psi)) j₀).trace.re = 1 := hfEq.trans hf₀
+    have hj : j = j₀ := by
+      by_contra hj
+      have hj₀ : j₀ ≠ j := Ne.symm hj
+      have hfzero : (T (Pi.single i (pureStateProj psi)) j₀).trace.re = 0 := by
+        rw [hout, Pi.single_eq_of_ne hj₀]
+        simp
+      linarith
+    subst j
+    exact ⟨Q, hQ, hout⟩
+  choose τ hτ using hassignment
+  exact ⟨τ, hτ⟩
+
+private theorem isRankOneOrthogonalProjection_pureStateMatrix
+    (p : Projectivization ℂ (Fin D → ℂ)) :
+    IsRankOneOrthogonalProjection (Projectivization.pureStateMatrix p) := by
+  have hP := Projectivization.isOrthogonalProjection_pureStateMatrix p
+  refine ⟨hP, ?_⟩
+  have hrank := hP.1.rank_eq_trace_re_of_idem hP.2
+  rw [Projectivization.trace_pureStateMatrix] at hrank
+  norm_num at hrank ⊢
+  exact_mod_cast hrank
+
+omit [Fintype ι] [Fintype κ]
+    [∀ i, NeZero (d i)] [∀ j, NeZero (e j)] in
+private theorem directSumBlockMap_eq_zero_of_ne
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {τ : ι → κ}
+    (hτ : ∀ i P, IsRankOneOrthogonalProjection P →
+      ∃ Q, IsRankOneOrthogonalProjection Q ∧
+        T (Pi.single i P) = Pi.single (τ i) Q)
+    (i : ι) {j : κ} (hj : j ≠ τ i) :
+    directSumBlockMap T i j = 0 := by
+  apply Projectivization.linearMap_eq_of_eq_on_pureStateMatrix
+  intro p
+  obtain ⟨Q, hQ, hout⟩ := hτ i (Projectivization.pureStateMatrix p)
+    (isRankOneOrthogonalProjection_pureStateMatrix p)
+  change T (Pi.single i (Projectivization.pureStateMatrix p)) j = 0
+  rw [hout, Pi.single_eq_of_ne hj]
+
+omit [Fintype ι] [Fintype κ]
+    [∀ i, NeZero (d i)] [∀ j, NeZero (e j)] in
+private theorem map_single_eq_single_targetBlock
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {τ : ι → κ}
+    (hτ : ∀ i P, IsRankOneOrthogonalProjection P →
+      ∃ Q, IsRankOneOrthogonalProjection Q ∧
+        T (Pi.single i P) = Pi.single (τ i) Q)
+    (i : ι) (X : Matrix (Fin (d i)) (Fin (d i)) ℂ) :
+    T (Pi.single i X) = Pi.single (τ i) (directSumBlockMap T i (τ i) X) := by
+  classical
+  funext j
+  by_cases hj : j = τ i
+  · subst j
+    rw [Pi.single_eq_same]
+    rfl
+  · rw [Pi.single_eq_of_ne hj]
+    exact LinearMap.congr_fun (directSumBlockMap_eq_zero_of_ne hτ i hj) X
+
+private theorem exists_rankOneOrthogonalProjection (D : ℕ) [NeZero D] :
+    ∃ P : Matrix (Fin D) (Fin D) ℂ, IsRankOneOrthogonalProjection P := by
+  have hC := isConnected_pureStateProj_image (NeZero.pos D)
+  obtain ⟨P, psi, hpsi, rfl⟩ := hC.nonempty
+  exact ⟨pureStateProj psi,
+    hpsi.isRankOneOrthogonalProjection_pureStateProj⟩
+
+omit [Fintype ι] [∀ i, NeZero (d i)] in
+private theorem index_eq_of_single_eq_single_rankOne
+    {a b : ι} {P : Matrix (Fin (d a)) (Fin (d a)) ℂ}
+    {Q : Matrix (Fin (d b)) (Fin (d b)) ℂ}
+    (hP : IsRankOneOrthogonalProjection P)
+    (heq : (Pi.single a P : ∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) =
+      Pi.single b Q) : a = b := by
+  classical
+  by_contra hab
+  have hsame :
+      (Pi.single a P : ∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) a = P :=
+    by simp only [Pi.single_eq_same]
+  have hdiff :
+      (Pi.single b Q : ∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) a = 0 :=
+    by simp only [Pi.single_eq_of_ne hab]
+  have hzero : P = 0 := hsame.symm.trans ((congrFun heq a).trans hdiff)
+  have hrank := hP.2
+  rw [hzero] at hrank
+  simp at hrank
+
+omit [∀ i, NeZero (d i)] in
+private theorem sum_trace_pi_single
+    (i : ι) (X : Matrix (Fin (d i)) (Fin (d i)) ℂ) :
+    ∑ k, ((Pi.single i X : ∀ l, Matrix (Fin (d l)) (Fin (d l)) ℂ) k).trace =
+      X.trace := by
+  classical
+  rw [Finset.sum_eq_single i]
+  · simp only [Pi.single_eq_same]
+  · intro k _ hki
+    rw [Pi.single_eq_of_ne hki, Matrix.trace_zero]
+  · simp
+
+/-- The block permutation and the induced maps supplied by Wolf's pure-face
+argument for mutually inverse positive trace-preserving direct-sum maps.
+
+The field `dimension_eq` compares only the full-matrix dimensions. -/
+structure DirectSumFacePermutation
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ))
+    (S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)) where
+  /-- The permutation of full-matrix summands. -/
+  blockEquiv : ι ≃ κ
+  /-- The forward map is supported on the matched target summand. -/
+  map_single : ∀ i X,
+    T (Pi.single i X) =
+      Pi.single (blockEquiv i) (directSumBlockMap T i (blockEquiv i) X)
+  /-- The inverse map is supported on the matched source summand. -/
+  inverse_map_single : ∀ j Y,
+    S (Pi.single j Y) =
+      Pi.single (blockEquiv.symm j)
+        (directSumBlockMap S j (blockEquiv.symm j) Y)
+  /-- A matched forward block map is positive. -/
+  blockMap_pos : ∀ i X, X.PosSemidef →
+    (directSumBlockMap T i (blockEquiv i) X).PosSemidef
+  /-- A matched inverse block map is positive. -/
+  inverseBlockMap_pos : ∀ j Y, Y.PosSemidef →
+    (directSumBlockMap S j (blockEquiv.symm j) Y).PosSemidef
+  /-- A matched forward block map preserves the ordinary matrix trace. -/
+  blockMap_trace : ∀ i X,
+    (directSumBlockMap T i (blockEquiv i) X).trace = X.trace
+  /-- A matched inverse block map preserves the ordinary matrix trace. -/
+  inverseBlockMap_trace : ∀ j Y,
+    (directSumBlockMap S j (blockEquiv.symm j) Y).trace = Y.trace
+  /-- The matched inverse block map is a left inverse. -/
+  blockMap_leftInverse : ∀ i X,
+    directSumBlockMap S (blockEquiv i) i
+      (directSumBlockMap T i (blockEquiv i) X) = X
+  /-- The matched inverse block map is a right inverse. -/
+  blockMap_rightInverse : ∀ i Y,
+    directSumBlockMap T i (blockEquiv i)
+      (directSumBlockMap S (blockEquiv i) i Y) = Y
+  /-- Matched full-matrix summands have equal dimensions. -/
+  dimension_eq : ∀ i, d i = e (blockEquiv i)
+
+/-- Mutually inverse positive trace-preserving maps between finite direct sums
+permute the full-matrix summands and induce mutually inverse positive
+trace-preserving maps on each matched pair.
+
+This is the pure-state-face and dimension-matching conclusion in Wolf's proof
+of Theorem 6.16, lines 1641--1659. It does not compare the later multiplicity
+dimensions. -/
+theorem exists_directSumFacePermutation_of_mutualInverse
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (hT : IsPositiveBetweenDirectSums T)
+    (hS : IsPositiveBetweenDirectSums S)
+    (hTTP : IsTracePreservingBetweenDirectSums T)
+    (hSTP : IsTracePreservingBetweenDirectSums S)
+    (hST : S.comp T = LinearMap.id)
+    (hTS : T.comp S = LinearMap.id) :
+    Nonempty (DirectSumFacePermutation T S) := by
+  classical
+  have hTextreme :=
+    mapsTo_extremePoints_directSumDensityMatrices_of_mutualInverse
+      hT hS hTTP hSTP hST hTS
+  have hSextreme :=
+    mapsTo_extremePoints_directSumDensityMatrices_of_mutualInverse
+      hS hT hSTP hTTP hTS hST
+  obtain ⟨τ, hτ⟩ := exists_targetBlock_assignment hTextreme
+  obtain ⟨υ, hυ⟩ := exists_targetBlock_assignment hSextreme
+  have hυτ : Function.LeftInverse υ τ := by
+    intro i
+    obtain ⟨P, hP⟩ := exists_rankOneOrthogonalProjection (d i)
+    obtain ⟨Q, hQ, houtT⟩ := hτ i P hP
+    obtain ⟨R, hR, houtS⟩ := hυ (τ i) Q hQ
+    symm
+    apply index_eq_of_single_eq_single_rankOne hP
+    calc
+      Pi.single i P = S (T (Pi.single i P)) :=
+        (LinearMap.congr_fun hST (Pi.single i P)).symm
+      _ = S (Pi.single (τ i) Q) := congrArg S houtT
+      _ = Pi.single (υ (τ i)) R := houtS
+  have hτυ : Function.RightInverse υ τ := by
+    intro j
+    obtain ⟨Q, hQ⟩ := exists_rankOneOrthogonalProjection (e j)
+    obtain ⟨P, hP, houtS⟩ := hυ j Q hQ
+    obtain ⟨R, hR, houtT⟩ := hτ (υ j) P hP
+    symm
+    apply index_eq_of_single_eq_single_rankOne hQ
+    calc
+      Pi.single j Q = T (S (Pi.single j Q)) :=
+        (LinearMap.congr_fun hTS (Pi.single j Q)).symm
+      _ = T (Pi.single (υ j) P) := congrArg T houtS
+      _ = Pi.single (τ (υ j)) R := houtT
+  let σ : ι ≃ κ := ⟨τ, υ, hυτ, hτυ⟩
+  have hmap : ∀ i X,
+      T (Pi.single i X) =
+        Pi.single (σ i) (directSumBlockMap T i (σ i) X) := by
+    intro i X
+    exact map_single_eq_single_targetBlock hτ i X
+  have hmapS : ∀ j Y,
+      S (Pi.single j Y) =
+        Pi.single (σ.symm j) (directSumBlockMap S j (σ.symm j) Y) := by
+    intro j Y
+    exact map_single_eq_single_targetBlock hυ j Y
+  have hposT : ∀ i X, X.PosSemidef →
+      (directSumBlockMap T i (σ i) X).PosSemidef := by
+    intro i X hX
+    apply hT (Pi.single i X) _ (σ i)
+    intro k
+    by_cases hk : k = i
+    · subst k
+      simpa only [Pi.single_eq_same]
+    · rw [Pi.single_eq_of_ne hk]
+      exact PosSemidef.zero
+  have hposS : ∀ j Y, Y.PosSemidef →
+      (directSumBlockMap S j (σ.symm j) Y).PosSemidef := by
+    intro j Y hY
+    apply hS (Pi.single j Y) _ (σ.symm j)
+    intro l
+    by_cases hl : l = j
+    · subst l
+      simpa only [Pi.single_eq_same]
+    · rw [Pi.single_eq_of_ne hl]
+      exact PosSemidef.zero
+  have htraceT : ∀ i X,
+      (directSumBlockMap T i (σ i) X).trace = X.trace := by
+    intro i X
+    calc
+      (directSumBlockMap T i (σ i) X).trace =
+          ∑ j, ((Pi.single (σ i) (directSumBlockMap T i (σ i) X) :
+            ∀ l, Matrix (Fin (e l)) (Fin (e l)) ℂ) j).trace :=
+        (sum_trace_pi_single (σ i) (directSumBlockMap T i (σ i) X)).symm
+      _ = ∑ j, (T (Pi.single i X) j).trace :=
+        congrArg (fun A ↦ ∑ j, (A j).trace) (hmap i X).symm
+      _ = ∑ k, ((Pi.single i X :
+          ∀ l, Matrix (Fin (d l)) (Fin (d l)) ℂ) k).trace :=
+        hTTP (Pi.single i X)
+      _ = X.trace := sum_trace_pi_single i X
+  have htraceS : ∀ j Y,
+      (directSumBlockMap S j (σ.symm j) Y).trace = Y.trace := by
+    intro j Y
+    calc
+      (directSumBlockMap S j (σ.symm j) Y).trace =
+          ∑ i, ((Pi.single (σ.symm j)
+            (directSumBlockMap S j (σ.symm j) Y) :
+              ∀ l, Matrix (Fin (d l)) (Fin (d l)) ℂ) i).trace :=
+        (sum_trace_pi_single (σ.symm j)
+          (directSumBlockMap S j (σ.symm j) Y)).symm
+      _ = ∑ i, (S (Pi.single j Y) i).trace :=
+        congrArg (fun A ↦ ∑ i, (A i).trace) (hmapS j Y).symm
+      _ = ∑ l, ((Pi.single j Y :
+          ∀ k, Matrix (Fin (e k)) (Fin (e k)) ℂ) l).trace :=
+        hSTP (Pi.single j Y)
+      _ = Y.trace := sum_trace_pi_single j Y
+  have hleftBlock : ∀ i X,
+      directSumBlockMap S (σ i) i
+        (directSumBlockMap T i (σ i) X) = X := by
+    intro i X
+    change S (Pi.single (σ i) (directSumBlockMap T i (σ i) X)) i = X
+    calc
+      S (Pi.single (σ i) (directSumBlockMap T i (σ i) X)) i =
+          S (T (Pi.single i X)) i := congrFun (congrArg S (hmap i X).symm) i
+      _ = ((Pi.single i X :
+          ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) i) := by
+        simpa only [LinearMap.comp_apply, LinearMap.id_apply] using
+          congrFun (LinearMap.congr_fun hST (Pi.single i X)) i
+      _ = X := by simp only [Pi.single_eq_same]
+  have hTblockInjective : ∀ i,
+      Function.Injective (directSumBlockMap T i (σ i)) := by
+    intro i X Y hXY
+    calc
+      X = directSumBlockMap S (σ i) i
+          (directSumBlockMap T i (σ i) X) := (hleftBlock i X).symm
+      _ = directSumBlockMap S (σ i) i
+          (directSumBlockMap T i (σ i) Y) := congrArg _ hXY
+      _ = Y := hleftBlock i Y
+  have hSinjective : Function.Injective S := by
+    intro A B hAB
+    calc
+      A = T (S A) := by
+        simpa only [LinearMap.comp_apply, LinearMap.id_apply] using
+          (LinearMap.congr_fun hTS A).symm
+      _ = T (S B) := congrArg T hAB
+      _ = B := by
+        simpa only [LinearMap.comp_apply, LinearMap.id_apply] using
+          LinearMap.congr_fun hTS B
+  have hSblockInjective : ∀ j,
+      Function.Injective (directSumBlockMap S j (σ.symm j)) := by
+    intro j X Y hXY
+    have hfull : S (Pi.single j X) = S (Pi.single j Y) := by
+      calc
+        S (Pi.single j X) = Pi.single (σ.symm j)
+            (directSumBlockMap S j (σ.symm j) X) := hmapS j X
+        _ = Pi.single (σ.symm j)
+            (directSumBlockMap S j (σ.symm j) Y) :=
+          congrArg (fun Z ↦ (Pi.single (σ.symm j) Z :
+            ∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)) hXY
+        _ = S (Pi.single j Y) := (hmapS j Y).symm
+    have hsingle := hSinjective hfull
+    have hcoord := congrFun hsingle j
+    simpa only [Pi.single_eq_same] using hcoord
+  have hdim : ∀ i, d i = e (σ i) := by
+    intro i
+    have hleT := LinearMap.finrank_le_finrank_of_injective
+      (hTblockInjective i)
+    have hleS := LinearMap.finrank_le_finrank_of_injective
+      (hSblockInjective (σ i))
+    rw [Module.finrank_matrix, Module.finrank_matrix] at hleT hleS
+    simp only [Module.finrank_self, Fintype.card_fin, mul_one,
+      Equiv.symm_apply_apply] at hleT hleS
+    exact Nat.mul_self_inj.mp (le_antisymm hleT hleS)
+  have hrightBlock : ∀ i Y,
+      directSumBlockMap T i (σ i)
+        (directSumBlockMap S (σ i) i Y) = Y := by
+    intro i Y
+    have hfinrank : Module.finrank ℂ
+        (Matrix (Fin (d i)) (Fin (d i)) ℂ) =
+        Module.finrank ℂ (Matrix (Fin (e (σ i))) (Fin (e (σ i))) ℂ) := by
+      rw [Module.finrank_matrix, Module.finrank_matrix]
+      simp only [Module.finrank_self, Fintype.card_fin, mul_one, hdim i]
+    have hsurjective : Function.Surjective (directSumBlockMap T i (σ i)) :=
+      (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hfinrank).mp
+        (hTblockInjective i)
+    obtain ⟨X, hX⟩ := hsurjective Y
+    rw [← hX, hleftBlock]
+  exact ⟨{
+    blockEquiv := σ
+    map_single := hmap
+    inverse_map_single := hmapS
+    blockMap_pos := hposT
+    inverseBlockMap_pos := hposS
+    blockMap_trace := htraceT
+    inverseBlockMap_trace := htraceS
+    blockMap_leftInverse := hleftBlock
+    blockMap_rightInverse := hrightBlock
+    dimension_eq := hdim }⟩
+
+end Matrix

--- a/QICLean/Channel/Wigner/ProjectivePureState.lean
+++ b/QICLean/Channel/Wigner/ProjectivePureState.lean
@@ -96,10 +96,11 @@ theorem star_dot_self_smul_normalizedPureStateMatrix (v : Fin d → ℂ) (hv : v
   rw [normalizedPureStateMatrix, smul_smul, mul_inv_cancel₀ (star_dot_self_ne_zero v hv),
     one_smul]
 
-/-- Two complex-linear matrix maps that agree on every normalized pure-state
-matrix agree on all matrices. -/
+/-- Two complex-linear maps from a full matrix algebra to an arbitrary complex
+module that agree on every normalized pure-state matrix agree everywhere. -/
 theorem linearMap_eq_of_eq_on_pureStateMatrix
-    (T S : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ)
+    {E : Type*} [AddCommGroup E] [Module ℂ E]
+    (T S : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] E)
     (h : ∀ p : ℙ ℂ (Fin d → ℂ), T (pureStateMatrix p) = S (pureStateMatrix p)) :
     T = S := by
   apply WolfProps.linearMap_eq_of_eq_on_rankOne

--- a/blueprint/src/chapter/ch01_spectrum_and_wigner.tex
+++ b/blueprint/src/chapter/ch01_spectrum_and_wigner.tex
@@ -361,7 +361,8 @@ $v$ is multiplied by a nonzero scalar.
     \lean{Projectivization.linearMap_eq_of_eq_on_pureStateMatrix}
     \leanok
     \uses{def:projective_pure_state_matrix}
-    Let $T,S:\MN{d}\to\MN{d}$ be complex-linear maps. If
+    Let $E$ be a complex module and let $T,S:\MN{d}\to E$ be
+    complex-linear maps. If
     \begin{align}
         T(P_p)=S(P_p)
     \end{align}

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -710,6 +710,105 @@ classification theorem is already proved.
     hypothesis on $T^*$; no adjoint-stability implication is used.
 \end{proof}
 
+\begin{theorem}[Permutation of density-block pure-state faces]
+    \label{thm:wolf_cycle_density_block_face_permutation}
+    \lean{Matrix.densityBlockWithZeroEmbedding,
+        Matrix.densityBlockWithZeroEmbedding_apply,
+        Matrix.densityBlockWithZeroCompression,
+        Matrix.densityBlockWithZeroCompression_apply,
+        Matrix.densityBlockWithZeroCompression_embedding,
+        Matrix.densityBlockWithZeroCompression_posSemidef,
+        Matrix.densityBlockWithZeroEmbedding_posSemidef,
+        Matrix.densityBlockWithZeroEmbedding_posSemidef_iff,
+        Matrix.trace_densityBlockWithZeroEmbedding,
+        Matrix.densityBlockWithZeroEmbedding_mem_densityMatrices_iff,
+        Matrix.densityBlockWithZeroEmbedding_fixed,
+        Matrix.densityBlockWithZeroEmbedding_compression_of_fixed,
+        Matrix.densityBlockDynamics,
+        Matrix.densityBlockDynamics_apply,
+        Matrix.densityBlockWithZeroEmbedding_densityBlockDynamics,
+        Matrix.densityBlockWithZeroEmbedding_densityBlockRestrictedInverse,
+        Matrix.densityBlockRestrictedInverse_comp_densityBlockDynamics,
+        Matrix.densityBlockDynamics_comp_densityBlockRestrictedInverse,
+        Matrix.densityBlockDynamics_isPositiveDirectSumMap,
+        Matrix.densityBlockDynamics_isTracePreservingBetweenDirectSums,
+        IsPositiveMap.exists_peripheralDensityBlockDynamics,
+        Matrix.IsPositiveBetweenDirectSums,
+        Matrix.directSumBlockMap,
+        Matrix.IsPositiveBetweenDirectSums.mapsTo_directSumDensityMatrices,
+        Matrix.mapsTo_extremePoints_directSumDensityMatrices_of_mutualInverse,
+        Matrix.DirectSumFacePermutation,
+        Matrix.exists_directSumFacePermutation_of_mutualInverse,
+        Matrix.DirectSumFacePermutation.map_apply,
+        Matrix.DirectSumFacePermutation.inverse_apply,
+        IsPositiveMap.exists_peripheralDensityBlockFacePermutation}
+    \leanok
+    \uses{thm:wolf_6_14,
+        thm:wolf_cycle_recurrent_peripheral_inverse,
+        thm:extreme_direct_sum_density_matrices,
+        thm:wolf_connected_pure_state_proj_image,
+        thm:linear_map_eq_of_eq_on_pure_state_matrix}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, with $D>0$,
+    and suppose that $T^*$ is Schwarz. Choose the zero-extended density-block
+    coordinates of the recurrent projection from Theorem~\ref{thm:wolf_6_14},
+    in the formal tensor-factor order $\sigma_k\otimes X_k$, and let $E$ and
+    $R$ denote their embedding and compression maps. If $S$ is the recurrent
+    inverse from Theorem~\ref{thm:wolf_cycle_recurrent_peripheral_inverse}, set
+    \begin{align}
+        \bar T&=R\circ T\circ E,
+        &
+        \bar S&=R\circ S\circ E.
+        \notag
+    \end{align}
+    Then $\bar T$ and $\bar S$ are mutually inverse positive maps on
+    $\bigoplus_{k<K}\MN{d_k}$ and preserve the total trace. There is an
+    equivalence $\tau:\Fin K\simeq\Fin K$ such that, with Wolf's
+    output-to-input permutation $\pi=\tau^{-1}$,
+    \begin{align}
+        (\bar T X)_j
+          &=\bar T_{\pi(j),j}\bigl(X_{\pi(j)}\bigr),
+        &
+        (\bar S Y)_i
+          &=\bar S_{\tau(i),i}\bigl(Y_{\tau(i)}\bigr),
+        \notag\\
+        d_{\pi(j)}&=d_j.
+        \notag
+    \end{align}
+    Every matched block map and its inverse is positive, preserves the
+    ordinary matrix trace, and the two compositions are identities. The
+    conclusion compares only the full-matrix dimensions $d_k$.
+
+    This is exactly the relative-pure-state, connectedness, and block
+    permutation step at source lines 1641--1659 of Wolf's proof of
+    Theorem~6.16. It does not compare the multiplicities $m_k$, transport the
+    ordinary Schwarz inequality to the matched block maps, assemble the
+    exclusion of the transpose alternative, or prove Equation~(6.68); those
+    remain separate source-facing follow-ups.
+    % Tracking: GitHub issues #417 and #411.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The density-block embedding and compression are inverse on the fixed
+    range. They reflect componentwise positivity, identify total block trace
+    with ambient trace, and identify the direct-sum density states with the
+    density states in the recurrent image. Consequently $\bar T$ and
+    $\bar S$ inherit positivity, trace preservation, the two embedding
+    intertwinings, and both inverse identities from $T$ and $S$.
+
+    Mutual inverse affine bijections preserve the relative extreme states.
+    For a fixed input summand, the rank-one projectors form a connected set,
+    while the trace of each output coordinate on that set takes values only
+    in the discrete set $\{0,1\}$. Hence the occupied output summand is
+    independent of the projector. Polarization extends the resulting
+    single-summand formula from rank-one projectors to the whole matrix
+    block. Applying the same argument to $\bar S$ shows that the two block
+    assignments are inverse. The matched block maps are positive and
+    trace-preserving; their two-sided inverse identities imply injections in
+    both directions, and equality of finite matrix-space dimensions gives
+    $d_i=d_{\tau(i)}$.
+\end{proof}
+
 \begin{theorem}[The Schwarz condition excludes matrix transpositions]
     \label{thm:wolf_cycle_schwarz_excludes_transpose}
     \lean{ChannelDeterminant.Internal.transposeLinearMapComplex_not_isSchwarzMap,

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -1498,16 +1498,54 @@ is false under the single printed hypothesis.
     convex-extreme points with families supported on one block, where the
     occupied block is a rank-one orthogonal projection.
 
-* The remaining **existence direction** — that every trace-preserving positive
-  map for which both `T` and `T*` satisfy the Schwarz inequality admits a
-  `MultiCycleDecomposition` on its asymptotic image, with the cycles coming
-  from the now-formalized density-block decomposition of the fixed-point
-  space — now requires proving that the induced positive inverse permutes
-  these now-characterized density-block faces with equal dimensions, and
-  assembling the exact weighted Equations (6.66)--(6.68). The conditional
-  `CycleStructure` and
-  `MultiCycleDecomposition` objects above are consumers of that theorem; they
-  are not substitutes for the missing source-facing declaration.
+* The density-block coordinate transport assembled from the recurrent-inverse
+  setup at source lines 1637--1640, and used by the subsequent
+  1641--1659 argument, is formalized in
+  `QICLean.Channel.Peripheral.DensityBlockCoordinates` and
+  `QICLean.Channel.Peripheral.DensityBlockDynamics`:
+  - `Matrix.densityBlockWithZeroEmbedding` and
+    `Matrix.densityBlockWithZeroCompression` are the maps `E` and `R` for the
+    exact zero-extended witnesses of
+    `IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero`, in the
+    established formal tensor-factor order `sigma k ⊗ X k`;
+  - the round-trip, positivity, trace, density-state, and fixed-range lemmas
+    show that these coordinates carry exactly the direct-sum density-state
+    geometry, without introducing another decomposition;
+  - `Matrix.densityBlockDynamics` is `R.comp (A.comp E)`, and
+    `IsPositiveMap.exists_peripheralDensityBlockDynamics` packages the maps
+    `Tbar` and `Sbar`, both embedding intertwinings, their two inverse
+    identities, positivity, and preservation of total block trace.
+
+* The relative-pure-state and permutation argument at source lines 1641--1659
+  is formalized by:
+  - `Matrix.IsPositiveBetweenDirectSums` and
+    `Matrix.mapsTo_extremePoints_directSumDensityMatrices_of_mutualInverse`,
+    which express positivity between dependent matrix families and
+    preservation of their relative extreme states;
+  - `Matrix.exists_directSumFacePermutation_of_mutualInverse`, which uses the
+    connected rank-one-projector locus to make the occupied output block
+    constant, applies the same construction to the inverse, and returns
+    `Matrix.DirectSumFacePermutation` with positive, trace-preserving,
+    mutually inverse matched block maps and equality only of their
+    full-matrix dimensions;
+  - the public full-family formulas
+    `Matrix.DirectSumFacePermutation.map_apply` and
+    `Matrix.DirectSumFacePermutation.inverse_apply`;
+  - `IsPositiveMap.exists_peripheralDensityBlockFacePermutation`, which
+    combines the exact Theorem 6.14 witnesses and recurrent inverse with that
+    direct-sum argument. Its block equivalence is source-to-target, while its
+    inverse is Wolf's output-to-input permutation `pi`, so
+    `(Tbar X) j` depends only on `X (pi j)` and `d (pi j) = d j`.
+
+* This completes exactly the bounded pure-face/permutation passage at source
+  lines 1641--1659, not all of Theorem 6.16. The remaining **existence
+  assembly** for a `MultiCycleDecomposition` must still compare the matched
+  multiplicities `m`, transport the ordinary Schwarz inequality to the
+  matched weighted block maps, combine the already formalized exclusion of
+  the transpose alternative, and obtain the exact weighted Equation (6.68).
+  Those steps remain tracked by #417 and #411. The conditional
+  `CycleStructure` and `MultiCycleDecomposition` objects above are consumers
+  of that later theorem; they are not substitutes for it.
 
 ---
 


### PR DESCRIPTION
Closes #409.

## Source boundary

Formalizes Wolf, *Quantum Channels & Operations*, Chapter 6, proof of Theorem 6.16, `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1641–1659.

The implementation follows the printed relative-pure-state route: the exact #39 coordinates `sigma k ⊗ₖ X k`, the positive trace-preserving recurrent inverse, preservation of direct-sum extreme density states, connectedness of rank-one projectors, bijectivity of the block assignment, and equality of the matched full-matrix dimensions.

## Changes

- Adds the zero-extended density-block embedding/compression and transported recurrent dynamics.
- Adds the generic direct-sum pure-face permutation engine.
- Adds `IsPositiveMap.exists_peripheralDensityBlockFacePermutation` with Wolf output-to-input `pi = blockEquiv.symm` and full-family block-action formulas.
- Generalizes the existing pure-state projectivization extensionality lemma to an arbitrary complex-module codomain.
- Synchronizes the Blueprint and Wolf numbering coverage with the exact proved boundary.

This PR proves only equality of the matched `d` factors. It does not claim equality of multiplicities `m`, transport ordinary Schwarz to weighted blocks, use CP/Kraus classification, exclude transpose branches, or assemble Equation (6.68); those remain #417 and #411.

## Validation

- `lake build QICLean.Channel.Peripheral.DensityBlockCoordinates`
- `lake build QICLean.Channel.Peripheral.DensityBlockDynamics`
- `lake build QICLean.Channel.Peripheral.DirectSumFacePermutation`
- `lake build QICLean.Channel.Peripheral.DensityBlockFacePermutation`
- `lake build QICLean.Channel.Peripheral`
- `lake build QICLean` (9,262 jobs)
- Blueprint sync 2,163 / 2,163, `checkdecls`, and reverse changed-declaration coverage
- import aggregator generator tests and `--check`
- style, reader-prose, paper-gap, numbering, oversized-file, module-policy, and ChkTeX checks
- forbidden-token and axiom audits; only `propext`, `Classical.choice`, and `Quot.sound`
- independent exact-head source/API review and duplicate focused/full builds: approved