### PR TITLE
feat(analysis): specialize Wolf semidefinite duality

### DIFF
--- a/QICLean/Analysis.lean
+++ b/QICLean/Analysis.lean
@@ -29,6 +29,7 @@ import QICLean.Analysis.EntropyReindex
 import QICLean.Analysis.FiniteRangeKnabe
 import QICLean.Analysis.FittingDecomposition
 import QICLean.Analysis.HayashiMarkovStructure
+import QICLean.Analysis.HermitianMatrixCone
 import QICLean.Analysis.IdempotentEndomorphism
 import QICLean.Analysis.InjectiveRangeProjector
 import QICLean.Analysis.IsometricCompression
@@ -66,6 +67,7 @@ import QICLean.Analysis.RpowConvexity
 import QICLean.Analysis.SandwichedRenyi
 import QICLean.Analysis.SandwichedRenyiTwo
 import QICLean.Analysis.SchattenNorm
+import QICLean.Analysis.SemidefiniteDuality
 import QICLean.Analysis.SemidefiniteProgram
 import QICLean.Analysis.SpectralQuadraticForm
 import QICLean.Analysis.SpectralRadius

--- a/QICLean/Analysis/HermitianMatrixCone.lean
+++ b/QICLean/Analysis/HermitianMatrixCone.lean
@@ -1,0 +1,363 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Algebra.FrobeniusHilbert
+import Mathlib.Analysis.Convex.Cone.InnerDual
+import Mathlib.Analysis.InnerProductSpace.Subspace
+
+noncomputable section
+
+open scoped BigOperators ComplexConjugate ComplexOrder InnerProductSpace RealInnerProductSpace
+  Matrix.Norms.Frobenius
+
+namespace SemidefiniteProgram
+
+/-!
+# The positive-semidefinite cone of Hermitian matrices
+
+This file equips Hermitian matrices with Wolf's real trace pairing and realizes the
+positive-semidefinite matrices as a self-dual proper cone.  Its interior is the
+positive-definite locus, including when the index type is empty.
+-/
+
+variable (n : Type*) [Fintype n]
+
+noncomputable def matrixRealLinearEquiv :
+    EuclideanSpace ℂ (n × n) ≃ₗ[ℝ] Matrix n n ℂ :=
+  (Matrix.frobeniusEquivEuclidean n n).symm.toLinearEquiv.restrictScalars ℝ
+
+noncomputable def hermitianSubmodule : Submodule ℝ (EuclideanSpace ℂ (n × n)) where
+  carrier := {x | (matrixRealLinearEquiv n x).IsHermitian}
+  zero_mem' := by simp [matrixRealLinearEquiv]
+  add_mem' hx hy := by
+    change (matrixRealLinearEquiv n (_ + _)).IsHermitian
+    rw [map_add]
+    exact hx.add hy
+  smul_mem' r x hx := by
+    change (matrixRealLinearEquiv n (_ • _)).IsHermitian
+    rw [map_smul]
+    exact hx.smul (IsSelfAdjoint.all r)
+
+abbrev HermitianMatrix := hermitianSubmodule n
+
+namespace HermitianMatrix
+
+noncomputable instance : CompleteSpace (HermitianMatrix n) :=
+  FiniteDimensional.complete ℝ (HermitianMatrix n)
+
+noncomputable def toMatrix (A : HermitianMatrix n) : Matrix n n ℂ :=
+  matrixRealLinearEquiv n A.1
+
+theorem toMatrix_isHermitian (A : HermitianMatrix n) : (toMatrix n A).IsHermitian := A.2
+
+noncomputable def ofMatrix (A : Matrix n n ℂ) (hA : A.IsHermitian) : HermitianMatrix n :=
+  ⟨Matrix.frobeniusEquivEuclidean n n A, by
+    change ((Matrix.frobeniusEquivEuclidean n n).symm
+      (Matrix.frobeniusEquivEuclidean n n A)).IsHermitian
+    rw [LinearIsometryEquiv.symm_apply_apply]
+    exact hA⟩
+
+@[simp] theorem toMatrix_ofMatrix (A : Matrix n n ℂ) (hA : A.IsHermitian) :
+    toMatrix n (ofMatrix n A hA) = A := by
+  change (Matrix.frobeniusEquivEuclidean n n).symm
+    (Matrix.frobeniusEquivEuclidean n n A) = A
+  exact LinearIsometryEquiv.symm_apply_apply _ _
+
+@[simp] theorem toMatrix_zero : toMatrix n (0 : HermitianMatrix n) = 0 := by
+  simp [toMatrix, matrixRealLinearEquiv]
+
+@[simp] theorem toMatrix_add (A B : HermitianMatrix n) :
+    toMatrix n (A + B) = toMatrix n A + toMatrix n B := by
+  simp [toMatrix, matrixRealLinearEquiv]
+
+@[simp] theorem toMatrix_sub (A B : HermitianMatrix n) :
+    toMatrix n (A - B) = toMatrix n A - toMatrix n B := by
+  simp [toMatrix, matrixRealLinearEquiv]
+
+@[simp] theorem toMatrix_smul (r : ℝ) (A : HermitianMatrix n) :
+    toMatrix n (r • A) = (r : ℂ) • toMatrix n A := by
+  simp [toMatrix, matrixRealLinearEquiv]
+
+private theorem continuous_toMatrix : Continuous (toMatrix n) := by
+  exact (Matrix.frobeniusEquivEuclidean n n).symm.continuous.comp continuous_subtype_val
+
+private theorem real_inner_eq_complex_re
+    (x y : EuclideanSpace ℂ (n × n)) :
+    inner ℝ x y = (inner ℂ x y).re := by
+  simp [PiLp.inner_apply, RCLike.inner_apply, Complex.inner]
+
+/-- The real Frobenius inner product on Hermitian matrices is Wolf's real trace pairing. -/
+theorem inner_eq_re_trace_mul (A B : HermitianMatrix n) :
+    inner ℝ A B = (Matrix.trace (toMatrix n A * toMatrix n B)).re := by
+  change inner ℝ (A : EuclideanSpace ℂ (n × n))
+      (B : EuclideanSpace ℂ (n × n)) = _
+  rw [real_inner_eq_complex_re]
+  have hA : Matrix.frobeniusEquivEuclidean n n (toMatrix n A) = A := by
+    exact LinearIsometryEquiv.apply_symm_apply _ _
+  have hB : Matrix.frobeniusEquivEuclidean n n (toMatrix n B) = B := by
+    exact LinearIsometryEquiv.apply_symm_apply _ _
+  rw [← hA, ← hB, Matrix.inner_frobeniusEquivEuclidean,
+    (toMatrix_isHermitian n A).eq]
+
+/-- The trace of a product of Hermitian matrices is real and equals the real Frobenius pairing. -/
+theorem trace_mul_eq_ofReal_inner (A B : HermitianMatrix n) :
+    Matrix.trace (toMatrix n A * toMatrix n B) = (inner ℝ A B : ℂ) := by
+  apply Complex.ext
+  · exact (inner_eq_re_trace_mul n A B).symm
+  · rw [Complex.ofReal_im]
+    apply (Complex.im_eq_zero_iff_isSelfAdjoint _).mpr
+    rw [isSelfAdjoint_iff, ← Matrix.trace_conjTranspose, Matrix.conjTranspose_mul,
+      (toMatrix_isHermitian n A).eq, (toMatrix_isHermitian n B).eq, Matrix.trace_mul_comm]
+
+noncomputable def psdCone : ProperCone ℝ (HermitianMatrix n) where
+  carrier := {A | (toMatrix n A).PosSemidef}
+  zero_mem' := by
+    change (toMatrix n (0 : HermitianMatrix n)).PosSemidef
+    rw [toMatrix_zero]
+    exact Matrix.PosSemidef.zero
+  add_mem' hA hB := by simpa using hA.add hB
+  smul_mem' := by
+    intro r A hA
+    change (toMatrix n ((r : ℝ) • A)).PosSemidef
+    rw [toMatrix_smul]
+    exact hA.smul (a := (r : ℝ)) r.2
+  isClosed' := Matrix.posSemidef_is_closed.preimage (continuous_toMatrix n)
+
+@[simp] theorem mem_psdCone_iff (A : HermitianMatrix n) :
+    A ∈ psdCone n ↔ (toMatrix n A).PosSemidef := Iff.rfl
+
+/-- The positive-semidefinite cone of Hermitian matrices is self-dual for the real Frobenius
+inner product. -/
+theorem mem_innerDual_psdCone_iff (A : HermitianMatrix n) :
+    A ∈ ProperCone.innerDual (psdCone n : Set (HermitianMatrix n)) ↔ A ∈ psdCone n := by
+  constructor
+  · intro hA
+    apply Matrix.PosSemidef.of_forall_trace_mul_nonneg (toMatrix_isHermitian n A)
+    intro B hB
+    let B' : HermitianMatrix n := ofMatrix n B hB.isHermitian
+    have hinner : 0 ≤ inner ℝ B' A := ProperCone.mem_innerDual.mp hA hB
+    have hre : 0 ≤ (Matrix.trace (toMatrix n A * B)).re := by
+      rw [inner_eq_re_trace_mul, toMatrix_ofMatrix, Matrix.trace_mul_comm] at hinner
+      exact hinner
+    have hself : IsSelfAdjoint (Matrix.trace (toMatrix n A * B)) := by
+      rw [isSelfAdjoint_iff, ← Matrix.trace_conjTranspose, Matrix.conjTranspose_mul,
+        (toMatrix_isHermitian n A).eq, hB.isHermitian.eq, Matrix.trace_mul_comm]
+    exact (Complex.re_nonneg_iff_nonneg hself).mp hre
+  · intro hA
+    apply ProperCone.mem_innerDual.mpr
+    intro B hB
+    rw [inner_eq_re_trace_mul]
+    exact (Complex.nonneg_iff.mp (hB.trace_mul_nonneg hA)).1
+
+theorem innerDual_psdCone :
+    ProperCone.innerDual (psdCone n : Set (HermitianMatrix n)) = psdCone n := by
+  ext A
+  exact mem_innerDual_psdCone_iff n A
+
+/-- Positive definiteness is strict positivity of the trace pairing against every nonzero
+positive-semidefinite Hermitian matrix. -/
+theorem posDef_iff_forall_inner_pos (A : HermitianMatrix n) :
+    (toMatrix n A).PosDef ↔
+      ∀ B : HermitianMatrix n, B ∈ psdCone n → B ≠ 0 → 0 < inner ℝ B A := by
+  constructor
+  · intro hA B hB hBne
+    rw [inner_eq_re_trace_mul]
+    have hnonneg := hB.trace_mul_nonneg hA.posSemidef
+    have htrace_ne : Matrix.trace (toMatrix n B * toMatrix n A) ≠ 0 := by
+      intro htrace
+      apply hBne
+      apply Subtype.ext
+      apply (matrixRealLinearEquiv n).injective
+      change toMatrix n B = toMatrix n (0 : HermitianMatrix n)
+      rw [toMatrix_zero]
+      apply Matrix.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero hB hA
+      rw [Matrix.trace_mul_comm]
+      exact htrace
+    have hre_nonneg : 0 ≤ (Matrix.trace (toMatrix n B * toMatrix n A)).re :=
+      (Complex.nonneg_iff.mp hnonneg).1
+    exact lt_of_le_of_ne hre_nonneg fun hre_eq ↦ htrace_ne <|
+      Complex.ext hre_eq.symm (by simpa using (Complex.nonneg_iff.mp hnonneg).2.symm)
+  · intro h
+    apply Matrix.PosDef.of_dotProduct_mulVec_pos (toMatrix_isHermitian n A)
+    intro x hx
+    let P : Matrix n n ℂ := Matrix.vecMulVec x (star x)
+    have hP : P.PosSemidef := Matrix.posSemidef_vecMulVec_self_star x
+    let P' : HermitianMatrix n := ofMatrix n P hP.isHermitian
+    have hPne : P' ≠ 0 := by
+      intro hzero
+      have hmatrix' := congrArg (toMatrix n) hzero
+      have hmatrix : P = 0 := by
+        simpa [P', toMatrix_ofMatrix, toMatrix_zero] using hmatrix'
+      exact (Matrix.vecMulVec_ne_zero hx (star_ne_zero.mpr hx)) hmatrix
+    have hpos := h P' hP hPne
+    rw [inner_eq_re_trace_mul, toMatrix_ofMatrix] at hpos
+    have hre : 0 < (star x ⬝ᵥ (toMatrix n A).mulVec x).re := by
+      rw [Matrix.trace_mul_comm] at hpos
+      change 0 < (Matrix.trace
+        (toMatrix n A * Matrix.vecMulVec x (star x))).re at hpos
+      rw [Matrix.mul_vecMulVec, Matrix.trace_vecMulVec, dotProduct_comm] at hpos
+      exact hpos
+    rw [Complex.pos_iff]
+    exact ⟨hre, (toMatrix_isHermitian n A).im_star_dotProduct_mulVec_self x |>.symm⟩
+
+private theorem forall_inner_pos_of_mem_interior {A : HermitianMatrix n}
+    (hA : A ∈ interior (psdCone n : Set (HermitianMatrix n))) :
+    ∀ B : HermitianMatrix n, B ∈ psdCone n → B ≠ 0 → 0 < inner ℝ B A := by
+  intro B hB hBne
+  have hAcone : A ∈ psdCone n := interior_subset hA
+  have hnonneg : 0 ≤ inner ℝ B A :=
+    by simpa [real_inner_comm] using
+      ProperCone.mem_innerDual.mp ((mem_innerDual_psdCone_iff n B).mpr hB) hAcone
+  obtain ⟨ε, hε, hball⟩ :=
+    Metric.mem_nhds_iff.mp (mem_interior_iff_mem_nhds.mp hA)
+  by_contra hnot
+  have hzero : inner ℝ B A = 0 := le_antisymm (le_of_not_gt hnot) hnonneg
+  have hBnorm : 0 < ‖B‖ := norm_pos_iff.mpr hBne
+  let δ : ℝ := ε / (2 * ‖B‖)
+  have hδ : 0 < δ := div_pos hε (mul_pos two_pos hBnorm)
+  let A' : HermitianMatrix n := A - δ • B
+  have hdist : dist A' A < ε := by
+    rw [dist_eq_norm]
+    rw [show A' - A = (-δ) • B by dsimp [A']; module]
+    rw [norm_smul, Real.norm_eq_abs, abs_of_neg (neg_lt_zero.mpr hδ), neg_neg]
+    have hδnorm : δ * ‖B‖ = ε / 2 := by
+      dsimp [δ]
+      field_simp [hBnorm.ne']
+      exact div_self hBnorm.ne'
+    rw [hδnorm]
+    linarith
+  have hA' : A' ∈ psdCone n := hball (Metric.mem_ball.mpr hdist)
+  have hinner_nonneg : 0 ≤ inner ℝ B A' :=
+    by simpa [real_inner_comm] using
+      ProperCone.mem_innerDual.mp ((mem_innerDual_psdCone_iff n B).mpr hB) hA'
+  have hinner_neg : inner ℝ B A' < 0 := by
+    rw [show A' = A - δ • B by rfl, inner_sub_right, real_inner_smul_right,
+      hzero, zero_sub]
+    exact neg_lt_zero.mpr (mul_pos hδ (real_inner_self_pos.mpr hBne))
+  exact (not_le_of_gt hinner_neg) hinner_nonneg
+
+private theorem mem_interior_of_forall_inner_pos [Nonempty n] {A : HermitianMatrix n}
+    (hA : ∀ B : HermitianMatrix n, B ∈ psdCone n → B ≠ 0 → 0 < inner ℝ B A) :
+    A ∈ interior (psdCone n : Set (HermitianMatrix n)) := by
+  classical
+  let S : Set (HermitianMatrix n) :=
+    Metric.sphere 0 1 ∩ (psdCone n : Set (HermitianMatrix n))
+  let f : HermitianMatrix n → ℝ := fun B ↦ inner ℝ B A
+  let I' : HermitianMatrix n := ofMatrix n (1 : Matrix n n ℂ) Matrix.isHermitian_one
+  have hI' : I' ∈ psdCone n := by
+    change (toMatrix n I').PosSemidef
+    simpa [I'] using (Matrix.PosSemidef.one : (1 : Matrix n n ℂ).PosSemidef)
+  have hI'ne : I' ≠ 0 := by
+    intro hzero
+    have hmatrix := congrArg (toMatrix n) hzero
+    have : (1 : Matrix n n ℂ) = 0 := by
+      simp only [I', toMatrix_ofMatrix, toMatrix_zero] at hmatrix
+      exact hmatrix
+    exact one_ne_zero this
+  have hI'norm : 0 < ‖I'‖ := norm_pos_iff.mpr hI'ne
+  let U : HermitianMatrix n := ‖I'‖⁻¹ • I'
+  have hUmem : U ∈ S := by
+    constructor
+    · rw [Metric.mem_sphere, dist_zero_right]
+      change ‖‖I'‖⁻¹ • I'‖ = 1
+      rw [norm_smul, Real.norm_of_nonneg (inv_nonneg.mpr hI'norm.le)]
+      exact inv_mul_cancel₀ hI'norm.ne'
+    · exact (psdCone n).smul_mem hI' (inv_nonneg.mpr hI'norm.le)
+  let _ : ProperSpace (HermitianMatrix n) := FiniteDimensional.proper ℝ _
+  have hScompact : IsCompact S :=
+    (isCompact_sphere (0 : HermitianMatrix n) 1).inter_right (psdCone n).isClosed
+  have hfcontinuous : Continuous f := by fun_prop
+  obtain ⟨B₀, hB₀S, hB₀min⟩ :=
+    hScompact.exists_isMinOn ⟨U, hUmem⟩ hfcontinuous.continuousOn
+  let c : ℝ := f B₀
+  have hB₀ne : B₀ ≠ 0 := by
+    intro hzero
+    have := hB₀S.1
+    simp [hzero] at this
+  have hc : 0 < c := hA B₀ hB₀S.2 hB₀ne
+  apply mem_interior_iff_mem_nhds.mpr
+  apply Metric.mem_nhds_iff.mpr
+  refine ⟨c, hc, ?_⟩
+  intro X hX
+  apply (mem_innerDual_psdCone_iff n X).mp
+  apply ProperCone.mem_innerDual.mpr
+  intro B hB
+  by_cases hBzero : B = 0
+  · simp [hBzero]
+  have hBnorm : 0 < ‖B‖ := norm_pos_iff.mpr hBzero
+  let B' : HermitianMatrix n := ‖B‖⁻¹ • B
+  have hB'S : B' ∈ S := by
+    constructor
+    · rw [Metric.mem_sphere, dist_zero_right]
+      change ‖‖B‖⁻¹ • B‖ = 1
+      rw [norm_smul, Real.norm_of_nonneg (inv_nonneg.mpr hBnorm.le)]
+      exact inv_mul_cancel₀ hBnorm.ne'
+    · exact (psdCone n).smul_mem hB (inv_nonneg.mpr hBnorm.le)
+  have hc_le : c ≤ inner ℝ B' A := hB₀min hB'S
+  have hdistXA : ‖X - A‖ < c := by
+    simpa [Metric.mem_ball, dist_eq_norm] using hX
+  have hperturb : -(c : ℝ) < inner ℝ B' (X - A) := by
+    have habs := abs_real_inner_le_norm B' (X - A)
+    have hB'norm : ‖B'‖ = 1 := by simpa [Metric.mem_sphere, dist_zero_right] using hB'S.1
+    rw [hB'norm, one_mul] at habs
+    exact lt_of_lt_of_le (neg_lt_neg hdistXA) (neg_le_of_abs_le habs)
+  have hB'X : 0 < inner ℝ B' X := by
+    rw [show X = A + (X - A) by abel, inner_add_right]
+    linarith
+  have hscale : inner ℝ B X = ‖B‖ * inner ℝ B' X := by
+    change inner ℝ B X = ‖B‖ * inner ℝ (‖B‖⁻¹ • B) X
+    rw [real_inner_smul_left]
+    field_simp
+  rw [hscale]
+  exact (mul_pos hBnorm hB'X).le
+
+private theorem interior_psdCone_eq_posDef_of_nonempty [Nonempty n] :
+    interior (psdCone n : Set (HermitianMatrix n)) =
+      {A | (toMatrix n A).PosDef} := by
+  ext A
+  rw [Set.mem_ofPred_eq, posDef_iff_forall_inner_pos]
+  exact ⟨forall_inner_pos_of_mem_interior n, mem_interior_of_forall_inner_pos n⟩
+
+private theorem interior_psdCone_eq_posDef_of_isEmpty [IsEmpty n] :
+    interior (psdCone n : Set (HermitianMatrix n)) =
+      {A | (toMatrix n A).PosDef} := by
+  ext A
+  constructor
+  · intro _hA
+    apply Matrix.PosDef.of_dotProduct_mulVec_pos (toMatrix_isHermitian n A)
+    intro x hx
+    exact False.elim (hx (Subsingleton.elim x 0))
+  · intro _hA
+    have hcone : (psdCone n : Set (HermitianMatrix n)) = Set.univ := by
+      ext B
+      constructor
+      · intro _
+        exact Set.mem_univ B
+      · intro _
+        have hzero : toMatrix n B = 0 := Subsingleton.elim _ _
+        change (toMatrix n B).PosSemidef
+        rw [hzero]
+        exact Matrix.PosSemidef.zero
+    rw [hcone]
+    simp
+
+/-- The interior of the positive-semidefinite cone is exactly the positive-definite locus,
+including the zero-dimensional Hermitian matrix space. -/
+theorem interior_psdCone_eq_posDef :
+    interior (psdCone n : Set (HermitianMatrix n)) =
+      {A | (toMatrix n A).PosDef} := by
+  rcases isEmpty_or_nonempty n with hn | hn
+  · let _ := hn
+    exact interior_psdCone_eq_posDef_of_isEmpty n
+  · let _ := hn
+    exact interior_psdCone_eq_posDef_of_nonempty n
+
+theorem mem_interior_psdCone_iff_posDef (A : HermitianMatrix n) :
+    A ∈ interior (psdCone n : Set (HermitianMatrix n)) ↔ (toMatrix n A).PosDef := by
+  rw [interior_psdCone_eq_posDef]
+  rfl
+
+end HermitianMatrix
+end SemidefiniteProgram

--- a/QICLean/Analysis/SemidefiniteDuality.lean
+++ b/QICLean/Analysis/SemidefiniteDuality.lean
@@ -1,0 +1,285 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Analysis.HermitianMatrixCone
+import QICLean.Analysis.ConicProgram
+import QICLean.Analysis.SemidefiniteProgram
+
+/-!
+# Semidefinite duality in Wolf's trace formulation
+
+This file specializes the corrected conic-duality development to Wolf, *Quantum Channels &
+Operations*, Chapter 4, lines 85--116.  The analysis map is
+`T(X)ᵢ = tr(Fᵢ X)`, its adjoint is `T†(y) = ∑ᵢ yᵢ Fᵢ`, and self-duality of the
+positive-semidefinite cone gives the exact Loewner signs in equation (4.3).
+
+The value and optimizer notions remain those of `ConicProgram`; no competing SDP model is
+introduced. The Slater statements retain the finite-value hypothesis required by the corrected
+conic theorem and absent from the printed paragraph at lines 100--105.
+-/
+
+noncomputable section
+
+open scoped BigOperators ComplexOrder InnerProductSpace RealInnerProductSpace
+
+namespace SemidefiniteProgram
+
+variable {ι n : Type*} [Fintype ι] [Fintype n]
+
+open HermitianMatrix
+
+noncomputable def traceAnalysisMap (F : ι → HermitianMatrix n) :
+    HermitianMatrix n →ₗ[ℝ] EuclideanSpace ℝ ι where
+  toFun X := WithLp.toLp 2 fun i ↦ inner ℝ (F i) X
+  map_add' X Y := by
+    ext i
+    simp [inner_add_right]
+  map_smul' r X := by
+    ext i
+    simp [real_inner_smul_right]
+
+omit [Fintype ι] in
+@[simp] theorem traceAnalysisMap_apply (F : ι → HermitianMatrix n) (X : HermitianMatrix n)
+    (i : ι) :
+    (traceAnalysisMap F X).ofLp i = inner ℝ (F i) X :=
+  rfl
+
+omit [Fintype ι] in
+theorem traceAnalysisMap_apply_eq_re_trace (F : ι → HermitianMatrix n)
+    (X : HermitianMatrix n) (i : ι) :
+    (traceAnalysisMap F X).ofLp i =
+      (Matrix.trace (toMatrix n (F i) * toMatrix n X)).re := by
+  rw [traceAnalysisMap_apply, inner_eq_re_trace_mul]
+
+omit [Fintype ι] in
+/-- Wolf's coordinate identity, with the real coordinate coerced to the complex trace scalar. -/
+theorem traceAnalysisMap_apply_eq_trace (F : ι → HermitianMatrix n)
+    (X : HermitianMatrix n) (i : ι) :
+    Matrix.trace (toMatrix n (F i) * toMatrix n X) =
+      ((traceAnalysisMap F X).ofLp i : ℂ) := by
+  rw [trace_mul_eq_ofReal_inner, traceAnalysisMap_apply]
+
+noncomputable def hermitianSum (F : ι → HermitianMatrix n) (y : EuclideanSpace ℝ ι) :
+    HermitianMatrix n :=
+  ∑ i, y.ofLp i • F i
+
+@[simp] theorem toMatrix_hermitianSum (F : ι → HermitianMatrix n)
+    (y : EuclideanSpace ℝ ι) :
+    toMatrix n (hermitianSum F y) = ∑ i, (y.ofLp i : ℂ) • toMatrix n (F i) := by
+  classical
+  simp [hermitianSum, toMatrix, matrixRealLinearEquiv]
+
+theorem traceAnalysisMap_adjoint (F : ι → HermitianMatrix n) (y : EuclideanSpace ℝ ι) :
+    (traceAnalysisMap F).toContinuousLinearMap.adjoint y = hermitianSum F y := by
+  apply ext_inner_right ℝ
+  intro X
+  rw [ContinuousLinearMap.adjoint_inner_left]
+  rw [PiLp.inner_apply, hermitianSum, sum_inner]
+  simp only [RCLike.inner_apply, conj_trivial, real_inner_smul_left]
+  change (∑ i, inner ℝ (F i) X * y.ofLp i) =
+    ∑ i, y.ofLp i * inner ℝ (F i) X
+  simp only [mul_comm]
+
+private theorem euclidean_inner_eq_sum_mul (b y : EuclideanSpace ℝ ι) :
+    inner ℝ b y = ∑ i, b.ofLp i * y.ofLp i := by
+  rw [PiLp.inner_apply]
+  simp only [RCLike.inner_apply, conj_trivial, mul_comm]
+
+/-- Wolf's primal constraints are exactly conic feasibility for the trace-analysis map. -/
+theorem mem_primalFeasible_iff (F : ι → HermitianMatrix n) (b : EuclideanSpace ℝ ι)
+    (X : HermitianMatrix n) :
+    X ∈ ConicProgram.primalFeasible (psdCone n) (traceAnalysisMap F) b ↔
+      (toMatrix n X).PosSemidef ∧
+        ∀ i, (Matrix.trace (toMatrix n (F i) * toMatrix n X)).re = b.ofLp i := by
+  change (X ∈ psdCone n ∧ traceAnalysisMap F X = b) ↔ _
+  rw [mem_psdCone_iff]
+  constructor
+  · rintro ⟨hX, hTX⟩
+    refine ⟨hX, fun i ↦ ?_⟩
+    have hi := congrArg (fun z : EuclideanSpace ℝ ι ↦ z.ofLp i) hTX
+    simpa only [traceAnalysisMap_apply_eq_re_trace] using hi
+  · rintro ⟨hX, hconstraints⟩
+    refine ⟨hX, ?_⟩
+    ext i
+    rw [traceAnalysisMap_apply_eq_re_trace, hconstraints i]
+
+/-- Wolf's Loewner constraint `F₀ ≥ ∑ᵢ yᵢFᵢ` is exactly conic dual feasibility. -/
+theorem mem_dualFeasible_iff (F₀ : HermitianMatrix n) (F : ι → HermitianMatrix n)
+    (y : EuclideanSpace ℝ ι) :
+    y ∈ ConicProgram.dualFeasible (psdCone n) (traceAnalysisMap F) F₀ ↔
+      (toMatrix n F₀ - ∑ i, (y.ofLp i : ℂ) • toMatrix n (F i)).PosSemidef := by
+  change F₀ - (traceAnalysisMap F).toContinuousLinearMap.adjoint y ∈
+      ProperCone.innerDual (psdCone n : Set (HermitianMatrix n)) ↔ _
+  rw [traceAnalysisMap_adjoint, innerDual_psdCone]
+  change (toMatrix n (F₀ - hermitianSum F y)).PosSemidef ↔ _
+  rw [toMatrix_sub, toMatrix_hermitianSum]
+
+/-- Wolf's strict primal feasibility condition `X > 0` is conic strict feasibility. -/
+theorem isPrimalStrictlyFeasible_iff (F : ι → HermitianMatrix n)
+    (b : EuclideanSpace ℝ ι) :
+    ConicProgram.IsPrimalStrictlyFeasible (psdCone n) (traceAnalysisMap F) b ↔
+      ∃ X : HermitianMatrix n, (toMatrix n X).PosDef ∧
+        ∀ i, (Matrix.trace (toMatrix n (F i) * toMatrix n X)).re = b.ofLp i := by
+  constructor
+  · rintro ⟨X, hX, hTX⟩
+    refine ⟨X, (mem_interior_psdCone_iff_posDef n X).mp hX, fun i ↦ ?_⟩
+    have hi := congrArg (fun z : EuclideanSpace ℝ ι ↦ z.ofLp i) hTX
+    simpa only [traceAnalysisMap_apply_eq_re_trace] using hi
+  · rintro ⟨X, hX, hconstraints⟩
+    refine ⟨X, (mem_interior_psdCone_iff_posDef n X).mpr hX, ?_⟩
+    ext i
+    rw [traceAnalysisMap_apply_eq_re_trace, hconstraints i]
+
+/-- Wolf's strict dual condition `F₀ > ∑ᵢ yᵢFᵢ` is conic dual strict feasibility. -/
+theorem isDualStrictlyFeasible_iff (F₀ : HermitianMatrix n) (F : ι → HermitianMatrix n) :
+    ConicProgram.IsDualStrictlyFeasible (psdCone n) (traceAnalysisMap F) F₀ ↔
+      ∃ y : EuclideanSpace ℝ ι,
+        (toMatrix n F₀ - ∑ i, (y.ofLp i : ℂ) • toMatrix n (F i)).PosDef := by
+  constructor
+  · rintro ⟨y, hy⟩
+    refine ⟨y, ?_⟩
+    rw [innerDual_psdCone, traceAnalysisMap_adjoint,
+      mem_interior_psdCone_iff_posDef] at hy
+    rwa [toMatrix_sub, toMatrix_hermitianSum] at hy
+  · rintro ⟨y, hy⟩
+    refine ⟨y, ?_⟩
+    rw [innerDual_psdCone, traceAnalysisMap_adjoint,
+      mem_interior_psdCone_iff_posDef]
+    rwa [toMatrix_sub, toMatrix_hermitianSum]
+
+/-- **Semidefinite pointwise weak duality** in exactly Wolf's trace and Loewner notation. -/
+theorem weak_duality_pointwise
+    (F₀ : HermitianMatrix n) (F : ι → HermitianMatrix n) (b y : EuclideanSpace ℝ ι)
+    (X : HermitianMatrix n) (hX : (toMatrix n X).PosSemidef)
+    (hconstraints : ∀ i,
+      (Matrix.trace (toMatrix n (F i) * toMatrix n X)).re = b.ofLp i)
+    (hslack :
+      (toMatrix n F₀ - ∑ i, (y.ofLp i : ℂ) • toMatrix n (F i)).PosSemidef) :
+    ∑ i, b.ofLp i * y.ofLp i ≤ (Matrix.trace (toMatrix n F₀ * toMatrix n X)).re := by
+  have hconic := ConicProgram.weak_duality_pointwise
+    ((mem_primalFeasible_iff F b X).mpr ⟨hX, hconstraints⟩)
+    ((mem_dualFeasible_iff F₀ F y).mpr hslack)
+  rwa [euclidean_inner_eq_sum_mul, inner_eq_re_trace_mul] at hconic
+
+/-- **Semidefinite weak duality for optimal values**, Wolf's equation (4.3). The values and their
+empty/unbounded semantics are the existing conic values, not a parallel SDP model. -/
+theorem weak_duality (F₀ : HermitianMatrix n) (F : ι → HermitianMatrix n)
+    (b : EuclideanSpace ℝ ι) :
+    ConicProgram.dualValue (psdCone n) (traceAnalysisMap F) F₀ b ≤
+      ConicProgram.primalValue (psdCone n) (traceAnalysisMap F) F₀ b :=
+  ConicProgram.weak_duality
+
+/-- **Primal-strict semidefinite Slater attainment, corrected.** Wolf's `X > 0` condition and a
+finite primal value give a dual optimizer. The finite-value hypothesis is the necessary correction
+to the printed statement at lines 100--105. -/
+theorem exists_dualOptimizer_of_primalStrict_of_primalValue_eq_coe
+    (F₀ : HermitianMatrix n) (F : ι → HermitianMatrix n) (b : EuclideanSpace ℝ ι) (p : ℝ)
+    (hstrict : ∃ X : HermitianMatrix n, (toMatrix n X).PosDef ∧
+      ∀ i, (Matrix.trace (toMatrix n (F i) * toMatrix n X)).re = b.ofLp i)
+    (hvalue : ConicProgram.primalValue (psdCone n) (traceAnalysisMap F) F₀ b = (p : EReal)) :
+    ∃ y : EuclideanSpace ℝ ι,
+      ConicProgram.IsDualOptimizer (psdCone n) (traceAnalysisMap F) F₀ b y ∧
+        ∑ i, b.ofLp i * y.ofLp i = p := by
+  have hstrict' := (isPrimalStrictlyFeasible_iff F b).mpr hstrict
+  obtain ⟨y, hy, hyobj⟩ :=
+    ConicProgram.exists_isDualOptimizer_of_isPrimalStrictlyFeasible_of_primalValue_eq_coe
+      hstrict' hvalue
+  refine ⟨y, hy, ?_⟩
+  rwa [euclidean_inner_eq_sum_mul] at hyobj
+
+/-- **Primal-strict semidefinite strong duality, corrected.** This is a direct specialization of
+the conic theorem and retains its finite-primal-value boundary. -/
+theorem values_eq_of_primalStrict_of_primalValue_eq_coe
+    (F₀ : HermitianMatrix n) (F : ι → HermitianMatrix n) (b : EuclideanSpace ℝ ι) (p : ℝ)
+    (hstrict : ∃ X : HermitianMatrix n, (toMatrix n X).PosDef ∧
+      ∀ i, (Matrix.trace (toMatrix n (F i) * toMatrix n X)).re = b.ofLp i)
+    (hvalue : ConicProgram.primalValue (psdCone n) (traceAnalysisMap F) F₀ b = (p : EReal)) :
+    ConicProgram.primalValue (psdCone n) (traceAnalysisMap F) F₀ b =
+      ConicProgram.dualValue (psdCone n) (traceAnalysisMap F) F₀ b := by
+  exact ConicProgram.values_eq_of_isPrimalStrictlyFeasible_of_primalValue_eq_coe
+    ((isPrimalStrictlyFeasible_iff F b).mpr hstrict) hvalue
+
+/-- **Dual-strict semidefinite Slater attainment, corrected.** Wolf's
+`F₀ > ∑ᵢ yᵢFᵢ` condition and a finite dual value give a primal optimizer. -/
+theorem exists_primalOptimizer_of_dualStrict_of_dualValue_eq_coe
+    (F₀ : HermitianMatrix n) (F : ι → HermitianMatrix n) (b : EuclideanSpace ℝ ι) (p : ℝ)
+    (hstrict : ∃ y : EuclideanSpace ℝ ι,
+      (toMatrix n F₀ - ∑ i, (y.ofLp i : ℂ) • toMatrix n (F i)).PosDef)
+    (hvalue : ConicProgram.dualValue (psdCone n) (traceAnalysisMap F) F₀ b = (p : EReal)) :
+    ∃ X : HermitianMatrix n,
+      ConicProgram.IsPrimalOptimizer (psdCone n) (traceAnalysisMap F) F₀ b X ∧
+        (Matrix.trace (toMatrix n F₀ * toMatrix n X)).re = p := by
+  have hstrict' := (isDualStrictlyFeasible_iff F₀ F).mpr hstrict
+  obtain ⟨X, hX, hXobj⟩ :=
+    ConicProgram.exists_isPrimalOptimizer_of_isDualStrictlyFeasible_of_dualValue_eq_coe
+      hstrict' hvalue
+  refine ⟨X, hX, ?_⟩
+  rwa [inner_eq_re_trace_mul] at hXobj
+
+/-- **Dual-strict semidefinite strong duality, corrected.** This direct conic specialization
+retains the finite-dual-value boundary missing from the printed paragraph. -/
+theorem values_eq_of_dualStrict_of_dualValue_eq_coe
+    (F₀ : HermitianMatrix n) (F : ι → HermitianMatrix n) (b : EuclideanSpace ℝ ι) (p : ℝ)
+    (hstrict : ∃ y : EuclideanSpace ℝ ι,
+      (toMatrix n F₀ - ∑ i, (y.ofLp i : ℂ) • toMatrix n (F i)).PosDef)
+    (hvalue : ConicProgram.dualValue (psdCone n) (traceAnalysisMap F) F₀ b = (p : EReal)) :
+    ConicProgram.primalValue (psdCone n) (traceAnalysisMap F) F₀ b =
+      ConicProgram.dualValue (psdCone n) (traceAnalysisMap F) F₀ b := by
+  exact ConicProgram.values_eq_of_isDualStrictlyFeasible_of_dualValue_eq_coe
+    ((isDualStrictlyFeasible_iff F₀ F).mpr hstrict) hvalue
+
+/-- Wolf's optimizer characterization following complementary slackness. Assuming equality of
+the conic values and primal attainment, a dual vector is optimal exactly when it participates in
+a feasible primal--dual pair satisfying `(F₀ - ∑ᵢ yᵢFᵢ) X = 0`.
+
+Source: Wolf, Chapter 4, lines 107--116. -/
+theorem isDualOptimizer_iff_exists_complementary
+    (F₀ : HermitianMatrix n) (F : ι → HermitianMatrix n)
+    (b y : EuclideanSpace ℝ ι)
+    (hvalues : ConicProgram.primalValue (psdCone n) (traceAnalysisMap F) F₀ b =
+      ConicProgram.dualValue (psdCone n) (traceAnalysisMap F) F₀ b)
+    (hprimalAttained : ∃ X : HermitianMatrix n,
+      ConicProgram.IsPrimalOptimizer (psdCone n) (traceAnalysisMap F) F₀ b X) :
+    ConicProgram.IsDualOptimizer (psdCone n) (traceAnalysisMap F) F₀ b y ↔
+      ∃ X : HermitianMatrix n,
+        (toMatrix n X).PosSemidef ∧
+        (∀ i, (Matrix.trace (toMatrix n (F i) * toMatrix n X)).re = b.ofLp i) ∧
+        (toMatrix n F₀ - ∑ i, (y.ofLp i : ℂ) • toMatrix n (F i)).PosSemidef ∧
+        (toMatrix n F₀ - ∑ i, (y.ofLp i : ℂ) • toMatrix n (F i)) * toMatrix n X = 0 := by
+  constructor
+  · intro hy
+    obtain ⟨X, hX⟩ := hprimalAttained
+    have hXfeasible := (mem_primalFeasible_iff F b X).mp hX.1
+    have hyfeasible := (mem_dualFeasible_iff F₀ F y).mp hy.1
+    refine ⟨X, hXfeasible.1, hXfeasible.2, hyfeasible, ?_⟩
+    have hp := ConicProgram.primalValue_eq_of_isPrimalOptimizer hX
+    have hd := ConicProgram.dualValue_eq_of_isDualOptimizer hy
+    have hobjectives : inner ℝ F₀ X = inner ℝ b y := by
+      apply EReal.coe_eq_coe_iff.mp
+      rw [← hp, hvalues, hd]
+    rw [inner_eq_re_trace_mul, euclidean_inner_eq_sum_mul] at hobjectives
+    exact complementary_slackness
+      (toMatrix n F₀) (fun i ↦ toMatrix n (F i))
+      (fun i ↦ b.ofLp i) (fun i ↦ y.ofLp i) (toMatrix n X)
+      (toMatrix_isHermitian n F₀) (fun i ↦ toMatrix_isHermitian n (F i))
+      hXfeasible.1 hXfeasible.2 hyfeasible hobjectives
+  · rintro ⟨X, hX, hconstraints, hslack, hcomplementary⟩
+    have hXfeasible := (mem_primalFeasible_iff F b X).mpr ⟨hX, hconstraints⟩
+    have hyfeasible := (mem_dualFeasible_iff F₀ F y).mpr hslack
+    have hobjectives :
+        (Matrix.trace (toMatrix n F₀ * toMatrix n X)).re =
+          ∑ i, b.ofLp i * y.ofLp i := by
+      have hgap := re_trace_slack_mul_eq_objective_sub
+        (toMatrix n F₀) (fun i ↦ toMatrix n (F i))
+        (fun i ↦ b.ofLp i) (fun i ↦ y.ofLp i) (toMatrix n X) hconstraints
+      rw [hcomplementary, Matrix.trace_zero, Complex.zero_re] at hgap
+      linarith
+    have hobjectives' : inner ℝ F₀ X = inner ℝ b y := by
+      rw [inner_eq_re_trace_mul, euclidean_inner_eq_sum_mul]
+      exact hobjectives
+    exact (ConicProgram.optimizers_of_feasible_of_objectives_eq
+      hXfeasible hyfeasible hobjectives').2
+
+end SemidefiniteProgram

--- a/blueprint/src/chapter/ch04_convex_structure.tex
+++ b/blueprint/src/chapter/ch04_convex_structure.tex
@@ -189,14 +189,109 @@ This chapter follows the convex-optimization framework of
     then gives equality of the two extended-real values in both cases.
 \end{proof}
 
+\begin{definition}[Hermitian trace space and the positive-semidefinite cone]
+    \label{def:hermitian_psd_cone}
+    \lean{SemidefiniteProgram.matrixRealLinearEquiv,
+        SemidefiniteProgram.hermitianSubmodule,
+        SemidefiniteProgram.HermitianMatrix,
+        SemidefiniteProgram.HermitianMatrix.toMatrix,
+        SemidefiniteProgram.HermitianMatrix.toMatrix_isHermitian,
+        SemidefiniteProgram.HermitianMatrix.ofMatrix,
+        SemidefiniteProgram.HermitianMatrix.toMatrix_ofMatrix,
+        SemidefiniteProgram.HermitianMatrix.toMatrix_zero,
+        SemidefiniteProgram.HermitianMatrix.toMatrix_add,
+        SemidefiniteProgram.HermitianMatrix.toMatrix_sub,
+        SemidefiniteProgram.HermitianMatrix.toMatrix_smul,
+        SemidefiniteProgram.HermitianMatrix.inner_eq_re_trace_mul,
+        SemidefiniteProgram.HermitianMatrix.trace_mul_eq_ofReal_inner,
+        SemidefiniteProgram.HermitianMatrix.psdCone,
+        SemidefiniteProgram.HermitianMatrix.mem_psdCone_iff,
+        SemidefiniteProgram.HermitianMatrix.mem_innerDual_psdCone_iff,
+        SemidefiniteProgram.HermitianMatrix.innerDual_psdCone,
+        SemidefiniteProgram.HermitianMatrix.posDef_iff_forall_inner_pos,
+        SemidefiniteProgram.HermitianMatrix.interior_psdCone_eq_posDef,
+        SemidefiniteProgram.HermitianMatrix.mem_interior_psdCone_iff_posDef}
+    \leanok
+    The Hermitian $n\times n$ matrices form a finite-dimensional real Hilbert
+    space for Wolf's trace pairing
+    $\langle A|B\rangle=\operatorname{Re}\tr(AB)$.  Its positive-semidefinite
+    matrices form a closed proper cone $K_{\mathrm{psd}}$ satisfying
+    $K_{\mathrm{psd}}^*=K_{\mathrm{psd}}$, and
+    $\operatorname{int}K_{\mathrm{psd}}=\{A:A>0\}$.  The last identity also
+    covers the zero-dimensional matrix space, where positive definiteness is
+    vacuous and the cone is the whole space.
+\end{definition}
+
+\begin{definition}[Wolf's semidefinite trace-analysis map]
+    \label{def:semidefinite_trace_analysis}
+    \lean{SemidefiniteProgram.traceAnalysisMap,
+        SemidefiniteProgram.traceAnalysisMap_apply,
+        SemidefiniteProgram.traceAnalysisMap_apply_eq_re_trace,
+        SemidefiniteProgram.traceAnalysisMap_apply_eq_trace,
+        SemidefiniteProgram.hermitianSum,
+        SemidefiniteProgram.toMatrix_hermitianSum,
+        SemidefiniteProgram.traceAnalysisMap_adjoint,
+        SemidefiniteProgram.mem_primalFeasible_iff,
+        SemidefiniteProgram.mem_dualFeasible_iff,
+        SemidefiniteProgram.isPrimalStrictlyFeasible_iff,
+        SemidefiniteProgram.isDualStrictlyFeasible_iff}
+    \leanok
+    \uses{def:conic_programs, def:conic_strict_feasibility_and_attainment,
+        def:hermitian_psd_cone}
+    For Hermitian data $F_i$, the traces $\tr(F_iX)$ are real; define
+    $T(X)_i=\tr(F_iX)$.  Then
+    $T^*(y)=\sum_i y_iF_i$.  Consequently the conic primal constraint is
+    precisely $X\geq0$ and $\tr(F_iX)=b_i$, while conic dual feasibility is
+    precisely $F_0-\sum_i y_iF_i\geq0$.  The two conic strict-feasibility
+    predicates become, respectively, $X>0$ with the trace constraints and
+    $F_0-\sum_i y_iF_i>0$, exactly as in
+    \cite[Chapter~4, lines~85--105]{Wolf2012Quantum}.
+\end{definition}
+
+\begin{theorem}[Semidefinite weak duality and corrected Slater duality]
+    \label{thm:semidefinite_duality}
+    \lean{SemidefiniteProgram.weak_duality_pointwise,
+        SemidefiniteProgram.weak_duality,
+        SemidefiniteProgram.exists_dualOptimizer_of_primalStrict_of_primalValue_eq_coe,
+        SemidefiniteProgram.values_eq_of_primalStrict_of_primalValue_eq_coe,
+        SemidefiniteProgram.exists_primalOptimizer_of_dualStrict_of_dualValue_eq_coe,
+        SemidefiniteProgram.values_eq_of_dualStrict_of_dualValue_eq_coe}
+    \leanok
+    \uses{def:semidefinite_trace_analysis}
+    For every feasible $X$ and $y$,
+    \begin{align}
+        \sum_i b_i y_i\leq\tr(F_0X).
+    \end{align}
+    Taking the supremum and infimum gives Wolf's semidefinite weak-duality
+    inequality, equation~(4.3), with the extended-real conventions of
+    Definition~\ref{def:conic_programs}.  If there is a strictly feasible
+    $X>0$ and the primal value is finite, equality holds and the dual optimum
+    is attained.  Dually, a strictly positive slack and a finite dual value
+    give equality and primal attainment.  These finiteness hypotheses are the
+    correction required for the unqualified printed claim at lines~100--105.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:hermitian_psd_cone, thm:conic_weak_duality,
+        thm:conic_corrected_slater}
+    Self-duality of $K_{\mathrm{psd}}$ and the adjoint identity turn the
+    displayed trace conditions into the primal and dual feasible sets of
+    Definition~\ref{def:conic_programs}.  The conclusions are therefore the
+    direct specializations of Theorems~\ref{thm:conic_weak_duality} and
+    \ref{thm:conic_corrected_slater}.
+\end{proof}
+
 \begin{theorem}[Complementary slackness]
     \label{thm:semidefinite_complementary_slackness}
     \lean{Matrix.PosSemidef.mul_eq_zero_of_trace_mul_eq_zero,
         Matrix.PosSemidef.supportProj_mul_supportProj_eq_zero_of_mul_eq_zero,
         SemidefiniteProgram.re_trace_slack_mul_eq_objective_sub,
         SemidefiniteProgram.complementary_slackness,
-        SemidefiniteProgram.complementary_slackness_supports}
+        SemidefiniteProgram.complementary_slackness_supports,
+        SemidefiniteProgram.isDualOptimizer_iff_exists_complementary}
     \leanok
+    \uses{def:conic_programs, def:semidefinite_trace_analysis}
     Let $b\in\R^n$ and let $F_0,F_1,\ldots,F_n$ be Hermitian matrices.
     Suppose that $X^0\geq0$, $\tr(F_iX^0)=b_i$ for every $i$,
     $F_0-\sum_i y_i^0F_i\geq0$, and the two objective values are equal.
@@ -207,14 +302,24 @@ This chapter follows the convex-optimization framework of
         \label{eq:semidefinite_complementary_slackness}
     \end{align}
     Thus $X^0$ and $F_0-\sum_i y_i^0F_i$ have orthogonal supports.
+    Under equality of the conic values and primal attainment, a dual vector
+    $y^0$ is optimal if and only if there is a primal-feasible $X^0\geq0$
+    satisfying this equation and the dual slack is positive semidefinite, as
+    stated at lines~113--116.
 \end{theorem}
 
 \begin{proof}
     \leanok
+    \uses{thm:conic_zero_gap_optimizers}
     The equality constraints and equality of the objectives give
     $\tr((F_0-\sum_i y_i^0F_i)X^0)=0$.  If two positive semidefinite matrices
     have zero trace pairing, the product of their positive square roots has
     zero Hilbert--Schmidt norm; hence their product and the product of their
     support projections vanish.  This proves
     (\ref{eq:semidefinite_complementary_slackness}) and the support statement.
+    For the optimizer characterization, choose a primal optimizer.  Equality
+    of the two values identifies its objective with that of every dual
+    optimizer, so complementary slackness applies.  Conversely, the vanishing
+    product forces the trace pairing, hence the objective gap, to vanish;
+    pointwise weak duality then makes both feasible points optimizers.
 \end{proof}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -545,6 +545,43 @@ so that the cited formal statements are available from the main project import.
 
 ---
 
+## Wolf Lecture Notes — Chapter 4: Convex Structure
+
+### Equation 4.3 and lines 85–105 (semidefinite duality) — FORMALIZED WITH FINITENESS CORRECTION
+
+- `SemidefiniteProgram.HermitianMatrix.psdCone`, `innerDual_psdCone`, and
+  `interior_psdCone_eq_posDef` realize the Hermitian positive-semidefinite
+  matrices as a self-dual proper cone for the real trace pairing, with the
+  zero-dimensional case included.
+- `SemidefiniteProgram.traceAnalysisMap` and `traceAnalysisMap_adjoint` prove
+  the source identities `T(X)ᵢ = tr(FᵢX)` (the trace is real) and
+  `T†(y) = ∑ᵢ yᵢFᵢ`. The primal/dual and strict-feasibility iff lemmas expose
+  exactly Wolf's trace constraints and Loewner signs.
+- `SemidefiniteProgram.weak_duality_pointwise` and `weak_duality` specialize
+  the existing conic values to Equation 4.3, retaining their documented
+  empty and unbounded extended-real semantics.
+- The four `*_of_primalStrict_of_primalValue_eq_coe` and
+  `*_of_dualStrict_of_dualValue_eq_coe` declarations specialize corrected
+  Slater duality and attainment. They require a finite value on the strictly
+  feasible side; the unqualified printed claim at lines 100–105 is false
+  without this boundary, as recorded in
+  `docs/paper-gaps/wolf_slater_attainment_conditions.tex`.
+
+### Equation 4.4 and lines 107–116 (complementary slackness) — FORMALIZED
+
+- `SemidefiniteProgram.complementary_slackness` proves
+  `(F₀ - ∑ᵢ yᵢFᵢ)X = 0` from explicit primal/dual feasibility and equal
+  objectives; `complementary_slackness_supports` proves the orthogonal-support
+  consequence.
+- `SemidefiniteProgram.isDualOptimizer_iff_exists_complementary` gives Wolf's
+  optimizer characterization under equality of the conic values and explicit
+  primal attainment, with every trace and Loewner feasibility hypothesis in
+  the statement.
+
+The surrounding complexity prose at source lines 80–83 is not formalized.
+
+---
+
 ## Wolf Chapter 6 — Spectral Properties: Public Theorem Index
 
 This module serves as a **navigational index** that maps the formalized theorems


### PR DESCRIPTION
Closes #111.

## Source boundary

Formalizes Wolf, *Quantum Channels & Operations*, Chapter 4, `Notes/WolfNoteTexSource/ch04_convex_structure.tex`, lines 85–116.

The implementation uses Wolf’s literal Hermitian trace formulation: `T(X)_i = tr(F_i X)`, `T*(y) = sum_i y_i F_i`, the PSD cone and its Loewner order, semidefinite weak duality, corrected strict-feasibility duality/attainment, and complementary slackness.

## Changes

- Adds the finite real Frobenius Hilbert space of Hermitian matrices.
- Defines the PSD proper cone, proves self-duality, and identifies its interior with positive-definite matrices, including the zero-dimensional edge.
- Defines Wolf’s trace-analysis map and proves the exact adjoint, primal/dual feasibility, and strict-feasibility characterizations.
- Specializes the existing `ConicProgram` pointwise/value weak duality and both corrected finite-value Slater theorems; no parallel optimizer or value model is introduced.
- Adds the source optimizer characterization using the existing complementary-slackness product-zero theorem.
- Synchronizes the Analysis aggregator, Blueprint, and Wolf numbering coverage.

The printed lines 100–105 omit the finite-value/opposite-feasibility condition needed for attainment. This PR preserves the already-recorded corrected boundary and does not formalize the surrounding informal complexity discussion.

## Validation

- focused `HermitianMatrixCone` and `SemidefiniteDuality` build (3,047 jobs)
- `lake build QICLean.Analysis`
- `lake build QICLean` on the rebased exact head (9,264 jobs)
- Blueprint semantic sync 2,201 / 2,201, reverse changed-declaration coverage, and fresh `checkdecls`
- style, import, prose, ChkTeX, paper-gap, numbered-module, oversized-file, forbidden-token, and integrity audits
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`
- independent exact-head mathematical/API review and duplicate focused/full builds: approved