### PR TITLE
feat(channel): transport Schwarz to Wolf density blocks

### DIFF
--- a/QICLean/Channel/Peripheral.lean
+++ b/QICLean/Channel/Peripheral.lean
@@ -26,10 +26,12 @@ import QICLean.Channel.Peripheral.CyclicGroupKraus
 import QICLean.Channel.Peripheral.DensityBlockCoordinates
 import QICLean.Channel.Peripheral.DensityBlockDynamics
 import QICLean.Channel.Peripheral.DensityBlockFacePermutation
+import QICLean.Channel.Peripheral.DensityBlockSchwarz
 import QICLean.Channel.Peripheral.DirectSumFacePermutation
 import QICLean.Channel.Peripheral.GroupStructure
 import QICLean.Channel.Peripheral.IrreducibleChannel
 import QICLean.Channel.Peripheral.JordanBlocks
+import QICLean.Channel.Peripheral.MatchedBlockEndomorphism
 import QICLean.Channel.Peripheral.MultiCycleDecomposition
 import QICLean.Channel.Peripheral.PeriodicityRemoval
 import QICLean.Channel.Peripheral.Powers

--- a/QICLean/Channel/Peripheral/DensityBlockCoordinates.lean
+++ b/QICLean/Channel/Peripheral/DensityBlockCoordinates.lean
@@ -22,8 +22,10 @@ whereas Wolf writes the full-matrix factor first.  No second block decomposition
 ## Main declarations
 
 * `Matrix.densityBlockWithZeroEmbedding`
+* `Matrix.densityBlockWithZeroPrincipalCompression`
 * `Matrix.densityBlockWithZeroCompression`
 * `Matrix.densityBlockWithZeroCompression_embedding`
+* `Matrix.densityBlockWithZeroEmbedding_eq_one`
 
 ## Reference
 
@@ -131,6 +133,202 @@ theorem densityBlockWithZeroEmbedding_apply
             (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))) * star U := by
   simp [densityBlockWithZeroEmbedding, zeroBottomRightEmbedding,
     densityBlockTensorEmbedding, Matrix.unitaryReindexLinearEquiv_symm_apply]
+
+/-- Compress an ambient matrix to the full principal block indexed by `k` in Wolf's
+zero-extended density-block coordinates.
+
+Unlike `densityBlockWithZeroCompression`, this map does not take a partial trace: its
+codomain retains both factors `Fin (m k) × Fin (d k)`.  This is the principal-block
+compression used in the scalar repair following Wolf Theorem 6.16, lines 1660--1663. -/
+noncomputable def densityBlockWithZeroPrincipalCompression
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (k : Fin K) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ :=
+  (Matrix.directSumBlockCompression (m := m) (d := d) k).comp
+    ((Matrix.reindexLinearEquiv ℂ ℂ e.symm e.symm).toLinearMap.comp
+      (bottomRightCompression.comp
+        (Matrix.unitaryReindexLinearEquiv e₀ U hU).toLinearMap))
+
+@[simp]
+theorem densityBlockWithZeroPrincipalCompression_apply
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (B : Matrix (Fin D) (Fin D) ℂ) (k : Fin K) :
+    densityBlockWithZeroPrincipalCompression e e₀ U hU k B =
+      Matrix.directSumBlockCompression (m := m) (d := d) k
+        (Matrix.reindex e.symm e.symm
+          (Matrix.unitaryReindexLinearEquiv e₀ U hU B).toBlocks₂₂) := by
+  rfl
+
+/-- Principal-block compression recovers the full Kronecker block before partial trace. -/
+@[simp]
+theorem densityBlockWithZeroPrincipalCompression_embedding
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) (k : Fin K) :
+    densityBlockWithZeroPrincipalCompression e e₀ U hU k
+        (densityBlockWithZeroEmbedding e e₀ U hU sigma X) =
+      sigma k ⊗ₖ X k := by
+  let Phi := Matrix.unitaryReindexLinearEquiv e₀ U hU
+  let A : Matrix (Fin (D - n) ⊕ Fin n) (Fin (D - n) ⊕ Fin n) ℂ :=
+    Matrix.fromBlocks 0 0 0
+      (Matrix.reindex e e
+        (Matrix.blockDiagonal' fun j ↦ sigma j ⊗ₖ X j))
+  have hcoord : Phi (densityBlockWithZeroEmbedding e e₀ U hU sigma X) = A := by
+    change Phi (Phi.symm A) = A
+    exact Phi.apply_symm_apply A
+  rw [densityBlockWithZeroPrincipalCompression_apply, hcoord]
+  simp [A]
+
+/-- Every full principal block of the ambient identity remains the identity in
+density-block coordinates. -/
+@[simp]
+theorem densityBlockWithZeroPrincipalCompression_one
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (k : Fin K) :
+    densityBlockWithZeroPrincipalCompression e e₀ U hU k 1 = 1 := by
+  rw [densityBlockWithZeroPrincipalCompression_apply,
+    Matrix.unitaryReindexLinearEquiv_one]
+  ext i j
+  simp only [Matrix.directSumBlockCompression_apply, Matrix.reindex_apply,
+    Matrix.toBlocks₂₂, Matrix.one_apply, Sum.inr.injEq]
+  change (if e ⟨k, i⟩ = e ⟨k, j⟩ then 1 else 0) =
+    if i = j then 1 else 0
+  by_cases hij : i = j
+  · subst j
+    simp
+  · have heij : e ⟨k, i⟩ ≠ e ⟨k, j⟩ := by
+      intro he
+      apply hij
+      simpa using e.injective he
+    simp [hij, heij]
+
+/-- Principal-block compression preserves positive semidefiniteness. -/
+theorem densityBlockWithZeroPrincipalCompression_posSemidef
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (k : Fin K) {B : Matrix (Fin D) (Fin D) ℂ} (hB : B.PosSemidef) :
+    (densityBlockWithZeroPrincipalCompression e e₀ U hU k B).PosSemidef := by
+  rw [densityBlockWithZeroPrincipalCompression_apply]
+  apply Matrix.directSumBlockCompression_isPositiveMap k
+  have hcoord : (Matrix.unitaryReindexLinearEquiv e₀ U hU B).PosSemidef :=
+    Matrix.unitaryReindexLinearEquiv_posSemidef e₀ U hU hB
+  have hbottom : (Matrix.unitaryReindexLinearEquiv e₀ U hU B).toBlocks₂₂.PosSemidef := by
+    exact hcoord.submatrix Sum.inr
+  simpa only [Matrix.reindex_apply, Equiv.symm_symm,
+    Matrix.posSemidef_submatrix_equiv] using hbottom
+
+/-- If an encoded density-block family is the ambient identity, then Wolf's zero summand
+has dimension zero.
+
+This is the zero-summand step omitted between Wolf Theorem 6.16, lines 1660--1663.  It
+uses only the exact coordinates from Theorem 6.14 and remains valid in the zero-dimensional
+edge case. -/
+theorem densityBlockWithZeroEmbedding_eq_one_dimension
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)
+    (hOne : densityBlockWithZeroEmbedding e e₀ U hU sigma X = 1) :
+    n = D := by
+  let Phi := Matrix.unitaryReindexLinearEquiv e₀ U hU
+  let A : Matrix (Fin (D - n) ⊕ Fin n) (Fin (D - n) ⊕ Fin n) ℂ :=
+    Matrix.fromBlocks 0 0 0
+      (Matrix.reindex e e
+        (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))
+  have hencode : Phi (densityBlockWithZeroEmbedding e e₀ U hU sigma X) = A := by
+    change Phi (Phi.symm A) = A
+    exact Phi.apply_symm_apply A
+  have hcoord : A = 1 := by
+    calc
+      A = Phi (densityBlockWithZeroEmbedding e e₀ U hU sigma X) := hencode.symm
+      _ = Phi 1 := congrArg (fun B ↦ Phi B) hOne
+      _ = 1 := Matrix.unitaryReindexLinearEquiv_one e₀ U hU
+  have hsub : D - n = 0 := by
+    by_contra hne
+    let i : Fin (D - n) := ⟨0, Nat.pos_of_ne_zero hne⟩
+    have hentry := congrFun (congrFun hcoord (Sum.inl i)) (Sum.inl i)
+    have hzeroone : (0 : ℂ) = 1 := by
+      simp [A] at hentry
+    exact zero_ne_one hzeroone
+  have hcard := Fintype.card_congr e₀
+  simp only [Fintype.card_sum, Fintype.card_fin] at hcard
+  omega
+
+/-- In an identity-valued density-block encoding, each full principal block is the
+identity, so its trace-one left factor is maximally mixed and its right factor is the
+compensating scalar identity.
+
+This is the per-block scalar step omitted in Wolf Theorem 6.16, lines 1660--1663. -/
+theorem densityBlockWithZeroEmbedding_eq_one_block
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hd : ∀ k, 0 < d k) (hm : ∀ k, 0 < m k)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)
+    (hOne : densityBlockWithZeroEmbedding e e₀ U hU sigma X = 1)
+    (k : Fin K) :
+    sigma k = (m k : ℂ)⁻¹ • 1 ∧ X k = (m k : ℂ) • 1 := by
+  let _ : NeZero (m k) := ⟨Nat.ne_of_gt (hm k)⟩
+  let _ : NeZero (d k) := ⟨Nat.ne_of_gt (hd k)⟩
+  apply Matrix.kronecker_eq_one_of_left_trace_eq_one (hsigmaTrace k)
+  calc
+    sigma k ⊗ₖ X k = densityBlockWithZeroPrincipalCompression e e₀ U hU k
+        (densityBlockWithZeroEmbedding e e₀ U hU sigma X) :=
+      (densityBlockWithZeroPrincipalCompression_embedding
+        e e₀ U hU sigma X k).symm
+    _ = densityBlockWithZeroPrincipalCompression e e₀ U hU k 1 :=
+      congrArg (fun B ↦ densityBlockWithZeroPrincipalCompression e e₀ U hU k B) hOne
+    _ = 1 := densityBlockWithZeroPrincipalCompression_one e e₀ U hU k
+
+/-- Exact identity coordinates for Wolf's zero-extended density-block decomposition.
+
+If the encoded family is the ambient identity, the zero summand disappears (`n = D`),
+every density factor is maximally mixed, and every full-matrix factor is its compensating
+scalar identity.  The statement includes the vacuous empty-family and zero-dimensional
+edge cases and does not assert multiplicativity of the coordinate maps. -/
+theorem densityBlockWithZeroEmbedding_eq_one
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hd : ∀ k, 0 < d k) (hm : ∀ k, 0 < m k)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)
+    (hOne : densityBlockWithZeroEmbedding e e₀ U hU sigma X = 1) :
+    n = D ∧ ∀ k, sigma k = (m k : ℂ)⁻¹ • 1 ∧ X k = (m k : ℂ) • 1 := by
+  exact ⟨densityBlockWithZeroEmbedding_eq_one_dimension
+      e e₀ U hU sigma X hOne,
+    densityBlockWithZeroEmbedding_eq_one_block
+      e e₀ U hU sigma hd hm hsigmaTrace X hOne⟩
 
 /-- Recover the full-matrix factors from Wolf's zero-extended density-block coordinates.
 

