### PR TITLE
feat(channel): formalize canonical qubit representatives

### DIFF
--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -55,6 +55,7 @@ import QICLean.Channel.KrausUnitaryFreedom
 import QICLean.Channel.LocalizedKrausCPTP
 import QICLean.Channel.LorentzNormalForm
 import QICLean.Channel.LorentzNormalForm.Basic
+import QICLean.Channel.LorentzNormalForm.CanonicalQubitChannels
 import QICLean.Channel.LorentzNormalForm.Infimum
 import QICLean.Channel.LorentzNormalForm.InvertibleFilter
 import QICLean.Channel.LorentzNormalForm.NormalForm

--- a/QICLean/Channel/LorentzNormalForm.lean
+++ b/QICLean/Channel/LorentzNormalForm.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Channel.LorentzNormalForm.Basic
+import QICLean.Channel.LorentzNormalForm.CanonicalQubitChannels
 import QICLean.Channel.LorentzNormalForm.Infimum
 import QICLean.Channel.LorentzNormalForm.InvertibleFilter
 import QICLean.Channel.LorentzNormalForm.NormalForm
@@ -15,11 +16,14 @@ import QICLean.Channel.LorentzNormalForm.SpinorAction
 # Lorentz normal form for quantum channels (Wolf Section 2.4, Propositions 2.8–2.11)
 
 Thin module assembling the normal-form development for quantum channels under
-filtering operations from seven focused submodules.
+filtering operations from eight focused submodules.
 
 * `QICLean.Channel.LorentzNormalForm.Basic` — SL-filtering operations, the
   doubly-stochastic predicates, and the shared Kronecker-conjugation and
   partial-trace identities.
+* `QICLean.Channel.LorentzNormalForm.CanonicalQubitChannels` — the exact
+  non-diagonal and singular qubit representatives, their Pauli-transfer
+  action, and their Choi/Kraus ranks.
 * `QICLean.Channel.LorentzNormalForm.Infimum` — the compactness/minimisation
   argument (Wolf Equation (2.36)): attainment of the infimum and the AM–GM
   optimality lemmas.

