### PR TITLE
feat(channel): assemble Wolf theorem 6.16

### DIFF
--- a/QICLean/Channel/Peripheral.lean
+++ b/QICLean/Channel/Peripheral.lean
@@ -41,6 +41,7 @@ import QICLean.Channel.Peripheral.SchurAsymptoticConvergence
 import QICLean.Channel.Peripheral.SpectralProjection
 import QICLean.Channel.Peripheral.SpectralRadius
 import QICLean.Channel.Peripheral.Spectrum
+import QICLean.Channel.Peripheral.StructureOfCycles
 import QICLean.Channel.Peripheral.TransferMatrix
 import QICLean.Channel.Peripheral.UnitalKraus
 import QICLean.Channel.Peripheral.WeightedCesaro

--- a/QICLean/Channel/Peripheral/DensityBlockFacePermutation.lean
+++ b/QICLean/Channel/Peripheral/DensityBlockFacePermutation.lean
@@ -24,8 +24,9 @@ This is an intentionally partial boundary of Theorem 6.16.  It proves equality
 only of the full-matrix dimensions `d`, not of the multiplicity dimensions `m`.
 Transport of the ordinary Schwarz inequality to the matched block maps,
 comparison of multiplicities, exclusion of the transpose alternative in the
-assembled density-block coordinates, and Equation (6.68) remain separate
-follow-up work.  No CP/Kraus or ring-ideal classification is used.
+assembled density-block coordinates, and Equation (6.68) are handled by the
+subsequent source-facing modules.  No CP/Kraus or ring-ideal classification is
+used here.
 -/
 
 open scoped Matrix MatrixOrder ComplexOrder BigOperators Kronecker
@@ -77,6 +78,46 @@ theorem DirectSumFacePermutation.map_apply
         apply F.blockEquiv.injective
         rw [Equiv.apply_symm_apply]
         exact hji.symm
+      · simp
+
+omit [∀ i, NeZero (d i)] [∀ j, NeZero (e j)] in
+/-- The source-indexed form of the full-family block action.  Evaluating at
+the target `F.blockEquiv i` reads the input block `i` without transporting a
+dependent matrix through `F.blockEquiv.symm_apply_apply`.
+
+This is equivalent to `DirectSumFacePermutation.map_apply`, but is the more
+stable interface when the matrix sizes depend on the block index. -/
+theorem DirectSumFacePermutation.map_apply_blockEquiv
+    {T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)}
+    {S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ)}
+    (F : DirectSumFacePermutation T S)
+    (X : ∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) (i : iota) :
+    T X (F.blockEquiv i) =
+      directSumBlockMap T i (F.blockEquiv i) (X i) := by
+  classical
+  let := Fintype.ofFinite iota
+  let := Fintype.ofFinite kappa
+  calc
+    T X (F.blockEquiv i) = T (∑ r, Pi.single r (X r)) (F.blockEquiv i) := by
+      rw [Finset.univ_sum_single]
+    _ = (∑ r, T (Pi.single r (X r))) (F.blockEquiv i) := by
+      rw [map_sum]
+    _ = ∑ r, T (Pi.single r (X r)) (F.blockEquiv i) := by
+      rw [Finset.sum_apply]
+    _ = ∑ r, (Pi.single (F.blockEquiv r)
+        (directSumBlockMap T r (F.blockEquiv r) (X r)) :
+          ∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) (F.blockEquiv i) := by
+      apply Finset.sum_congr rfl
+      intro r _
+      rw [F.map_single]
+    _ = directSumBlockMap T i (F.blockEquiv i) (X i) := by
+      rw [Finset.sum_eq_single i]
+      · rw [Pi.single_eq_same]
+      · intro r _ hri
+        rw [Pi.single_eq_of_ne]
+        exact fun h ↦ hri (F.blockEquiv.injective h.symm)
       · simp
 
 omit [∀ i, NeZero (d i)] [∀ j, NeZero (e j)] in