--- a/QICLean/Channel/Peripheral/DensityBlockSchwarz.lean
+++ b/QICLean/Channel/Peripheral/DensityBlockSchwarz.lean
@@ -1,0 +1,467 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Channel.Peripheral.DensityBlockFacePermutation
+import QICLean.Channel.Peripheral.MatchedBlockEndomorphism
+import QICLean.Channel.Schwarz.TracePreserving
+
+/-!
+# Schwarz inequalities on Wolf's matched density blocks
+
+This file implements the scalar repair omitted in the proof of Wolf Theorem
+6.16, at `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines
+1660--1663.  The argument first uses the ordinary Schwarz hypothesis on the
+ambient positive trace-preserving map to prove unitality.  Exact identity
+coordinates then remove the zero summand and make every density factor
+maximally mixed.  Trace preservation on the matched full-matrix blocks gives
+equality of the corresponding multiplicities.  Only after that equality is
+known do we compress the ambient weighted Schwarz defect and cancel its common
+positive scalar.
+
+The direct Schwarz hypothesis on `T` and the trace-adjoint Schwarz hypothesis
+used by Wolf Theorem 6.14 remain separate.  No complete-positivity, Kraus,
+literal weighted-subalgebra restriction, or modified-product argument is used.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder BigOperators Kronecker
+
+noncomputable section
+
+namespace Matrix
+
+/-- Exact identity witnesses in Wolf's zero-extended density-block coordinates.
+
+Once the recurrent projection fixes the ambient identity, compression supplies
+the unique full-matrix coordinate family.  Re-embedding that family is the
+identity, so the zero summand vanishes and every density weight is maximally
+mixed.  This is the first omitted step at Wolf Theorem 6.16, proof lines
+1660--1663. -/
+theorem exists_densityBlockIdentityCoordinates
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hd : ∀ k, 0 < d k) (hm : ∀ k, 0 < m k)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    {P : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hfixed : ∀ B, P B = B ↔
+      ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+        star U * B * U = Matrix.reindex e₀ e₀
+          (Matrix.fromBlocks 0 0 0
+            (Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))))
+    (hPone : P 1 = 1) :
+    ∃ Xone : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+      densityBlockWithZeroEmbedding e e₀ U hU sigma Xone = 1 ∧
+      n = D ∧
+      ∀ k, sigma k = (m k : ℂ)⁻¹ • 1 ∧
+        Xone k = (m k : ℂ) • 1 := by
+  let Xone := densityBlockWithZeroCompression e e₀ U hU (1 : Matrix (Fin D) (Fin D) ℂ)
+  have hEncode : densityBlockWithZeroEmbedding e e₀ U hU sigma Xone = 1 :=
+    densityBlockWithZeroEmbedding_compression_of_fixed
+      e e₀ U hU sigma hsigmaTrace hfixed hPone
+  obtain ⟨hn, hblocks⟩ := densityBlockWithZeroEmbedding_eq_one
+    e e₀ U hU sigma hd hm hsigmaTrace Xone hEncode
+  exact ⟨Xone, hEncode, hn, hblocks⟩
+
+/-- Multiplication of a single maximally-mixed density block produces exactly
+one additional inverse-multiplicity scalar.
+
+This is the weighted-coordinate calculation omitted at Wolf Theorem 6.16,
+proof lines 1660--1663. -/
+theorem densityBlockWithZeroEmbedding_single_conjTranspose_mul
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigma : ∀ k, sigma k = (m k : ℂ)⁻¹ • 1)
+    (k : Fin K) (X : Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    (densityBlockWithZeroEmbedding e e₀ U hU sigma
+        (Pi.single k X))ᴴ *
+        densityBlockWithZeroEmbedding e e₀ U hU sigma (Pi.single k X) =
+      (m k : ℂ)⁻¹ •
+        densityBlockWithZeroEmbedding e e₀ U hU sigma
+          (Pi.single k (Xᴴ * X)) := by
+  classical
+  let Phi := Matrix.unitaryReindexLinearEquiv e₀ U hU
+  have hcoord (Z : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ) :
+      Phi (densityBlockWithZeroEmbedding e e₀ U hU sigma Z) =
+        Matrix.fromBlocks 0 0 0
+          (Matrix.reindex e e
+            (Matrix.blockDiagonal' fun j ↦ sigma j ⊗ₖ Z j)) := by
+    change Phi (Phi.symm _) = _
+    exact Phi.apply_symm_apply _
+  apply Phi.injective
+  rw [Matrix.unitaryReindexLinearEquiv_mul]
+  rw [← Matrix.star_eq_conjTranspose,
+    Matrix.unitaryReindexLinearEquiv_star]
+  rw [map_smul]
+  rw [hcoord (Pi.single k X)]
+  rw [hcoord (Pi.single k (Xᴴ * X))]
+  simp only [Matrix.star_eq_conjTranspose, Matrix.fromBlocks_conjTranspose,
+    Matrix.fromBlocks_multiply]
+  simp only [Matrix.conjTranspose_zero, Matrix.zero_mul, Matrix.mul_zero,
+    zero_add]
+  rw [Matrix.fromBlocks_smul]
+  congr 1
+  · simp
+  · simp
+  · simp
+  · let A := Matrix.blockDiagonal' fun j ↦ sigma j ⊗ₖ
+        (Pi.single k X : ∀ l, Matrix (Fin (d l)) (Fin (d l)) ℂ) j
+    let B := Matrix.blockDiagonal' fun j ↦ sigma j ⊗ₖ
+        (Pi.single k (Xᴴ * X) : ∀ l, Matrix (Fin (d l)) (Fin (d l)) ℂ) j
+    change (Matrix.reindexLinearEquiv ℂ ℂ e e A)ᴴ *
+        Matrix.reindexLinearEquiv ℂ ℂ e e A =
+      (m k : ℂ)⁻¹ • Matrix.reindexLinearEquiv ℂ ℂ e e B
+    simp only [Matrix.coe_reindexLinearEquiv]
+    rw [Matrix.conjTranspose_reindex]
+    let R := Matrix.reindexAlgEquiv ℂ ℂ e
+    change R Aᴴ * R A = (m k : ℂ)⁻¹ • R B
+    rw [← map_mul, ← map_smul]
+    apply congrArg R
+    simp only [A, B, Matrix.blockDiagonal'_conjTranspose]
+    rw [← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_smul]
+    congr 1
+    funext j
+    by_cases hj : j = k
+    · subst j
+      simp only [Pi.single_eq_same, Pi.smul_apply]
+      rw [hsigma k]
+      simp [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
+        Matrix.smul_kronecker, smul_smul]
+    · simp [Pi.single_eq_of_ne hj]
+
+/-- Intertwining with a unital ambient map fixes the exact identity-coordinate
+family.
+
+Injectivity is obtained from the existing density-block compression; no
+algebra structure is imposed on the weighted embedding.  Source: Wolf Theorem
+6.16, proof lines 1660--1663. -/
+theorem densityBlockMap_fixed_identityCoordinates
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigmaTrace : ∀ k, (sigma k).trace = 1)
+    {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    {Tbar : Module.End ℂ (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)}
+    (hencode : ∀ X,
+      densityBlockWithZeroEmbedding e e₀ U hU sigma (Tbar X) =
+        T (densityBlockWithZeroEmbedding e e₀ U hU sigma X))
+    (hTone : T 1 = 1)
+    (Xone : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)
+    (hXone : densityBlockWithZeroEmbedding e e₀ U hU sigma Xone = 1) :
+    Tbar Xone = Xone := by
+  have hEmbed : densityBlockWithZeroEmbedding e e₀ U hU sigma (Tbar Xone) =
+      densityBlockWithZeroEmbedding e e₀ U hU sigma Xone := by
+    calc
+      densityBlockWithZeroEmbedding e e₀ U hU sigma (Tbar Xone) =
+          T (densityBlockWithZeroEmbedding e e₀ U hU sigma Xone) := hencode Xone
+      _ = T 1 := congrArg T hXone
+      _ = 1 := hTone
+      _ = densityBlockWithZeroEmbedding e e₀ U hU sigma Xone := hXone.symm
+  have hCompressed := congrArg
+    (densityBlockWithZeroCompression e e₀ U hU) hEmbed
+  simpa only [densityBlockWithZeroCompression_embedding
+    e e₀ U hU sigma hsigmaTrace] using hCompressed
+
+/-- Matched density blocks have equal multiplicity dimensions once the
+identity-coordinate family is fixed.
+
+The proof uses only the full-family block action, ordinary block trace
+preservation, and the previously established equality of the full-matrix
+dimensions.  This is the multiplicity calculation omitted at Wolf Theorem
+6.16, proof line 1663. -/
+theorem DirectSumFacePermutation.multiplicity_eq_of_fixed_scalar_identity
+    {K : ℕ} {d m : Fin K → ℕ}
+    {Tbar Sbar : Module.End ℂ (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)}
+    (F : DirectSumFacePermutation Tbar Sbar)
+    (hd : ∀ k, 0 < d k)
+    (Xone : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)
+    (hXone : ∀ k, Xone k = (m k : ℂ) • 1)
+    (hFixed : Tbar Xone = Xone) (i : Fin K) :
+    m i = m (F.blockEquiv i) := by
+  have hAction := F.map_apply Xone (F.blockEquiv i)
+  rw [show F.blockEquiv.symm (F.blockEquiv i) = i from
+    F.blockEquiv.symm_apply_apply i] at hAction
+  have hBlock : directSumBlockMap Tbar i (F.blockEquiv i) (Xone i) =
+      Xone (F.blockEquiv i) := hAction.symm.trans (congrFun hFixed (F.blockEquiv i))
+  have hTrace := congrArg Matrix.trace hBlock
+  rw [hXone i, map_smul, Matrix.trace_smul, F.blockMap_trace,
+    Matrix.trace_one, Fintype.card_fin, hXone (F.blockEquiv i),
+    Matrix.trace_smul, Matrix.trace_one, Fintype.card_fin, ← F.dimension_eq i] at hTrace
+  simp only [smul_eq_mul] at hTrace
+  have hdComplex : (d i : ℂ) ≠ 0 := by exact_mod_cast (Nat.ne_of_gt (hd i))
+  have hmComplex : (m i : ℂ) = m (F.blockEquiv i) :=
+    mul_right_cancel₀ hdComplex hTrace
+  exact_mod_cast hmComplex
+
+/-- A raw matched block map fixes the identity after the matched
+multiplicities have been identified. -/
+theorem DirectSumFacePermutation.blockMap_one_of_fixed_scalar_identity
+    {K : ℕ} {d m : Fin K → ℕ}
+    {Tbar Sbar : Module.End ℂ (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)}
+    (F : DirectSumFacePermutation Tbar Sbar)
+    (hm : ∀ k, 0 < m k)
+    (Xone : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)
+    (hXone : ∀ k, Xone k = (m k : ℂ) • 1)
+    (hFixed : Tbar Xone = Xone)
+    (hmMatch : ∀ i, m i = m (F.blockEquiv i)) (i : Fin K) :
+    directSumBlockMap Tbar i (F.blockEquiv i) 1 = 1 := by
+  have hAction := F.map_apply Xone (F.blockEquiv i)
+  rw [show F.blockEquiv.symm (F.blockEquiv i) = i from
+    F.blockEquiv.symm_apply_apply i] at hAction
+  have hBlock : directSumBlockMap Tbar i (F.blockEquiv i) (Xone i) =
+      Xone (F.blockEquiv i) := hAction.symm.trans (congrFun hFixed (F.blockEquiv i))
+  rw [hXone i, map_smul, hXone (F.blockEquiv i), ← hmMatch i] at hBlock
+  have hmComplex : (m i : ℂ) ≠ 0 := by exact_mod_cast (Nat.ne_of_gt (hm i))
+  exact smul_right_injective _ hmComplex hBlock
+
+set_option maxHeartbeats 800000 in
+-- The indexed density-block rewrites elaborate through several dependent matrix types.
+/-- Compressing the ambient Schwarz defect gives the ordinary Schwarz
+inequality on every raw matched density-block map.
+
+The two density-block multiplications initially contribute the unequal
+coefficients `(m i : ℂ)⁻¹ * (m (F.blockEquiv i) : ℂ)⁻¹` and
+`(m (F.blockEquiv i) : ℂ)⁻¹ * (m (F.blockEquiv i) : ℂ)⁻¹`.
+They are identified only by `hmMatch`; the resulting positive scalar is then
+cancelled before positivity is reflected through the nonzero identity tensor
+factor.  This is Wolf Theorem 6.16, proof line 1663. -/
+theorem DirectSumFacePermutation.rawBlock_isSchwarzMap_of_ambientDensityBlocks
+    {D n K : ℕ} {d m : Fin K → ℕ}
+    (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+    (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hsigma : ∀ k, sigma k = (m k : ℂ)⁻¹ • 1)
+    {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    {Tbar Sbar : Module.End ℂ (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)}
+    (F : DirectSumFacePermutation Tbar Sbar)
+    (hm : ∀ k, 0 < m k)
+    (hmMatch : ∀ i, m i = m (F.blockEquiv i))
+    (hPos : IsPositiveMap T) (hSchwarz : IsSchwarzMap T)
+    (hencode : ∀ X,
+      densityBlockWithZeroEmbedding e e₀ U hU sigma (Tbar X) =
+        T (densityBlockWithZeroEmbedding e e₀ U hU sigma X))
+    (i : Fin K) :
+    ∀ X : Matrix (Fin (d i)) (Fin (d i)) ℂ,
+      (directSumBlockMap Tbar i (F.blockEquiv i) (Xᴴ * X) -
+        directSumBlockMap Tbar i (F.blockEquiv i) Xᴴ *
+          directSumBlockMap Tbar i (F.blockEquiv i) X).PosSemidef := by
+  classical
+  intro X
+  let j := F.blockEquiv i
+  let raw := directSumBlockMap Tbar i j
+  have hRawPos : IsPositiveMap raw := fun Z hZ ↦ F.blockMap_pos i Z hZ
+  let E := densityBlockWithZeroEmbedding e e₀ U hU sigma
+  let A := E (Pi.single i X)
+  have hTsingle (Z : Matrix (Fin (d i)) (Fin (d i)) ℂ) :
+      T (E (Pi.single i Z)) = E (Pi.single j (raw Z)) := by
+    calc
+      T (E (Pi.single i Z)) = E (Tbar (Pi.single i Z)) :=
+        (hencode (Pi.single i Z)).symm
+      _ = E (Pi.single j (raw Z)) := by
+        rw [F.map_single]
+  have hAprod :
+      Aᴴ * A = (m i : ℂ)⁻¹ • E (Pi.single i (Xᴴ * X)) := by
+    exact densityBlockWithZeroEmbedding_single_conjTranspose_mul
+      e e₀ U hU sigma hsigma i X
+  have hFirst :
+      T (Aᴴ * A) =
+        (m i : ℂ)⁻¹ • E (Pi.single j (raw (Xᴴ * X))) := by
+    rw [hAprod, map_smul, hTsingle]
+  have hTA : T A = E (Pi.single j (raw X)) := hTsingle X
+  have hSecond :
+      T Aᴴ * T A =
+        (m j : ℂ)⁻¹ • E (Pi.single j ((raw X)ᴴ * raw X)) := by
+    rw [hPos.map_conjTranspose A, hTA]
+    exact densityBlockWithZeroEmbedding_single_conjTranspose_mul
+      e e₀ U hU sigma hsigma j (raw X)
+  have hAmbient := hSchwarz A
+  rw [hFirst, hSecond] at hAmbient
+  have hCompressed := densityBlockWithZeroPrincipalCompression_posSemidef
+    e e₀ U hU j hAmbient
+  dsimp only [E] at hCompressed
+  simp only [map_sub, map_smul,
+    densityBlockWithZeroPrincipalCompression_embedding, Pi.single_eq_same,
+    hsigma, Matrix.smul_kronecker, smul_smul] at hCompressed
+  change
+    (((m i : ℂ)⁻¹ * (m j : ℂ)⁻¹) •
+          ((1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ raw (Xᴴ * X)) -
+        ((m j : ℂ)⁻¹ * (m j : ℂ)⁻¹) •
+          ((1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ
+            ((raw X)ᴴ * raw X))).PosSemidef at hCompressed
+  have hmScalar : (m i : ℂ)⁻¹ = (m j : ℂ)⁻¹ := by
+    exact congrArg (fun a : ℕ ↦ (a : ℂ)⁻¹) (hmMatch i)
+  rw [hmScalar] at hCompressed
+  let c : ℂ := (m j : ℂ)⁻¹ * (m j : ℂ)⁻¹
+  let defect := raw (Xᴴ * X) - (raw X)ᴴ * raw X
+  have hScaled :
+      (c • ((1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ defect)).PosSemidef := by
+    convert hCompressed using 1
+    ext a b
+    simp only [c, defect, Matrix.smul_apply, Matrix.kroneckerMap_apply,
+      Matrix.sub_apply, smul_eq_mul]
+    ring
+  have hmComplexPos : (0 : ℂ) < m j := by
+    exact_mod_cast hm j
+  have hcPos : (0 : ℂ) < c := by
+    exact mul_pos (inv_pos.mpr hmComplexPos) (inv_pos.mpr hmComplexPos)
+  have hOneTensor :
+      ((1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ defect).PosSemidef := by
+    have hRescaled := hScaled.smul (inv_pos.mpr hcPos).le
+    simpa only [smul_smul, inv_mul_cancel₀ (ne_of_gt hcPos), one_smul] using hRescaled
+  let _ : NeZero (m j) := ⟨Nat.ne_of_gt (hm j)⟩
+  have hRawStar : raw Xᴴ = (raw X)ᴴ := hRawPos.map_conjTranspose X
+  simpa only [defect, raw, j, hRawStar] using
+    Matrix.PosSemidef.right_of_one_kronecker hOneTensor
+
+end Matrix
+
+namespace IsPositiveMap
+
+/-- A positive trace-preserving Schwarz map and its recurrent projection both
+fix the identity.
+
+The first equality is the direct-Schwarz unitality step.  The second places the
+identity in Wolf's asymptotic image before density-block coordinates are
+normalized.  Source: Wolf Theorem 6.16, proof lines 1629--1633 and 1660--1663. -/
+theorem map_one_and_peripheralProjection_one_of_tracePreserving_of_isSchwarzMap
+    {D : ℕ} [NeZero D]
+    {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap T) :
+    T 1 = 1 ∧ T.peripheralProjection 1 = 1 := by
+  have hTone := hPos.map_one_eq_one_of_tracePreserving_of_isSchwarzMap hTP hSchwarz
+  have hEig : Module.End.HasEigenvalue T 1 :=
+    hasEigenvalue_of_eigenvector_eq T 1 1
+      (by simpa only [one_smul] using hTone) one_ne_zero
+  have hOneMem : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ T.eigenspace 1 :=
+    Module.End.mem_eigenspace_iff.mpr (by simpa only [one_smul] using hTone)
+  exact ⟨hTone,
+    T.peripheralProjection_apply_of_mem_eigenspace hEig (by simp) hOneMem⟩
+
+/-- **Wolf Theorem 6.16: Schwarz maps on the matched density blocks.**
+
+This is the source-facing handoff after the pure-state-face permutation and
+before excluding the transpose alternative.  In addition to the exact
+density-block data and actions returned by
+`exists_peripheralDensityBlockFacePermutation`, it proves that the zero
+summand disappears, the weights are maximally mixed, matched multiplicities
+agree, and both the raw and canonically reindexed matched block maps satisfy
+the ordinary Schwarz inequality.
+
+The direct Schwarz hypothesis on `T` is intentionally distinct from the
+trace-adjoint Schwarz hypothesis used to obtain Wolf Theorem 6.14.  No unitary
+classification or Equation (6.68) is asserted here. -/
+theorem exists_peripheralDensityBlockSchwarz
+    {D : ℕ} [NeZero D]
+    {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hPos : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap T)
+    (hAdjointSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T)) :
+    ∃ (n K : ℕ) (d m : Fin K → ℕ)
+      (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+      (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+      (U : Matrix (Fin D) (Fin D) ℂ)
+      (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+      (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+      (S : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)),
+      (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ k, (sigma k).PosDef) ∧ (∀ k, (sigma k).trace = 1) ∧
+        (∀ B, T.peripheralProjection B = B ↔
+          ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+            star U * B * U = Matrix.reindex e₀ e₀
+              (Matrix.fromBlocks 0 0 0
+                (Matrix.reindex e e
+                  (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k)))) ∧
+        IsPositiveMap S ∧ IsTracePreservingMap S ∧
+        (let Tbar := Matrix.densityBlockDynamics e e₀ U hU sigma T
+         let Sbar := Matrix.densityBlockDynamics e e₀ U hU sigma S
+         (∀ X, Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma (Tbar X) =
+            T (Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma X)) ∧
+         (∀ X, Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma (Sbar X) =
+            S (Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma X)) ∧
+         Sbar.comp Tbar = LinearMap.id ∧
+         Tbar.comp Sbar = LinearMap.id ∧
+         Matrix.IsPositiveDirectSumMap Tbar ∧
+         Matrix.IsPositiveDirectSumMap Sbar ∧
+         Matrix.IsTracePreservingBetweenDirectSums Tbar ∧
+         Matrix.IsTracePreservingBetweenDirectSums Sbar ∧
+         ∃ F : Matrix.DirectSumFacePermutation Tbar Sbar,
+           let pi := F.blockEquiv.symm
+           (∀ X j, Tbar X j =
+             Matrix.directSumBlockMap Tbar (pi j) j (X (pi j))) ∧
+           (∀ Y i, Sbar Y i =
+             Matrix.directSumBlockMap Sbar (pi.symm i) i (Y (pi.symm i))) ∧
+           (∀ j, d (pi j) = d j) ∧
+           n = D ∧
+           (∀ k, sigma k = (m k : ℂ)⁻¹ • 1) ∧
+           (∀ i, m i = m (F.blockEquiv i)) ∧
+           (∀ i, Matrix.directSumBlockMap Tbar i (F.blockEquiv i) 1 = 1) ∧
+           (∀ i X, (Matrix.directSumBlockMap Tbar i (F.blockEquiv i) (Xᴴ * X) -
+             Matrix.directSumBlockMap Tbar i (F.blockEquiv i) Xᴴ *
+               Matrix.directSumBlockMap Tbar i (F.blockEquiv i) X).PosSemidef) ∧
+           ∀ i, IsSchwarzMap (F.matchedBlockEndomorphism i)) := by
+  classical
+  obtain ⟨n, K, d, m, e, e₀, U, sigma, hU, S, hd, hm, hsigmaPosDef,
+      hsigmaTrace, hfixed, hSPos, hSTP, hDynamics⟩ :=
+    hPos.exists_peripheralDensityBlockFacePermutation hTP hAdjointSchwarz
+  obtain ⟨hTone, hPone⟩ :=
+    hPos.map_one_and_peripheralProjection_one_of_tracePreserving_of_isSchwarzMap
+      hTP hSchwarz
+  obtain ⟨Xone, hXone, hn, hIdentityBlocks⟩ :=
+    Matrix.exists_densityBlockIdentityCoordinates e e₀ U hU sigma hd hm
+      hsigmaTrace hfixed hPone
+  have hsigma : ∀ k, sigma k = (m k : ℂ)⁻¹ • 1 :=
+    fun k ↦ (hIdentityBlocks k).1
+  have hXoneScalar : ∀ k, Xone k = (m k : ℂ) • 1 :=
+    fun k ↦ (hIdentityBlocks k).2
+  dsimp only at hDynamics
+  rcases hDynamics with
+    ⟨hTencode, hSencode, hST, hTS, hTPos, hSbarPos, hTTP, hSTPbar,
+      F, hMap, hInverseMap, hDimension⟩
+  have hXoneFixed := Matrix.densityBlockMap_fixed_identityCoordinates
+    e e₀ U hU sigma hsigmaTrace hTencode hTone Xone hXone
+  have hmMatch : ∀ i, m i = m (F.blockEquiv i) := fun i ↦
+    F.multiplicity_eq_of_fixed_scalar_identity hd Xone hXoneScalar hXoneFixed i
+  have hBlockOne : ∀ i,
+      Matrix.directSumBlockMap
+        (Matrix.densityBlockDynamics e e₀ U hU sigma T)
+        i (F.blockEquiv i) 1 = 1 := fun i ↦
+    F.blockMap_one_of_fixed_scalar_identity hm Xone hXoneScalar
+      hXoneFixed hmMatch i
+  have hRawSchwarz : ∀ i X,
+      (Matrix.directSumBlockMap
+          (Matrix.densityBlockDynamics e e₀ U hU sigma T)
+          i (F.blockEquiv i) (Xᴴ * X) -
+        Matrix.directSumBlockMap
+          (Matrix.densityBlockDynamics e e₀ U hU sigma T)
+          i (F.blockEquiv i) Xᴴ *
+        Matrix.directSumBlockMap
+          (Matrix.densityBlockDynamics e e₀ U hU sigma T)
+          i (F.blockEquiv i) X).PosSemidef := fun i ↦
+    F.rawBlock_isSchwarzMap_of_ambientDensityBlocks e e₀ U hU sigma hsigma
+      hm hmMatch hPos hSchwarz hTencode i
+  have hMatchedSchwarz : ∀ i, IsSchwarzMap (F.matchedBlockEndomorphism i) :=
+    fun i ↦ F.matchedBlockEndomorphism_isSchwarzMap_of_raw i (hRawSchwarz i)
+  refine ⟨n, K, d, m, e, e₀, U, sigma, hU, S, hd, hm, hsigmaPosDef,
+    hsigmaTrace, hfixed, hSPos, hSTP, ?_⟩
+  dsimp only
+  exact ⟨hTencode, hSencode, hST, hTS, hTPos, hSbarPos, hTTP, hSTPbar,
+    F, hMap, hInverseMap, hDimension, hn, hsigma, hmMatch, hBlockOne,
+    hRawSchwarz, hMatchedSchwarz⟩
+
+end IsPositiveMap

--- a/QICLean/Channel/Peripheral/MatchedBlockEndomorphism.lean
+++ b/QICLean/Channel/Peripheral/MatchedBlockEndomorphism.lean
@@ -1,0 +1,300 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Channel.Peripheral.DirectSumFacePermutation
+
+/-!
+# Endomorphisms on matched full-matrix blocks
+
+Wolf's pure-state-face argument in the proof of Theorem 6.16 matches a source
+full-matrix block with a target block of the same dimension.  This module
+uses that dimension equality only to reindex the matched forward block map to
+an endomorphism of the source matrix algebra.  The matched inverse block map
+is transported in the opposite direction.
+
+The resulting two endomorphisms are positive, trace preserving, and mutually
+inverse.  A separate bridge records that an ordinary Schwarz inequality for
+the raw matched block map becomes `IsSchwarzMap` after reindexing.  Establishing
+that raw inequality from Wolf's weighted density-block coordinates is not done
+here.
+
+Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines
+1641--1663.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder
+
+noncomputable section
+
+namespace Matrix
+
+variable {ι κ : Type*}
+variable [DecidableEq ι] [DecidableEq κ]
+variable {d : ι → ℕ} {e : κ → ℕ}
+
+/-- The forward map on a matched full-matrix block, transported back along
+the dimension equality so that it is literally an endomorphism of the source
+matrix algebra.
+
+This is the map denoted `T_k` at Wolf Theorem 6.16, proof line 1663. -/
+noncomputable def DirectSumFacePermutation.matchedBlockEndomorphism
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι) :
+    Module.End ℂ (Matrix (Fin (d i)) (Fin (d i)) ℂ) :=
+  (Matrix.reindexAlgEquiv ℂ ℂ
+      (finCongr (F.dimension_eq i))).symm.toLinearMap.comp
+    (directSumBlockMap T i (F.blockEquiv i))
+
+/-- The matched inverse block map, transported to an endomorphism of the same
+source matrix algebra. -/
+noncomputable def DirectSumFacePermutation.matchedBlockInverseEndomorphism
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι) :
+    Module.End ℂ (Matrix (Fin (d i)) (Fin (d i)) ℂ) :=
+  (directSumBlockMap S (F.blockEquiv i) i).comp
+    (Matrix.reindexAlgEquiv ℂ ℂ
+      (finCongr (F.dimension_eq i))).toLinearMap
+
+@[simp]
+theorem DirectSumFacePermutation.matchedBlockEndomorphism_apply
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι)
+    (X : Matrix (Fin (d i)) (Fin (d i)) ℂ) :
+    F.matchedBlockEndomorphism i X =
+      Matrix.reindex (finCongr (F.dimension_eq i)).symm
+        (finCongr (F.dimension_eq i)).symm
+        (directSumBlockMap T i (F.blockEquiv i) X) := by
+  rfl
+
+@[simp]
+theorem DirectSumFacePermutation.matchedBlockInverseEndomorphism_apply
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι)
+    (X : Matrix (Fin (d i)) (Fin (d i)) ℂ) :
+    F.matchedBlockInverseEndomorphism i X =
+      directSumBlockMap S (F.blockEquiv i) i
+        (Matrix.reindex (finCongr (F.dimension_eq i))
+          (finCongr (F.dimension_eq i)) X) := by
+  rfl
+
+/-- The transported forward block map is positive. -/
+theorem DirectSumFacePermutation.matchedBlockEndomorphism_isPositiveMap
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι) :
+    IsPositiveMap (F.matchedBlockEndomorphism i) := by
+  intro X hX
+  rw [F.matchedBlockEndomorphism_apply]
+  exact (F.blockMap_pos i X hX).submatrix
+    (finCongr (F.dimension_eq i))
+
+/-- The transported matched inverse block map is positive. -/
+theorem DirectSumFacePermutation.matchedBlockInverseEndomorphism_isPositiveMap
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι) :
+    IsPositiveMap (F.matchedBlockInverseEndomorphism i) := by
+  intro X hX
+  rw [F.matchedBlockInverseEndomorphism_apply]
+  have hReindex :
+      (Matrix.reindex (finCongr (F.dimension_eq i))
+        (finCongr (F.dimension_eq i)) X).PosSemidef :=
+    hX.submatrix (finCongr (F.dimension_eq i)).symm
+  have h := F.inverseBlockMap_pos (F.blockEquiv i) _ hReindex
+  rw [F.blockEquiv.symm_apply_apply] at h
+  exact h
+
+/-- The transported forward block map preserves the ordinary matrix trace. -/
+theorem DirectSumFacePermutation.matchedBlockEndomorphism_isTracePreservingMap
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι) :
+    IsTracePreservingMap (F.matchedBlockEndomorphism i) := by
+  intro X
+  rw [F.matchedBlockEndomorphism_apply, Matrix.trace_reindex,
+    F.blockMap_trace]
+
+/-- The transported matched inverse block map also preserves the ordinary
+matrix trace. -/
+theorem DirectSumFacePermutation.matchedBlockInverseEndomorphism_isTracePreservingMap
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι) :
+    IsTracePreservingMap (F.matchedBlockInverseEndomorphism i) := by
+  intro X
+  rw [F.matchedBlockInverseEndomorphism_apply]
+  have h := F.inverseBlockMap_trace (F.blockEquiv i)
+    (Matrix.reindex (finCongr (F.dimension_eq i))
+      (finCongr (F.dimension_eq i)) X)
+  rw [F.blockEquiv.symm_apply_apply] at h
+  exact h.trans (Matrix.trace_reindex (finCongr (F.dimension_eq i)) X)
+
+/-- The transported inverse block map is a left inverse of the transported
+forward block map. -/
+theorem DirectSumFacePermutation.matchedBlockEndomorphism_leftInverse
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι) :
+    Function.LeftInverse (F.matchedBlockInverseEndomorphism i)
+      (F.matchedBlockEndomorphism i) := by
+  intro X
+  rw [F.matchedBlockInverseEndomorphism_apply,
+    F.matchedBlockEndomorphism_apply]
+  let q := finCongr (F.dimension_eq i)
+  have hReindex (Y : Matrix (Fin (e (F.blockEquiv i)))
+      (Fin (e (F.blockEquiv i))) ℂ) :
+      Matrix.reindex q q (Matrix.reindex q.symm q.symm Y) = Y := by
+    exact (Matrix.reindexLinearEquiv ℂ ℂ q q).apply_symm_apply Y
+  rw [hReindex]
+  exact F.blockMap_leftInverse i X
+
+/-- The transported inverse block map is also a right inverse of the
+transported forward block map. -/
+theorem DirectSumFacePermutation.matchedBlockEndomorphism_rightInverse
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι) :
+    Function.RightInverse (F.matchedBlockInverseEndomorphism i)
+      (F.matchedBlockEndomorphism i) := by
+  intro X
+  rw [F.matchedBlockEndomorphism_apply,
+    F.matchedBlockInverseEndomorphism_apply,
+    F.blockMap_rightInverse]
+  let q := finCongr (F.dimension_eq i)
+  exact (Matrix.reindexLinearEquiv ℂ ℂ q q).symm_apply_apply X
+
+/-- The transported inverse composed after the transported forward block map
+is the identity. -/
+theorem DirectSumFacePermutation.matchedBlockInverseEndomorphism_comp
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι) :
+    (F.matchedBlockInverseEndomorphism i).comp
+      (F.matchedBlockEndomorphism i) = LinearMap.id := by
+  apply LinearMap.ext
+  intro X
+  exact F.matchedBlockEndomorphism_leftInverse i X
+
+/-- The transported forward block map composed after its transported inverse
+is the identity. -/
+theorem DirectSumFacePermutation.matchedBlockEndomorphism_comp_inverse
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι) :
+    (F.matchedBlockEndomorphism i).comp
+      (F.matchedBlockInverseEndomorphism i) = LinearMap.id := by
+  apply LinearMap.ext
+  intro X
+  exact F.matchedBlockEndomorphism_rightInverse i X
+
+/-- The transported forward block map is bijective. -/
+theorem DirectSumFacePermutation.matchedBlockEndomorphism_bijective
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι) :
+    Function.Bijective (F.matchedBlockEndomorphism i) :=
+  ⟨(F.matchedBlockEndomorphism_leftInverse i).injective,
+    (F.matchedBlockEndomorphism_rightInverse i).surjective⟩
+
+/-- The transported matched inverse is the canonical inverse linear map of
+the transported forward block map.  This consumer-independent form unfolds
+directly to the inverse used by the positive-invertible-map classification. -/
+theorem DirectSumFacePermutation.matchedBlockInverseEndomorphism_eq_canonicalInverse
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι)
+    (hBij : Function.Bijective (F.matchedBlockEndomorphism i)) :
+    F.matchedBlockInverseEndomorphism i =
+      (LinearEquiv.ofBijective (F.matchedBlockEndomorphism i) hBij).symm.toLinearMap := by
+  apply LinearMap.ext
+  intro X
+  apply hBij.1
+  calc
+    F.matchedBlockEndomorphism i
+        (F.matchedBlockInverseEndomorphism i X) = X :=
+      F.matchedBlockEndomorphism_rightInverse i X
+    _ = F.matchedBlockEndomorphism i
+        ((LinearEquiv.ofBijective
+          (F.matchedBlockEndomorphism i) hBij).symm X) :=
+      (LinearEquiv.ofBijective
+        (F.matchedBlockEndomorphism i) hBij).apply_symm_apply X |>.symm
+
+/-- The canonical inverse of the transported forward block map is positive. -/
+theorem DirectSumFacePermutation.matchedBlockCanonicalInverse_isPositiveMap
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι)
+    (hBij : Function.Bijective (F.matchedBlockEndomorphism i)) :
+    IsPositiveMap
+      (LinearEquiv.ofBijective (F.matchedBlockEndomorphism i) hBij).symm.toLinearMap := by
+  rw [← F.matchedBlockInverseEndomorphism_eq_canonicalInverse i hBij]
+  exact F.matchedBlockInverseEndomorphism_isPositiveMap i
+
+/-- An ordinary Schwarz inequality for the raw matched block map becomes the
+ordinary Schwarz inequality for its transported endomorphism.
+
+This is only a change-of-index bridge.  In the application to Wolf Theorem
+6.16, the premise must be proved separately by compressing the ambient
+Schwarz defect in the weighted density-block coordinates; it is not obtained
+by treating those coordinates as an ordinary algebra embedding.  The premise
+is the block Schwarz inequality asserted at proof line 1663. -/
+theorem DirectSumFacePermutation.matchedBlockEndomorphism_isSchwarzMap_of_raw
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S) (i : ι)
+    (hSchwarz : ∀ X : Matrix (Fin (d i)) (Fin (d i)) ℂ,
+      (directSumBlockMap T i (F.blockEquiv i) (Xᴴ * X) -
+        directSumBlockMap T i (F.blockEquiv i) Xᴴ *
+          directSumBlockMap T i (F.blockEquiv i) X).PosSemidef) :
+    IsSchwarzMap (F.matchedBlockEndomorphism i) := by
+  intro X
+  let q := finCongr (F.dimension_eq i)
+  have hTransport :
+      ((Matrix.reindexAlgEquiv ℂ ℂ q).symm
+        (directSumBlockMap T i (F.blockEquiv i) (Xᴴ * X) -
+          directSumBlockMap T i (F.blockEquiv i) Xᴴ *
+            directSumBlockMap T i (F.blockEquiv i) X)).PosSemidef := by
+    exact (hSchwarz X).submatrix q
+  simp only [F.matchedBlockEndomorphism_apply]
+  simpa only [q, map_sub, map_mul, Matrix.symm_reindexAlgEquiv,
+    Matrix.coe_reindexAlgEquiv] using hTransport
+
+end Matrix

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -629,12 +629,10 @@ classification theorem is already proved.
     $\tr(\sigma)=1$ and $\sigma\otimes X=\Id_{md}$, then
     $\sigma=m^{-1}\Id_m$ and $X=m\Id_d$.
 
-    These auxiliary facts are needed before the matched-multiplicity comparison
+    These auxiliary facts are used below in the matched-multiplicity comparison
     and the transport of the ambient Schwarz defect to an individual weighted
-    full-matrix block map at source lines 1660--1663. They establish neither
-    remaining step; that source-facing assembly remains open. This is not a
+    full-matrix block map at source lines 1660--1663. This is not a
     modified-product argument.
-    % Tracking: GitHub issue #417.
 \end{theorem}
 
 \begin{proof}
@@ -807,6 +805,121 @@ classification theorem is already proved.
     trace-preserving; their two-sided inverse identities imply injections in
     both directions, and equality of finite matrix-space dimensions gives
     $d_i=d_{\tau(i)}$.
+\end{proof}
+
+\begin{theorem}[Schwarz inequalities on matched density blocks]
+    \label{thm:wolf_cycle_density_block_schwarz}
+    \lean{Matrix.densityBlockWithZeroPrincipalCompression,
+        Matrix.densityBlockWithZeroPrincipalCompression_apply,
+        Matrix.densityBlockWithZeroPrincipalCompression_embedding,
+        Matrix.densityBlockWithZeroPrincipalCompression_one,
+        Matrix.densityBlockWithZeroPrincipalCompression_posSemidef,
+        Matrix.densityBlockWithZeroEmbedding_eq_one_dimension,
+        Matrix.densityBlockWithZeroEmbedding_eq_one_block,
+        Matrix.densityBlockWithZeroEmbedding_eq_one,
+        Matrix.exists_densityBlockIdentityCoordinates,
+        Matrix.densityBlockWithZeroEmbedding_single_conjTranspose_mul,
+        Matrix.densityBlockMap_fixed_identityCoordinates,
+        Matrix.DirectSumFacePermutation.multiplicity_eq_of_fixed_scalar_identity,
+        Matrix.DirectSumFacePermutation.blockMap_one_of_fixed_scalar_identity,
+        Matrix.DirectSumFacePermutation.rawBlock_isSchwarzMap_of_ambientDensityBlocks,
+        IsPositiveMap.map_one_and_peripheralProjection_one_of_tracePreserving_of_isSchwarzMap,
+        Matrix.DirectSumFacePermutation.matchedBlockEndomorphism,
+        Matrix.DirectSumFacePermutation.matchedBlockInverseEndomorphism,
+        Matrix.DirectSumFacePermutation.matchedBlockEndomorphism_apply,
+        Matrix.DirectSumFacePermutation.matchedBlockInverseEndomorphism_apply,
+        Matrix.DirectSumFacePermutation.matchedBlockEndomorphism_isPositiveMap,
+        Matrix.DirectSumFacePermutation.matchedBlockInverseEndomorphism_isPositiveMap,
+        Matrix.DirectSumFacePermutation.matchedBlockEndomorphism_isTracePreservingMap,
+        Matrix.DirectSumFacePermutation.matchedBlockInverseEndomorphism_isTracePreservingMap,
+        Matrix.DirectSumFacePermutation.matchedBlockEndomorphism_leftInverse,
+        Matrix.DirectSumFacePermutation.matchedBlockEndomorphism_rightInverse,
+        Matrix.DirectSumFacePermutation.matchedBlockInverseEndomorphism_comp,
+        Matrix.DirectSumFacePermutation.matchedBlockEndomorphism_comp_inverse,
+        Matrix.DirectSumFacePermutation.matchedBlockEndomorphism_bijective,
+        Matrix.DirectSumFacePermutation.matchedBlockInverseEndomorphism_eq_canonicalInverse,
+        Matrix.DirectSumFacePermutation.matchedBlockCanonicalInverse_isPositiveMap,
+        Matrix.DirectSumFacePermutation.matchedBlockEndomorphism_isSchwarzMap_of_raw,
+        IsPositiveMap.exists_peripheralDensityBlockSchwarz}
+    \leanok
+    \uses{def:positive_map,def:trace_preserving,
+        def:abstract_schwarz_inequality,
+        thm:wolf_cycle_density_block_face_permutation}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, with $D>0$.
+    Suppose separately that $T$ and its trace-pairing adjoint $T^*$ satisfy
+    the Schwarz inequality. In the density-block coordinates and notation of
+    Theorem~\ref{thm:wolf_cycle_density_block_face_permutation}, the zero
+    summand has dimension zero and
+    \begin{align}
+        n&=D, &
+        \sigma_k&=m_k^{-1}\Id_{m_k}. \label{eq:cycle_mixed_weights}
+    \end{align}
+    If $\tau$ is the source-to-target block permutation, then
+    \begin{align}
+        m_i&=m_{\tau(i)}, &
+        \bar T_{i,\tau(i)}(\Id_{d_i})&=\Id_{d_{\tau(i)}}. \label{eq:cycle_matched_multiplicity}
+    \end{align}
+    For every $X\in\MN{d_i}$, the raw matched block map satisfies
+    \begin{align}
+        \bar T_{i,\tau(i)}(X^\dagger X)
+        -\bar T_{i,\tau(i)}(X^\dagger)
+         \bar T_{i,\tau(i)}(X)&\succeq0. \label{eq:cycle_raw_schwarz}
+    \end{align}
+    Transporting along $d_i=d_{\tau(i)}$ gives an endomorphism of
+    $\MN{d_i}$ with the ordinary Schwarz property. Together with the matched
+    block conclusions of
+    Theorem~\ref{thm:wolf_cycle_density_block_face_permutation}, this
+    endomorphism is positive, trace preserving, bijective, and has a positive
+    inverse, exactly the hypotheses needed for the subsequent exclusion of
+    matrix transposition.
+
+    Two printed dimension defects are kept explicit. At source line 1499,
+    $\rho_k\in\MN{m_k}$ and the full algebra acts on the $d_k$ factor, so the
+    compatible identity is $\Id_{d_k}\otimes\rho_k$, not the printed
+    $\Id_{m_k}\otimes\rho_k$; in the formal tensor-factor order this is
+    $\sigma_k\otimes\Id_{d_k}$. At source lines 1614--1616 the statement asks
+    $\pi$ to preserve the dimension $d_km_k$ of the whole space
+    $\mathcal H_k$, whereas the pure-face argument at lines 1653--1656 proves
+    only equality of $d_k$. The equality of $m_k$ in
+    (\ref{eq:cycle_matched_multiplicity}) supplies the missing comparison.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:wolf_cycle_schwarz_unital_kronecker,
+        thm:wolf_cycle_density_block_face_permutation}
+    The direct Schwarz inequality, positivity, and trace preservation give
+    $T(\Id)=\Id$, so the recurrent projection also fixes $\Id$. Compressing
+    this identity in the zero-extended density-block coordinates eliminates
+    the zero summand and gives (\ref{eq:cycle_mixed_weights}), together with
+    identity coordinates $X_k=m_k\Id_{d_k}$. Intertwining with $T$ fixes this
+    coordinate family. Applying the matched block action, taking the ordinary
+    matrix trace, and using preservation of trace and
+    $d_i=d_{\tau(i)}$ gives $m_i=m_{\tau(i)}$; cancellation of the same
+    nonzero scalar gives the unitality in
+    (\ref{eq:cycle_matched_multiplicity}).
+
+    Put $c_k=m_k^{-1}$ and embed a matrix $X$ in source block $i$. Weighted
+    multiplication gives
+    \begin{align}
+        E_i(X)^\dagger E_i(X)&=c_i E_i(X^\dagger X).
+    \end{align}
+    Apply the ambient Schwarz inequality and compress to the target block
+    $j=\tau(i)$. Before using the multiplicity equality, the resulting defect
+    is
+    \begin{align}
+        c_i c_j\,\Id_{m_j}\otimes
+          \bar T_{i,j}(X^\dagger X)
+        -c_j^2\,\Id_{m_j}\otimes
+          \bigl(\bar T_{i,j}(X)^\dagger\bar T_{i,j}(X)\bigr)
+        &\succeq0. \label{eq:cycle_weighted_defect}
+    \end{align}
+    The equality $m_i=m_j$ turns the two coefficients in
+    (\ref{eq:cycle_weighted_defect}) into the same positive scalar. Cancel
+    that scalar and reflect positivity through the nonzero identity tensor
+    factor to obtain (\ref{eq:cycle_raw_schwarz}). Reindexing the equal
+    $d$-dimensional factors preserves multiplication, adjoints, and positive
+    semidefiniteness.
 \end{proof}
 
 \begin{theorem}[The Schwarz condition excludes matrix transpositions]

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -1469,10 +1469,10 @@ is false under the single printed hypothesis.
     traces to show that \(\tr(\sigma)=1\) and
     \(\sigma\otimes X=\Id_{md}\) force
     \(\sigma=m^{-1}\Id_m\) and \(X=m\Id_d\).
-  These helpers neither compare the matched block multiplicities nor transport
-  the ambient Schwarz defect to the individual weighted full-matrix block
-  maps. That remaining source-facing assembly is tracked by #417. No
-  modified-product proof or complete-positivity hypothesis is introduced here.
+  These facts are assembled below to compare the matched block
+  multiplicities and transport the ambient Schwarz defect to the individual
+  weighted full-matrix block maps. No modified-product proof or
+  complete-positivity hypothesis is introduced.
 
 * The final classification step at source lines 1660--1663 is formalized
   under exactly Wolf's positive, trace-preserving, positive-inverse, and
@@ -1574,13 +1574,54 @@ is false under the single printed hypothesis.
     inverse is Wolf's output-to-input permutation `pi`, so
     `(Tbar X) j` depends only on `X (pi j)` and `d (pi j) = d j`.
 
-* This completes exactly the bounded pure-face/permutation passage at source
-  lines 1641--1659, not all of Theorem 6.16. The remaining **existence
-  assembly** for a `MultiCycleDecomposition` must still compare the matched
-  multiplicities `m`, transport the ordinary Schwarz inequality to the
-  matched weighted block maps, combine the already formalized exclusion of
-  the transpose alternative, and obtain the exact weighted Equation (6.68).
-  Those steps remain tracked by #417 and #411. The conditional
+* The scalar/multiplicity comparison and ordinary block-Schwarz transport at
+  source lines 1660--1663 are formalized in
+  `QICLean.Channel.Peripheral.DensityBlockSchwarz` and
+  `QICLean.Channel.Peripheral.MatchedBlockEndomorphism`:
+  - `IsPositiveMap.map_one_and_peripheralProjection_one_of_tracePreserving_of_isSchwarzMap`
+    proves that both `T` and its recurrent projection fix the identity;
+  - `Matrix.exists_densityBlockIdentityCoordinates` eliminates the zero
+    summand, proves `n = D`, and identifies every density factor as
+    `sigma k = (m k : ℂ)⁻¹ • 1`;
+  - `Matrix.DirectSumFacePermutation.multiplicity_eq_of_fixed_scalar_identity`
+    uses the matched block action, ordinary block trace preservation, and the
+    already proved equality of the `d` dimensions to obtain
+    `m i = m (F.blockEquiv i)`;
+  - `Matrix.DirectSumFacePermutation.blockMap_one_of_fixed_scalar_identity`
+    proves unitality of each raw matched block map;
+  - `Matrix.densityBlockWithZeroEmbedding_single_conjTranspose_mul` computes
+    the extra inverse-multiplicity scalar introduced by multiplication in the
+    weighted coordinates;
+  - `Matrix.DirectSumFacePermutation.rawBlock_isSchwarzMap_of_ambientDensityBlocks`
+    compresses the ambient Schwarz defect. Before using the matched
+    multiplicity equality, its two coefficients are respectively
+    `c_i * c_j` and `c_j * c_j`, where `c_k = (m k : ℂ)⁻¹`. Only then
+    does it cancel the common positive scalar and reflect positivity through
+    `1 ⊗ₖ B`;
+  - `Matrix.DirectSumFacePermutation.matchedBlockEndomorphism_isSchwarzMap_of_raw`
+    transports that raw inequality along the proved equality of the `d`
+    dimensions;
+  - `IsPositiveMap.exists_peripheralDensityBlockSchwarz` consumes the exact
+    face-permutation witnesses above and returns `n = D`, maximally mixed
+    weights, equality of matched multiplicities, raw block unitality, the raw
+    ordinary Schwarz inequalities, and Schwarz for the canonically reindexed
+    matched endomorphisms. Its hypotheses keep Schwarz for `T` separate from
+    Schwarz for `T*`.
+
+  This also records two printed defects without silently changing the source.
+  Source line 1499 writes `1_(m_k) ⊗ rho_k`, although
+  `rho_k ∈ M_(m_k)` and the full algebra is `M_(d_k)`; the compatible
+  identity is `1_(d_k) ⊗ rho_k`, written `sigma k ⊗ₖ 1_(d_k)` in the
+  formal tensor-factor order. Source lines 1614--1616 require the permutation
+  to preserve the whole block dimension `d_k * m_k`, whereas the pure-face
+  argument at lines 1653--1656 proves only equality of `d_k`; the new trace
+  calculation supplies the missing equality of `m_k`.
+
+* This completes the bounded pure-face/permutation passage and the repaired
+  scalar block-Schwarz step, but not all of Theorem 6.16. The remaining
+  **existence assembly** must apply the already formalized exclusion of the
+  transpose alternative to the matched endomorphisms and prove the exact
+  weighted Equation (6.68). That step remains tracked by #411. The conditional
   `CycleStructure` and `MultiCycleDecomposition` objects above are consumers
   of that later theorem; they are not substitutes for it.
 


### PR DESCRIPTION
## Summary

- consume the exact density-block face-permutation witnesses from #409;
- use direct Schwarz plus trace preservation to fix the ambient identity, prove \(n=D\), and identify Wolf's density factors as \(\sigma_k=m_k^{-1}I\);
- derive equality of matched multiplicities from the existing block trace preservation and matched full-matrix dimensions;
- compress the ambient weighted Schwarz defect with its two coefficients kept asymmetric until the proved multiplicity equality, then obtain ordinary Schwarz for both raw and canonically reindexed matched block maps;
- synchronize the Peripheral aggregator, Blueprint, and Wolf numbering coverage, including both printed source defects tracked by #417.

The direct Schwarz hypothesis on \(T\) and the trace-adjoint Schwarz hypothesis used by Wolf Theorem 6.14 remain separate. This PR does not use CP/Kraus, literal weighted restriction, or a modified product, and stops before #410 classification and #411 / Equation (6.68).

Source: Wolf, *Quantum Channels & Operations*, `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, especially proof lines 1660–1663, with the line 1499 and lines 1614–1616 defects recorded explicitly.

## Validation

- `lake build QICLean.Channel.Peripheral.DensityBlockSchwarz QICLean.Channel.Peripheral` (8871 jobs)
- full `lake build` (9266 jobs)
- Blueprint sync 2233/2233; reverse changed-declaration coverage zero; `checkdecls` green
- import aggregators current (30 generated / 525 production modules)
- style, module-policy, diff, forbidden-token, and source-contract audits green
- load-bearing axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`
- independent exact-head review approved `df90a12cb4a618557f8ad2d8ba41ddd8bd6450a6`

Closes #417.