--- a/QICLean/Channel/LorentzNormalForm/CanonicalQubitChannels.lean
+++ b/QICLean/Channel/LorentzNormalForm/CanonicalQubitChannels.lean
@@ -1,0 +1,437 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Channel.KrausMap
+import QICLean.Channel.KrausRank
+import QICLean.Channel.LorentzNormalForm.SpinorAction
+
+/-!
+# Canonical non-diagonal and singular qubit channels
+
+This module formalizes the two non-generic channel representatives displayed in
+Verstraete--Verschelde, *On Quantum Channels*, arXiv:quant-ph/0202124v2,
+Theorem 8, Equations (17)--(19), and repeated in Wolf, Proposition 2.11
+(`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 1021--1035).
+
+Only the displayed representatives are treated here.  In particular, this file
+does not prove that every qubit channel has one of these forms, does not derive
+the necessary range `0 ≤ x ≤ 1`, and does not construct filtering maps.
+
+The Pauli-transfer convention is Wolf's
+`T̂ᵢⱼ = tr[σᵢ T(σⱼ)] / 2`.  QICLean's Choi matrix is normalized, so
+for a trace-preserving qubit map
+`tau = (1/4) sum i j, T̂ᵢⱼ σᵢ ⊗ σⱼᵀ`.  Consequently a raw Pauli
+correlation matrix of `tau` has the extra sign in its `σ₂` input column
+coming from `σ₂ᵀ = -σ₂`; no raw-correlation matrix is identified with
+the transfer matrix below.
+-/
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+open Matrix Finset
+
+noncomputable section
+
+namespace Wolf
+
+private abbrev QubitMatrix := Matrix (Fin 2) (Fin 2) ℂ
+private abbrev QubitMap := QubitMatrix →ₗ[ℂ] QubitMatrix
+
+/-! ## The non-diagonal representative -/
+
+/-- The three fixed matrix directions in the Kraus family of
+Verstraete--Verschelde, Equation (19). -/
+def nonDiagonalKrausBase : Fin 3 → QubitMatrix
+  | 0 => !![1, 0; 0, (1 / Real.sqrt 3 : ℝ)]
+  | 1 => !![1, 0; 0, (-1 / Real.sqrt 3 : ℝ)]
+  | 2 => !![0, 1; 0, 0]
+
+/-- The three real coefficients in the Kraus family of
+Verstraete--Verschelde, Equation (19). -/
+def nonDiagonalKrausCoefficient (x : ℝ) : Fin 3 → ℝ
+  | 0 => Real.sqrt ((1 + x) / 2)
+  | 1 => Real.sqrt ((1 - x) / 2)
+  | 2 => Real.sqrt (2 / 3)
+
+/-- The exact three-operator non-diagonal Kraus family from
+Verstraete--Verschelde, Equation (19).  The hypotheses `0 ≤ x ≤ 1` are
+used only when certifying that this family is trace preserving. -/
+def nonDiagonalKraus (x : ℝ) : Fin 3 → QubitMatrix :=
+  fun i ↦ (nonDiagonalKrausCoefficient x i : ℂ) • nonDiagonalKrausBase i
+
+/-- The canonical non-diagonal completely positive map displayed in
+Verstraete--Verschelde, Theorem 8. -/
+def nonDiagonalMap (x : ℝ) : QubitMap :=
+  Kraus.mapLM (nonDiagonalKraus x)
+
+/-- The source-displayed non-diagonal Kraus family is trace preserving on
+the stated parameter interval. -/
+theorem nonDiagonalKraus_isTP {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x ≤ 1) :
+    Kraus.IsTP (nonDiagonalKraus x) := by
+  have hplus : 0 ≤ (1 + x) / 2 := by linarith
+  have hminus : 0 ≤ (1 - x) / 2 := by linarith
+  have hsplus := Real.sq_sqrt hplus
+  have hsminus := Real.sq_sqrt hminus
+  have hstwo := Real.sq_sqrt (show (0 : ℝ) ≤ 2 / 3 by norm_num)
+  have hplus' : 0 ≤ 1 + x := by linarith
+  have hminus' : 0 ≤ 1 - x := by linarith
+  have hsplus' := Real.sq_sqrt hplus'
+  have hsminus' := Real.sq_sqrt hminus'
+  have hsqrtTwo := Real.sq_sqrt (show (0 : ℝ) ≤ 2 by norm_num)
+  have hsqrtThree := Real.sq_sqrt (show (0 : ℝ) ≤ 3 by norm_num)
+  have hsqrtTwo_ne : Real.sqrt 2 ≠ 0 := by positivity
+  have hsqrtThree_ne : Real.sqrt 3 ≠ 0 := by positivity
+  have hsqrtTwoFour : Real.sqrt 2 ^ 4 = 4 := by
+    rw [show Real.sqrt 2 ^ 4 = (Real.sqrt 2 ^ 2) ^ 2 by ring, hsqrtTwo]
+    norm_num
+  rw [Kraus.IsTP]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [nonDiagonalKraus, nonDiagonalKrausCoefficient,
+      nonDiagonalKrausBase, Fin.sum_univ_three, Matrix.mul_apply,
+      Matrix.vecMul, dotProduct, Matrix.conjTranspose_apply,
+      hsplus, hsminus, hstwo]
+  all_goals norm_cast
+  all_goals field_simp [hsqrtTwo_ne, hsqrtThree_ne]
+  all_goals norm_num [hsplus', hsminus', hsqrtTwo, hsqrtThree, hsqrtTwoFour]
+
+/-- The source-displayed non-diagonal Kraus family defines a channel on
+`0 ≤ x ≤ 1`.  This is a sufficiency statement, not a derivation of the
+parameter range. -/
+theorem nonDiagonalMap_isChannel {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x ≤ 1) :
+    IsChannel (nonDiagonalMap x) :=
+  Kraus.isChannel_mapLM _ (nonDiagonalKraus_isTP hx0 hx1)
+
+/-- Entrywise action of the canonical non-diagonal representative. -/
+theorem nonDiagonalMap_apply {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x ≤ 1)
+    (X : QubitMatrix) :
+    nonDiagonalMap x X =
+      !![X 0 0 + (2 / 3 : ℂ) * X 1 1, (x / Real.sqrt 3 : ℝ) * X 0 1;
+         (x / Real.sqrt 3 : ℝ) * X 1 0, (1 / 3 : ℂ) * X 1 1] := by
+  have hplus : 0 ≤ (1 + x) / 2 := by linarith
+  have hminus : 0 ≤ (1 - x) / 2 := by linarith
+  have hsplus : Real.sqrt ((1 + x) / 2) ^ 2 = (1 + x) / 2 := Real.sq_sqrt hplus
+  have hsminus : Real.sqrt ((1 - x) / 2) ^ 2 = (1 - x) / 2 := Real.sq_sqrt hminus
+  have hstwo : Real.sqrt (2 / 3) ^ 2 = (2 / 3 : ℝ) :=
+    Real.sq_sqrt (by norm_num)
+  have hsqrtThree : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have hsqrtThree_ne : Real.sqrt 3 ≠ 0 := by positivity
+  have hplus' : 0 ≤ 1 + x := by linarith
+  have hminus' : 0 ≤ 1 - x := by linarith
+  have hsplus' : Real.sqrt (1 + x) ^ 2 = 1 + x := Real.sq_sqrt hplus'
+  have hsminus' : Real.sqrt (1 - x) ^ 2 = 1 - x := Real.sq_sqrt hminus'
+  have hsqrtTwo : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have hsqrtTwo_ne : Real.sqrt 2 ≠ 0 := by positivity
+  have hsumReal :
+      Real.sqrt (1 + x) / Real.sqrt 2 * (Real.sqrt (1 + x) / Real.sqrt 2) +
+        Real.sqrt (1 - x) / Real.sqrt 2 * (Real.sqrt (1 - x) / Real.sqrt 2) = 1 := by
+    field_simp [hsqrtTwo_ne]
+    nlinarith [hsplus', hsminus', hsqrtTwo]
+  have hdiffReal :
+      Real.sqrt (1 + x) / Real.sqrt 2 * (Real.sqrt (1 + x) / Real.sqrt 2) -
+        Real.sqrt (1 - x) / Real.sqrt 2 * (Real.sqrt (1 - x) / Real.sqrt 2) = x := by
+    field_simp [hsqrtTwo_ne]
+    nlinarith [hsplus', hsminus', hsqrtTwo]
+  have hraiseReal :
+      Real.sqrt 2 / Real.sqrt 3 * (Real.sqrt 2 / Real.sqrt 3) = 2 / 3 := by
+    field_simp [hsqrtThree_ne, hsqrtTwo_ne]
+    nlinarith [hsqrtTwo, hsqrtThree]
+  have hinvThreeReal :
+      (Real.sqrt 3)⁻¹ * (Real.sqrt 3)⁻¹ = 1 / 3 := by
+    field_simp [hsqrtThree_ne]
+    nlinarith [hsqrtThree]
+  have hsum :
+      ((Real.sqrt (1 + x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ) *
+          (((Real.sqrt (1 + x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ)) +
+        ((Real.sqrt (1 - x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ) *
+          (((Real.sqrt (1 - x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ)) = 1 := by
+    exact_mod_cast hsumReal
+  have hdiff :
+      ((Real.sqrt (1 + x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ) *
+          (((Real.sqrt (1 + x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ)) -
+        ((Real.sqrt (1 - x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ) *
+          (((Real.sqrt (1 - x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ)) = x := by
+    exact_mod_cast hdiffReal
+  have hraise :
+      ((Real.sqrt 2 : ℝ) : ℂ) / ((Real.sqrt 3 : ℝ) : ℂ) *
+          (((Real.sqrt 2 : ℝ) : ℂ) / ((Real.sqrt 3 : ℝ) : ℂ)) =
+        ((2 / 3 : ℝ) : ℂ) := by
+    exact_mod_cast hraiseReal
+  have hinvThree :
+      (((Real.sqrt 3 : ℝ) : ℂ))⁻¹ * (((Real.sqrt 3 : ℝ) : ℂ))⁻¹ =
+        ((1 / 3 : ℝ) : ℂ) := by
+    exact_mod_cast hinvThreeReal
+  norm_num at hraise hinvThree
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [nonDiagonalMap, Kraus.map_apply, nonDiagonalKraus,
+      nonDiagonalKrausCoefficient, nonDiagonalKrausBase, Fin.sum_univ_three,
+      Matrix.mul_apply, Matrix.vecMul, dotProduct, Matrix.conjTranspose_apply]
+  · linear_combination (X 0 0) * hsum + (X 1 1) * hraise
+  · linear_combination (X 0 1 * (((Real.sqrt 3 : ℝ) : ℂ))⁻¹) * hdiff
+  · linear_combination (X 1 0 * (((Real.sqrt 3 : ℝ) : ℂ))⁻¹) * hdiff
+  · have hdiag :
+        ((((Real.sqrt (1 + x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ)) *
+              (((Real.sqrt (1 + x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ)) +
+            (((Real.sqrt (1 - x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ)) *
+              (((Real.sqrt (1 - x) : ℝ) : ℂ) / ((Real.sqrt 2 : ℝ) : ℂ))) *
+            ((((Real.sqrt 3 : ℝ) : ℂ))⁻¹ * (((Real.sqrt 3 : ℝ) : ℂ))⁻¹) = 1 / 3 := by
+        rw [hsum, hinvThree]
+        norm_num
+    linear_combination (X 1 1) * hdiag
+
+/-- Exact Pauli-transfer matrix of the non-diagonal representative in
+Wolf, Proposition 2.11 case 2. -/
+theorem pauliTransferMatrix_nonDiagonalMap {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x ≤ 1) :
+    pauliTransferMatrix (nonDiagonalMap x) =
+      (!![1, 0, 0, 0;
+          0, (x / Real.sqrt 3 : ℝ), 0, 0;
+          0, 0, (x / Real.sqrt 3 : ℝ), 0;
+          (2 / 3 : ℝ), 0, 0, (1 / 3 : ℝ)] : Matrix (Fin 4) (Fin 4) ℝ).map
+        Complex.ofReal := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [pauliTransferMatrix, pauliTransferEntry,
+      nonDiagonalMap_apply hx0 hx1, pauliMatrices, Matrix.trace_fin_two,
+      Matrix.mul_apply]
+  all_goals ring_nf
+  all_goals rw [Complex.I_sq]
+  all_goals ring
+
+/-- The displayed map satisfies the existing non-diagonal normal-form
+predicate.  This does not assert existence of such a representative in every
+filtering orbit. -/
+theorem isLorentzNonDiagonal_nonDiagonalMap {x : ℝ}
+    (hx0 : 0 ≤ x) (hx1 : x ≤ 1) :
+    IsLorentzNonDiagonal (nonDiagonalMap x) := by
+  refine ⟨nonDiagonalMap_isChannel hx0 hx1, x, hx0, hx1, ?_, ?_, ?_, ?_, ?_⟩
+  · have h := congrArg (fun M : Matrix (Fin 4) (Fin 4) ℂ ↦ M 3 0)
+      (pauliTransferMatrix_nonDiagonalMap hx0 hx1)
+    simpa [pauliTransferMatrix] using h
+  · have h := congrArg (fun M : Matrix (Fin 4) (Fin 4) ℂ ↦ M 1 1)
+      (pauliTransferMatrix_nonDiagonalMap hx0 hx1)
+    simpa [pauliTransferMatrix] using h
+  · have h := congrArg (fun M : Matrix (Fin 4) (Fin 4) ℂ ↦ M 2 2)
+      (pauliTransferMatrix_nonDiagonalMap hx0 hx1)
+    simpa [pauliTransferMatrix] using h
+  · have h := congrArg (fun M : Matrix (Fin 4) (Fin 4) ℂ ↦ M 3 3)
+      (pauliTransferMatrix_nonDiagonalMap hx0 hx1)
+    simpa [pauliTransferMatrix] using h
+  · intro i j hij htranslation
+    have h := congrArg (fun M : Matrix (Fin 4) (Fin 4) ℂ ↦ M i j)
+      (pauliTransferMatrix_nonDiagonalMap hx0 hx1)
+    fin_cases i <;> fin_cases j <;> simp_all [pauliTransferMatrix]
+
+/-! ## Choi/Kraus ranks of the displayed family -/
+
+private theorem rank_sum_vecMulVec_eq_card_of_linearIndependent
+    {n : Type*} [Fintype n] {r : ℕ} (v : Fin r → n → ℂ)
+    (hv : LinearIndependent ℂ v) :
+    (∑ i : Fin r, Matrix.vecMulVec (v i) (star (v i))).rank = r := by
+  let C : Matrix n (Fin r) ℂ := fun p i ↦ v i p
+  have hsum :
+      ∑ i : Fin r, Matrix.vecMulVec (v i) (star (v i)) = C * Cᴴ := by
+    ext p q
+    rw [Matrix.sum_apply, Matrix.mul_apply]
+    change (∑ i : Fin r, v i p * star (v i q)) =
+      ∑ i : Fin r, v i p * star (v i q)
+    rfl
+  rw [hsum, Matrix.rank_self_mul_conjTranspose, Matrix.rank_eq_finrank_span_cols]
+  change Module.finrank ℂ (Submodule.span ℂ (Set.range v)) = r
+  simpa using finrank_span_eq_card hv
+
+private theorem choiRank_mapLM_eq_card_of_linearIndependent {r : ℕ}
+    (K : Fin r → QubitMatrix) (hK : LinearIndependent ℂ K) :
+    Channel.choiRank (Kraus.mapLM K) = r := by
+  let c : ℂ := 1 / ((2 : ℝ).sqrt : ℂ)
+  let v : Fin r → (Fin 2 × Fin 2) → ℂ :=
+    fun j p ↦ c * K j p.1 p.2
+  have hc : c ≠ 0 := by
+    dsimp [c]
+    positivity
+  have hv : LinearIndependent ℂ v := by
+    rw [Fintype.linearIndependent_iff] at hK ⊢
+    intro g hg i
+    apply hK g _ i
+    apply Matrix.ext
+    intro a b
+    have hab := congrFun hg (a, b)
+    have hentry : c * (∑ j : Fin r, g j * K j a b) = 0 := by
+      simpa [v, Finset.mul_sum, mul_comm, mul_left_comm, mul_assoc] using hab
+    rw [Matrix.sum_apply, show (0 : QubitMatrix) a b = 0 by rfl]
+    simpa only [Matrix.smul_apply, smul_eq_mul] using
+      (mul_eq_zero.mp hentry).resolve_left hc
+  change (ChoiJamiolkowski.choiMatrix (Kraus.mapLM K)).rank = r
+  rw [Channel.choiMatrix_mapLM_eq_sum_vecMulVec]
+  exact rank_sum_vecMulVec_eq_card_of_linearIndependent v hv
+
+private theorem nonDiagonalKrausBase_linearIndependent :
+    LinearIndependent ℂ nonDiagonalKrausBase := by
+  rw [Fintype.linearIndependent_iff]
+  intro g hg i
+  have h00 := congrArg (fun M : QubitMatrix ↦ M 0 0) hg
+  have h11 := congrArg (fun M : QubitMatrix ↦ M 1 1) hg
+  have h01 := congrArg (fun M : QubitMatrix ↦ M 0 1) hg
+  simp [Fin.sum_univ_three, nonDiagonalKrausBase] at h00 h11 h01
+  have hsqrt : ((Real.sqrt 3 : ℝ) : ℂ) ≠ 0 := by positivity
+  field_simp [hsqrt] at h11
+  have hg0 : g 0 = 0 := by linear_combination (h00 + h11) / 2
+  have hg1 : g 1 = 0 := by linear_combination (h00 - h11) / 2
+  fin_cases i
+  · exact hg0
+  · exact hg1
+  · exact h01
+
+private theorem nonDiagonalKraus_linearIndependent {x : ℝ}
+    (hx0 : 0 ≤ x) (hx1 : x < 1) :
+    LinearIndependent ℂ (nonDiagonalKraus x) := by
+  have hcoeff : ∀ i : Fin 3, ((nonDiagonalKrausCoefficient x i : ℝ) : ℂ) ≠ 0 := by
+    intro i
+    apply Complex.ofReal_ne_zero.mpr
+    fin_cases i
+    · apply Real.sqrt_ne_zero'.2
+      nlinarith
+    · apply Real.sqrt_ne_zero'.2
+      nlinarith
+    · apply Real.sqrt_ne_zero'.2
+      norm_num
+  let u : Fin 3 → ℂˣ := fun i ↦ Units.mk0 _ (hcoeff i)
+  have hli := nonDiagonalKrausBase_linearIndependent.units_smul u
+  have heq : u • nonDiagonalKrausBase = nonDiagonalKraus x := by
+    ext i a b
+    rfl
+  rw [← heq]
+  exact hli
+
+/-- For `0 ≤ x < 1`, all three operators in Equation (19) are needed:
+the canonical non-diagonal channel has Choi/Kraus rank three. -/
+theorem choiRank_nonDiagonalMap_eq_three {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x < 1) :
+    Channel.choiRank (nonDiagonalMap x) = 3 :=
+  choiRank_mapLM_eq_card_of_linearIndependent _
+    (nonDiagonalKraus_linearIndependent hx0 hx1)
+
+/-- The two nonzero Kraus operators left by Equation (19) at `x = 1`. -/
+def nonDiagonalBoundaryKraus : Fin 2 → QubitMatrix
+  | 0 => nonDiagonalKraus 1 0
+  | 1 => nonDiagonalKraus 1 2
+
+/-- The middle operator in Equation (19) vanishes at the endpoint `x = 1`. -/
+@[simp] theorem nonDiagonalKraus_one_one : nonDiagonalKraus 1 1 = 0 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [nonDiagonalKraus, nonDiagonalKrausCoefficient]
+
+/-- At `x = 1`, the middle operator in Equation (19) vanishes and the
+three-operator map equals the displayed two-nonzero-operator map. -/
+theorem nonDiagonalMap_one_eq_boundaryMap :
+    nonDiagonalMap 1 = Kraus.mapLM nonDiagonalBoundaryKraus := by
+  apply LinearMap.ext
+  intro X
+  simp [nonDiagonalMap, Kraus.map_apply, Fin.sum_univ_three,
+    Fin.sum_univ_two, nonDiagonalBoundaryKraus, nonDiagonalKraus,
+    nonDiagonalKrausCoefficient]
+  norm_cast
+
+private theorem nonDiagonalBoundaryKraus_linearIndependent :
+    LinearIndependent ℂ nonDiagonalBoundaryKraus := by
+  rw [Fintype.linearIndependent_iff]
+  intro g hg i
+  have h00 := congrArg (fun M : QubitMatrix ↦ M 0 0) hg
+  have h01 := congrArg (fun M : QubitMatrix ↦ M 0 1) hg
+  have hg0 : g 0 = 0 := by
+    simpa [Fin.sum_univ_two, nonDiagonalBoundaryKraus, nonDiagonalKraus,
+      nonDiagonalKrausCoefficient, nonDiagonalKrausBase] using h00
+  have hg1 : g 1 = 0 := by
+    simpa [Fin.sum_univ_two, nonDiagonalBoundaryKraus, nonDiagonalKraus,
+      nonDiagonalKrausCoefficient, nonDiagonalKrausBase] using h01
+  fin_cases i
+  · exact hg0
+  · exact hg1
+
+/-- At the endpoint `x = 1`, the canonical non-diagonal channel has
+Choi/Kraus rank two, as stated in Wolf, Proposition 2.11. -/
+theorem choiRank_nonDiagonalMap_one :
+    Channel.choiRank (nonDiagonalMap 1) = 2 := by
+  rw [nonDiagonalMap_one_eq_boundaryMap]
+  exact choiRank_mapLM_eq_card_of_linearIndependent _
+    nonDiagonalBoundaryKraus_linearIndependent
+
+/-! ## The singular constant-output representative -/
+
+/-- The two Kraus operators of the singular representative:
+`|0><0|` and `|0><1|`. -/
+def singularKraus : Fin 2 → QubitMatrix
+  | 0 => !![1, 0; 0, 0]
+  | 1 => !![0, 1; 0, 0]
+
+/-- The singular qubit channel of Wolf, Proposition 2.11 case 3. -/
+def singularMap : QubitMap :=
+  Kraus.mapLM singularKraus
+
+/-- The singular two-operator family is trace preserving. -/
+theorem singularKraus_isTP : Kraus.IsTP singularKraus := by
+  rw [Kraus.IsTP]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [singularKraus, Fin.sum_univ_two, Matrix.mul_apply,
+      Matrix.conjTranspose_apply]
+
+/-- The singular representative is a channel. -/
+theorem singularMap_isChannel : IsChannel singularMap :=
+  Kraus.isChannel_mapLM _ singularKraus_isTP
+
+/-- Exact action of the singular representative on arbitrary matrices.
+On density matrices this is the constant output `|0><0|`; on arbitrary
+matrices the output is scaled by the input trace. -/
+theorem singularMap_apply (X : QubitMatrix) :
+    singularMap X = Matrix.trace X • !![1, 0; 0, 0] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [singularMap, Kraus.map_apply, singularKraus, Fin.sum_univ_two,
+      Matrix.mul_apply, Matrix.vecMul, dotProduct, Matrix.conjTranspose_apply,
+      Matrix.trace_fin_two]
+
+/-- Exact Pauli-transfer matrix of the singular representative in Wolf,
+Proposition 2.11 case 3. -/
+theorem pauliTransferMatrix_singularMap :
+    pauliTransferMatrix singularMap =
+      !![1, 0, 0, 0;
+         0, 0, 0, 0;
+         0, 0, 0, 0;
+         1, 0, 0, 0] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [pauliTransferMatrix, pauliTransferEntry, singularMap_apply,
+      pauliMatrices, Matrix.trace_fin_two, Matrix.mul_apply]
+
+/-- The singular map satisfies the existing singular normal-form predicate. -/
+theorem isLorentzSingular_singularMap : IsLorentzSingular singularMap := by
+  refine ⟨singularMap_isChannel, ?_, ?_⟩
+  · have h := congrArg (fun M : Matrix (Fin 4) (Fin 4) ℂ ↦ M 3 0)
+      pauliTransferMatrix_singularMap
+    simpa [pauliTransferMatrix] using h
+  · intro i j hij
+    have h := congrArg (fun M : Matrix (Fin 4) (Fin 4) ℂ ↦ M i j)
+      pauliTransferMatrix_singularMap
+    fin_cases i <;> fin_cases j <;> simp_all [pauliTransferMatrix]
+
+private theorem singularKraus_linearIndependent :
+    LinearIndependent ℂ singularKraus := by
+  rw [Fintype.linearIndependent_iff]
+  intro g hg i
+  have h00 := congrArg (fun M : QubitMatrix ↦ M 0 0) hg
+  have h01 := congrArg (fun M : QubitMatrix ↦ M 0 1) hg
+  have hg0 : g 0 = 0 := by
+    simpa [Fin.sum_univ_two, singularKraus] using h00
+  have hg1 : g 1 = 0 := by
+    simpa [Fin.sum_univ_two, singularKraus] using h01
+  fin_cases i
+  · exact hg0
+  · exact hg1
+
+/-- The singular constant-output channel has Choi/Kraus rank two. -/
+theorem choiRank_singularMap : Channel.choiRank singularMap = 2 :=
+  choiRank_mapLM_eq_card_of_linearIndependent _ singularKraus_linearIndependent
+
+end Wolf

--- a/QICLean/Channel/LorentzNormalForm/QubitNormalForm.lean
+++ b/QICLean/Channel/LorentzNormalForm/QubitNormalForm.lean
@@ -12,8 +12,7 @@ This module collects the Pauli-basis definitions and the three canonical-form
 predicates for qubit channels of Wolf Proposition 2.11
 (`Notes/WolfNoteTexSource/ch02_representations.tex`, Section 2.4): the
 diagonal, non-diagonal, and singular Lorentz normal forms.  The existence
-
-theorem is pending; see
+result is pending; see
 `docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex`.
 
 ## Main definitions
@@ -55,13 +54,15 @@ After SL(2, ℂ) filtering (which acts on `T̂` as a Lorentz transformation
 `L₂ T̂ L₁` with `L_i ∈ SO⁺(1,3)`), the transfer matrix can be brought to
 one of three canonical forms (Wolf Proposition 2.11):
 
-1. **Diagonal** (generic, full Kraus rank): `T̂` is diagonal —
+1. **Diagonal** (generic): `T̂` is diagonal —
    `v = 0` and `Δ = diag(λ₁, λ₂, λ₃)` with the CP condition
-   `λ₁ + λ₂ ≤ 1 + λ₃`.  This is the doubly-stochastic case.
+   `λ₁ + λ₂ ≤ 1 + λ₃`.  This is the doubly-stochastic case; the generic
+   interior has full Kraus rank, while boundary representatives can have
+   smaller rank.
 
-2. **Non-diagonal** (Kraus rank 3): `T̂` has
+2. **Non-diagonal**: `T̂` has
    `Δ = diag(x/√3, x/√3, 1/3)`, `v = (0, 0, 2/3)`, with
-   `0 ≤ x ≤ 1`.
+   `0 ≤ x ≤ 1`; its Kraus rank is 3 for `x < 1` and 2 for `x = 1`.
 
 3. **Singular** (Kraus rank 2): `T̂` has `Δ = 0` and `v = (0, 0, 1)`;
    the channel maps every input to a single pure state. -/
@@ -122,7 +123,7 @@ def IsLorentzNonDiagonal
 /-- A Hermiticity-preserving TP qubit channel `T'` is in **singular Lorentz normal
 form** (Wolf Proposition 2.11, case 3) if its Pauli-basis transfer matrix has
 `Δ = 0` and `v = (0, 0, 1)`.  That is, only `T̂_{00} = 1` and
-`T̂_{30} = 1` are nonzero; the channel maps every input to the pure state
+`T̂_{30} = 1` are nonzero; the channel maps every input state to the pure state
 `(1 + σ_z)/2`. -/
 def IsLorentzSingular
     (T' : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) : Prop :=

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -752,11 +752,65 @@ This section states the existence theorems from
     Trace preservation supplies the first row of the displayed matrix.
 \end{definition}
 
+\begin{theorem}[Displayed non-diagonal and singular representatives]
+    \label{thm:lorentz_displayed_qubit_representatives}
+    \uses{def:lorentz_non_diagonal, def:lorentz_singular}
+    \lean{Wolf.nonDiagonalKrausBase,
+        Wolf.nonDiagonalKrausCoefficient,
+        Wolf.nonDiagonalKraus,
+        Wolf.nonDiagonalMap,
+        Wolf.nonDiagonalKraus_isTP,
+        Wolf.nonDiagonalMap_isChannel,
+        Wolf.nonDiagonalMap_apply,
+        Wolf.pauliTransferMatrix_nonDiagonalMap,
+        Wolf.isLorentzNonDiagonal_nonDiagonalMap,
+        Wolf.choiRank_nonDiagonalMap_eq_three,
+        Wolf.nonDiagonalBoundaryKraus,
+        Wolf.nonDiagonalKraus_one_one,
+        Wolf.nonDiagonalMap_one_eq_boundaryMap,
+        Wolf.choiRank_nonDiagonalMap_one,
+        Wolf.singularKraus,
+        Wolf.singularMap,
+        Wolf.singularKraus_isTP,
+        Wolf.singularMap_isChannel,
+        Wolf.singularMap_apply,
+        Wolf.pauliTransferMatrix_singularMap,
+        Wolf.isLorentzSingular_singularMap,
+        Wolf.choiRank_singularMap}
+    \leanok
+    For every $x\in[0,1]$, the three Kraus operators displayed in
+    \cite[Theorem~8, Eq.~(19)]{VerstraeteVerschelde2002QuantumChannels}
+    define the non-diagonal representative
+    \begin{align}
+        \Delta
+        &=\operatorname{diag}(x/\sqrt{3},x/\sqrt{3},1/3),
+        &v&=(0,0,2/3).
+    \end{align}
+    Its Choi rank, equivalently its minimal Kraus rank, is $3$ when
+    $x<1$ and $2$ when $x=1$.  The singular representative is the
+    trace-to-state channel
+    \begin{align}
+        X\longmapsto \tr(X)\,\lvert0\rangle\!\langle0\rvert;
+    \end{align}
+    it has $\Delta=0$, $v=(0,0,1)$, and Choi/Kraus rank $2$.
+
+    These are constructions and rank calculations for the representatives
+    in \cite[Theorem~8, Eqs.~(17)--(19)]{VerstraeteVerschelde2002QuantumChannels}
+    and Wolf Proposition~2.11, not the Lorentz-orbit classification or the
+    derivation that the non-diagonal parameter must lie in $[0,1]$.
+    The normalized Choi convention is
+    $\tau=\frac14\sum_{ij}\widehat T_{ij}\sigma_i\otimes\sigma_j^{\mathsf T}$;
+    hence a raw Pauli correlation matrix has a sign change in the
+    $\sigma_2$ input column and is not silently identified with
+    $\widehat T$.
+\end{theorem}
+
 % Pending Lean formalization: there is currently no declaration for this theorem.
 \begin{theorem}[Lorentz normal form for qubit channels]\label{thm:lorentz_normal_form_qubit}
     \uses{thm:exists_normal_form_generic,
         def:invertible_filtering, def:lorentz_diagonal,
-        def:lorentz_non_diagonal, def:lorentz_singular}
+        def:lorentz_non_diagonal, def:lorentz_singular,
+        thm:lorentz_displayed_qubit_representatives}
     For every qubit channel $T : \MN{2} \to \MN{2}$, there exist invertible
     completely positive maps $\Phi_{1},\Phi_{2}$, both of Kraus rank one, such
     that the filtered channel $T'=\Phi_{2}\circ T\circ\Phi_{1}$ is in one
@@ -766,7 +820,9 @@ This section states the existence theorems from
     with $S_i\in\SL(2,\C)$ separates the Lorentz action from the positive
     map scalar $|c_1c_2|^2$; only the latter can normalize the resulting
     representative to a channel. A proof still requires this scalar
-    normalization and the classification of Lorentz orbits.
+    normalization and the classification of Lorentz orbits.  The displayed
+    non-diagonal and singular representatives and their ranks are already
+    supplied by Theorem~\ref{thm:lorentz_displayed_qubit_representatives}.
 \end{theorem}
 
 \begin{definition}[Pauli--Minkowski identification]

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -29,6 +29,15 @@
                   archival PDF at \url{https://mediatum.ub.tum.de/doc/1099654/1099654.pdf}},
 }
 
+@unpublished{VerstraeteVerschelde2002QuantumChannels,
+  author       = {Verstraete, Frank and Verschelde, Henri},
+  title        = {On Quantum Channels},
+  year         = {2002},
+  eprint       = {quant-ph/0202124},
+  eprinttype   = {arxiv},
+  note         = {arXiv:quant-ph/0202124v2},
+}
+
 @article{Yamagami1993Cyclic,
   author       = {Yamagami, Shigeru},
   title        = {Cyclic Inequalities},

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -6,6 +6,15 @@
   url          = {https://mediatum.ub.tum.de/doc/1099654/1099654.pdf},
 }
 
+@unpublished{VerstraeteVerschelde2002QuantumChannels,
+  author       = {Verstraete, Frank and Verschelde, Henri},
+  title        = {On Quantum Channels},
+  year         = {2002},
+  eprint       = {quant-ph/0202124},
+  eprinttype   = {arxiv},
+  note         = {arXiv:quant-ph/0202124v2},
+}
+
 @article{Yamagami1993Cyclic,
   author       = {Yamagami, Shigeru},
   title        = {Cyclic Inequalities},

--- a/docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex
+++ b/docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex
@@ -98,6 +98,25 @@ $L_2\widehat T L_1$ are also formalized.\footnote{Formal declarations
 asserting existence of a canonical representative for every qubit channel
 remains open.
 
+The two non-generic representatives themselves are now formalized directly
+from the source formulas in
+\cite[Theorem~8, Eqs.~(17)--(19)]{VerstraeteVerschelde2002QuantumChannels}.
+The exact non-diagonal three-Kraus family defines a channel for each assumed
+$x\in[0,1]$, has the Pauli data
+$\Delta=\operatorname{diag}(x/\sqrt3,x/\sqrt3,1/3)$ and
+$v=(0,0,2/3)$, and has Choi/Kraus rank three for $x<1$ and two at $x=1$.
+The singular two-Kraus family realizes
+$X\mapsto\tr(X)\lvert0\rangle\!\langle0\rvert$ and has Choi/Kraus rank two.
+\footnote{Formal declarations
+\leanid{Wolf.nonDiagonalMap},
+\leanid{Wolf.choiRank_nonDiagonalMap_eq_three},
+\leanid{Wolf.choiRank_nonDiagonalMap_one},
+\leanid{Wolf.singularMap}, and
+\leanid{Wolf.choiRank_singularMap} in
+\doclink{QICLean/Channel/LorentzNormalForm/CanonicalQubitChannels}.}
+This bounded construction proves sufficiency for an already supplied
+$x\in[0,1]$; it does not derive that range or classify Lorentz orbits.
+
 \section{Elimination plan}
 
 A source-faithful proof requires the following steps.
@@ -127,15 +146,19 @@ A source-faithful proof requires the following steps.
     prove the full two-to-one assertion or the rotation and boost formulas of
     Wolf's Equation~(2.44).
   \item Choose the scalar factors so that the canonical representative is trace
-    preserving, and verify complete positivity and the stated parameter bounds.
+    preserving, and derive the stated parameter bounds from the positive
+    two-qubit normal forms.  Once $x\in[0,1]$ is supplied, the exact Kraus
+    constructions, complete positivity, transfer data, and rank calculations
+    for the non-diagonal and singular representatives are already formalized.
   \item Prove the three-case existence theorem using the general filters and link
     it to the existing canonical-form predicates.
 \end{enumerate}
 
-The discrepancy is an open gap: the canonical forms, the generic minimisation
-theorem in square dimension, and the determinant-one Lorentz action are
-available, but the scalar-normalized Lorentz-orbit classification required by
-Proposition~2.11 has not yet been formalized.
+The discrepancy is an open gap: the canonical predicates, the exact
+non-generic representatives and their ranks, the generic minimisation theorem
+in square dimension, and the determinant-one Lorentz action are available,
+but the scalar-normalized Lorentz-orbit classification and necessity of the
+parameter range required by Proposition~2.11 have not yet been formalized.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -387,6 +387,15 @@ so that the cited formal statements are available from the main project import.
 * `IsLorentzDiagonal` — diagonal Lorentz normal form (Wolf Proposition 2.11 case 1) ✓
 * `IsLorentzNonDiagonal` — non-diagonal Lorentz normal form (case 2) ✓
 * `IsLorentzSingular` — singular Lorentz normal form (case 3) ✓
+* `Wolf.nonDiagonalKraus` / `Wolf.nonDiagonalMap` — the exact three-operator
+  non-diagonal representative in Verstraete--Verschelde Theorem 8,
+  Equation (19), with its arbitrary-matrix action and Pauli transfer matrix ✓
+* `Wolf.choiRank_nonDiagonalMap_eq_three` /
+  `Wolf.choiRank_nonDiagonalMap_one` — the non-diagonal representative has
+  Choi/Kraus rank 3 for `0 ≤ x < 1` and rank 2 at `x = 1` ✓
+* `Wolf.singularKraus` / `Wolf.singularMap` — the singular representative is
+  `X ↦ tr(X)|0⟩⟨0|`, has the stated Pauli transfer matrix, and satisfies
+  `Wolf.choiRank_singularMap : Channel.choiRank singularMap = 2` ✓
 * `Wolf.infimum_is_attained` — **key compactness lemma**: trace minimisation
   over SL(d₁, ℂ) × SL(d₂, ℂ) filterings of a positive-definite operator on
   ℂ^{d₂} ⊗ ℂ^{d₁} attains its infimum ✓ (rectangular form)
@@ -411,12 +420,15 @@ so that the cited formal statements are available from the main project import.
   doubly-stochastic ✓ (derived from `Wolf.exists_normal_form_generic_tau` by
   the rectangular Choi transformation and partial-trace identities)
 * **Wolf Proposition 2.11 (Lorentz normal form for qubit channels)** remains
-  pending. The required general invertible Kraus-rank-one CP filters and their
-  scalar freedom, the determinant-one spinor action, and its exact action on
-  Pauli transfer matrices are now formalized. The Lorentz-orbit classification
-  and the final trace-preserving normalization have no Lean declaration yet.
-  The former determinant-one `SLFiltering` formulation was false and was
-  removed.
+  pending as an existence and orbit-classification theorem. The required
+  general invertible Kraus-rank-one CP filters and their scalar freedom, the
+  determinant-one spinor action, and its exact action on Pauli transfer
+  matrices are formalized. The source-displayed non-diagonal and singular
+  representatives, including their exact actions and Choi/Kraus ranks, are
+  also formalized. The Lorentz-orbit classification, necessity of the
+  non-diagonal parameter range, and final trace-preserving normalization have
+  no Lean declaration yet. The former determinant-one `SLFiltering`
+  formulation was false and was removed.
 
 #### Formalization
 
@@ -465,6 +477,13 @@ so that the cited formal statements are available from the main project import.
 | Diagonal Lorentz form | `LorentzNormalForm.lean` | `IsLorentzDiagonal` |
 | Non-diagonal Lorentz form | `LorentzNormalForm.lean` | `IsLorentzNonDiagonal` |
 | Singular Lorentz form | `LorentzNormalForm.lean` | `IsLorentzSingular` |
+| Canonical non-diagonal and singular representatives |
+  `LorentzNormalForm/CanonicalQubitChannels.lean` |
+  `Wolf.nonDiagonalMap`, `Wolf.singularMap` |
+| Canonical representative Choi/Kraus ranks |
+  `LorentzNormalForm/CanonicalQubitChannels.lean` |
+  `Wolf.choiRank_nonDiagonalMap_eq_three`,
+  `Wolf.choiRank_nonDiagonalMap_one`, `Wolf.choiRank_singularMap` |
 
 #### Not yet formalized
 
@@ -473,8 +492,11 @@ so that the cited formal statements are available from the main project import.
 | Section 2.4 Lorentz normal form (Proposition 2.11) | Correctly formulated
   statement and proof remain pending. The general invertible Kraus-rank-one
   filters, their scalar/SL decomposition, and the determinant-one Lorentz
-  action on Pauli transfer matrices are available. The proof still needs the
-  Lorentz-orbit classification and the final trace-preserving normalization. |
+  action on Pauli transfer matrices are available. The displayed
+  non-diagonal and singular representatives and their ranks are also
+  available. The proof still needs the Lorentz-orbit classification, the
+  necessity of the parameter bounds, and the final trace-preserving
+  normalization. |
 | Section 2.4 full spinor double cover and Equation (2.44) | Image inclusion,
   multiplicativity, and the equality `L(-X) = L(X)` are available. Surjectivity,
   exact two-point fibres, and the rotation/boost exponential formulas remain
@@ -484,6 +506,8 @@ so that the cited formal statements are available from the main project import.
 ### References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2][Wolf2012QChannels]
+* [F. Verstraete and H. Verschelde, *On Quantum Channels*,
+  arXiv:quant-ph/0202124v2](https://arxiv.org/abs/quant-ph/0202124v2)
 
 ---
 


### PR DESCRIPTION
## Source boundary

This formalizes the two displayed non-generic qubit-channel representatives in Wolf, Proposition 2.11 (`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 1021–1035), following Verstraete–Verschelde, *On Quantum Channels*, Theorem 8, Equations (17)–(19). Equation (19) is specialized to `A = B = I`.

## Formalized

- the exact three-operator non-diagonal Kraus family for an assumed `0 ≤ x ≤ 1`;
- trace preservation, channel structure, arbitrary-matrix action, and Pauli-transfer data `Δ = diag(x/√3, x/√3, 1/3)`, `v = (0, 0, 2/3)`;
- Choi/Kraus rank three for `0 ≤ x < 1` and rank two at `x = 1`;
- the singular trace-to-pure-state channel, its exact transfer matrix, and rank two;
- the normalized-Choi transpose-sign bridge `σ₂ᵀ = -σ₂`;
- Blueprint, coverage, paper-gap, and primary-source bibliography synchronization.

## Deliberate boundary

This proves sufficiency and ranks for the source-displayed representatives only. It does not derive the necessity of `0 ≤ x ≤ 1`, classify Lorentz orbits, construct general filters, prove spinor surjectivity, or complete Wolf Proposition 2.11. Issue #379 therefore remains open.

## Validation

- focused, aggregate, and full `lake build` passed;
- Blueprint sync and reverse declaration coverage passed;
- standalone paper-gap and 326-page Blueprint PDF builds passed;
- style, imports, module policies, `checkdecls`, bibliography, and diff checks passed;
- proof-integrity scan is clean; endpoint axioms are only `propext`, `Classical.choice`, and `Quot.sound`;
- independent exact-head source review approved `71bc29fd6ab6096dc99e75298167666234725f60`.

Refs #379