--- a/QICLean/Channel/Peripheral/StructureOfCycles.lean
+++ b/QICLean/Channel/Peripheral/StructureOfCycles.lean
@@ -1,0 +1,231 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Algebra.MatrixReindexUnitary
+import QICLean.Channel.Determinant.PositiveInverse
+import QICLean.Channel.Peripheral.DensityBlockSchwarz
+
+/-!
+# Structure of cycles (Wolf Theorem 6.16)
+
+This file assembles the source-facing density-block statement and dynamics in
+Wolf Theorem 6.16, Equations (6.66)--(6.68).  The direct Schwarz hypothesis on
+the map and the Schwarz hypothesis on its trace adjoint remain separate.
+
+The formal density-block coordinates use the tensor order `sigma k ⊗ₖ X k`.
+Wolf prints `x k ⊗ rho k`; the two conventions differ only by the canonical
+interchange of the tensor factors.
+
+Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines
+1597--1664.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder Kronecker
+
+noncomputable section
+
+namespace Matrix
+
+/-- The matched full-matrix maps in Wolf Theorem 6.16 are unitary
+conjugations, expressed with Wolf's output-to-input permutation.
+
+The face permutation `F.blockEquiv` sends an input block to its output block.
+Thus Wolf's permutation is `pi := F.blockEquiv.symm`.  The unitary returned by
+the positive-invertible Schwarz classification acts first on the input-indexed
+copy of the matrix algebra; simultaneous reindexing along `d (pi k) = d k`
+makes it an output-indexed unitary `V k`.
+
+Source: Wolf Theorem 6.16, proof lines 1637--1663. -/
+theorem DirectSumFacePermutation.exists_reindexedUnitaryBlockAction
+    {K : ℕ} {d : Fin K → ℕ}
+    {Tbar Sbar : Module.End ℂ
+      (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)}
+    (F : DirectSumFacePermutation Tbar Sbar)
+    (hd : ∀ k, 0 < d k)
+    (hSchwarz : ∀ i, IsSchwarzMap (F.matchedBlockEndomorphism i)) :
+    let pi := F.blockEquiv.symm
+    ∃ (hdpi : ∀ k, d (pi k) = d k)
+      (V : ∀ k, Matrix.unitaryGroup (Fin (d k)) ℂ),
+      ∀ X k,
+        Tbar X k =
+          (V k : Matrix (Fin (d k)) (Fin (d k)) ℂ) *
+            Matrix.reindex (finCongr (hdpi k)) (finCongr (hdpi k))
+              (X (pi k)) *
+            (V k : Matrix (Fin (d k)) (Fin (d k)) ℂ)ᴴ := by
+  classical
+  dsimp only
+  let : ∀ k, NeZero (d k) := fun k ↦ ⟨Nat.ne_of_gt (hd k)⟩
+  have hdpi : ∀ k, d (F.blockEquiv.symm k) = d k := fun k ↦ by
+    simpa only [Equiv.apply_symm_apply] using
+      F.dimension_eq (F.blockEquiv.symm k)
+  have hUnitary : ∀ i, ∃ W : Matrix.unitaryGroup (Fin (d i)) ℂ,
+      F.matchedBlockEndomorphism i =
+        unitaryChannel W := by
+    intro i
+    let hBij := F.matchedBlockEndomorphism_bijective i
+    exact ChannelDeterminant.Internal.wolfPositiveInvertibleSchwarzMaps hBij
+      (F.matchedBlockEndomorphism_isPositiveMap i)
+      (F.matchedBlockEndomorphism_isTracePreservingMap i)
+      (F.matchedBlockCanonicalInverse_isPositiveMap i hBij) (hSchwarz i)
+  choose W hW using hUnitary
+  let V : ∀ k, Matrix.unitaryGroup (Fin (d k)) ℂ := fun k ↦
+    ⟨Matrix.reindex (finCongr (hdpi k)) (finCongr (hdpi k))
+        (W (F.blockEquiv.symm k) :
+          Matrix (Fin (d (F.blockEquiv.symm k)))
+            (Fin (d (F.blockEquiv.symm k))) ℂ),
+      Matrix.reindex_mem_unitaryGroup (finCongr (hdpi k)) _
+        (W (F.blockEquiv.symm k)).property⟩
+  refine ⟨hdpi, V, ?_⟩
+  have hActionAtSource
+      (X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) (i : Fin K) :
+      Tbar X (F.blockEquiv i) =
+        (V (F.blockEquiv i) :
+          Matrix (Fin (d (F.blockEquiv i)))
+            (Fin (d (F.blockEquiv i))) ℂ) *
+          Matrix.reindex (finCongr (hdpi (F.blockEquiv i)))
+            (finCongr (hdpi (F.blockEquiv i)))
+            (X (F.blockEquiv.symm (F.blockEquiv i))) *
+          (V (F.blockEquiv i) :
+            Matrix (Fin (d (F.blockEquiv i)))
+              (Fin (d (F.blockEquiv i))) ℂ)ᴴ := by
+    have hMatched :
+        F.matchedBlockEndomorphism i (X i) =
+          (W i : Matrix (Fin (d i)) (Fin (d i)) ℂ) * X i *
+            (W i : Matrix (Fin (d i)) (Fin (d i)) ℂ)ᴴ := by
+      simpa only [unitaryChannel, LinearMap.coe_mk, AddHom.coe_mk] using
+        LinearMap.congr_fun (hW i) (X i)
+    have hRawAtEquiv :
+        Matrix.directSumBlockMap Tbar i (F.blockEquiv i) (X i) =
+          Matrix.reindex (finCongr (F.dimension_eq i))
+            (finCongr (F.dimension_eq i))
+            ((W i : Matrix (Fin (d i)) (Fin (d i)) ℂ) * X i *
+              (W i : Matrix (Fin (d i)) (Fin (d i)) ℂ)ᴴ) := by
+      let R := Matrix.reindexAlgEquiv ℂ ℂ (finCongr (F.dimension_eq i))
+      apply R.symm.injective
+      change R.symm (Matrix.directSumBlockMap Tbar i (F.blockEquiv i) (X i)) =
+        R.symm (R ((W i : Matrix (Fin (d i)) (Fin (d i)) ℂ) * X i *
+          (W i : Matrix (Fin (d i)) (Fin (d i)) ℂ)ᴴ))
+      rw [R.symm_apply_apply]
+      simpa only [R, F.matchedBlockEndomorphism_apply,
+        Matrix.symm_reindexAlgEquiv, Matrix.coe_reindexAlgEquiv] using hMatched
+    rw [F.map_apply_blockEquiv, hRawAtEquiv]
+    dsimp only [V]
+    suffices ∀ (s : Fin K), s = i →
+        ∀ hsi : d s = d (F.blockEquiv i),
+          Matrix.reindex (finCongr (F.dimension_eq i))
+              (finCongr (F.dimension_eq i))
+              ((W i : Matrix (Fin (d i)) (Fin (d i)) ℂ) * X i *
+                (W i : Matrix (Fin (d i)) (Fin (d i)) ℂ)ᴴ) =
+            Matrix.reindex (finCongr hsi) (finCongr hsi)
+                (W s : Matrix (Fin (d s)) (Fin (d s)) ℂ) *
+              Matrix.reindex (finCongr hsi) (finCongr hsi) (X s) *
+              (Matrix.reindex (finCongr hsi) (finCongr hsi)
+                (W s : Matrix (Fin (d s)) (Fin (d s)) ℂ))ᴴ by
+      exact this (F.blockEquiv.symm (F.blockEquiv i))
+        (F.blockEquiv.symm_apply_apply i) (hdpi (F.blockEquiv i))
+    intro s hs hsi
+    subst s
+    have hhsi : hsi = F.dimension_eq i := Subsingleton.elim _ _
+    cases hhsi
+    rw [Matrix.conjTranspose_reindex]
+    let R := Matrix.reindexAlgEquiv ℂ ℂ (finCongr (F.dimension_eq i))
+    change R ((W i : Matrix (Fin (d i)) (Fin (d i)) ℂ) * X i *
+        (W i : Matrix (Fin (d i)) (Fin (d i)) ℂ)ᴴ) =
+      R (W i : Matrix (Fin (d i)) (Fin (d i)) ℂ) * R (X i) *
+        R (W i : Matrix (Fin (d i)) (Fin (d i)) ℂ)ᴴ
+    rw [map_mul, map_mul]
+  intro X k
+  obtain ⟨i, rfl⟩ := F.blockEquiv.surjective k
+  exact hActionAtSource X i
+
+end Matrix
+
+namespace IsPositiveMap
+
+/-- **Wolf Theorem 6.16, Equations (6.66)--(6.68).**
+
+Let `T` be a positive trace-preserving map satisfying the Schwarz inequality,
+and suppose separately that its trace adjoint is Schwarz as required by Wolf
+Theorem 6.14.  Its asymptotic image has the zero-extended density-block form
+of Equations (6.66)--(6.67).  The zero summand has dimension zero, every
+density factor is maximally mixed, and the coordinate action permutes equal
+`d`- and `m`-dimensional blocks and conjugates by output-indexed unitaries.
+The final equality is the ambient form of Equation (6.68).
+
+The formal coordinates retain `sigma k ⊗ₖ X k`, whereas Wolf prints
+`x k ⊗ rho k`; these are related by the canonical tensor-factor swap.  The
+explicit `e₀` and `Matrix.fromBlocks 0 0 0` are deliberately retained even
+though `n = D`, avoiding a dependent rewrite of the zero summand.
+
+Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines
+1597--1664, Equations (6.66)--(6.68). -/
+theorem exists_wolfTheorem616
+    {D : ℕ} [NeZero D]
+    {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hPos : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap T)
+    (hAdjointSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T)) :
+    ∃ (n K : ℕ) (d m : Fin K → ℕ)
+      (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+      (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+      (U : Matrix (Fin D) (Fin D) ℂ)
+      (sigma : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+      (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+      (pi : Fin K ≃ Fin K)
+      (hdpi : ∀ k, d (pi k) = d k)
+      (V : ∀ k, Matrix.unitaryGroup (Fin (d k)) ℂ)
+      (A : Module.End ℂ (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)),
+      (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ k, (sigma k).PosDef) ∧ (∀ k, (sigma k).trace = 1) ∧
+        (∀ B, B ∈ T.peripheralSubspace ↔
+          ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+            star U * B * U = Matrix.reindex e₀ e₀
+              (Matrix.fromBlocks 0 0 0
+                (Matrix.reindex e e
+                  (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k)))) ∧
+        n = D ∧
+        (∀ k, sigma k = (m k : ℂ)⁻¹ • 1) ∧
+        (∀ k, m (pi k) = m k) ∧
+        (∀ X k,
+          A X k =
+            (V k : Matrix (Fin (d k)) (Fin (d k)) ℂ) *
+              Matrix.reindex (finCongr (hdpi k)) (finCongr (hdpi k))
+                (X (pi k)) *
+              (V k : Matrix (Fin (d k)) (Fin (d k)) ℂ)ᴴ) ∧
+        ∀ X,
+          T (Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma X) =
+            Matrix.densityBlockWithZeroEmbedding e e₀ U hU sigma (A X) := by
+  classical
+  obtain ⟨n, K, d, m, e, e₀, U, sigma, hU, S, hd, hm, hsigmaPosDef,
+      hsigmaTrace, hfixed, hSPos, hSTP, hDynamics⟩ :=
+    hPos.exists_peripheralDensityBlockSchwarz hTP hSchwarz hAdjointSchwarz
+  dsimp only at hDynamics
+  rcases hDynamics with
+    ⟨hTencode, hSencode, hST, hTS, hTPos, hSbarPos, hTTP, hSTPbar,
+      F, hMap, hInverseMap, hDimension, hn, hsigma, hmMatch, hBlockOne,
+      hRawSchwarz, hMatchedSchwarz⟩
+  obtain ⟨hdpi, V, hAction⟩ :=
+    F.exists_reindexedUnitaryBlockAction hd hMatchedSchwarz
+  let pi : Fin K ≃ Fin K := F.blockEquiv.symm
+  let A := Matrix.densityBlockDynamics e e₀ U hU sigma T
+  have hmpi : ∀ k, m (pi k) = m k := fun k ↦ by
+    simpa only [pi, Equiv.apply_symm_apply] using
+      hmMatch (F.blockEquiv.symm k)
+  have hperipheral : ∀ B, B ∈ T.peripheralSubspace ↔
+      ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+        star U * B * U = Matrix.reindex e₀ e₀
+          (Matrix.fromBlocks 0 0 0
+            (Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k ↦ sigma k ⊗ₖ X k))) := fun B ↦
+    (Module.End.peripheralProjection_apply_eq_self_iff T B).symm.trans
+      (hfixed B)
+  refine ⟨n, K, d, m, e, e₀, U, sigma, hU, pi, hdpi, V, A,
+    hd, hm, hsigmaPosDef, hsigmaTrace, hperipheral, hn, hsigma, hmpi, ?_, ?_⟩
+  · simpa only [A, pi] using hAction
+  · intro X
+    simpa only [A] using (hTencode X).symm
+
+end IsPositiveMap

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -781,8 +781,7 @@ classification theorem is already proved.
     Theorem~6.16. It does not compare the multiplicities $m_k$, transport the
     ordinary Schwarz inequality to the matched block maps, assemble the
     exclusion of the transpose alternative, or prove Equation~(6.68); those
-    remain separate source-facing follow-ups.
-    % Tracking: GitHub issues #417 and #411.
+    are assembled in Theorem~\ref{thm:wolf_6_16} below.
 \end{theorem}
 
 \begin{proof}
@@ -954,6 +953,83 @@ classification theorem is already proved.
     by a unitary is an order automorphism, so the unitary-conjugated transpose
     branch fails the same inequality. For $d=1$, ordinary transposition is the
     identity and this alternative is already unitary conjugation.
+\end{proof}
+
+\begin{theorem}[Structure of cycles]
+    \label{thm:wolf_6_16}
+    \lean{Matrix.DirectSumFacePermutation.map_apply_blockEquiv,
+        Matrix.DirectSumFacePermutation.exists_reindexedUnitaryBlockAction,
+        IsPositiveMap.exists_wolfTheorem616}
+    \leanok
+    \uses{thm:wolf_cycle_density_block_schwarz,
+        thm:wolf_cycle_schwarz_excludes_transpose}
+    This is Wolf, Chapter~6, Theorem~6.16, Equations~(6.66)--(6.68),
+    local source lines~1597--1664, under the separately retained
+    trace-adjoint-Schwarz contract required by the printed proof's invocation
+    of Theorem~6.14.
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, with $D>0$.
+    Suppose separately that $T$ and its trace-pairing adjoint $T^*$ satisfy
+    the Schwarz inequality. There are zero-extended density-block
+    coordinates $E$, positive integers $d_k,m_k$, density matrices
+    $\sigma_k\in\MN{m_k}$, a permutation $\pi$ of the blocks, and unitaries
+    $V_k\in\MN{d_k}$ such that
+    \begin{align}
+        \mathcal X_T
+          &=0\oplus\bigoplus_{k<K}
+              \bigl(\sigma_k\otimes\MN{d_k}\bigr),
+              \tag{6.66}\label{eq:wolf_6_16_density_blocks}\\
+        B\in\mathcal X_T
+          &\Longleftrightarrow
+            B=E(X)\quad\text{for some }X=(X_k)_{k<K},
+              \tag{6.67}\label{eq:wolf_6_16_coordinates}\\
+        d_{\pi(k)}&=d_k,
+        &m_{\pi(k)}&=m_k,
+        &\sigma_k&=m_k^{-1}\Id_{m_k}.
+        \notag
+    \end{align}
+    If $q_k:\Fin{d_{\pi(k)}}\simeq\Fin{d_k}$ is the canonical reindexing,
+    the coordinate action $A$ and its ambient realization are
+    \begin{align}
+        (AX)_k
+          &=V_k\,\operatorname{reindex}_{q_k,q_k}
+              (X_{\pi(k)})\,V_k^\dagger,
+          \notag\\
+        T(E(X))&=E(AX).
+          \tag{6.68}\label{eq:wolf_6_16_action}
+    \end{align}
+    Here $\pi$ is explicitly the output-to-input permutation: output block
+    $k$ reads input block $\pi(k)$. In the formal coordinates the tensor
+    order is $\sigma_k\otimes X_k$; Wolf's displayed
+    $X_k\otimes\rho_k$ differs by the canonical tensor-factor swap.
+
+    The compiled statement retains the equivalence $e_0$ and the literal
+    zero extension $\operatorname{fromBlocks}(0,0,0,-)$ while also proving
+    $n=D$. This records Equations~(6.66)--(6.67) without a dependent rewrite
+    that erases Wolf's zero-summand form. The inverse used to classify each
+    matched block is only the inverse on the peripheral image; no inverse of
+    the ambient map $T$ is asserted.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Theorem~\ref{thm:wolf_cycle_density_block_schwarz} supplies the exact
+    density-block coordinates, $n=D$, maximally mixed weights, the
+    source-to-target face permutation $\tau$, equality of matched
+    multiplicities, and a positive trace-preserving bijective Schwarz
+    endomorphism on each matched full-matrix block whose canonical inverse is
+    positive. Apply
+    Theorem~\ref{thm:wolf_cycle_schwarz_excludes_transpose} to each such
+    endomorphism. Thus it is unitary conjugation.
+
+    Set $\pi=\tau^{-1}$. Reindex the source unitary along
+    $d_{\pi(k)}=d_k$ to obtain the output-indexed $V_k$; simultaneous
+    reindexing preserves multiplication, adjoints, and unitarity. The
+    source-indexed full-family block action then gives the displayed formula
+    for $A$. Finally the existing density-block intertwining equality is
+    reversed to read $T(E(X))=E(AX)$, exactly Equation~(6.68). Membership in
+    $\mathcal X_T$ is the fixed-point characterization of the peripheral
+    projection, so the preceding zero-extended block characterization gives
+    Equations~(6.66)--(6.67) verbatim at the formal coordinate boundary.
 \end{proof}
 
 \begin{definition}[Block-permutation structure]

--- a/docs/paper-gaps/wolf_theorem6_16_schwarz_orientation.tex
+++ b/docs/paper-gaps/wolf_theorem6_16_schwarz_orientation.tex
@@ -82,11 +82,15 @@ Theorem~6.14 interface: positivity and trace preservation of a map $S$, and
 the Schwarz inequality for $S^*$.\footnote{Formal declaration:
 \leanid{IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero} in
 \doclink{QICLean/Channel/FixedPoint/WolfTheorem614}.}
-The source-facing Theorem~6.16 assembly will therefore expose both
-orientations.  Its recurrent-projection component may pass the second one to
-the fixed-point theorem, while its block-classification component retains the
-first one.  The remaining construction is tracked by \ghissue{40}; this
-contract audit is \ghissue{407}.
+The completed source-facing Theorem~6.16 assembly therefore exposes both
+orientations explicitly.  Its recurrent-projection component passes the
+second one to the fixed-point theorem, while its block-classification
+component retains the first one.\footnote{Formal declaration:
+\leanid{IsPositiveMap.exists_wolfTheorem616} in
+\doclink{QICLean/Channel/Peripheral/StructureOfCycles}. It retains the exact
+zero-extended density-block membership form and proves Wolf's output-indexed
+unitary action in Equation~(6.68).} The construction is organized by
+\ghissue{40}; this contract audit is \ghissue{407}.
 
 \section{Conclusion}
 

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -1431,7 +1431,7 @@ records that `X_T` is the fixed-point space of `T_φ`, and
 `Module.End.map_eigenspace_of_ne_zero` supplies the one-eigenvalue case of
 clause 3.
 
-#### Wolf Theorem 6.16 (Structure of cycles) — PARTIALLY FORMALIZED
+#### Wolf Theorem 6.16 (Structure of cycles) — FORMALIZED
 
 The source-contract audit is resolved in
 `docs/paper-gaps/wolf_theorem6_16_schwarz_orientation.tex`.  The printed
@@ -1439,7 +1439,7 @@ proof uses the Schwarz inequality for `T` itself when it excludes the
 transpose branch, but obtains Equation (6.66) by applying Theorem 6.14 to the
 recurrent projection `I`; that theorem requires the trace adjoint `I*` to be
 Schwarz.  Closure under powers and limits transports the two orientations
-separately.  Therefore the source-facing assembly will explicitly assume that
+separately.  Therefore the source-facing assembly explicitly assumes that
 both `T` and `T*` are Schwarz.  No implication between these hypotheses is
 silently introduced, and the note does not claim that the theorem's conclusion
 is false under the single printed hypothesis.
@@ -1590,8 +1590,11 @@ is false under the single printed hypothesis.
     mutually inverse matched block maps and equality only of their
     full-matrix dimensions;
   - the public full-family formulas
-    `Matrix.DirectSumFacePermutation.map_apply` and
-    `Matrix.DirectSumFacePermutation.inverse_apply`;
+    `Matrix.DirectSumFacePermutation.map_apply`,
+    `Matrix.DirectSumFacePermutation.map_apply_blockEquiv`, and
+    `Matrix.DirectSumFacePermutation.inverse_apply`; the source-indexed
+    `map_apply_blockEquiv` form avoids dependent casts when the matrix size
+    varies with the block;
   - `IsPositiveMap.exists_peripheralDensityBlockFacePermutation`, which
     combines the exact Theorem 6.14 witnesses and recurrent inverse with that
     direct-sum argument. Its block equivalence is source-to-target, while its
@@ -1641,13 +1644,32 @@ is false under the single printed hypothesis.
   argument at lines 1653--1656 proves only equality of `d_k`; the new trace
   calculation supplies the missing equality of `m_k`.
 
-* This completes the bounded pure-face/permutation passage and the repaired
-  scalar block-Schwarz step, but not all of Theorem 6.16. The remaining
-  **existence assembly** must apply the already formalized exclusion of the
-  transpose alternative to the matched endomorphisms and prove the exact
-  weighted Equation (6.68). That step remains tracked by #411. The conditional
-  `CycleStructure` and `MultiCycleDecomposition` objects above are consumers
-  of that later theorem; they are not substitutes for it.
+* The final source-facing assembly lives in
+  `QICLean.Channel.Peripheral.StructureOfCycles`:
+  - `Matrix.DirectSumFacePermutation.exists_reindexedUnitaryBlockAction`
+    applies the positive-invertible Schwarz classification to each matched
+    endomorphism, sets Wolf's output-to-input permutation to
+    `pi = F.blockEquiv.symm`, and reindexes the classified source unitary to
+    an output-indexed unitary `V k`;
+  - `IsPositiveMap.exists_wolfTheorem616` is the compiled Theorem 6.16
+    boundary. It identifies membership in `T.peripheralSubspace` with the
+    literal zero-extended `Matrix.fromBlocks 0 0 0` density-block form of
+    Equations (6.66)--(6.67), retains `e₀`, and separately proves `n = D`
+    and `sigma k = (m k : ℂ)⁻¹ • 1`;
+  - the same declaration returns `pi`, both equalities
+    `d (pi k) = d k` and `m (pi k) = m k`, output-indexed unitaries, the
+    coordinate action
+    `A X k = V k * reindex (X (pi k)) * V kᴴ`, and the ambient Equation
+    (6.68), `T (E X) = E (A X)`;
+  - Schwarz for `T` and Schwarz for `T*` remain distinct hypotheses, and the
+    positive trace-preserving inverse consumed by the block classification is
+    only the recurrent inverse on the peripheral image.
+
+  Thus the exact source theorem is complete without CP/Kraus hypotheses,
+  a modified product, a global inverse for `T`, or a substitute through the
+  conditional `CycleStructure` and `MultiCycleDecomposition` records. Those
+  records remain independent downstream interfaces rather than part of the
+  source theorem.
 
 ---
 


### PR DESCRIPTION
## Source boundary

This assembles Wolf, *Quantum Channels & Operations*, Chapter 6, Theorem 6.16, Equations (6.66)–(6.68), from `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1597–1664.

The declaration keeps the direct Schwarz hypothesis on `T` separate from the trace-adjoint Schwarz hypothesis required by the printed proof's invocation of Theorem 6.14. It does not invent an implication between those contracts.

## Formalized

- a reusable source-indexed `DirectSumFacePermutation.map_apply_blockEquiv` API for dependent block sizes;
- unitary classification of every matched block and output-to-input orientation `pi = blockEquiv.symm`;
- exact peripheral-subspace membership in the zero-extended density-block form of Equations (6.66)–(6.67);
- explicit `e₀` and `fromBlocks 0 0 0`, while separately proving `n = D`;
- maximally mixed weights and equality of both matched full-matrix and multiplicity dimensions;
- coordinate action by reindexed output unitaries and the ambient equality `T (E X) = E (A X)` of Equation (6.68);
- Blueprint, Wolf-numbering coverage, and source-contract documentation synchronization.

The module is source-shaped as `Channel/Peripheral/StructureOfCycles.lean`. The proof uses only the recurrent inverse on the peripheral image and the canonical inverse of a matched block. It does not assert a global inverse for `T`, use CP/Kraus hypotheses, or substitute the weaker conditional `CycleStructure`/`MultiCycleDecomposition` records.

## Validation

- focused Peripheral and top-level Channel builds passed on current main;
- full `lake build`, style, import, module-policy, and proof-integrity gates passed;
- Blueprint sync is 2,258/2,258 with zero reverse-coverage gaps;
- paper-gap, bibliography, rendered-page, prose, and diff checks passed;
- declaration axioms are only `propext`, `Classical.choice`, and `Quot.sound`;
- independent exact-head source review approved `50aed51afd8831c422dae0069a3ebe773b896212` on main `0d307e011e9a0069c49bb54875a80684366b18a3`.

Closes #411
