### PR TITLE
feat(channel): complete the SL(2,C) spinor epimorphism and two-point fibres

### DIFF
--- a/QICLean/Algebra/SpinCover.lean
+++ b/QICLean/Algebra/SpinCover.lean
@@ -9,3 +9,4 @@ Authors: QICLean contributors
 -- Generated aggregator module: QICLean.Algebra.SpinCover
 
 import QICLean.Algebra.SpinCover.Basic
+import QICLean.Algebra.SpinCover.EulerAngles

--- a/QICLean/Algebra/SpinCover/EulerAngles.lean
+++ b/QICLean/Algebra/SpinCover/EulerAngles.lean
@@ -1,0 +1,361 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Algebra.SpinCover.Basic
+import QICLean.Algebra.ComplexPhasePositivity
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+
+/-!
+# The spin-`½` double cover `SU(2) → SO(3)` — Euler-angle surjectivity
+
+This module proves that the spin-`½` real-rotation cover defined in
+`QICLean.Algebra.SpinCover.Basic` is surjective onto `SO(3)` via an explicit
+Euler-angle (`ZXZ`) factorization.  It was transferred from
+`TNLean.Algebra.SpinCover.EulerAngles`, which owned this development before
+the spin-cover material moved into QICLean.
+
+## Main results
+
+* `SpinCover.so3_euler_decomp` : every `SO(3)` matrix factors as a `ZXZ` product
+  of coordinate rotations
+* `SpinCover.spinHalfCover_surjective_onto_SO3` : every `SO(3)` rotation is a
+  Pauli conjugation by some `SU(2)` element
+
+The algebraic definitions and results about Pauli matrices, `spinHalfCover`,
+orthogonality, and `spinHalfCoverSO3` are proved in
+`QICLean.Algebra.SpinCover.Basic`.
+
+## References
+
+* RMP review (arXiv:2011.12127) around line 1159 (`A^i = σ^i`, on-site `SO(3)`)
+-/
+
+open scoped Matrix BigOperators
+open Matrix Finset
+
+noncomputable section
+
+namespace SpinCover
+
+/-! ### Generators of `SU(2)` and `SO(3)`
+
+The surjectivity of the spin-`½` cover is proved through an explicit
+Euler-angle factorization.  Every rotation of three-space is a product of a
+rotation about the `z`-axis, a rotation about the `x`-axis, and a further
+rotation about the `z`-axis, and each of these one-parameter families is the
+image under the cover of a one-parameter family in `SU(2)`. -/
+
+/-- The diagonal `SU(2)` matrix `diag(e^{-iθ/2}, e^{iθ/2})` covering a rotation by
+`θ` about the `z`-axis. -/
+def su2Diag (θ : ℝ) : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![Complex.exp (-(θ / 2) * Complex.I), 0; 0, Complex.exp (θ / 2 * Complex.I)]
+
+/-- The `SU(2)` matrix covering a rotation by `β` about the `x`-axis. -/
+def su2Xrot (β : ℝ) : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![Real.cos (β / 2), -Complex.I * Real.sin (β / 2);
+    -Complex.I * Real.sin (β / 2), Real.cos (β / 2)]
+
+/-- The rotation by `θ` about the `z`-axis. -/
+def rotZ (θ : ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
+  !![Real.cos θ, -Real.sin θ, 0; Real.sin θ, Real.cos θ, 0; 0, 0, 1]
+
+/-- The rotation by `β` about the `x`-axis. -/
+def rotX (β : ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
+  !![1, 0, 0; 0, Real.cos β, -Real.sin β; 0, Real.sin β, Real.cos β]
+
+lemma su2Diag_mem_specialUnitaryGroup (θ : ℝ) :
+    su2Diag θ ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ := by
+  rw [Matrix.mem_specialUnitaryGroup_iff]
+  refine ⟨?_, ?_⟩
+  · rw [Matrix.mem_unitaryGroup_iff]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp only [su2Diag, Matrix.mul_apply, Fin.sum_univ_two, Matrix.star_apply,
+        Matrix.one_apply, Complex.star_def, Fin.mk_zero, Fin.mk_one, Matrix.cons_val_zero,
+        Matrix.cons_val_one, Matrix.of_apply, Matrix.cons_val', Matrix.empty_val',
+        Matrix.cons_val_fin_one, ← Complex.exp_conj, ← Complex.exp_add, map_zero, mul_zero,
+        zero_mul, add_zero, zero_add, Fin.isValue, Fin.reduceEq, ite_true, ite_false] <;>
+      first
+        | rfl
+        | (rw [← Complex.exp_zero]; congr 1
+           simp only [map_mul, Complex.conj_I, Complex.conj_ofReal, map_div₀,
+             map_neg, map_ofNat]
+           ring)
+  · rw [su2Diag, Matrix.det_fin_two_of, mul_zero, sub_zero, ← Complex.exp_add]
+    rw [show -(θ / 2) * Complex.I + θ / 2 * Complex.I = 0 by ring, Complex.exp_zero]
+
+lemma su2Xrot_mem_specialUnitaryGroup (β : ℝ) :
+    su2Xrot β ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ := by
+  have hp : ((Real.cos (β / 2) : ℂ)) ^ 2 + ((Real.sin (β / 2) : ℂ)) ^ 2 = 1 := by
+    rw [← Complex.ofReal_pow, ← Complex.ofReal_pow, ← Complex.ofReal_add,
+      Real.cos_sq_add_sin_sq, Complex.ofReal_one]
+  rw [Matrix.mem_specialUnitaryGroup_iff]
+  refine ⟨?_, ?_⟩
+  · rw [Matrix.mem_unitaryGroup_iff]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp only [su2Xrot, Matrix.mul_apply, Fin.sum_univ_two, Matrix.star_apply,
+        Matrix.one_apply, Fin.mk_zero, Fin.mk_one, Matrix.cons_val_zero, Matrix.cons_val_one,
+        Matrix.of_apply, Matrix.cons_val', Matrix.empty_val',
+        Matrix.cons_val_fin_one, Complex.star_def, map_neg, map_mul,
+        Complex.conj_I, Complex.conj_ofReal, Fin.isValue, Fin.reduceEq,
+        ite_true, ite_false] <;>
+      first
+        | linear_combination hp - (Real.sin (β / 2) : ℂ) ^ 2 * Complex.I_sq
+        | ring
+  · rw [su2Xrot, Matrix.det_fin_two_of]
+    linear_combination hp - (Real.sin (β / 2) : ℂ) ^ 2 * Complex.I_sq
+
+/-! ### The cover sends the chosen generators to the coordinate rotations -/
+
+/-- Conjugating the Pauli vector by the diagonal cover `su2Diag θ` realizes the
+rotation by `θ` about the `z`-axis. -/
+lemma R_su2Diag_eq_rotZ (θ : ℝ) :
+    pauliConjAd (su2ToGL (su2Diag θ) (su2Diag_mem_specialUnitaryGroup θ))
+      = (rotZ θ).map Complex.ofReal := by
+  have hexpP : Complex.exp ((θ : ℂ) / 2 * Complex.I)
+      = (Real.cos (θ / 2) : ℂ) + (Real.sin (θ / 2) : ℂ) * Complex.I := by
+    rw [show (θ : ℂ) / 2 = ((θ / 2 : ℝ) : ℂ) by push_cast; ring, Complex.exp_mul_I,
+      Complex.ofReal_cos, Complex.ofReal_sin]
+  have hexpN : Complex.exp (-((θ : ℂ) / 2 * Complex.I))
+      = (Real.cos (θ / 2) : ℂ) - (Real.sin (θ / 2) : ℂ) * Complex.I := by
+    have harg : -((θ : ℂ) / 2 * Complex.I) = ((-(θ / 2) : ℝ) : ℂ) * Complex.I := by
+      push_cast; ring
+    rw [harg, Complex.exp_mul_I, Complex.ofReal_cos, Complex.ofReal_sin, Complex.ofReal_neg,
+      Complex.cos_neg, Complex.sin_neg]
+    ring
+  have hcos : (Real.cos θ : ℂ)
+      = (Real.cos (θ / 2) : ℂ) ^ 2 - (Real.sin (θ / 2) : ℂ) ^ 2 := by
+    have h : Real.cos θ = Real.cos (θ / 2) ^ 2 - Real.sin (θ / 2) ^ 2 := by
+      rw [← Real.cos_two_mul' (θ / 2), show 2 * (θ / 2) = θ by ring]
+    rw [h]; push_cast; ring
+  have hsin : (Real.sin θ : ℂ) = 2 * (Real.sin (θ / 2) : ℂ) * (Real.cos (θ / 2) : ℂ) := by
+    have h : Real.sin θ = 2 * Real.sin (θ / 2) * Real.cos (θ / 2) := by
+      rw [← Real.sin_two_mul, show 2 * (θ / 2) = θ by ring]
+    rw [h]; push_cast; ring
+  have hpyth : (↑(Real.cos (θ * (1 / 2))) : ℂ) ^ 2
+      + (↑(Real.sin (θ * (1 / 2))) : ℂ) ^ 2 = 1 := by
+    rw [← Complex.ofReal_pow, ← Complex.ofReal_pow, ← Complex.ofReal_add,
+      Real.cos_sq_add_sin_sq, Complex.ofReal_one]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp only [pauliConjAd, su2ToGL_coe, su2ToGL_inv_coe, pauli, su2Diag, rotZ,
+      Matrix.adjugate_fin_two_of, Matrix.trace_fin_two, Matrix.mul_apply, Fin.sum_univ_two,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Matrix.of_apply,
+      Matrix.cons_val', Matrix.empty_val', Matrix.cons_val_fin_one, Matrix.head_fin_const,
+      Matrix.map_apply, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Fin.zero_eta,
+      Fin.mk_one, Fin.isValue, Complex.ofReal_zero, Complex.ofReal_one, Complex.ofReal_neg,
+      neg_mul, mul_neg, neg_zero, mul_zero, zero_mul, add_zero, zero_add, mul_one, one_mul,
+      hexpP, hexpN, hcos, hsin] <;>
+    (ring_nf; (try (simp only [Complex.I_sq, Complex.I_pow_four]; ring_nf));
+      (try linear_combination hpyth))
+
+/-- Conjugating the Pauli vector by the cover `su2Xrot β` realizes the rotation by
+`β` about the `x`-axis. -/
+lemma R_su2Xrot_eq_rotX (β : ℝ) :
+    pauliConjAd (su2ToGL (su2Xrot β) (su2Xrot_mem_specialUnitaryGroup β))
+      = (rotX β).map Complex.ofReal := by
+  have hcos : (Real.cos β : ℂ)
+      = (Real.cos (β / 2) : ℂ) ^ 2 - (Real.sin (β / 2) : ℂ) ^ 2 := by
+    have h : Real.cos β = Real.cos (β / 2) ^ 2 - Real.sin (β / 2) ^ 2 := by
+      rw [← Real.cos_two_mul' (β / 2), show 2 * (β / 2) = β by ring]
+    rw [h]; push_cast; ring
+  have hsin : (Real.sin β : ℂ) = 2 * (Real.sin (β / 2) : ℂ) * (Real.cos (β / 2) : ℂ) := by
+    have h : Real.sin β = 2 * Real.sin (β / 2) * Real.cos (β / 2) := by
+      rw [← Real.sin_two_mul, show 2 * (β / 2) = β by ring]
+    rw [h]; push_cast; ring
+  have hpyth : (↑(Real.cos (β * (1 / 2))) : ℂ) ^ 2
+      + (↑(Real.sin (β * (1 / 2))) : ℂ) ^ 2 = 1 := by
+    rw [← Complex.ofReal_pow, ← Complex.ofReal_pow, ← Complex.ofReal_add,
+      Real.cos_sq_add_sin_sq, Complex.ofReal_one]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp only [pauliConjAd, su2ToGL_coe, su2ToGL_inv_coe, pauli, su2Xrot, rotX,
+      Matrix.adjugate_fin_two_of, Matrix.trace_fin_two, Matrix.mul_apply, Fin.sum_univ_two,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Matrix.of_apply,
+      Matrix.cons_val', Matrix.empty_val', Matrix.cons_val_fin_one, Matrix.head_fin_const,
+      Matrix.map_apply, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Fin.zero_eta,
+      Fin.mk_one, Fin.isValue, Complex.ofReal_zero, Complex.ofReal_one, Complex.ofReal_neg,
+      neg_mul, mul_neg, neg_zero, mul_zero, zero_mul, add_zero, zero_add, mul_one, one_mul,
+      hcos, hsin] <;>
+    (ring_nf; (try (simp only [Complex.I_sq, Complex.I_pow_four]; ring_nf));
+      (try linear_combination hpyth))
+
+/-! ### Surjectivity of the cover via the Euler-angle factorization -/
+
+/-- A point on the unit circle is the cosine-sine pair of an angle.  Existence of
+the angle comes from the argument of the corresponding unit complex number. -/
+lemma exists_cos_sin {c s : ℝ} (h : c ^ 2 + s ^ 2 = 1) :
+    ∃ θ : ℝ, Real.cos θ = c ∧ Real.sin θ = s := by
+  have hn : ‖(⟨c, s⟩ : ℂ)‖ = 1 := by
+    rw [Complex.norm_def, Complex.normSq_mk,
+      show c * c + s * s = 1 by nlinarith only [h]]
+    simp
+  have hz : (⟨c, s⟩ : ℂ) ≠ 0 := Complex.ne_zero_of_norm_eq_one hn
+  exact ⟨Complex.arg (⟨c, s⟩ : ℂ), by rw [Complex.cos_arg hz, hn]; simp,
+    by rw [Complex.sin_arg, hn]; simp⟩
+
+-- The Euler decomposition verifies all nine entries of a three-by-three rotation
+-- against the product of three coordinate rotations, each closed by a polynomial
+-- certificate over the orthonormality and cofactor relations.  Arithmetic calls
+-- are restricted with `only` to avoid passing the full matrix context to each
+-- normalization.
+lemma so3_euler_decomp (M : Matrix (Fin 3) (Fin 3) ℝ)
+    (hM : M ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ) :
+    ∃ α β γ : ℝ, M = rotZ α * rotX β * rotZ γ := by
+  rw [Matrix.mem_specialOrthogonalGroup_iff] at hM
+  obtain ⟨ho, hdet⟩ := hM
+  have hoM : M * Mᵀ = 1 := (Matrix.mem_orthogonalGroup_iff (Fin 3) ℝ).mp ho
+  have hoT : Mᵀ * M = 1 := (Matrix.mem_orthogonalGroup_iff' (Fin 3) ℝ).mp ho
+  have hadj : Mᵀ = M.adjugate := by
+    rw [show Mᵀ = M⁻¹ from (Matrix.inv_eq_right_inv hoM).symm, Matrix.inv_def, hdet]; simp
+  -- concrete row/column dot products and cofactors
+  have row : ∀ p q : Fin 3, M p 0 * M q 0 + M p 1 * M q 1 + M p 2 * M q 2 =
+      if p = q then 1 else 0 := by
+    intro p q
+    have := congrFun (congrFun hoM p) q
+    simpa only [Matrix.mul_apply, Fin.sum_univ_three, Matrix.transpose_apply,
+      Matrix.one_apply] using this
+  have col : ∀ p q : Fin 3, M 0 p * M 0 q + M 1 p * M 1 q + M 2 p * M 2 q =
+      if p = q then 1 else 0 := by
+    intro p q
+    have := congrFun (congrFun hoT p) q
+    simpa only [Matrix.mul_apply, Fin.sum_univ_three, Matrix.transpose_apply,
+      Matrix.one_apply] using this
+  have cof : ∀ p q : Fin 3, M q p = (M.adjugate) p q := by
+    intro p q
+    have := congrFun (congrFun hadj p) q; rwa [Matrix.transpose_apply] at this
+  -- the nine cofactor identities
+  have cof00 : M 0 0 = M 1 1 * M 2 2 - M 1 2 * M 2 1 := by
+    have := cof 0 0; simp only [Matrix.adjugate_fin_three, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_fin_one, Matrix.empty_val'] at this
+    linarith only [this]
+  have cof01 : M 1 0 = -(M 0 1 * M 2 2) + M 0 2 * M 2 1 := by
+    have := cof 0 1; simp only [Matrix.adjugate_fin_three, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one,
+      Matrix.empty_val'] at this
+    linarith only [this]
+  have cof10 : M 0 1 = -(M 1 0 * M 2 2) + M 1 2 * M 2 0 := by
+    have := cof 1 0; simp only [Matrix.adjugate_fin_three, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one,
+      Matrix.empty_val'] at this
+    linarith only [this]
+  have cof11 : M 1 1 = M 0 0 * M 2 2 - M 0 2 * M 2 0 := by
+    have := cof 1 1; simp only [Matrix.adjugate_fin_three, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one,
+      Matrix.empty_val'] at this
+    linarith only [this]
+  -- norms of relevant rows/cols
+  have hr22 : M 2 0 * M 2 0 + M 2 1 * M 2 1 + M 2 2 * M 2 2 = 1 := by
+    have := row 2 2; rwa [ite_eq_left rfl] at this
+  have hc22 : M 0 2 * M 0 2 + M 1 2 * M 1 2 + M 2 2 * M 2 2 = 1 := by
+    have := col 2 2; rwa [ite_eq_left rfl] at this
+  have hbound : M 2 2 ^ 2 ≤ 1 := by
+    nlinarith only [hr22, sq_nonneg (M 2 0), sq_nonneg (M 2 1)]
+  set sβ := Real.sqrt (1 - M 2 2 ^ 2) with hsβdef
+  have hsβsq : sβ ^ 2 = 1 - M 2 2 ^ 2 := by
+    rw [hsβdef, Real.sq_sqrt (by nlinarith only [hbound])]
+  obtain ⟨β, hcosβ, hsinβ⟩ :=
+    exists_cos_sin (c := M 2 2) (s := sβ) (by nlinarith only [hsβsq])
+  by_cases hs : sβ = 0
+  · -- gimbal lock: sin β = 0, so M 2 2 = ±1 and the off-axis entries vanish
+    have h22sq : M 2 2 ^ 2 = 1 := by
+      have : sβ ^ 2 = 0 := by rw [hs]; ring
+      rw [this] at hsβsq
+      linarith only [hsβsq]
+    have hz20 : M 2 0 = 0 := by
+      nlinarith only [hr22, h22sq, sq_nonneg (M 2 0), sq_nonneg (M 2 1)]
+    have hz21 : M 2 1 = 0 := by
+      nlinarith only [hr22, h22sq, sq_nonneg (M 2 0), sq_nonneg (M 2 1)]
+    have hz02 : M 0 2 = 0 := by
+      nlinarith only [hc22, h22sq, sq_nonneg (M 0 2), sq_nonneg (M 1 2)]
+    have hz12 : M 1 2 = 0 := by
+      nlinarith only [hc22, h22sq, sq_nonneg (M 0 2), sq_nonneg (M 1 2)]
+    have hcol0 : M 0 0 ^ 2 + M 1 0 ^ 2 = 1 := by
+      have := col 0 0
+      rw [ite_eq_left rfl] at this
+      nlinarith only [this, hz20]
+    obtain ⟨α, hcosα, hsinα⟩ :=
+      exists_cos_sin (c := M 0 0) (s := M 1 0) (by nlinarith only [hcol0])
+    refine ⟨α, β, 0, ?_⟩
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp only [rotZ, rotX, Matrix.mul_apply, Fin.sum_univ_three,
+        Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+        Matrix.head_cons, Matrix.tail_cons, Matrix.cons_val', Matrix.empty_val',
+        Matrix.cons_val_fin_one, Matrix.head_fin_const,
+        Fin.zero_eta, Fin.mk_one, Fin.isValue, Fin.reduceFinMk,
+        hcosα, hsinα, hcosβ, hsinβ, Real.cos_zero, Real.sin_zero, hs,
+        hz02, hz12, hz20, hz21] <;>
+      first
+        | linear_combination cof10 + M 1 2 * hz20
+        | linear_combination cof11 - M 0 2 * hz20
+        | ring
+  · have hsβne : sβ ≠ 0 := hs
+    obtain ⟨α, hcosα, hsinα⟩ := exists_cos_sin (c := -M 1 2 / sβ) (s := M 0 2 / sβ) (by
+      rw [div_pow, div_pow, ← add_div, div_eq_one_iff_eq (pow_ne_zero 2 hsβne)]
+      nlinarith only [hc22, hsβsq])
+    obtain ⟨γ, hcosγ, hsinγ⟩ := exists_cos_sin (c := M 2 1 / sβ) (s := M 2 0 / sβ) (by
+      rw [div_pow, div_pow, ← add_div, div_eq_one_iff_eq (pow_ne_zero 2 hsβne)]
+      nlinarith only [hr22, hsβsq])
+    refine ⟨α, β, γ, ?_⟩
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp only [rotZ, rotX, Matrix.mul_apply, Fin.sum_univ_three,
+        Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+        Matrix.head_cons, Matrix.tail_cons, Matrix.cons_val', Matrix.empty_val',
+        Matrix.cons_val_fin_one, Matrix.head_fin_const,
+        Fin.zero_eta, Fin.mk_one, Fin.isValue, Fin.reduceFinMk,
+        hcosα, hsinα, hcosβ, hsinβ, hcosγ, hsinγ] <;>
+      field_simp <;>
+      first
+        | linear_combination M 0 0 * hsβsq + cof00 + M 2 2 * cof11
+        | linear_combination M 0 1 * hsβsq + cof10 - M 2 2 * cof01
+        | linear_combination M 1 0 * hsβsq + cof01 - M 2 2 * cof10
+        | linear_combination M 1 1 * hsβsq + cof11 + M 2 2 * cof00
+        | nlinarith only [hsβsq, hr22, hc22]
+
+/-! ### The spin-½ cover is onto `SO(3)` -/
+
+/-- The spin-`½` cover is surjective onto `SO(3)`: every rotation of three-space
+is the adjoint action of some `SU(2)` matrix on the Pauli vector.  The witness is
+read off the Euler-angle factorization of the rotation. -/
+theorem spinHalfCover_surjective_onto_SO3 (M : Matrix (Fin 3) (Fin 3) ℝ)
+    (hM : M ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ) :
+    ∃ U : Matrix (Fin 2) (Fin 2) ℂ, ∃ hU : U ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ,
+      pauliConjAd (su2ToGL U hU) = M.map Complex.ofReal := by
+  obtain ⟨α, β, γ, hαβγ⟩ := so3_euler_decomp M hM
+  have hd : ∀ θ, su2Diag θ ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ :=
+    su2Diag_mem_specialUnitaryGroup
+  have hx : ∀ b, su2Xrot b ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ :=
+    su2Xrot_mem_specialUnitaryGroup
+  have hU1 : su2Diag α * su2Xrot β ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ :=
+    Submonoid.mul_mem _ (hd α) (hx β)
+  have hU : su2Diag α * su2Xrot β * su2Diag γ ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ :=
+    Submonoid.mul_mem _ hU1 (hd γ)
+  refine ⟨su2Diag α * su2Xrot β * su2Diag γ, hU, ?_⟩
+  rw [pauliConjAd_su2ToGL_mul _ _ hU1 (hd γ), pauliConjAd_su2ToGL_mul _ _ (hd α) (hx β),
+    R_su2Diag_eq_rotZ, R_su2Xrot_eq_rotX, R_su2Diag_eq_rotZ, hαβγ,
+    show (Complex.ofReal : ℝ → ℂ) = ⇑Complex.ofRealHom from rfl, ← Matrix.map_mul,
+    ← Matrix.map_mul]
+
+/-- The corestricted spin-`½` cover `SU(2) → SO(3)` is surjective: every
+rotation of three-space is `spinHalfCoverSO3` of some special unitary.  This is
+the bundled form of `spinHalfCover_surjective_onto_SO3`. -/
+theorem spinHalfCoverSO3_surjective : Function.Surjective spinHalfCoverSO3 := by
+  intro M
+  obtain ⟨U, hU, hUM⟩ := spinHalfCover_surjective_onto_SO3 M.1 M.2
+  refine ⟨⟨U, hU⟩, ?_⟩
+  apply Subtype.ext
+  apply Matrix.map_injective Complex.ofReal_injective
+  change (pauliConjAdReal U hU).map Complex.ofReal = (M : Matrix (Fin 3) (Fin 3) ℝ).map
+    Complex.ofReal
+  rw [show (pauliConjAdReal U hU).map Complex.ofReal =
+      ((spinHalfCoverSO3 ⟨U, hU⟩ : Matrix (Fin 3) (Fin 3) ℝ)).map Complex.ofReal from rfl,
+    spinHalfCoverSO3_coe_map]
+  exact hUM
+
+end SpinCover

--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -63,6 +63,7 @@ import QICLean.Channel.LorentzNormalForm.PauliBlockTruncation
 import QICLean.Channel.LorentzNormalForm.QubitNormalForm
 import QICLean.Channel.LorentzNormalForm.SpinorAction
 import QICLean.Channel.LorentzNormalForm.SpinorCover
+import QICLean.Channel.LorentzNormalForm.SpinorExponential
 import QICLean.Channel.MarginalSupportAbsorption
 import QICLean.Channel.MarginalSupportWhitenedChoi
 import QICLean.Channel.MaximalOverlap

--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -62,6 +62,7 @@ import QICLean.Channel.LorentzNormalForm.NormalForm
 import QICLean.Channel.LorentzNormalForm.PauliBlockTruncation
 import QICLean.Channel.LorentzNormalForm.QubitNormalForm
 import QICLean.Channel.LorentzNormalForm.SpinorAction
+import QICLean.Channel.LorentzNormalForm.SpinorCover
 import QICLean.Channel.MarginalSupportAbsorption
 import QICLean.Channel.MarginalSupportWhitenedChoi
 import QICLean.Channel.MaximalOverlap

--- a/QICLean/Channel/LorentzNormalForm.lean
+++ b/QICLean/Channel/LorentzNormalForm.lean
@@ -11,6 +11,7 @@ import QICLean.Channel.LorentzNormalForm.NormalForm
 import QICLean.Channel.LorentzNormalForm.PauliBlockTruncation
 import QICLean.Channel.LorentzNormalForm.QubitNormalForm
 import QICLean.Channel.LorentzNormalForm.SpinorAction
+import QICLean.Channel.LorentzNormalForm.SpinorCover
 
 /-!
 # Lorentz normal form for quantum channels (Wolf Section 2.4, Propositions 2.8–2.11)
@@ -41,6 +42,9 @@ filtering operations from eight focused submodules.
 * `QICLean.Channel.LorentzNormalForm.SpinorAction` — the four-dimensional
   Hermitian congruence action of `SL(2,ℂ)` and its action on Pauli transfer
   matrices (Wolf Equations (2.41)--(2.43)).
+* `QICLean.Channel.LorentzNormalForm.SpinorCover` — the spinor epimorphism
+  `SL(2,ℂ) → SO⁺(1,3)`: the bundled homomorphism, the rotation-block
+  reduction, and the unitary lift (Wolf Equations (2.42)--(2.44)).
 
 ## References
 

--- a/QICLean/Channel/LorentzNormalForm.lean
+++ b/QICLean/Channel/LorentzNormalForm.lean
@@ -12,6 +12,7 @@ import QICLean.Channel.LorentzNormalForm.PauliBlockTruncation
 import QICLean.Channel.LorentzNormalForm.QubitNormalForm
 import QICLean.Channel.LorentzNormalForm.SpinorAction
 import QICLean.Channel.LorentzNormalForm.SpinorCover
+import QICLean.Channel.LorentzNormalForm.SpinorExponential
 
 /-!
 # Lorentz normal form for quantum channels (Wolf Section 2.4, Propositions 2.8–2.11)
@@ -44,7 +45,10 @@ filtering operations from eight focused submodules.
   matrices (Wolf Equations (2.41)--(2.43)).
 * `QICLean.Channel.LorentzNormalForm.SpinorCover` — the spinor epimorphism
   `SL(2,ℂ) → SO⁺(1,3)`: the bundled homomorphism, the rotation-block
-  reduction, and the unitary lift (Wolf Equations (2.42)--(2.44)).
+  reduction, the boost lift, and the exact two-point fibres (Wolf
+  Equations (2.42)--(2.44)).
+* `QICLean.Channel.LorentzNormalForm.SpinorExponential` — the boost and
+  corrected-sign rotation exponential formulas in Wolf Equation (2.44).
 
 ## References
 

--- a/QICLean/Channel/LorentzNormalForm/SpinorAction.lean
+++ b/QICLean/Channel/LorentzNormalForm/SpinorAction.lean
@@ -778,11 +778,111 @@ noncomputable def spinorMap : SL(2, ℂ) →* Matrix (Fin 4) (Fin 4) ℝ where
   map_one' := spinorMatrix_one
   map_mul' := spinorMatrix_mul
 
+/-! ### The kernel of the spinor action
+
+The two-to-one assertion after Wolf, Equation (2.42) (lines 1057--1059 of the
+source) has two halves: `X` and `-X` act identically (proved above as
+`spinorMatrix_neg`), and no other pair does.  The second half is the kernel
+computation: if `L(X) = 1`, then congruence by `X` fixes every Hermitian
+matrix; unitarity follows from the identity matrix, scalarity from
+commutation with the Pauli basis, and `det X = 1` pins the scalar to `±1`. -/
+
+/-- If `X ∈ SL(2,ℂ)` acts trivially on Minkowski coordinates, then `X = ±1`.
+
+This is the kernel half of the two-to-one assertion after Wolf,
+Equation (2.42) (`Notes/WolfNoteTexSource/ch02_representations.tex`, lines
+1057--1059).  The route is the one sketched in the source: `X X† = 1` from
+the congruence action on the identity, then `X` commutes with every Pauli
+matrix, so `X` is scalar, and `det X = 1` forces the scalar to be `±1`. -/
+theorem spinorMatrix_eq_one_iff (X : SL(2, ℂ)) :
+    spinorMatrix X = 1 ↔ X = 1 ∨ X = -1 := by
+  constructor
+  · intro h
+    have hconj : ∀ j : Fin 4, X.1 * pauliMatrices j * X.1ᴴ = pauliMatrices j := by
+      intro j
+      have hx := pauliMatrixOfMinkowski_spinorMatrix_mulVec X (Pi.single j 1)
+      rw [h, Matrix.one_mulVec, pauliMatrixOfMinkowski_single] at hx
+      exact hx.symm
+    have hunit : X.1 * X.1ᴴ = 1 := by
+      have h0 := hconj 0
+      rwa [pauliMatrices_zero, Matrix.mul_one] at h0
+    have hleft : (X⁻¹ : SL(2, ℂ)).1 * X.1 = 1 := by
+      rw [← Matrix.SpecialLinearGroup.coe_mul, inv_mul_cancel,
+        Matrix.SpecialLinearGroup.coe_one]
+    have hunit' : X.1ᴴ * X.1 = 1 := by
+      have hu : X.1ᴴ = (X⁻¹ : SL(2, ℂ)).1 := by
+        calc X.1ᴴ = 1 * X.1ᴴ := (Matrix.one_mul _).symm
+        _ = ((X⁻¹ : SL(2, ℂ)).1 * X.1) * X.1ᴴ := by rw [hleft]
+        _ = (X⁻¹ : SL(2, ℂ)).1 * (X.1 * X.1ᴴ) := by rw [Matrix.mul_assoc]
+        _ = (X⁻¹ : SL(2, ℂ)).1 := by rw [hunit, Matrix.mul_one]
+      rw [hu]; exact hleft
+    have hcomm : ∀ j : Fin 4, X.1 * pauliMatrices j = pauliMatrices j * X.1 := by
+      intro j
+      calc X.1 * pauliMatrices j
+          = (X.1 * pauliMatrices j * X.1ᴴ) * X.1 := by
+            rw [Matrix.mul_assoc, hunit', Matrix.mul_one]
+        _ = pauliMatrices j * X.1 := by rw [hconj j]
+    have h01 : X.1 0 1 = 0 := by
+      have h01e := congrFun (congrFun (hcomm 3) 0) 1
+      simp [pauliMatrices, Matrix.mul_apply, Fin.sum_univ_two] at h01e
+      exact self_eq_neg.mp h01e.symm
+    have h10 : X.1 1 0 = 0 := by
+      have h10e := congrFun (congrFun (hcomm 3) 1) 0
+      simp [pauliMatrices, Matrix.mul_apply, Fin.sum_univ_two] at h10e
+      exact self_eq_neg.mp h10e
+    have hdiag : X.1 0 0 = X.1 1 1 := by
+      have he := congrFun (congrFun (hcomm 1) 0) 1
+      simp [pauliMatrices, Matrix.mul_apply, Fin.sum_univ_two] at he
+      exact he
+    have hdet : X.1 0 0 * X.1 0 0 = 1 := by
+      have hd := X.2
+      rw [Matrix.det_fin_two, h01, h10, ← hdiag] at hd
+      simpa using hd
+    have hscalar : X.1 = (X.1 0 0) • (1 : Matrix (Fin 2) (Fin 2) ℂ) := by
+      ext a b
+      fin_cases a <;> fin_cases b <;>
+        simp [h01, h10, hdiag]
+    rcases (sq_eq_one_iff (R := ℂ)).mp (by rw [pow_two]; exact hdet) with hc | hc
+    · left
+      apply Subtype.ext
+      rw [hscalar, hc]
+      simp [Matrix.SpecialLinearGroup.coe_one]
+    · right
+      apply Subtype.ext
+      rw [hscalar, hc]
+      simp [Matrix.SpecialLinearGroup.coe_neg, Matrix.SpecialLinearGroup.coe_one]
+  · rintro (rfl | rfl)
+    · exact spinorMatrix_one
+    · rw [spinorMatrix_neg]; exact spinorMatrix_one
+
+/-- The fibres of the spinor action are exactly the pairs `{X, -X}`.
+
+This is the full "two-to-one" assertion after Wolf, Equation (2.42)
+(`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 1057--1059),
+reduced to the kernel computation `spinorMatrix_eq_one_iff` by
+multiplicativity of the spinor map. -/
+theorem spinorMatrix_eq_iff_eq_or_eq_neg (X Y : SL(2, ℂ)) :
+    spinorMatrix X = spinorMatrix Y ↔ X = Y ∨ X = -Y := by
+  constructor
+  · intro h
+    have h1 : spinorMatrix (X * Y⁻¹) = 1 := by
+      rw [spinorMatrix_mul, h, ← spinorMatrix_mul, mul_inv_cancel, spinorMatrix_one]
+    rcases (spinorMatrix_eq_one_iff _).mp h1 with h2 | h2
+    · left
+      exact eq_of_mul_inv_eq_one h2
+    · right
+      calc X = X * Y⁻¹ * Y := by group
+        _ = -1 * Y := by rw [h2]
+        _ = -Y := neg_one_mul Y
+  · rintro (rfl | rfl)
+    · rfl
+    · exact spinorMatrix_neg Y
+
 /-!
-The inclusion of the spinor image in `SO⁺(1,3)` is now formalized. Wolf's
-stronger assertion that this map is a surjective double cover, and the explicit
-rotation/boost exponential formulas in Equation (2.44), are not inferred from
-the three-dimensional `SU(2)` result and are not asserted in this module.
+The inclusion of the spinor image in `SO⁺(1,3)` and the exact two-point
+fibres are formalized in this module.  Surjectivity of the spinor map onto
+`SO⁺(1,3)` and the explicit rotation/boost formulas of Wolf, Equation (2.44)
+are proved in `QICLean.Channel.LorentzNormalForm.SpinorCover`.
 -/
 
 end Wolf

--- a/QICLean/Channel/LorentzNormalForm/SpinorCover.lean
+++ b/QICLean/Channel/LorentzNormalForm/SpinorCover.lean
@@ -910,4 +910,3 @@ theorem spinorCoverHom_eq_one_iff (X : SL(2, ℂ)) :
   exact spinorCoverHom_eq_iff_eq_or_eq_neg X 1
 
 end Wolf
-

--- a/QICLean/Channel/LorentzNormalForm/SpinorCover.lean
+++ b/QICLean/Channel/LorentzNormalForm/SpinorCover.lean
@@ -33,6 +33,14 @@ gives the polar (Cartan) decomposition described by Wolf.
   rotation block `1 ⊕ R` with `R ∈ SO(3)`
 * `Wolf.spinorMatrix_su2ToSL2` : the rotation lift, `1 ⊕ R(U)` for
   `U ∈ SU(2)`
+* `Wolf.boostSpinor` : the boost spinor `P = (M(u) + I)/√(2(1+u₀))`
+* `Wolf.spinorMatrix_boostSpinorSL2` : the boost lift,
+  `spinorMatrix P_u = B_u`
+* `Wolf.exists_sl2_spinorMatrix_eq` : the spinor epimorphism; every
+  `L ∈ SO⁺(1,3)` is `spinorMatrix X` for some `X ∈ SL(2,ℂ)`
+* `Wolf.spinorCoverHom_surjective` : the bundled epimorphism
+* `Wolf.spinorCoverHom_eq_iff_eq_or_eq_neg` : the two-point fibres
+* `Wolf.spinorCoverHom_eq_one_iff` : the kernel is `{1, -1}`
 
 ## References
 
@@ -468,5 +476,438 @@ theorem exists_su2_spinorMatrix_eq_lorentzRotationBlock (R : Matrix (Fin 3) (Fin
   rw [h]
   exact Complex.ofReal_re _
 
+/-! ### The boost spinor -/
+
+
+/-- The spatial dot product `u₁x₁ + u₂x₂ + u₃x₃`. -/
+def spatialDot (u x : MinkowskiSpace) : ℝ :=
+  ∑ l : Fin 3, u l.succ * x l.succ
+
+/-- The spatial dot product in coordinates. -/
+theorem spatialDot_eq (u x : MinkowskiSpace) :
+    spatialDot u x = u 1 * x 1 + u 2 * x 2 + u 3 * x 3 := by
+  rw [spatialDot, Fin.sum_univ_three, Fin.succ_zero_eq_one', Fin.succ_one_eq_two',
+    show Fin.succ (2 : Fin 3) = 3 from rfl]
+
+/-- The canonical proper orthochronous boost `B_u` with `B_u e₀ = u`,
+for `u` on the unit hyperboloid `u₀² - u₁² - u₂² - u₃² = 1`, `u₀ > 0`.
+Writing `v` for the spatial part of `u`, the block formula
+`B = [[u₀, vᵀ], [v, I + vvᵀ/(1+u₀)]]` is uniform: for zero spatial part it
+gives the identity, so no case split is needed (the equivalent coefficient
+`(u₀-1)/|v|²` would need one). -/
+def lorentzBoost (u : MinkowskiSpace) : Matrix (Fin 4) (Fin 4) ℝ :=
+  Matrix.of (Fin.cons (fun j ↦ u j)
+    (fun k ↦ Fin.cons (u k.succ)
+      (fun l ↦ (if k = l then 1 else 0) + u k.succ * u l.succ / (1 + u 0))))
+
+@[simp] theorem lorentzBoost_zero_zero (u : MinkowskiSpace) :
+    lorentzBoost u 0 0 = u 0 := by
+  simp [lorentzBoost, Matrix.of_apply, Fin.cons_zero]
+
+@[simp] theorem lorentzBoost_zero_succ (u : MinkowskiSpace) (j : Fin 3) :
+    lorentzBoost u 0 j.succ = u j.succ := by
+  simp [lorentzBoost, Matrix.of_apply, Fin.cons_zero]
+
+@[simp] theorem lorentzBoost_succ_zero (u : MinkowskiSpace) (i : Fin 3) :
+    lorentzBoost u i.succ 0 = u i.succ := by
+  simp [lorentzBoost, Matrix.of_apply, Fin.cons_succ, Fin.cons_zero]
+
+@[simp] theorem lorentzBoost_succ_succ (u : MinkowskiSpace) (i j : Fin 3) :
+    lorentzBoost u i.succ j.succ =
+      (if i = j then 1 else 0) + u i.succ * u j.succ / (1 + u 0) := by
+  simp [lorentzBoost, Matrix.of_apply, Fin.cons_succ]
+
+/-- The time component of the boost action. -/
+theorem lorentzBoost_mulVec_zero (u x : MinkowskiSpace) :
+    (lorentzBoost u *ᵥ x) 0 = u 0 * x 0 + spatialDot u x := by
+  simp [Matrix.mulVec, dotProduct, Fin.sum_univ_succ, spatialDot]
+
+/-- The spatial components of the boost action. -/
+theorem lorentzBoost_mulVec_succ (u x : MinkowskiSpace) (k : Fin 3) :
+    (lorentzBoost u *ᵥ x) k.succ =
+      x k.succ + u k.succ * (x 0 + spatialDot u x / (1 + u 0)) := by
+  rw [Matrix.mulVec, dotProduct, Fin.sum_univ_succ, lorentzBoost_succ_zero]
+  rw [show (∑ l : Fin 3, lorentzBoost u k.succ l.succ * x l.succ) =
+      ∑ l : Fin 3, ((if l = k then x l.succ else 0) +
+        u k.succ * (u l.succ * x l.succ) / (1 + u 0)) from
+    Finset.sum_congr rfl fun l _ ↦ by
+      rw [lorentzBoost_succ_succ]
+      by_cases h : k = l
+      · subst h
+        simp only [ite_true]
+        ring
+      · have h' := Ne.symm h
+        simp only [h, h', ite_false, zero_add]
+        ring]
+  rw [Finset.sum_add_distrib]
+  have hif : (∑ l : Fin 3, if l = k then x l.succ else 0) = x k.succ := by
+    rw [Finset.sum_ite_eq']
+    simp only [Finset.mem_univ, ite_true]
+  rw [hif]
+  have hu : (∑ l : Fin 3, u k.succ * (u l.succ * x l.succ) / (1 + u 0)) =
+      u k.succ * spatialDot u x / (1 + u 0) := by
+    simp only [div_eq_mul_inv, spatialDot, Finset.mul_sum, Finset.sum_mul, mul_assoc]
+  rw [hu]
+  ring
+
+/-- The first column of the canonical boost is `u`: the boost maps the time
+axis `e₀` to the hyperboloid point `u`. -/
+theorem lorentzBoost_mulVec_single_zero (u : MinkowskiSpace) :
+    lorentzBoost u *ᵥ Pi.single 0 1 = u := by
+  rw [Matrix.mulVec_single_one]
+  ext i
+  cases i using Fin.cases <;> simp
+
+/-- Cayley--Hamilton for the Pauli coordinate matrix:
+`M(u)² = 2u₀·M(u) - η(u,u)·I`.  This is a polynomial identity; no
+hyperboloid hypothesis is needed. -/
+theorem pauliMatrixOfMinkowski_mul_self (u : MinkowskiSpace) :
+    pauliMatrixOfMinkowski u * pauliMatrixOfMinkowski u =
+      (2 * u 0 : ℂ) • pauliMatrixOfMinkowski u - (minkowskiQuadratic u : ℂ) • 1 := by
+  ext a b
+  fin_cases a <;> fin_cases b <;>
+    simp only [pauliMatrixOfMinkowski, Fin.sum_univ_four, Matrix.mul_apply, Fin.sum_univ_two,
+      Matrix.add_apply, Matrix.sub_apply, Matrix.smul_apply, smul_eq_mul, pauliMatrices,
+      Matrix.one_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.of_apply,
+      Matrix.cons_val', Matrix.empty_val', Matrix.cons_val_fin_one, Fin.isValue,
+      Fin.mk_zero, Fin.mk_one, Fin.reduceEq, ite_true, ite_false,
+      minkowskiQuadratic, Complex.ofReal_sub, Complex.ofReal_pow] <;>
+    ring_nf <;> try (simp only [Complex.I_sq]); ring_nf
+
+/-- The anticommutator of two Pauli coordinate matrices, expressed through
+the spatial dot product.  A polynomial identity. -/
+theorem pauliMatrixOfMinkowski_anticomm (u x : MinkowskiSpace) :
+    pauliMatrixOfMinkowski u * pauliMatrixOfMinkowski x +
+        pauliMatrixOfMinkowski x * pauliMatrixOfMinkowski u =
+      (2 * u 0 : ℂ) • pauliMatrixOfMinkowski x + (2 * x 0 : ℂ) • pauliMatrixOfMinkowski u +
+        (2 * (spatialDot u x - u 0 * x 0) : ℂ) • 1 := by
+  ext a b
+  fin_cases a <;> fin_cases b <;>
+    simp only [pauliMatrixOfMinkowski, Fin.sum_univ_four, Matrix.mul_apply, Fin.sum_univ_two,
+      Matrix.add_apply, Matrix.smul_apply, smul_eq_mul, pauliMatrices,
+      Matrix.one_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.of_apply,
+      Matrix.cons_val', Matrix.empty_val', Matrix.cons_val_fin_one, Fin.isValue,
+      Fin.mk_zero, Fin.mk_one, Fin.reduceEq, ite_true, ite_false,
+      spatialDot_eq, Complex.ofReal_mul, Complex.ofReal_add] <;>
+    ring_nf <;> try (simp only [Complex.I_sq]); ring_nf
+
+/-- The closed-form boost spinor `P = (M(u) + I)/√(2(1+u₀))`: the positive
+determinant-one square root of `M(u)` for `u` on the unit hyperboloid with
+`u₀ > 0`.  This is Wolf's `P = exp(m·σ/2)` of Equation (2.44) with
+`u = (cosh |m|, sinh |m| m̂)`, written without hyperbolic functions. -/
+noncomputable def boostSpinor (u : MinkowskiSpace) : Matrix (Fin 2) (Fin 2) ℂ :=
+  ((Real.sqrt (2 * (1 + u 0)) : ℂ))⁻¹ • (pauliMatrixOfMinkowski u + 1)
+
+/-- The boost spinor is Hermitian. -/
+theorem boostSpinor_isHermitian (u : MinkowskiSpace) :
+    (boostSpinor u).IsHermitian := by
+  rw [Matrix.IsHermitian, boostSpinor, Matrix.conjTranspose_smul,
+    Matrix.conjTranspose_add, (pauliMatrixOfMinkowski_isHermitian u).eq,
+    Matrix.conjTranspose_one]
+  congr 1
+  simp
+
+/-- The determinant of `M(u) + I` is `2(1+u₀)` on the unit hyperboloid. -/
+theorem det_pauliMatrixOfMinkowski_add_one (u : MinkowskiSpace)
+    (hu : minkowskiQuadratic u = 1) :
+    (pauliMatrixOfMinkowski u + 1).det = (2 * (1 + u 0) : ℂ) := by
+  have h1 : (pauliMatrixOfMinkowski u + 1).det =
+      (pauliMatrixOfMinkowski u).det + (pauliMatrixOfMinkowski u).trace + 1 := by
+    rw [Matrix.det_fin_two, Matrix.det_fin_two, Matrix.trace_fin_two]
+    simp only [Matrix.add_apply, Matrix.one_apply, Fin.reduceEq, ite_true, ite_false]
+    ring
+  rw [h1, det_pauliMatrixOfMinkowski, hu, trace_pauliMatrixOfMinkowski]
+  push_cast
+  ring
+
+/-- The boost spinor has determinant one. -/
+theorem boostSpinor_det (u : MinkowskiSpace) (hu : minkowskiQuadratic u = 1)
+    (hu0 : 0 < u 0) :
+    (boostSpinor u).det = 1 := by
+  have hc : (0:ℝ) < 2 * (1 + u 0) := by linarith
+  rw [boostSpinor, Matrix.det_smul, det_pauliMatrixOfMinkowski_add_one u hu]
+  simp only [Fintype.card_fin]
+  rw [inv_pow]
+  have h2 : ((Real.sqrt (2 * (1 + u 0)) : ℂ)) ^ 2 = (2 * (1 + u 0) : ℂ) := by
+    exact_mod_cast Real.sq_sqrt hc.le
+  rw [h2]
+  exact inv_mul_cancel₀ (by exact_mod_cast hc.ne')
+
+/-- The boost spinor as an element of `SL(2,ℂ)`. -/
+noncomputable def boostSpinorSL2 (u : MinkowskiSpace) (hu : minkowskiQuadratic u = 1)
+    (hu0 : 0 < u 0) : SL(2, ℂ) :=
+  ⟨boostSpinor u, boostSpinor_det u hu hu0⟩
+
+@[simp] theorem boostSpinorSL2_coe (u : MinkowskiSpace) (hu : minkowskiQuadratic u = 1)
+    (hu0 : 0 < u 0) :
+    (boostSpinorSL2 u hu hu0).1 = boostSpinor u := rfl
+
+/-- The boost spinor squares to `M(u)`: `P_u² = u·σ`. -/
+theorem boostSpinor_sq (u : MinkowskiSpace) (hu : minkowskiQuadratic u = 1)
+    (hu0 : 0 < u 0) :
+    boostSpinor u * boostSpinor u = pauliMatrixOfMinkowski u := by
+  have hc : (0:ℝ) < 2 * (1 + u 0) := by linarith
+  have hM2 := pauliMatrixOfMinkowski_mul_self u
+  rw [boostSpinor, smul_mul_assoc, mul_smul_comm, smul_smul]
+  have hexp : (pauliMatrixOfMinkowski u + 1) * (pauliMatrixOfMinkowski u + 1) =
+      pauliMatrixOfMinkowski u * pauliMatrixOfMinkowski u +
+        2 • pauliMatrixOfMinkowski u + 1 := by
+    noncomm_ring
+  rw [hexp, hM2]
+  have hmat : (2 * (u 0 : ℂ)) • pauliMatrixOfMinkowski u - (minkowskiQuadratic u : ℂ) • 1 +
+      2 • pauliMatrixOfMinkowski u + 1 = (2 * u 0 + 2 : ℂ) • pauliMatrixOfMinkowski u := by
+    rw [hu]
+    module
+  have hsc : ((Real.sqrt (2 * (1 + u 0)) : ℂ))⁻¹ * ((Real.sqrt (2 * (1 + u 0)) : ℂ))⁻¹ *
+      (2 * u 0 + 2 : ℂ) = 1 := by
+    rw [← pow_two, inv_pow,
+      show ((Real.sqrt (2 * (1 + u 0)) : ℂ)) ^ 2 = ((2 * (1 + u 0) : ℝ) : ℂ) from
+        by exact_mod_cast Real.sq_sqrt hc.le]
+    rw [show (2 * (u 0 : ℂ) + 2) = ((2 * (1 + u 0) : ℝ) : ℂ) from by push_cast; ring]
+    exact inv_mul_cancel₀ (Complex.ofReal_ne_zero.mpr hc.ne')
+  rw [hmat, smul_smul, hsc, one_smul]
+
+/-- `M(x)` is additive in its coordinates. -/
+theorem pauliMatrixOfMinkowski_add (x y : MinkowskiSpace) :
+    pauliMatrixOfMinkowski (x + y) =
+      pauliMatrixOfMinkowski x + pauliMatrixOfMinkowski y := by
+  simp [pauliMatrixOfMinkowski, Pi.add_apply, add_smul, Finset.sum_add_distrib]
+
+/-- `M(x)` is homogeneous in its coordinates. -/
+theorem pauliMatrixOfMinkowski_smul (c : ℝ) (x : MinkowskiSpace) :
+    pauliMatrixOfMinkowski (c • x) = (c : ℂ) • pauliMatrixOfMinkowski x := by
+  simp [pauliMatrixOfMinkowski, Pi.smul_apply, smul_eq_mul, Finset.smul_sum,
+    Complex.ofReal_mul, mul_smul]
+
+/-- The Pauli-coordinate assembly is injective. -/
+theorem pauliMatrixOfMinkowski_injective :
+    Function.Injective pauliMatrixOfMinkowski := by
+  intro x y h
+  ext i
+  have e1 := pauliMinkowskiCoordinate_pauliMatrixOfMinkowski x i
+  have e2 := pauliMinkowskiCoordinate_pauliMatrixOfMinkowski y i
+  simp only [pauliMinkowskiCoordinate] at e1 e2
+  rw [← e1, ← e2, h]
+
+/-- The spatial part of a Minkowski vector. -/
+def spatialPart (u : MinkowskiSpace) : MinkowskiSpace :=
+  fun i ↦ if i = 0 then 0 else u i
+
+@[simp] theorem spatialPart_zero (u : MinkowskiSpace) : spatialPart u 0 = 0 := rfl
+
+@[simp] theorem spatialPart_succ (u : MinkowskiSpace) (k : Fin 3) :
+    spatialPart u k.succ = u k.succ := by
+  simp [spatialPart, Fin.succ_ne_zero]
+
+/-- A Minkowski vector splits into its time component and spatial part. -/
+theorem eq_time_smul_single_add_spatialPart (u : MinkowskiSpace) :
+    u = (u 0 : ℝ) • Pi.single 0 1 + spatialPart u := by
+  ext i
+  cases i using Fin.cases with
+  | zero => simp
+  | succ k => simp
+
+/-- The unscaled conjugation identity: `(M(u)+I) M(x) (M(u)+I)` expanded as a
+combination of `M(u)`, `M(x)`, and `I`.  A matrix-level consequence of
+Cayley--Hamilton and the anticommutator; no hyperboloid hypothesis. -/
+theorem pauliMatrixOfMinkowski_conj_add_one (u x : MinkowskiSpace) :
+    (pauliMatrixOfMinkowski u + 1) * pauliMatrixOfMinkowski x * (pauliMatrixOfMinkowski u + 1) =
+      (2 * (u 0 * x 0 + spatialDot u x + x 0) : ℂ) • pauliMatrixOfMinkowski u +
+        (minkowskiQuadratic u + 2 * u 0 + 1 : ℂ) • pauliMatrixOfMinkowski x +
+        (2 * (spatialDot u x - u 0 * x 0 - x 0 * minkowskiQuadratic u) : ℂ) • 1 := by
+  have hM2 := pauliMatrixOfMinkowski_mul_self u
+  have hanti := pauliMatrixOfMinkowski_anticomm u x
+  have hMXM : pauliMatrixOfMinkowski u * pauliMatrixOfMinkowski x * pauliMatrixOfMinkowski u =
+      pauliMatrixOfMinkowski u * (pauliMatrixOfMinkowski u * pauliMatrixOfMinkowski x +
+        pauliMatrixOfMinkowski x * pauliMatrixOfMinkowski u) -
+        pauliMatrixOfMinkowski u * pauliMatrixOfMinkowski u * pauliMatrixOfMinkowski x := by
+    noncomm_ring
+  have hexp : (pauliMatrixOfMinkowski u + 1) * pauliMatrixOfMinkowski x *
+        (pauliMatrixOfMinkowski u + 1) =
+      pauliMatrixOfMinkowski u * pauliMatrixOfMinkowski x * pauliMatrixOfMinkowski u +
+        (pauliMatrixOfMinkowski u * pauliMatrixOfMinkowski x +
+          pauliMatrixOfMinkowski x * pauliMatrixOfMinkowski u) + pauliMatrixOfMinkowski x := by
+    noncomm_ring
+  rw [hexp, hMXM, hanti, hM2]
+  simp only [Matrix.mul_add, Matrix.mul_smul, Matrix.sub_mul, Matrix.smul_mul,
+    Matrix.one_mul, Matrix.mul_one]
+  rw [hM2]
+  module
+
+/-- On the unit hyperboloid, the unscaled conjugation by `M(u) + I` is `2(1+u₀)`
+times the Lorentz boost action on Pauli coordinates. -/
+theorem boostSpinor_conj_scaled (u x : MinkowskiSpace) (hu : minkowskiQuadratic u = 1)
+    (hu0 : 0 < u 0) :
+    (pauliMatrixOfMinkowski u + 1) * pauliMatrixOfMinkowski x * (pauliMatrixOfMinkowski u + 1) =
+      (2 * (1 + u 0) : ℂ) • pauliMatrixOfMinkowski (lorentzBoost u *ᵥ x) := by
+  have h1a : (1 : ℝ) + u 0 ≠ 0 := by linarith
+  rw [pauliMatrixOfMinkowski_conj_add_one, hu]
+  have hy : lorentzBoost u *ᵥ x =
+      x + (x 0 + spatialDot u x / (1 + u 0)) • spatialPart u +
+        (u 0 * x 0 + spatialDot u x - x 0) • Pi.single 0 1 := by
+    ext i
+    cases i using Fin.cases with
+    | zero =>
+        rw [lorentzBoost_mulVec_zero]
+        simp
+    | succ k =>
+        rw [lorentzBoost_mulVec_succ]
+        simp
+        ring
+  have hMu : pauliMatrixOfMinkowski (spatialPart u) =
+      pauliMatrixOfMinkowski u - (u 0 : ℂ) • 1 := by
+    have e2 : pauliMatrixOfMinkowski u =
+        (u 0 : ℂ) • 1 + pauliMatrixOfMinkowski (spatialPart u) := by
+      conv_lhs => rw [eq_time_smul_single_add_spatialPart u, pauliMatrixOfMinkowski_add,
+        pauliMatrixOfMinkowski_smul, pauliMatrixOfMinkowski_single, pauliMatrices_zero]
+    rw [e2]
+    module
+  rw [hy, pauliMatrixOfMinkowski_add, pauliMatrixOfMinkowski_add, pauliMatrixOfMinkowski_smul,
+    pauliMatrixOfMinkowski_smul, pauliMatrixOfMinkowski_single, pauliMatrices_zero, hMu]
+  have hsc : (2 * (1 + u 0) : ℂ) * ((x 0 + spatialDot u x / (1 + u 0) : ℝ) : ℂ) =
+      ((2 * (u 0 * x 0 + spatialDot u x + x 0) : ℝ) : ℂ) := by
+    have hR : (2 : ℝ) * (1 + u 0) * (x 0 + spatialDot u x / (1 + u 0)) =
+        2 * (u 0 * x 0 + spatialDot u x + x 0) := by
+      field_simp
+      ring
+    calc (2 * (1 + u 0) : ℂ) * ((x 0 + spatialDot u x / (1 + u 0) : ℝ) : ℂ)
+        = (((2 : ℝ) * (1 + u 0) * (x 0 + spatialDot u x / (1 + u 0)) : ℝ) : ℂ) := by norm_cast
+      _ = _ := by rw [hR]
+  simp only [smul_add, smul_smul]
+  rw [hsc]
+  push_cast
+  module
+
+/-- Conjugation by the boost spinor realizes the Lorentz boost on Pauli
+coordinates: `P M(x) Pᴴ = M(B_u x)`.  This is the boost half of Wolf,
+Equation (2.44), with `P_u = exp(m·σ/2)` in closed form. -/
+theorem boostSpinor_conj (u x : MinkowskiSpace) (hu : minkowskiQuadratic u = 1)
+    (hu0 : 0 < u 0) :
+    boostSpinor u * pauliMatrixOfMinkowski x * (boostSpinor u)ᴴ =
+      pauliMatrixOfMinkowski (lorentzBoost u *ᵥ x) := by
+  have hc : (0:ℝ) < 2 * (1 + u 0) := by linarith
+  rw [(boostSpinor_isHermitian u).eq, boostSpinor]
+  simp only [smul_mul_assoc, mul_smul_comm, smul_smul, ← pow_two]
+  rw [boostSpinor_conj_scaled u x hu hu0, smul_smul]
+  rw [show ((Real.sqrt (2 * (1 + u 0)) : ℂ))⁻¹ ^ 2 * (2 * (1 + u 0) : ℂ) = 1 from by
+    rw [inv_pow, show ((Real.sqrt (2 * (1 + u 0)) : ℂ)) ^ 2 = ((2 * (1 + u 0) : ℝ) : ℂ) from
+      by exact_mod_cast Real.sq_sqrt hc.le]
+    rw [show (2 * (1 + u 0) : ℂ) = ((2 * (1 + u 0) : ℝ) : ℂ) from by norm_cast]
+    exact inv_mul_cancel₀ (Complex.ofReal_ne_zero.mpr hc.ne')]
+  rw [one_smul]
+
+/-- The spinor matrix of the boost spinor is the canonical boost: the boost
+formula of Wolf, Equation (2.44). -/
+theorem spinorMatrix_boostSpinorSL2 (u : MinkowskiSpace) (hu : minkowskiQuadratic u = 1)
+    (hu0 : 0 < u 0) :
+    spinorMatrix (boostSpinorSL2 u hu hu0) = lorentzBoost u := by
+  apply Matrix.mulVec_injective
+  funext x
+  apply pauliMatrixOfMinkowski_injective
+  rw [pauliMatrixOfMinkowski_spinorMatrix_mulVec, boostSpinorSL2_coe,
+    boostSpinor_conj u x hu hu0]
+
+/-! ### Surjectivity of the spinor cover -/
+
+
+/-- The canonical boost of a future unit-hyperboloid point is special
+orthochronous Lorentz: it is the spinor matrix of the boost spinor. -/
+theorem lorentzBoost_isSpecialOrthochronousLorentz (u : MinkowskiSpace)
+    (hu : minkowskiQuadratic u = 1) (hu0 : 0 < u 0) :
+    IsSpecialOrthochronousLorentz (lorentzBoost u) := by
+  rw [← spinorMatrix_boostSpinorSL2 u hu hu0]
+  exact spinorMatrix_isSpecialOrthochronousLorentz _
+
+/-- The Minkowski quadratic form as the squared time component minus the
+squared spatial norm. -/
+theorem minkowskiQuadratic_eq_sub_sum (x : MinkowskiSpace) :
+    minkowskiQuadratic x = x 0 ^ 2 - ∑ k : Fin 3, x k.succ ^ 2 := by
+  simp only [minkowskiQuadratic, Fin.sum_univ_three, Fin.succ_zero_eq_one',
+    Fin.succ_one_eq_two', show Fin.succ (2 : Fin 3) = 3 from rfl]
+  ring
+
+/-- The first column of a special orthochronous Lorentz matrix lies on the
+unit hyperboloid. -/
+theorem IsSpecialOrthochronousLorentz.minkowskiQuadratic_firstCol
+    {L : Matrix (Fin 4) (Fin 4) ℝ} (hL : IsSpecialOrthochronousLorentz L) :
+    minkowskiQuadratic (L *ᵥ Pi.single 0 1) = 1 := by
+  have hcol := col_norm_of_lorentz hL.transpose_mul_metric_mul
+  rw [minkowskiQuadratic_eq_sub_sum]
+  have hent : ∀ i : Fin 4, (L *ᵥ Pi.single (0 : Fin 4) (1 : ℝ)) i = L i 0 :=
+    fun i ↦ congrFun (Matrix.mulVec_single_one L 0) i
+  rw [hent 0]
+  have hsum : (∑ k : Fin 3, (L *ᵥ Pi.single (0 : Fin 4) (1 : ℝ)) k.succ ^ 2) =
+      ∑ k : Fin 3, L k.succ 0 ^ 2 :=
+    Finset.sum_congr rfl fun k _ ↦ by rw [hent k.succ]
+  rw [hsum]
+  exact hcol
+
+/-- The spinor epimorphism of Wolf, Equation (2.42): every special
+orthochronous Lorentz matrix `L ∈ SO⁺(1,3)` is the spinor matrix of some
+`X ∈ SL(2,ℂ)`.  The preimage is constructed as the product `X = P_u U` of the
+boost spinor of the first column `u = L e₀` and a special unitary lifting the
+rotation block, giving the rotation--boost factorization of Wolf,
+Equation (2.44). -/
+theorem exists_sl2_spinorMatrix_eq {L : Matrix (Fin 4) (Fin 4) ℝ}
+    (hL : IsSpecialOrthochronousLorentz L) :
+    ∃ X : SL(2, ℂ), spinorMatrix X = L := by
+  have hu1 := hL.minkowskiQuadratic_firstCol
+  have hu0 : 0 < (L *ᵥ Pi.single (0 : Fin 4) (1 : ℝ)) 0 := by
+    have hent : (L *ᵥ Pi.single (0 : Fin 4) (1 : ℝ)) 0 = L 0 0 :=
+      congrFun (Matrix.mulVec_single_one L 0) 0
+    rw [hent]
+    exact hL.2.2
+  set u := L *ᵥ Pi.single (0 : Fin 4) (1 : ℝ) with hu
+  have hB : IsSpecialOrthochronousLorentz (lorentzBoost u) :=
+    lorentzBoost_isSpecialOrthochronousLorentz u hu1 hu0
+  have hdetB : IsUnit (lorentzBoost u).det := by rw [hB.1]; exact isUnit_one
+  have hBinv_u : (lorentzBoost u)⁻¹ *ᵥ u = Pi.single 0 1 := by
+    calc (lorentzBoost u)⁻¹ *ᵥ u
+        = (lorentzBoost u)⁻¹ *ᵥ (lorentzBoost u *ᵥ Pi.single 0 1) := by
+          rw [lorentzBoost_mulVec_single_zero]
+      _ = ((lorentzBoost u)⁻¹ * lorentzBoost u) *ᵥ Pi.single 0 1 :=
+          Matrix.mulVec_mulVec _ _ _
+      _ = Pi.single 0 1 := by
+          rw [Matrix.nonsing_inv_mul _ hdetB, Matrix.one_mulVec]
+  have hBL : IsSpecialOrthochronousLorentz ((lorentzBoost u)⁻¹ * L) :=
+    hB.inv.mul hL
+  have hfix : ((lorentzBoost u)⁻¹ * L) *ᵥ Pi.single 0 1 = Pi.single 0 1 := by
+    rw [← Matrix.mulVec_mulVec]
+    exact hBinv_u
+  obtain ⟨R, hR, hblk⟩ := exists_so3_block_of_fixes_time hfix
+    hBL.transpose_mul_metric_mul hBL.1
+  have hLdecomp : L = lorentzBoost u * lorentzRotationBlock R := by
+    calc L = lorentzBoost u * ((lorentzBoost u)⁻¹ * L) := by
+          rw [← Matrix.mul_assoc, Matrix.mul_nonsing_inv _ hdetB, Matrix.one_mul]
+      _ = lorentzBoost u * lorentzRotationBlock R := by rw [hblk]
+  obtain ⟨U, hU, hUlift⟩ := exists_su2_spinorMatrix_eq_lorentzRotationBlock R hR
+  refine ⟨boostSpinorSL2 u hu1 hu0 * su2ToSL2 U hU, ?_⟩
+  rw [spinorMatrix_mul, spinorMatrix_boostSpinorSL2 u hu1 hu0, hUlift]
+  exact hLdecomp.symm
+
+/-- The bundled spinor homomorphism `SL(2,ℂ) → SO⁺(1,3)` is surjective:
+Wolf's spinor map of Equation (2.42) is an epimorphism onto the special
+orthochronous Lorentz group. -/
+theorem spinorCoverHom_surjective : Function.Surjective spinorCoverHom := by
+  intro L
+  obtain ⟨X, hX⟩ := exists_sl2_spinorMatrix_eq L.2
+  exact ⟨X, Subtype.ext hX⟩
+
+/-- The fibres of the spinor cover have exactly two points: together with
+`spinorCoverHom_surjective` this says `SL(2,ℂ)` is a double cover of
+`SO⁺(1,3)`, as stated after Wolf, Equation (2.42). -/
+theorem spinorCoverHom_eq_iff_eq_or_eq_neg (X Y : SL(2, ℂ)) :
+    spinorCoverHom X = spinorCoverHom Y ↔ X = Y ∨ X = -Y := by
+  rw [Subtype.ext_iff]
+  exact spinorMatrix_eq_iff_eq_or_eq_neg X Y
+
+/-- The kernel of the spinor cover is exactly `{1, -1}`. -/
+theorem spinorCoverHom_eq_one_iff (X : SL(2, ℂ)) :
+    spinorCoverHom X = 1 ↔ X = 1 ∨ X = -1 := by
+  have h1 : (1 : ↥specialOrthochronousLorentzGroup) = spinorCoverHom 1 :=
+    (map_one spinorCoverHom).symm
+  rw [h1]
+  exact spinorCoverHom_eq_iff_eq_or_eq_neg X 1
 
 end Wolf
+

--- a/QICLean/Channel/LorentzNormalForm/SpinorCover.lean
+++ b/QICLean/Channel/LorentzNormalForm/SpinorCover.lean
@@ -1,0 +1,472 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Algebra.SpinCover.EulerAngles
+import QICLean.Channel.LorentzNormalForm.SpinorAction
+
+/-!
+# The spinor epimorphism `SL(2,ℂ) → SO⁺(1,3)`
+
+This module completes the group-theoretic part of Wolf's spinor discussion
+(Equations (2.42)--(2.44)): the spinor map of
+`QICLean.Channel.LorentzNormalForm.SpinorAction` is shown to be a
+homomorphism *onto* the special orthochronous Lorentz group `SO⁺(1,3)`, with
+exactly the two-point fibres `{X, -X}` proved in
+`Wolf.spinorMatrix_eq_iff_eq_or_eq_neg`.
+
+Following Wolf's rotation--boost discussion, surjectivity is proved without
+assuming a preimage: for `L ∈ SO⁺(1,3)` with first column `u`, the canonical
+boost `B_u` with `B_u e₀ = u` reduces `L` to a rotation block `1 ⊕ R` fixing
+the time axis, the rotation `R ∈ SO(3)` lifts through the Euler-angle cover
+`SU(2) → SO(3)` of `QICLean.Algebra.SpinCover.EulerAngles`, and the boost is
+lifted by an explicit positive determinant-one matrix `P_u` with
+`P_u² = u·σ`.  The product `S = P_u U` then realizes `L` and simultaneously
+gives the polar (Cartan) decomposition described by Wolf.
+
+## Main results
+
+* `Wolf.specialOrthochronousLorentzGroup` : `SO⁺(1,3)` as a matrix group
+* `Wolf.spinorCoverHom` : the bundled homomorphism `SL(2,ℂ) →* SO⁺(1,3)`
+* `Wolf.exists_so3_block_of_fixes_time` : a Lorentz matrix fixing `e₀` is a
+  rotation block `1 ⊕ R` with `R ∈ SO(3)`
+* `Wolf.spinorMatrix_su2ToSL2` : the rotation lift, `1 ⊕ R(U)` for
+  `U ∈ SU(2)`
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Equations
+  (2.42)--(2.44)]
+* `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 1037--1081
+-/
+
+open scoped Matrix MatrixGroups BigOperators ComplexOrder
+open Matrix Finset
+
+noncomputable section
+
+namespace Wolf
+
+/-! ### The special orthochronous Lorentz group `SO⁺(1,3)` -/
+
+
+@[simp] theorem minkowskiMetric_transpose : minkowskiMetricᵀ = minkowskiMetric := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> rfl
+
+theorem IsSpecialOrthochronousLorentz.transpose_mul_metric_mul
+    {L : Matrix (Fin 4) (Fin 4) ℝ} (h : IsSpecialOrthochronousLorentz L) :
+    Lᵀ * minkowskiMetric * L = minkowskiMetric := by
+  obtain ⟨hdet, hlorentz, -⟩ := h
+  have hdetunit : IsUnit L.det := by rw [hdet]; exact isUnit_one
+  have hinv : L * (minkowskiMetric * Lᵀ * minkowskiMetric) = 1 := by
+    calc L * (minkowskiMetric * Lᵀ * minkowskiMetric)
+        = (L * minkowskiMetric * Lᵀ) * minkowskiMetric := by simp only [Matrix.mul_assoc]
+      _ = minkowskiMetric * minkowskiMetric := by rw [hlorentz]
+      _ = 1 := minkowskiMetric_mul_self
+  have hLinv : L⁻¹ = minkowskiMetric * Lᵀ * minkowskiMetric := Matrix.inv_eq_right_inv hinv
+  have hT : Lᵀ = minkowskiMetric * L⁻¹ * minkowskiMetric := by
+    have e : minkowskiMetric * (minkowskiMetric * Lᵀ * minkowskiMetric) * minkowskiMetric
+        = Lᵀ := by
+      calc minkowskiMetric * (minkowskiMetric * Lᵀ * minkowskiMetric) * minkowskiMetric
+          = (minkowskiMetric * minkowskiMetric) * Lᵀ * (minkowskiMetric * minkowskiMetric) := by
+            noncomm_ring
+        _ = Lᵀ := by rw [minkowskiMetric_mul_self, Matrix.one_mul, Matrix.mul_one]
+    rw [← hLinv] at e
+    exact e.symm
+  calc Lᵀ * minkowskiMetric * L
+      = (minkowskiMetric * L⁻¹ * minkowskiMetric) * minkowskiMetric * L := by rw [hT]
+    _ = minkowskiMetric * L⁻¹ * (minkowskiMetric * minkowskiMetric) * L := by
+        simp only [Matrix.mul_assoc]
+    _ = minkowskiMetric * (L⁻¹ * L) := by
+        rw [minkowskiMetric_mul_self, Matrix.mul_one, Matrix.mul_assoc]
+    _ = minkowskiMetric := by rw [Matrix.nonsing_inv_mul L hdetunit, Matrix.mul_one]
+
+theorem IsSpecialOrthochronousLorentz.inv {L : Matrix (Fin 4) (Fin 4) ℝ}
+    (h : IsSpecialOrthochronousLorentz L) : IsSpecialOrthochronousLorentz L⁻¹ := by
+  obtain ⟨hdet, hlorentz, h00⟩ := h
+  have hdetunit : IsUnit L.det := by rw [hdet]; exact isUnit_one
+  have hinv : L * (minkowskiMetric * Lᵀ * minkowskiMetric) = 1 := by
+    calc L * (minkowskiMetric * Lᵀ * minkowskiMetric)
+        = (L * minkowskiMetric * Lᵀ) * minkowskiMetric := by simp only [Matrix.mul_assoc]
+      _ = minkowskiMetric * minkowskiMetric := by rw [hlorentz]
+      _ = 1 := minkowskiMetric_mul_self
+  have hLinv : L⁻¹ = minkowskiMetric * Lᵀ * minkowskiMetric := Matrix.inv_eq_right_inv hinv
+  have hcancelt : ∀ M : Matrix (Fin 4) (Fin 4) ℝ,
+      L⁻¹ * (L * M * Lᵀ) * (L⁻¹)ᵀ = M := by
+    intro M
+    calc L⁻¹ * (L * M * Lᵀ) * (L⁻¹)ᵀ
+        = (L⁻¹ * L) * M * (Lᵀ * (L⁻¹)ᵀ) := by noncomm_ring
+      _ = M := by
+          rw [Matrix.nonsing_inv_mul L hdetunit, Matrix.one_mul,
+            ← Matrix.transpose_mul, Matrix.nonsing_inv_mul L hdetunit,
+            Matrix.transpose_one, Matrix.mul_one]
+  refine ⟨?_, ?_, ?_⟩
+  · have hdetinv := Matrix.det_nonsing_inv_mul_det L hdetunit
+    rw [hdet, mul_one] at hdetinv
+    exact hdetinv
+  · have h1 : L * (L⁻¹ * minkowskiMetric * (L⁻¹)ᵀ) * Lᵀ = L * minkowskiMetric * Lᵀ := by
+      calc L * (L⁻¹ * minkowskiMetric * (L⁻¹)ᵀ) * Lᵀ
+          = (L * L⁻¹) * minkowskiMetric * ((L⁻¹)ᵀ * Lᵀ) := by noncomm_ring
+        _ = minkowskiMetric := by
+            rw [Matrix.mul_nonsing_inv L hdetunit, Matrix.one_mul,
+              ← Matrix.transpose_mul, Matrix.mul_nonsing_inv L hdetunit,
+              Matrix.transpose_one, Matrix.mul_one]
+        _ = L * minkowskiMetric * Lᵀ := hlorentz.symm
+    have h2 := congrArg (fun M ↦ L⁻¹ * M * (L⁻¹)ᵀ) h1
+    rw [hcancelt, hcancelt] at h2
+    exact h2
+  · rw [hLinv]
+    simp [Matrix.mul_apply, minkowskiMetric, Matrix.diagonal_apply]
+    exact h00
+
+/-- The time-row Minkowski norm identity from `L η Lᵀ = η`. -/
+theorem row_norm_of_lorentz {L : Matrix (Fin 4) (Fin 4) ℝ}
+    (h : L * minkowskiMetric * Lᵀ = minkowskiMetric) :
+    L 0 0 ^ 2 - ∑ k : Fin 3, L 0 k.succ ^ 2 = 1 := by
+  have h00 := congrFun (congrFun h 0) 0
+  simp [Matrix.mul_apply, Matrix.transpose_apply, minkowskiMetric,
+    Matrix.diagonal_apply, Fin.sum_univ_four] at h00
+  rw [Fin.sum_univ_three]
+  show L 0 0 ^ 2 - (L 0 1 ^ 2 + L 0 2 ^ 2 + L 0 3 ^ 2) = 1
+  linarith [h00]
+
+/-- The time-column Minkowski norm identity from `Lᵀ η L = η`. -/
+theorem col_norm_of_lorentz {L : Matrix (Fin 4) (Fin 4) ℝ}
+    (h : Lᵀ * minkowskiMetric * L = minkowskiMetric) :
+    L 0 0 ^ 2 - ∑ k : Fin 3, L k.succ 0 ^ 2 = 1 := by
+  have h00 := congrFun (congrFun h 0) 0
+  simp [Matrix.mul_apply, Matrix.transpose_apply, minkowskiMetric,
+    Matrix.diagonal_apply, Fin.sum_univ_four] at h00
+  rw [Fin.sum_univ_three]
+  show L 0 0 ^ 2 - (L 1 0 ^ 2 + L 2 0 ^ 2 + L 3 0 ^ 2) = 1
+  linarith [h00]
+
+theorem IsSpecialOrthochronousLorentz.mul {A B : Matrix (Fin 4) (Fin 4) ℝ}
+    (hA : IsSpecialOrthochronousLorentz A) (hB : IsSpecialOrthochronousLorentz B) :
+    IsSpecialOrthochronousLorentz (A * B) := by
+  obtain ⟨hdetA, hlorA, h00A⟩ := hA
+  obtain ⟨hdetB, hlorB, h00B⟩ := hB
+  refine ⟨?_, ?_, ?_⟩
+  · rw [Matrix.det_mul, hdetA, hdetB, mul_one]
+  · calc (A * B) * minkowskiMetric * (A * B)ᵀ
+        = A * (B * minkowskiMetric * Bᵀ) * Aᵀ := by
+          rw [Matrix.transpose_mul]; noncomm_ring
+      _ = A * minkowskiMetric * Aᵀ := by rw [hlorB]
+      _ = minkowskiMetric := hlorA
+  · have hrowA := row_norm_of_lorentz hlorA
+    have hcolB := col_norm_of_lorentz (IsSpecialOrthochronousLorentz.transpose_mul_metric_mul ⟨hdetB, hlorB, h00B⟩)
+    have hSA : 0 ≤ ∑ k : Fin 3, A 0 k.succ ^ 2 :=
+      Finset.sum_nonneg (fun k _ ↦ sq_nonneg (A 0 k.succ : ℝ))
+    have hSB : 0 ≤ ∑ k : Fin 3, B k.succ 0 ^ 2 :=
+      Finset.sum_nonneg (fun k _ ↦ sq_nonneg (B k.succ 0 : ℝ))
+    have hA0 : 1 ≤ A 0 0 := by
+      have hsq : (1 : ℝ) ^ 2 ≤ A 0 0 ^ 2 := by linarith [hrowA, hSA]
+      exact le_of_sq_le_sq hsq h00A.le
+    have hB0 : 1 ≤ B 0 0 := by
+      have hsq : (1 : ℝ) ^ 2 ≤ B 0 0 ^ 2 := by linarith [hcolB, hSB]
+      exact le_of_sq_le_sq hsq h00B.le
+    have hsum : (A * B) 0 0 =
+        A 0 0 * B 0 0 + ∑ k : Fin 3, A 0 k.succ * B k.succ 0 := by
+      rw [Matrix.mul_apply, Fin.sum_univ_succ]
+    rw [hsum]
+    have hcs : (∑ k : Fin 3, A 0 k.succ * B k.succ 0) ^ 2 ≤
+        (∑ k : Fin 3, A 0 k.succ ^ 2) * (∑ k : Fin 3, B k.succ 0 ^ 2) :=
+      Finset.sum_mul_sq_le_sq_mul_sq _ _ _
+    have hkey : (∑ k : Fin 3, A 0 k.succ ^ 2) * (∑ k : Fin 3, B k.succ 0 ^ 2) <
+        (A 0 0 * B 0 0) ^ 2 := by
+      have e1 : ∑ k : Fin 3, A 0 k.succ ^ 2 = A 0 0 ^ 2 - 1 := by linarith [hrowA]
+      have e2 : ∑ k : Fin 3, B k.succ 0 ^ 2 = B 0 0 ^ 2 - 1 := by linarith [hcolB]
+      rw [e1, e2]
+      nlinarith [hA0, hB0]
+    have habs : |∑ k : Fin 3, A 0 k.succ * B k.succ 0| < A 0 0 * B 0 0 := by
+      have h1 : (∑ k : Fin 3, A 0 k.succ * B k.succ 0) ^ 2 < (A 0 0 * B 0 0) ^ 2 :=
+        lt_of_le_of_lt hcs hkey
+      have h2 := (sq_lt_sq).mp h1
+      rwa [abs_of_nonneg (by positivity : 0 ≤ A 0 0 * B 0 0)] at h2
+    have hle := neg_abs_le (∑ k : Fin 3, A 0 k.succ * B k.succ 0)
+    linarith
+
+/-- The identity is special orthochronous Lorentz. -/
+theorem isSpecialOrthochronousLorentz_one :
+    IsSpecialOrthochronousLorentz (1 : Matrix (Fin 4) (Fin 4) ℝ) := by
+  refine ⟨?_, ?_, ?_⟩
+  · exact Matrix.det_one
+  · rw [Matrix.one_mul, Matrix.transpose_one, Matrix.mul_one]
+  · norm_num [Matrix.one_apply_eq]
+
+/-- The special orthochronous Lorentz group `SO⁺(1,3)` of Wolf,
+Equation (2.42), as a submonoid of real `4×4` matrices.  Membership of `L`
+in this submonoid is definitionally `IsSpecialOrthochronousLorentz L`. -/
+def specialOrthochronousLorentzGroup : Submonoid (Matrix (Fin 4) (Fin 4) ℝ) where
+  carrier := {L | IsSpecialOrthochronousLorentz L}
+  one_mem' := isSpecialOrthochronousLorentz_one
+  mul_mem' := IsSpecialOrthochronousLorentz.mul
+
+theorem mem_specialOrthochronousLorentzGroup_iff {L : Matrix (Fin 4) (Fin 4) ℝ} :
+    L ∈ specialOrthochronousLorentzGroup ↔ IsSpecialOrthochronousLorentz L :=
+  Iff.rfl
+
+instance : Group specialOrthochronousLorentzGroup where
+  inv := fun L ↦ ⟨L.1⁻¹, L.2.inv⟩
+  inv_mul_cancel L := Subtype.ext (Matrix.nonsing_inv_mul L.1 (by
+    rw [L.2.1]; exact isUnit_one))
+
+/-- The spinor map as a bundled homomorphism from `SL(2,ℂ)` onto the special
+orthochronous Lorentz group `SO⁺(1,3)` of Wolf, Equation (2.42). -/
+noncomputable def spinorCoverHom : SL(2, ℂ) →* specialOrthochronousLorentzGroup where
+  toFun X := ⟨spinorMatrix X, spinorMatrix_isSpecialOrthochronousLorentz X⟩
+  map_one' := Subtype.ext spinorMatrix_one
+  map_mul' X Y := Subtype.ext (spinorMatrix_mul X Y)
+
+
+/-! ### The rotation block `1 ⊕ R` -/
+
+
+/-- The Lorentz matrix `1 ⊕ R` fixing the time axis. -/
+def lorentzRotationBlock (R : Matrix (Fin 3) (Fin 3) ℝ) : Matrix (Fin 4) (Fin 4) ℝ :=
+  Matrix.of (Fin.cons (Pi.single 0 1) (fun i ↦ Fin.cons 0 (R i)))
+
+@[simp] theorem lorentzRotationBlock_zero_zero (R : Matrix (Fin 3) (Fin 3) ℝ) :
+    lorentzRotationBlock R 0 0 = 1 := by
+  simp [lorentzRotationBlock, Matrix.of_apply, Fin.cons_zero]
+
+@[simp] theorem lorentzRotationBlock_zero_succ (R : Matrix (Fin 3) (Fin 3) ℝ) (j : Fin 3) :
+    lorentzRotationBlock R 0 j.succ = 0 := by
+  simp [lorentzRotationBlock, Matrix.of_apply, Fin.cons_zero, Pi.single_eq_of_ne]
+
+@[simp] theorem lorentzRotationBlock_succ_zero (R : Matrix (Fin 3) (Fin 3) ℝ) (i : Fin 3) :
+    lorentzRotationBlock R i.succ 0 = 0 := by
+  simp [lorentzRotationBlock, Matrix.of_apply, Fin.cons_succ, Fin.cons_zero]
+
+@[simp] theorem lorentzRotationBlock_succ_succ (R : Matrix (Fin 3) (Fin 3) ℝ) (i j : Fin 3) :
+    lorentzRotationBlock R i.succ j.succ = R i j := by
+  simp [lorentzRotationBlock, Matrix.of_apply, Fin.cons_succ]
+
+@[simp] theorem lorentzRotationBlock_one : lorentzRotationBlock (1 : Matrix (Fin 3) (Fin 3) ℝ) = 1 := by
+  ext i j
+  rw [Matrix.one_apply]
+  cases i using Fin.cases <;> cases j using Fin.cases <;>
+    simp [Matrix.one_apply, (Ne.symm (Fin.succ_ne_zero _))]
+
+theorem lorentzRotationBlock_mul (R S : Matrix (Fin 3) (Fin 3) ℝ) :
+    lorentzRotationBlock (R * S) = lorentzRotationBlock R * lorentzRotationBlock S := by
+  ext i j
+  cases i using Fin.cases <;> cases j using Fin.cases <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_succ]
+
+theorem lorentzRotationBlock_mulVec_single_zero (R : Matrix (Fin 3) (Fin 3) ℝ) :
+    lorentzRotationBlock R *ᵥ Pi.single 0 1 = Pi.single 0 1 := by
+  ext i
+  cases i using Fin.cases <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
+
+@[simp] theorem lorentzRotationBlock_det (R : Matrix (Fin 3) (Fin 3) ℝ) :
+    (lorentzRotationBlock R).det = R.det := by
+  rw [Matrix.det_succ_row_zero, Fin.sum_univ_succ]
+  simp only [lorentzRotationBlock_zero_succ, mul_zero, zero_mul, Finset.sum_const_zero,
+    add_zero, lorentzRotationBlock_zero_zero, mul_one, Fin.val_zero, pow_zero, one_mul]
+  apply congrArg Matrix.det
+  ext i j
+  rw [Matrix.submatrix_apply, Fin.succAbove_zero]
+  exact lorentzRotationBlock_succ_succ R i j
+
+/-- The `(0, j)` entry of `LᵀηL` when the first column of `L` is `e₀`. -/
+theorem transpose_mul_metric_mul_apply_zero {L : Matrix (Fin 4) (Fin 4) ℝ}
+    (hcol : L.col 0 = Pi.single (0 : Fin 4) (1 : ℝ)) (j : Fin 4) :
+    (Lᵀ * minkowskiMetric * L) 0 j = L 0 j := by
+  have h0 : L 0 0 = 1 := by
+    have h := congrFun hcol 0
+    rwa [Matrix.col_apply, Pi.single_eq_same] at h
+  have h1 : L 1 0 = 0 := by
+    have h := congrFun hcol 1
+    rwa [Matrix.col_apply, Pi.single_eq_of_ne (by decide)] at h
+  have h2 : L 2 0 = 0 := by
+    have h := congrFun hcol 2
+    rwa [Matrix.col_apply, Pi.single_eq_of_ne (by decide)] at h
+  have h3 : L 3 0 = 0 := by
+    have h := congrFun hcol 3
+    rwa [Matrix.col_apply, Pi.single_eq_of_ne (by decide)] at h
+  simp only [Matrix.mul_apply, Matrix.transpose_apply, minkowskiMetric,
+    Matrix.diagonal_apply, Fin.sum_univ_four]
+  rw [h0, h1, h2, h3]
+  simp
+
+/-- The `(i, j)` entry of `LᵀηL` as the Minkowski-weighted column inner
+product. -/
+theorem transpose_mul_metric_mul_apply {L : Matrix (Fin 4) (Fin 4) ℝ} (i j : Fin 4) :
+    (Lᵀ * minkowskiMetric * L) i j =
+      L 0 i * L 0 j - (L 1 i * L 1 j + L 2 i * L 2 j + L 3 i * L 3 j) := by
+  simp only [Matrix.mul_apply, Matrix.transpose_apply, minkowskiMetric,
+    Matrix.diagonal_apply, Fin.sum_univ_four]
+  simp
+  ring
+
+/-- A Lorentz matrix fixing `e₀` is `1 ⊕ R` with `R ∈ SO(3)`.  This is the
+block-diagonalization step of the boost-rotation decomposition after Wolf,
+Equation (2.44). -/
+theorem exists_so3_block_of_fixes_time {L : Matrix (Fin 4) (Fin 4) ℝ}
+    (hfix : L *ᵥ Pi.single 0 1 = Pi.single 0 1)
+    (hlorentz : Lᵀ * minkowskiMetric * L = minkowskiMetric) (hdet : L.det = 1) :
+    ∃ R ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ, L = lorentzRotationBlock R := by
+  have hcol : L.col 0 = Pi.single (0 : Fin 4) (1 : ℝ) := by
+    rw [← Matrix.mulVec_single_one L 0]; exact hfix
+  have hrow : L.row 0 = Pi.single (0 : Fin 4) (1 : ℝ) := by
+    ext j
+    have h := congrFun (congrFun hlorentz 0) j
+    rw [transpose_mul_metric_mul_apply_zero hcol j] at h
+    rw [Matrix.row_apply, h]
+    cases j using Fin.cases with
+    | zero => simp [minkowskiMetric]
+    | succ j => simp [minkowskiMetric, (Ne.symm (Fin.succ_ne_zero _))]
+  have h00 : L 0 0 = 1 := by
+    have h := congrFun hcol 0
+    rwa [Matrix.col_apply, Pi.single_eq_same] at h
+  have hcs : ∀ i : Fin 3, L i.succ 0 = 0 := by
+    intro i
+    have h := congrFun hcol i.succ
+    rwa [Matrix.col_apply, Pi.single_eq_of_ne (Fin.succ_ne_zero i)] at h
+  have hrs : ∀ j : Fin 3, L 0 j.succ = 0 := by
+    intro j
+    have h := congrFun hrow j.succ
+    rwa [Matrix.row_apply, Pi.single_eq_of_ne (Fin.succ_ne_zero j)] at h
+  refine ⟨L.submatrix Fin.succ Fin.succ, ?_, ?_⟩
+  · rw [Matrix.mem_specialOrthogonalGroup_iff]
+    refine ⟨?_, ?_⟩
+    · rw [Matrix.mem_orthogonalGroup_iff']
+      ext i j
+      have h := congrFun (congrFun hlorentz i.succ) j.succ
+      rw [transpose_mul_metric_mul_apply] at h
+      rw [hrs i, zero_mul, zero_sub] at h
+      have hη : minkowskiMetric i.succ j.succ = if i = j then -1 else 0 := by
+        simp [minkowskiMetric, Matrix.diagonal_apply, Fin.succ_inj]
+      rw [hη] at h
+      have hR : ((L.submatrix Fin.succ Fin.succ)ᵀ * L.submatrix Fin.succ Fin.succ) i j =
+          L 1 i.succ * L 1 j.succ + L 2 i.succ * L 2 j.succ + L 3 i.succ * L 3 j.succ := by
+        simp only [Matrix.mul_apply, Matrix.transpose_apply, Fin.sum_univ_three,
+          Matrix.submatrix_apply]
+        show L 1 i.succ * L 1 j.succ + L 2 i.succ * L 2 j.succ + L 3 i.succ * L 3 j.succ =
+          L 1 i.succ * L 1 j.succ + L 2 i.succ * L 2 j.succ + L 3 i.succ * L 3 j.succ
+        rfl
+      rw [Matrix.one_apply, hR]
+      by_cases hij : i = j
+      · simp only [hij, ite_true] at h ⊢
+        linarith [h]
+      · simp only [hij, ite_false] at h ⊢
+        linarith [h]
+    · have hL : L = lorentzRotationBlock (L.submatrix Fin.succ Fin.succ) := by
+        ext i j
+        cases i using Fin.cases with
+        | zero =>
+            cases j using Fin.cases with
+            | zero => rw [lorentzRotationBlock_zero_zero]; exact h00
+            | succ j => rw [lorentzRotationBlock_zero_succ]; exact hrs j
+        | succ i =>
+            cases j using Fin.cases with
+            | zero => rw [lorentzRotationBlock_succ_zero]; exact hcs i
+            | succ j => rfl
+      rw [← lorentzRotationBlock_det, ← hL, hdet]
+  · ext i j
+    cases i using Fin.cases with
+    | zero =>
+        cases j using Fin.cases with
+        | zero => rw [lorentzRotationBlock_zero_zero]; exact h00
+        | succ j => rw [lorentzRotationBlock_zero_succ]; exact hrs j
+    | succ i =>
+        cases j using Fin.cases with
+        | zero => rw [lorentzRotationBlock_succ_zero]; exact hcs i
+        | succ j => rfl
+
+
+/-! ### The unitary lift through the Euler-angle cover -/
+/-- A special unitary matrix regarded as an element of `SL(2,ℂ)`. -/
+def su2ToSL2 (U : Matrix (Fin 2) (Fin 2) ℂ)
+    (hU : U ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ) : SL(2, ℂ) :=
+  ⟨U, (Matrix.mem_specialUnitaryGroup_iff.mp hU).2⟩
+
+@[simp] theorem su2ToSL2_coe (U : Matrix (Fin 2) (Fin 2) ℂ)
+    (hU : U ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ) :
+    (su2ToSL2 U hU).1 = U := rfl
+
+/-- The spinor matrix entries of a special unitary, in terms of `U` itself. -/
+theorem spinorMatrix_su2ToSL2_apply (U : Matrix (Fin 2) (Fin 2) ℂ)
+    (hU : U ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ) (i j : Fin 4) :
+    spinorMatrix (su2ToSL2 U hU) i j =
+      (Matrix.trace (pauliMatrices i * (U * pauliMatrices j * Uᴴ))).re / 2 :=
+  spinorMatrix_apply _ _ _
+
+/-- For a special unitary `U`, conjugation uses the conjugate transpose, and
+the spinor matrix of `U` is the rotation block `1 ⊕ R(U)`.  This is the
+rotation lift of Wolf, Equation (2.44). -/
+theorem spinorMatrix_su2ToSL2 (U : Matrix (Fin 2) (Fin 2) ℂ)
+    (hU : U ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ) :
+    spinorMatrix (su2ToSL2 U hU) =
+      lorentzRotationBlock (SpinCover.pauliConjAdReal U hU) := by
+  have hUunit : U ∈ Matrix.unitaryGroup (Fin 2) ℂ :=
+    (Matrix.mem_specialUnitaryGroup_iff.mp hU).1
+  have hUsU : U * Uᴴ = 1 := Matrix.mem_unitaryGroup_iff.mp hUunit
+  have hsUU : Uᴴ * U = 1 := Matrix.mem_unitaryGroup_iff'.mp hUunit
+  have hconj_adj : Uᴴ = U.adjugate := by
+    have hinv : U⁻¹ = Uᴴ := Matrix.inv_eq_right_inv hUsU
+    rw [← hinv, Matrix.inv_def, (Matrix.mem_specialUnitaryGroup_iff.mp hU).2]
+    simp
+  ext i j
+  cases i using Fin.cases with
+  | zero =>
+    cases j using Fin.cases with
+    | zero =>
+      rw [lorentzRotationBlock_zero_zero, spinorMatrix_su2ToSL2_apply]
+      simp only [pauliMatrices_zero, Matrix.mul_one, Matrix.one_mul]
+      rw [hUsU]
+      simp [Matrix.trace_one]
+    | succ j =>
+      rw [lorentzRotationBlock_zero_succ, spinorMatrix_su2ToSL2_apply]
+      simp only [pauliMatrices_zero, Matrix.one_mul, pauliMatrices_succ]
+      have htr : Matrix.trace (U * SpinCover.pauli j * Uᴴ) = 0 := by
+        calc Matrix.trace (U * SpinCover.pauli j * Uᴴ)
+            = Matrix.trace (Uᴴ * (U * SpinCover.pauli j)) :=
+              Matrix.trace_mul_comm _ _
+          _ = Matrix.trace ((Uᴴ * U) * SpinCover.pauli j) := by
+              rw [Matrix.mul_assoc]
+          _ = Matrix.trace (SpinCover.pauli j) := by rw [hsUU, Matrix.one_mul]
+          _ = 0 := SpinCover.trace_pauli j
+      rw [htr]
+      simp
+  | succ i =>
+    cases j using Fin.cases with
+    | zero =>
+      rw [lorentzRotationBlock_succ_zero, spinorMatrix_su2ToSL2_apply]
+      simp only [pauliMatrices_zero, Matrix.mul_one, pauliMatrices_succ]
+      rw [hUsU, Matrix.mul_one]
+      rw [SpinCover.trace_pauli i]
+      simp
+    | succ j =>
+      rw [lorentzRotationBlock_succ_succ, spinorMatrix_su2ToSL2_apply]
+      simp only [pauliMatrices_succ]
+      rw [SpinCover.pauliConjAdReal, SpinCover.pauliConjAd, SpinCover.su2ToGL_coe,
+        SpinCover.su2ToGL_inv_coe, ← hconj_adj]
+      have hre : ∀ z : ℂ, (z / 2).re = z.re / 2 := by
+        intro z
+        norm_num [Complex.div_re, Complex.normSq_ofReal]
+      simp only [Matrix.mul_assoc, hre]
+
+/-- Every rotation block `1 ⊕ R` with `R ∈ SO(3)` is the spinor matrix of a
+special unitary: the rotation factor of Wolf, Equation (2.44) lifts through
+the Euler-angle cover `SU(2) → SO(3)`. -/
+theorem exists_su2_spinorMatrix_eq_lorentzRotationBlock (R : Matrix (Fin 3) (Fin 3) ℝ)
+    (hR : R ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ) :
+    ∃ U : Matrix (Fin 2) (Fin 2) ℂ, ∃ hU : U ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ,
+      spinorMatrix (su2ToSL2 U hU) = lorentzRotationBlock R := by
+  obtain ⟨U, hU, hUR⟩ := SpinCover.spinHalfCover_surjective_onto_SO3 R hR
+  refine ⟨U, hU, ?_⟩
+  rw [spinorMatrix_su2ToSL2]
+  congr 1
+  ext i j
+  have h := congrFun (congrFun hUR i) j
+  rw [Matrix.map_apply] at h
+  change (SpinCover.pauliConjAd (SpinCover.su2ToGL U hU) i j).re = R i j
+  rw [h]
+  exact Complex.ofReal_re _
+
+
+end Wolf

--- a/QICLean/Channel/LorentzNormalForm/SpinorExponential.lean
+++ b/QICLean/Channel/LorentzNormalForm/SpinorExponential.lean
@@ -1,0 +1,505 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Channel.LorentzNormalForm.SpinorCover
+import Mathlib.Analysis.Normed.Algebra.MatrixExponential
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Series
+
+/-!
+# Exponential formulas for the Lorentz spinor cover
+
+This module formalizes Wolf's rotation and boost exponentials from Equation
+(2.44), `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 1037–1081.
+For a unit spatial axis `n`, it proves the closed forms for
+`exp(t n·σ)`, `exp(-i t n·σ)`, `exp(t n·B)`, and `exp(t n·R)`, identifies the
+boost exponential with the canonical Lorentz boost, and verifies both formulas
+under the concrete spinor map.
+
+The rotation formula follows the actual congruence action: Wolf's displayed
+spinor `exp(-i t n·σ/2)` maps to `exp(+t n·R)`.  The printed negative sign is
+recorded in `docs/paper-gaps/wolf_ch2_spinor_rotation_sign.tex`.
+
+## Main results
+
+* `Wolf.exp_smul_pauliVector` — closed boost-spinor exponential.
+* `Wolf.exp_smul_boostGenerator` — hyperbolic Rodrigues formula.
+* `Wolf.lorentzBoost_rapidityMinkowski_eq_exp` — Lorentz boost exponential.
+* `Wolf.exp_neg_I_smul_pauliVector` — closed rotation-spinor exponential.
+* `Wolf.exp_smul_rotationGenerator` — Rodrigues rotation formula.
+* `Wolf.spinorMatrix_boostExpSL2` — boost identity under the spinor map.
+* `Wolf.spinorMatrix_rotationExpSL2` — corrected-sign rotation identity.
+-/
+
+open scoped Matrix MatrixGroups BigOperators ComplexOrder Nat
+open Matrix Finset
+
+noncomputable section
+
+namespace Wolf
+
+/-! ### The even/odd split of the exponential series -/
+
+set_option maxHeartbeats 800000 in
+-- Elaborating this generic exponential-series rearrangement exceeds the project default.
+/-- The even/odd split of the exponential series: if the even subseries of the
+exponential series of `a` sums to `E` and the odd subseries to `O`, then
+`exp a = E + O`. -/
+theorem exp_eq_add_of_even_odd {𝔸 : Type*} [NormedRing 𝔸] [NormedAlgebra ℝ 𝔸]
+    [CompleteSpace 𝔸] (a E O : 𝔸)
+    (hE : HasSum (fun n ↦ NormedSpace.expSeries ℝ 𝔸 (2 * n) (fun _ ↦ a)) E)
+    (hO : HasSum (fun n ↦ NormedSpace.expSeries ℝ 𝔸 (2 * n + 1) (fun _ ↦ a)) O) :
+    NormedSpace.exp a = E + O := by
+  have hsum : HasSum (fun n ↦ NormedSpace.expSeries ℝ 𝔸 n (fun _ ↦ a)) (E + O) :=
+    hE.even_add_odd hO
+  rw [congrFun (NormedSpace.exp_eq_tsum ℝ) a]
+  simpa only [NormedSpace.expSeries_apply_eq] using hsum.tsum_eq
+
+/-! ### Scalar series tails -/
+
+/-- The even tail of the cosh series. -/
+theorem hasSum_cosh_sub_one (x : ℝ) :
+    HasSum (fun n ↦ x ^ (2 * (n + 1)) / (2 * (n + 1))!) (Real.cosh x - 1) := by
+  have h := (hasSum_nat_add_iff' 1).mpr (Real.hasSum_cosh x)
+  rw [Finset.sum_range_one] at h
+  simpa using h
+
+/-- The even tail of the cos series, as `1 - cos x`. -/
+theorem hasSum_one_sub_cos (x : ℝ) :
+    HasSum (fun n ↦ (-1) ^ n * x ^ (2 * (n + 1)) / (2 * (n + 1))!) (1 - Real.cos x) := by
+  have h := (hasSum_nat_add_iff' 1).mpr (Real.hasSum_cos x)
+  rw [Finset.sum_range_one] at h
+  norm_num [pow_zero] at h
+  have hneg := h.neg
+  have hfun : (fun n ↦ (-1) ^ n * x ^ (2 * (n + 1)) / (2 * (n + 1))!) =
+      fun n ↦ -((-1) ^ (n + 1) * x ^ (2 * (n + 1)) / (2 * (n + 1))!) := by
+    funext n
+    rw [pow_succ (-1 : ℝ) n]
+    ring
+  rw [hfun]
+  simpa only [neg_sub] using hneg
+
+
+/-! ### Wolf's boost and rotation generators -/
+
+/-- The Pauli contraction `n·σ` for a real spatial vector `n`. -/
+def pauliVector (n : Fin 3 → ℝ) : Matrix (Fin 2) (Fin 2) ℂ :=
+  ∑ k : Fin 3, (n k : ℂ) • SpinCover.pauli k
+
+/-- The Lorentz boost generator `n·B` from Wolf, Equation (2.44). -/
+def boostGenerator (n : Fin 3 → ℝ) : Matrix (Fin 4) (Fin 4) ℝ :=
+  fun i j ↦ if hi : i = 0 then (if _hj : j = 0 then 0 else n (Fin.pred j _hj))
+    else if _hj : j = 0 then n (Fin.pred i hi) else 0
+
+@[simp] theorem boostGenerator_zero_zero (n : Fin 3 → ℝ) : boostGenerator n 0 0 = 0 := by
+  simp [boostGenerator]
+
+@[simp] theorem boostGenerator_zero_succ (n : Fin 3 → ℝ) (j : Fin 3) :
+    boostGenerator n 0 j.succ = n j := by
+  simp [boostGenerator]
+
+@[simp] theorem boostGenerator_succ_zero (n : Fin 3 → ℝ) (i : Fin 3) :
+    boostGenerator n i.succ 0 = n i := by
+  simp [boostGenerator]
+
+@[simp] theorem boostGenerator_succ_succ (n : Fin 3 → ℝ) (i j : Fin 3) :
+    boostGenerator n i.succ j.succ = 0 := by
+  simp [boostGenerator]
+
+/-- The spatial generator `n·R` with Wolf's convention
+`Rᵢ = ∑ⱼₖ εᵢⱼₖ |k⟩⟨j|`.  Thus the third generator sends the first spatial
+coordinate toward the positive second coordinate. -/
+def rotationGenerator3 (n : Fin 3 → ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
+  !![0, -n 2, n 1; n 2, 0, -n 0; -n 1, n 0, 0]
+
+/-- The four-dimensional rotation generator, trivial on the time axis. -/
+def rotationGenerator (n : Fin 3 → ℝ) : Matrix (Fin 4) (Fin 4) ℝ :=
+  fun i j ↦ if h0 : i = 0 then 0 else if h1 : j = 0 then 0
+    else rotationGenerator3 n (Fin.pred i h0) (Fin.pred j h1)
+
+@[simp] theorem rotationGenerator_zero_apply (n : Fin 3 → ℝ) (j : Fin 4) :
+    rotationGenerator n 0 j = 0 := by simp [rotationGenerator]
+
+@[simp] theorem rotationGenerator_apply_zero (n : Fin 3 → ℝ) (i : Fin 4) :
+    rotationGenerator n i 0 = 0 := by simp [rotationGenerator]
+
+@[simp] theorem rotationGenerator_succ_succ (n : Fin 3 → ℝ) (i j : Fin 3) :
+    rotationGenerator n i.succ j.succ = rotationGenerator3 n i j := by
+  simp [rotationGenerator]
+
+/-- A unit spatial Pauli contraction squares to the identity. -/
+theorem pauliVector_sq (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) :
+    pauliVector n ^ 2 = 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pauliVector, SpinCover.pauli, pow_two, Matrix.mul_apply, Fin.sum_univ_two,
+      Fin.sum_univ_three] at hn ⊢ <;>
+    ring_nf at hn ⊢ <;> try simp_all [Complex.I_sq]
+  all_goals norm_cast <;> try nlinarith [hn]
+
+/-- A unit boost generator satisfies `(n·B)³ = n·B`. -/
+theorem boostGenerator_cube (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) :
+    boostGenerator n ^ 3 = boostGenerator n := by
+  have h0 := congrArg (fun x : ℝ ↦ n 0 * x) hn
+  have h1 := congrArg (fun x : ℝ ↦ n 1 * x) hn
+  have h2 := congrArg (fun x : ℝ ↦ n 2 * x) hn
+  simp only [Fin.sum_univ_three, mul_one] at h0 h1 h2
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pow_succ, Matrix.mul_apply, Fin.sum_univ_four, Fin.sum_univ_three,
+      boostGenerator] at hn ⊢ <;>
+    ring_nf at hn ⊢ <;> try rfl
+  all_goals linarith [h0, h1, h2]
+
+/-- A unit rotation generator satisfies `(n·R)³ = -(n·R)`. -/
+theorem rotationGenerator_cube (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) :
+    rotationGenerator n ^ 3 = -rotationGenerator n := by
+  have h0 := congrArg (fun x : ℝ ↦ n 0 * x) hn
+  have h1 := congrArg (fun x : ℝ ↦ n 1 * x) hn
+  have h2 := congrArg (fun x : ℝ ↦ n 2 * x) hn
+  simp only [Fin.sum_univ_three, mul_one] at h0 h1 h2
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pow_succ, Matrix.mul_apply, Fin.sum_univ_four, rotationGenerator,
+      rotationGenerator3, Fin.sum_univ_three] at hn ⊢ <;>
+    ring_nf at hn ⊢ <;> try rfl
+  all_goals linarith [h0, h1, h2]
+
+
+/-! ### Closed forms for exponentials of quadratic and cubic generators -/
+
+/-- Exponential closed form for a scalar multiple of an element whose square is
+`ε • 1`. -/
+theorem exp_smul_eq_of_sq_smul {𝔸 : Type*} [NormedRing 𝔸] [NormedAlgebra ℝ 𝔸]
+    [CompleteSpace 𝔸] (q : 𝔸) (ε t c s : ℝ) (hq : q ^ 2 = ε • 1)
+    (hc : HasSum (fun n ↦ ε ^ n * t ^ (2 * n) / (2 * n)!) c)
+    (hs : HasSum (fun n ↦ ε ^ n * t ^ (2 * n + 1) / (2 * n + 1)!) s) :
+    NormedSpace.exp (t • q) = c • 1 + s • q := by
+  have hEven : ∀ n : ℕ, q ^ (2 * n) = ε ^ n • (1 : 𝔸) := by
+    intro n
+    induction n with
+    | zero => simp
+    | succ n ih =>
+        rw [show 2 * (n + 1) = 2 * n + 2 by omega, pow_add, ih, hq,
+          smul_mul_assoc, one_mul, smul_smul, pow_succ]
+  have hOdd : ∀ n : ℕ, q ^ (2 * n + 1) = ε ^ n • q := by
+    intro n
+    rw [pow_succ, hEven n, smul_one_mul]
+  have heqE : (fun n ↦ NormedSpace.expSeries ℝ 𝔸 (2 * n) (fun _ ↦ t • q)) =
+      fun n ↦ (ε ^ n * t ^ (2 * n) / (2 * n)!) • (1 : 𝔸) := by
+    funext n
+    rw [NormedSpace.expSeries_apply_eq, smul_pow, hEven, smul_smul, smul_smul]
+    congr 1
+    rw [div_eq_mul_inv]
+    ring
+  have heqO : (fun n ↦ NormedSpace.expSeries ℝ 𝔸 (2 * n + 1) (fun _ ↦ t • q)) =
+      fun n ↦ (ε ^ n * t ^ (2 * n + 1) / (2 * n + 1)!) • q := by
+    funext n
+    rw [NormedSpace.expSeries_apply_eq, smul_pow, hOdd, smul_smul, smul_smul]
+    congr 1
+    rw [div_eq_mul_inv]
+    ring
+  exact exp_eq_add_of_even_odd (t • q) (c • 1) (s • q)
+    (heqE ▸ hc.smul_const (1 : 𝔸)) (heqO ▸ hs.smul_const q)
+
+/-- Exponential closed form for a scalar multiple of an element satisfying
+`q³ = ε • q`. -/
+theorem exp_smul_eq_of_cubic_smul {𝔸 : Type*} [NormedRing 𝔸] [NormedAlgebra ℝ 𝔸]
+    [CompleteSpace 𝔸] (q : 𝔸) (ε t c₂ s : ℝ) (hq : q ^ 3 = ε • q)
+    (hc : HasSum (fun n ↦ ε ^ n * t ^ (2 * (n + 1)) / (2 * (n + 1))!) c₂)
+    (hs : HasSum (fun n ↦ ε ^ n * t ^ (2 * n + 1) / (2 * n + 1)!) s) :
+    NormedSpace.exp (t • q) = 1 + c₂ • q ^ 2 + s • q := by
+  have hq4 : q ^ 4 = ε • q ^ 2 := by
+    rw [pow_succ, hq, smul_mul_assoc, pow_two]
+  have hEven : ∀ n : ℕ, q ^ (2 * (n + 1)) = ε ^ n • q ^ 2 := by
+    intro n
+    induction n with
+    | zero => simp
+    | succ n ih =>
+        rw [show 2 * (n + 1 + 1) = 2 * (n + 1) + 2 by omega, pow_add, ih,
+          smul_mul_assoc, show q ^ 2 * q ^ 2 = q ^ 4 by rw [← pow_add], hq4,
+          smul_smul]
+        congr 1
+  have hOdd : ∀ n : ℕ, q ^ (2 * n + 1) = ε ^ n • q := by
+    intro n
+    induction n with
+    | zero => simp
+    | succ n ih =>
+        rw [show 2 * (n + 1) + 1 = (2 * n + 1) + 2 by omega, pow_add, ih,
+          smul_mul_assoc, ← pow_succ', hq, smul_smul, pow_succ]
+  have heqE : (fun n ↦ NormedSpace.expSeries ℝ 𝔸 (2 * (n + 1)) (fun _ ↦ t • q)) =
+      fun n ↦ (ε ^ n * t ^ (2 * (n + 1)) / (2 * (n + 1))!) • q ^ 2 := by
+    funext n
+    rw [NormedSpace.expSeries_apply_eq, smul_pow, hEven, smul_smul, smul_smul]
+    congr 1
+    rw [div_eq_mul_inv]
+    ring
+  have heqO : (fun n ↦ NormedSpace.expSeries ℝ 𝔸 (2 * n + 1) (fun _ ↦ t • q)) =
+      fun n ↦ (ε ^ n * t ^ (2 * n + 1) / (2 * n + 1)!) • q := by
+    funext n
+    rw [NormedSpace.expSeries_apply_eq, smul_pow, hOdd, smul_smul, smul_smul]
+    congr 1
+    rw [div_eq_mul_inv]
+    ring
+  have htail : HasSum
+      (fun n ↦ NormedSpace.expSeries ℝ 𝔸 (2 * (n + 1)) (fun _ ↦ t • q))
+      (c₂ • q ^ 2) := heqE ▸ hc.smul_const (q ^ 2)
+  have hzero : NormedSpace.expSeries ℝ 𝔸 0 (fun _ ↦ t • q) = 1 := by
+    simp [NormedSpace.expSeries_apply_eq]
+  have hE : HasSum (fun n ↦ NormedSpace.expSeries ℝ 𝔸 (2 * n) (fun _ ↦ t • q))
+      (1 + c₂ • q ^ 2) := by
+    apply (hasSum_nat_add_iff' 1).mp
+    simpa only [Finset.sum_range_one, hzero, add_sub_cancel_left] using htail
+  exact exp_eq_add_of_even_odd (t • q) (1 + c₂ • q ^ 2) (s • q) hE
+    (heqO ▸ hs.smul_const q)
+
+/-- The boost spinor exponential `exp(t n·σ)`. -/
+theorem exp_smul_pauliVector (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    NormedSpace.exp (t • pauliVector n) =
+      Real.cosh t • 1 + Real.sinh t • pauliVector n := by
+  let _ : NormedRing (Matrix (Fin 2) (Fin 2) ℂ) := Matrix.linftyOpNormedRing
+  let _ : NormedAlgebra ℝ (Matrix (Fin 2) (Fin 2) ℂ) := Matrix.linftyOpNormedAlgebra
+  apply exp_smul_eq_of_sq_smul (pauliVector n) 1 t
+  · simpa using pauliVector_sq n hn
+  · simpa using Real.hasSum_cosh t
+  · simpa using Real.hasSum_sinh t
+
+/-- Rodrigues' hyperbolic formula for the Lorentz boost exponential. -/
+theorem exp_smul_boostGenerator (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    NormedSpace.exp (t • boostGenerator n) =
+      1 + (Real.cosh t - 1) • boostGenerator n ^ 2 +
+        Real.sinh t • boostGenerator n := by
+  let _ : NormedRing (Matrix (Fin 4) (Fin 4) ℝ) := Matrix.linftyOpNormedRing
+  let _ : NormedAlgebra ℝ (Matrix (Fin 4) (Fin 4) ℝ) := Matrix.linftyOpNormedAlgebra
+  apply exp_smul_eq_of_cubic_smul (boostGenerator n) 1 t
+  · simpa using boostGenerator_cube n hn
+  · simpa using hasSum_cosh_sub_one t
+  · simpa using Real.hasSum_sinh t
+
+/-- The corrected-sign rotation spinor exponential
+`exp(-i t n·σ) = cos(t)I - i sin(t)n·σ`. -/
+theorem exp_neg_I_smul_pauliVector (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    NormedSpace.exp (t • ((-Complex.I) • pauliVector n)) =
+      Real.cos t • 1 + Real.sin t • ((-Complex.I) • pauliVector n) := by
+  let _ : NormedRing (Matrix (Fin 2) (Fin 2) ℂ) := Matrix.linftyOpNormedRing
+  let _ : NormedAlgebra ℝ (Matrix (Fin 2) (Fin 2) ℂ) := Matrix.linftyOpNormedAlgebra
+  apply exp_smul_eq_of_sq_smul ((-Complex.I) • pauliVector n) (-1) t
+  · rw [smul_pow, pauliVector_sq n hn]
+    norm_num [Complex.I_sq]
+  · simpa [mul_assoc] using Real.hasSum_cos t
+  · simpa [mul_assoc] using Real.hasSum_sin t
+
+/-- Rodrigues' formula for the Lorentz rotation exponential.  With Wolf's
+printed generators this has the positive sign matching the congruence action. -/
+theorem exp_smul_rotationGenerator (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    NormedSpace.exp (t • rotationGenerator n) =
+      1 + (1 - Real.cos t) • rotationGenerator n ^ 2 +
+        Real.sin t • rotationGenerator n := by
+  let _ : NormedRing (Matrix (Fin 4) (Fin 4) ℝ) := Matrix.linftyOpNormedRing
+  let _ : NormedAlgebra ℝ (Matrix (Fin 4) (Fin 4) ℝ) := Matrix.linftyOpNormedAlgebra
+  apply exp_smul_eq_of_cubic_smul (rotationGenerator n) (-1) t
+  · simpa using rotationGenerator_cube n hn
+  · simpa [mul_assoc] using hasSum_one_sub_cos t
+  · simpa [mul_assoc] using Real.hasSum_sin t
+
+
+
+/-! ### Rapidity coordinates for the canonical boost -/
+
+/-- The future unit-hyperboloid point
+`(cosh t, sinh t n₁, sinh t n₂, sinh t n₃)` for a spatial axis `n`. -/
+def rapidityMinkowski (n : Fin 3 → ℝ) (t : ℝ) : MinkowskiSpace :=
+  Fin.cons (Real.cosh t) fun k ↦ Real.sinh t * n k
+
+@[simp] theorem rapidityMinkowski_zero (n : Fin 3 → ℝ) (t : ℝ) :
+    rapidityMinkowski n t 0 = Real.cosh t := by
+  simp [rapidityMinkowski]
+
+@[simp] theorem rapidityMinkowski_succ (n : Fin 3 → ℝ) (t : ℝ) (k : Fin 3) :
+    rapidityMinkowski n t k.succ = Real.sinh t * n k := by
+  simp [rapidityMinkowski]
+
+/-- Rapidity coordinates lie on the unit hyperboloid. -/
+theorem minkowskiQuadratic_rapidityMinkowski (n : Fin 3 → ℝ)
+    (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    minkowskiQuadratic (rapidityMinkowski n t) = 1 := by
+  rw [minkowskiQuadratic_eq_sub_sum]
+  simp only [rapidityMinkowski_zero, rapidityMinkowski_succ, mul_pow,
+    ← Finset.mul_sum]
+  rw [hn, mul_one]
+  exact Real.cosh_sq_sub_sinh_sq t
+
+/-- The Lorentz exponential `exp(t n·B)` is the canonical boost with rapidity
+`t` and unit spatial axis `n`. -/
+theorem lorentzBoost_rapidityMinkowski_eq_exp (n : Fin 3 → ℝ)
+    (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    lorentzBoost (rapidityMinkowski n t) = NormedSpace.exp (t • boostGenerator n) := by
+  rw [exp_smul_boostGenerator n hn]
+  have hpos : 0 < 1 + Real.cosh t := by
+    nlinarith [Real.cosh_pos t]
+  have hquot : Real.sinh t ^ 2 / (1 + Real.cosh t) = Real.cosh t - 1 := by
+    field_simp
+    nlinarith [Real.cosh_sq_sub_sinh_sq t]
+  have hquot' : Real.sinh t ^ 2 * (1 + Real.cosh t)⁻¹ = Real.cosh t - 1 := by
+    simpa [div_eq_mul_inv] using hquot
+  have hn' : n 0 ^ 2 + n 1 ^ 2 + n 2 ^ 2 = 1 := by
+    simpa [Fin.sum_univ_three] using hn
+  ext i j
+  cases i using Fin.cases with
+  | zero =>
+      cases j using Fin.cases with
+      | zero =>
+          simp [lorentzBoost, rapidityMinkowski, boostGenerator, pow_two,
+            Matrix.mul_apply, Fin.sum_univ_succ]
+          nlinarith [hn']
+      | succ j =>
+          simpa [lorentzBoost, rapidityMinkowski, boostGenerator, pow_two,
+            Matrix.mul_apply, Matrix.one_apply] using (Fin.succ_ne_zero j).symm
+  | succ i =>
+      cases j using Fin.cases with
+      | zero =>
+          simp [lorentzBoost, rapidityMinkowski, boostGenerator, pow_two,
+            Matrix.mul_apply, Fin.sum_univ_succ]
+      | succ j =>
+          simp [lorentzBoost, rapidityMinkowski, boostGenerator, pow_two,
+            Matrix.mul_apply, Matrix.one_apply]
+          simp only [← hquot']
+          ring
+
+/-! ### Exponential spinors and the spinor-map identities -/
+
+/-- The closed boost exponential `exp(t n·σ/2)`. -/
+def boostExpMatrix (n : Fin 3 → ℝ) (t : ℝ) : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![(Real.cosh (t / 2) + Real.sinh (t / 2) * n 2 : ℝ),
+      (Real.sinh (t / 2) * n 0 : ℝ) - Complex.I * (Real.sinh (t / 2) * n 1 : ℝ);
+    (Real.sinh (t / 2) * n 0 : ℝ) + Complex.I * (Real.sinh (t / 2) * n 1 : ℝ),
+      (Real.cosh (t / 2) - Real.sinh (t / 2) * n 2 : ℝ)]
+
+/-- The closed rotation exponential `exp(-i t n·σ/2)`. -/
+def rotationExpMatrix (n : Fin 3 → ℝ) (t : ℝ) : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![(Real.cos (t / 2) : ℂ) - Complex.I * (Real.sin (t / 2) * n 2 : ℝ),
+      (-Real.sin (t / 2) * n 1 : ℝ) - Complex.I * (Real.sin (t / 2) * n 0 : ℝ);
+    (Real.sin (t / 2) * n 1 : ℝ) - Complex.I * (Real.sin (t / 2) * n 0 : ℝ),
+      (Real.cos (t / 2) : ℂ) + Complex.I * (Real.sin (t / 2) * n 2 : ℝ)]
+
+/-- The boost exponential has determinant one for a unit axis. -/
+theorem boostExpMatrix_det (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    (boostExpMatrix n t).det = 1 := by
+  rw [Matrix.det_fin_two]
+  simp only [boostExpMatrix, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.of_apply]
+  have h := Real.cosh_sq_sub_sinh_sq (t / 2)
+  have hn' : n 0 ^ 2 + n 1 ^ 2 + n 2 ^ 2 = 1 := by
+    simpa [Fin.sum_univ_three] using hn
+  have hsn := congrArg (fun x : ℝ ↦ Real.sinh (t / 2) ^ 2 * x) hn'
+  simp only [mul_one] at hsn
+  apply Complex.ext <;> simp [-Complex.ofReal_cosh, -Complex.ofReal_sinh]
+  · ring_nf at hn hsn h ⊢
+    linear_combination h - hsn
+  · ring
+
+/-- The rotation exponential has determinant one for a unit axis. -/
+theorem rotationExpMatrix_det (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    (rotationExpMatrix n t).det = 1 := by
+  rw [Matrix.det_fin_two]
+  simp only [rotationExpMatrix, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.of_apply]
+  have h := Real.cos_sq_add_sin_sq (t / 2)
+  have hn' : n 0 ^ 2 + n 1 ^ 2 + n 2 ^ 2 = 1 := by
+    simpa [Fin.sum_univ_three] using hn
+  have hsn := congrArg (fun x : ℝ ↦ Real.sin (t / 2) ^ 2 * x) hn'
+  simp only [mul_one] at hsn
+  apply Complex.ext <;> simp [-Complex.ofReal_cos, -Complex.ofReal_sin]
+  · ring_nf at hn hsn h ⊢
+    linear_combination h + hsn
+  · ring
+
+/-- `exp(t n·σ/2)` as an element of `SL(2,ℂ)`. -/
+def boostExpSL2 (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) : SL(2, ℂ) :=
+  ⟨boostExpMatrix n t, boostExpMatrix_det n hn t⟩
+
+/-- `exp(-i t n·σ/2)` as an element of `SL(2,ℂ)`. -/
+def rotationExpSL2 (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) : SL(2, ℂ) :=
+  ⟨rotationExpMatrix n t, rotationExpMatrix_det n hn t⟩
+
+/-- The closed boost spinor is the matrix exponential `exp(t n·σ/2)`. -/
+theorem boostExpSL2_coe_eq_exp (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    (boostExpSL2 n hn t).1 = NormedSpace.exp ((t / 2) • pauliVector n) := by
+  rw [exp_smul_pauliVector n hn]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [boostExpSL2, boostExpMatrix, pauliVector, SpinCover.pauli, Fin.sum_univ_three] <;>
+    ring
+
+/-- The closed rotation spinor is the matrix exponential `exp(-i t n·σ/2)`. -/
+theorem rotationExpSL2_coe_eq_exp (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    (rotationExpSL2 n hn t).1 =
+      NormedSpace.exp ((t / 2) • ((-Complex.I) • pauliVector n)) := by
+  rw [exp_neg_I_smul_pauliVector n hn]
+  ext i j
+  fin_cases i <;> fin_cases j
+  all_goals
+    apply Complex.ext <;>
+      simp [rotationExpSL2, rotationExpMatrix, pauliVector, SpinCover.pauli,
+        Fin.sum_univ_three, Complex.mul_re, Complex.mul_im] <;>
+      ring
+
+/-- Wolf's boost identity in Equation (2.44): the spinor map sends
+`exp(t n·σ/2)` to `exp(t n·B)`. -/
+theorem spinorMatrix_boostExpSL2 (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    spinorMatrix (boostExpSL2 n hn t) = NormedSpace.exp (t • boostGenerator n) := by
+  rw [exp_smul_boostGenerator n hn]
+  have hc : Real.cosh t = Real.cosh (t / 2) ^ 2 + Real.sinh (t / 2) ^ 2 := by
+    convert Real.cosh_two_mul (t / 2) using 1 ; ring
+  have hs : Real.sinh t = 2 * Real.sinh (t / 2) * Real.cosh (t / 2) := by
+    convert Real.sinh_two_mul (t / 2) using 1 ; ring
+  have hu : n 0 ^ 2 + n 1 ^ 2 + n 2 ^ 2 = 1 := by
+    simpa [Fin.sum_univ_three] using hn
+  have hh := Real.cosh_sq_sub_sinh_sq (t / 2)
+  have hk : Real.cosh t = 1 + 2 * Real.sinh (t / 2) ^ 2 := by
+    nlinarith [hc, hh]
+  have hus := congrArg (fun x : ℝ ↦ Real.sinh (t / 2) ^ 2 * x) hu
+  simp only [mul_one] at hus
+  ext i j
+  rw [spinorMatrix_apply]
+  fin_cases i <;> fin_cases j <;>
+    simp [boostExpSL2, boostExpMatrix, pauliMatrices,
+      Matrix.trace_fin_two, Matrix.mul_apply, Matrix.vecMul, dotProduct,
+      Matrix.conjTranspose_apply, Fin.sum_univ_two, Fin.sum_univ_four, boostGenerator, pow_two,
+      -Complex.ofReal_cosh, -Complex.ofReal_sinh] <;>
+    simp only [hk, hs]
+  all_goals ring_nf at hu hh hus ⊢ <;> linarith [hh, hus]
+
+/-- Corrected-sign rotation identity for Wolf, Equation (2.44): with the
+printed generators `Rᵢ`, the congruence action sends `exp(-i t n·σ/2)` to
+`exp(+t n·R)`, not to the printed negative exponential.
+
+**Local fix (Wolf Eq. (2.44), ch02 lines 1070–1077):** the printed minus sign
+on the Lorentz exponential conflicts with the Pauli and column-vector
+conventions.  See `docs/paper-gaps/wolf_ch2_spinor_rotation_sign.tex`. -/
+theorem spinorMatrix_rotationExpSL2 (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (t : ℝ) :
+    spinorMatrix (rotationExpSL2 n hn t) =
+      NormedSpace.exp (t • rotationGenerator n) := by
+  rw [exp_smul_rotationGenerator n hn]
+  have hc : Real.cos t = 2 * Real.cos (t / 2) ^ 2 - 1 := by
+    convert Real.cos_two_mul (t / 2) using 1 ; ring
+  have hs : Real.sin t = 2 * Real.sin (t / 2) * Real.cos (t / 2) := by
+    convert Real.sin_two_mul (t / 2) using 1 ; ring
+  have hu : n 0 ^ 2 + n 1 ^ 2 + n 2 ^ 2 = 1 := by
+    simpa [Fin.sum_univ_three] using hn
+  have hh := Real.cos_sq_add_sin_sq (t / 2)
+  have hk : Real.cos t = 1 - 2 * Real.sin (t / 2) ^ 2 := by
+    nlinarith [hc, hh]
+  have hus := congrArg (fun x : ℝ ↦ Real.sin (t / 2) ^ 2 * x) hu
+  simp only [mul_one] at hus
+  ext i j
+  rw [spinorMatrix_apply]
+  fin_cases i <;> fin_cases j <;>
+    simp [rotationExpSL2, rotationExpMatrix, pauliMatrices,
+      Matrix.trace_fin_two, Matrix.mul_apply, Matrix.vecMul, dotProduct,
+      Matrix.conjTranspose_apply, Fin.sum_univ_two, Fin.sum_univ_four, rotationGenerator,
+      rotationGenerator3, pow_two, -Complex.ofReal_cos, -Complex.ofReal_sin] <;>
+    try simp only [hk, hs]
+  all_goals ring_nf at hu hh hus ⊢ <;> linarith [hh, hus]
+
+end Wolf
+end

--- a/QICLean/Channel/LorentzNormalForm/SpinorExponential.lean
+++ b/QICLean/Channel/LorentzNormalForm/SpinorExponential.lean
@@ -449,9 +449,9 @@ theorem spinorMatrix_boostExpSL2 (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1) (
     spinorMatrix (boostExpSL2 n hn t) = NormedSpace.exp (t • boostGenerator n) := by
   rw [exp_smul_boostGenerator n hn]
   have hc : Real.cosh t = Real.cosh (t / 2) ^ 2 + Real.sinh (t / 2) ^ 2 := by
-    convert Real.cosh_two_mul (t / 2) using 1 ; ring
+    convert Real.cosh_two_mul (t / 2) using 1; ring
   have hs : Real.sinh t = 2 * Real.sinh (t / 2) * Real.cosh (t / 2) := by
-    convert Real.sinh_two_mul (t / 2) using 1 ; ring
+    convert Real.sinh_two_mul (t / 2) using 1; ring
   have hu : n 0 ^ 2 + n 1 ^ 2 + n 2 ^ 2 = 1 := by
     simpa [Fin.sum_univ_three] using hn
   have hh := Real.cosh_sq_sub_sinh_sq (t / 2)
@@ -481,9 +481,9 @@ theorem spinorMatrix_rotationExpSL2 (n : Fin 3 → ℝ) (hn : ∑ k, n k ^ 2 = 1
       NormedSpace.exp (t • rotationGenerator n) := by
   rw [exp_smul_rotationGenerator n hn]
   have hc : Real.cos t = 2 * Real.cos (t / 2) ^ 2 - 1 := by
-    convert Real.cos_two_mul (t / 2) using 1 ; ring
+    convert Real.cos_two_mul (t / 2) using 1; ring
   have hs : Real.sin t = 2 * Real.sin (t / 2) * Real.cos (t / 2) := by
-    convert Real.sin_two_mul (t / 2) using 1 ; ring
+    convert Real.sin_two_mul (t / 2) using 1; ring
   have hu : n 0 ^ 2 + n 1 ^ 2 + n 2 ^ 2 = 1 := by
     simpa [Fin.sum_univ_three] using hn
   have hh := Real.cos_sq_add_sin_sq (t / 2)

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -970,18 +970,120 @@ This section states the existence theorems from
     $(-X)M(-X)^\dagger$.
 \end{proof}
 
-\begin{remark}[Boundary of the spinor formalization]
-    \label{rem:spinor_double_cover_pending}
-    Theorem~\ref{thm:spinor_image_special_orthochronous} proves that the
-    spinor image lies in $\mathrm{SO}^+(1,3)$ and that $X$ and $-X$ have the
-    same effect. It does not prove that every special orthochronous Lorentz
-    transformation is in the image, nor that these are the only two points
-    in each fibre. Thus the full double-cover assertion after
-    \cite[Eq.~(2.42)]{Wolf2012Quantum} remains open. The rotation and boost
-    exponential formulas in \cite[Eq.~(2.44)]{Wolf2012Quantum} also remain
-    open; neither assertion is inferred from the analogous result for
-    $\mathrm{SU}(2)$ and $\mathrm{SO}(3)$.
-\end{remark}
+\begin{definition}[Spinor covering homomorphism]
+    \label{def:spinor_cover_homomorphism}
+    \lean{Wolf.specialOrthochronousLorentzGroup, Wolf.spinorCoverHom}
+    \leanok
+    \uses{def:spinor_action_minkowski}
+    Regard $\mathrm{SO}^+(1,3)$ from
+    (\ref{eq:representations_special_orthochronous_lorentz}) as a matrix
+    group.  The spinor action defines the homomorphism
+    \begin{align}
+        \Lambda:\SL(2,\C)&\longrightarrow\mathrm{SO}^+(1,3),
+        &\Lambda(X)&=L(X).
+        \label{eq:representations_spinor_cover_hom}
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Spinor epimorphism and two-point fibres]
+    \label{thm:spinor_epimorphism_two_point_fibres}
+    \lean{Wolf.exists_sl2_spinorMatrix_eq,
+        Wolf.spinorCoverHom_surjective,
+        Wolf.spinorMatrix_eq_one_iff,
+        Wolf.spinorCoverHom_eq_iff_eq_or_eq_neg,
+        Wolf.spinorCoverHom_eq_one_iff}
+    \leanok
+    \uses{def:spinor_cover_homomorphism}
+    The homomorphism $\Lambda$ in
+    (\ref{eq:representations_spinor_cover_hom}) is surjective.  Its fibres
+    contain exactly two points: for all $X,Y\in\SL(2,\C)$,
+    \begin{align}
+        \Lambda(X)=\Lambda(Y)
+        &\iff X=Y\ \text{or}\ X=-Y,
+        &\ker\Lambda&=\{I,-I\}.
+        \label{eq:representations_spinor_two_point_fibres}
+    \end{align}
+    Thus $\SL(2,\C)$ is a double cover of $\mathrm{SO}^+(1,3)$, as stated
+    after \cite[Eq.~(2.42)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:spinor_image_special_orthochronous}
+    Given $L\in\mathrm{SO}^+(1,3)$, set $u=Le_0$.  The Lorentz identities
+    give $q(u)=1$ and $u_0>0$.  The canonical boost $B_u$, whose first column
+    is $u$, has the spinor lift
+    $P_u=(M(u)+I)/\sqrt{2(1+u_0)}$.  The matrix $B_u^{-1}L$ fixes $e_0$;
+    its Lorentz equations force the block form $1\oplus R$ with
+    $R\in\mathrm{SO}(3)$.  Lift $R$ to $U\in\mathrm{SU}(2)$.  Multiplicativity
+    then gives $\Lambda(P_uU)=B_u(1\oplus R)=L$.
+
+    If $\Lambda(X)=I$, congruence applied to $M=I$ gives $XX^\dagger=I$.
+    Congruence applied to the Pauli basis then makes $X$ commute with every
+    Pauli matrix, so $X$ is scalar.  The equation $\det X=1$ gives
+    $X=\pm I$.  Applying this kernel computation to $XY^{-1}$ proves
+    (\ref{eq:representations_spinor_two_point_fibres}).
+\end{proof}
+
+\begin{theorem}[Boost and rotation spinor exponentials]
+    \label{thm:spinor_boost_rotation_exponentials}
+    \lean{Wolf.pauliVector, Wolf.boostGenerator, Wolf.rotationGenerator,
+        Wolf.exp_smul_pauliVector, Wolf.exp_smul_boostGenerator,
+        Wolf.exp_neg_I_smul_pauliVector,
+        Wolf.exp_smul_rotationGenerator, Wolf.rapidityMinkowski,
+        Wolf.lorentzBoost_rapidityMinkowski_eq_exp,
+        Wolf.boostExpSL2, Wolf.rotationExpSL2,
+        Wolf.boostExpSL2_coe_eq_exp, Wolf.rotationExpSL2_coe_eq_exp,
+        Wolf.spinorMatrix_boostExpSL2,
+        Wolf.spinorMatrix_rotationExpSL2}
+    \leanok
+    \uses{def:spinor_cover_homomorphism}
+    Let $n\in\R^3$ be a unit vector.  Write $n\cdot\sigma$ for its Pauli
+    contraction, $n\cdot B$ for the boost generator with time--space blocks
+    $n$ and $n^{\mathsf T}$, and $n\cdot R$ for Wolf's rotation generator
+    $R_i=\sum_{j,k}\varepsilon_{ijk}\lvert k\rangle\langle j\rvert$.
+    For every $t\in\R$,
+    \begin{align}
+        \begin{aligned}
+            \exp(t\,n\cdot\sigma)
+            &=\cosh(t)I+\sinh(t)n\cdot\sigma,\\
+            \exp(t\,n\cdot B)
+            &=I+(\cosh(t)-1)(n\cdot B)^2+\sinh(t)n\cdot B,\\
+            \exp(-it\,n\cdot\sigma)
+            &=\cos(t)I-i\sin(t)n\cdot\sigma,\\
+            \exp(t\,n\cdot R)
+            &=I+(1-\cos(t))(n\cdot R)^2+\sin(t)n\cdot R.
+        \end{aligned}
+        \label{eq:representations_spinor_exponential_closed_forms}
+    \end{align}
+    If $u(n,t)=(\cosh(t),\sinh(t)n)$, then
+    $B_{u(n,t)}=\exp(t\,n\cdot B)$, and the spinor map satisfies
+    \begin{align}
+        \begin{aligned}
+            \Lambda\!\left(\exp\!\left(\frac{t}{2}n\cdot\sigma\right)\right)
+            &=\exp(t\,n\cdot B),\\
+            \Lambda\!\left(\exp\!\left(-\frac{it}{2}n\cdot\sigma\right)\right)
+            &=\exp(t\,n\cdot R).
+        \end{aligned}
+        \label{eq:representations_spinor_exponential_map}
+    \end{align}
+    The positive sign in the second Lorentz exponential is the correction to
+    the sign printed in \cite[Eq.~(2.44)]{Wolf2012Quantum}; with the displayed
+    Pauli matrices and column-vector convention, the printed negative sign
+    rotates in the opposite direction.
+\end{theorem}
+
+\begin{proof}\leanok
+    The Pauli contraction satisfies $(n\cdot\sigma)^2=I$, the boost generator
+    satisfies $(n\cdot B)^3=n\cdot B$, and the rotation generator satisfies
+    $(n\cdot R)^3=-n\cdot R$.  Splitting each exponential series into its even
+    and odd terms gives the four closed forms in
+    (\ref{eq:representations_spinor_exponential_closed_forms}).  Direct
+    substitution of $u(n,t)$ into the canonical boost gives
+    $B_{u(n,t)}=\exp(t\,n\cdot B)$.  The two half-parameter matrices have
+    determinant one, and evaluating their Pauli congruence entries with the
+    double-angle identities gives
+    (\ref{eq:representations_spinor_exponential_map}).
+\end{proof}
 
 \begin{theorem}[Pauli transfer matrix under two-sided filtering]
     \label{thm:pauli_transfer_two_sided_filtering}

--- a/docs/paper-gaps/wolf_ch2_spinor_rotation_sign.tex
+++ b/docs/paper-gaps/wolf_ch2_spinor_rotation_sign.tex
@@ -1,0 +1,82 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Rotation Sign in Wolf's Spinor Exponential Formula}
+\author{}
+\date{2026-08-24}
+
+\begin{document}
+\maketitle
+\gapnote{false-source}{resolved}
+
+\section{The printed formula}
+
+Wolf's Equation~(2.44) uses the standard Pauli matrices and defines the
+spatial rotation generators by
+\begin{align}
+  R_i &= \sum_{j,k=1}^3 \varepsilon_{ijk}\ketbra{k}{j}.
+\end{align}
+It then prints the spinor correspondence
+\begin{align}
+  U=\exp\!\left(-\frac{i}{2}\vec n\mathbin{\cdot}\vec\sigma\right)
+  \quad\longmapsto\quad
+  \exp\!\left(-\vec n\mathbin{\cdot}\vec R\right).
+  \tag{printed 2.44}
+\end{align}
+The local source is
+\path{Notes/WolfNoteTexSource/ch02_representations.tex}, lines~1070--1077.
+
+\section{The sign inconsistency}
+
+Take \(\vec n=(0,0,\theta)\).  With
+\(\sigma_2=\bigl(\begin{smallmatrix}0&-i\\ i&0\end{smallmatrix}\bigr)\)
+and the column-vector convention used in the notes,
+\begin{align}
+  e^{-i\theta\sigma_3/2}\,\sigma_1\,e^{i\theta\sigma_3/2}
+    &= \cos\theta\,\sigma_1+\sin\theta\,\sigma_2.
+\end{align}
+Thus the Pauli-coordinate vector of \(\sigma_1\) rotates toward the positive
+second coordinate.  On the other hand, the printed definition gives
+\(R_3\ket{1}=\ket{2}\), so
+\(e^{+\theta R_3}\) has this action while
+\(e^{-\theta R_3}\) rotates toward the negative second coordinate.
+The two signs in the printed correspondence therefore cannot both be correct.
+
+\section{Correction and formalization}
+
+For the displayed spinor and generators, the congruence action is
+\begin{align}
+  \exp\!\left(-\frac{i}{2}\vec n\mathbin{\cdot}\vec\sigma\right)
+  \quad\longmapsto\quad
+  \exp\!\left(+\vec n\mathbin{\cdot}\vec R\right).
+  \tag{corrected 2.44}
+\end{align}
+Equivalently, the printed negative Lorentz exponential is obtained from
+\(U=\exp(+i\vec n\cdot\vec\sigma/2)\).
+
+The corrected correspondence is formalized by
+\leanid{Wolf.spinorMatrix\_rotationExpSL2}.  The closed spinor exponential and
+Rodrigues formula are
+\leanid{Wolf.exp\_neg\_I\_smul\_pauliVector} and
+\leanid{Wolf.exp\_smul\_rotationGenerator}, respectively, all in
+\doclink{QICLean/Channel/LorentzNormalForm/SpinorExponential}.
+The positive-angle convention also agrees with the existing diagonal
+\(\mathrm{SU}(2)\) calculation \leanid{SpinCover.R\_su2Diag\_eq\_rotZ}.
+
+\section{Verdict}
+
+This is a genuine sign error in Equation~(2.44), not a change of convention in
+the formalization: the Pauli matrices, the displayed generators, and the
+column-vector action are all fixed explicitly by the source.  The boost half
+of Equation~(2.44) is unaffected.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -361,6 +361,51 @@ that Wolf's intended spectrum-preserver argument is false. The two displayed
 values contain the transition-probability information used in that argument;
 the characteristic polynomial records the complete multiplicity data.
 
+\section{The rotation sign in the spinor exponential formula}
+\label{sec:spinor-rotation-sign}
+
+\paragraph{Formalization trigger.}
+The rotation exponential is formalized as
+\leanid{Wolf.spinorMatrix\_rotationExpSL2} in
+\doclink{QICLean/Channel/LorentzNormalForm/SpinorExponential}.  The discrepancy
+is documented in
+\path{docs/paper-gaps/wolf_ch2_spinor_rotation_sign.tex}.
+
+\paragraph{Printed source and its role.}
+Wolf's Equation~(2.44), in
+\path{Notes/WolfNoteTexSource/ch02_representations.tex}, lines~1070--1077,
+defines
+\begin{equation}
+  R_i=\sum_{j,k=1}^3\varepsilon_{ijk}\ketbra{k}{j}
+\end{equation}
+and prints
+\begin{equation}
+  e^{-i\vec n\cdot\vec\sigma/2}\longmapsto e^{-\vec n\cdot\vec R}.
+\end{equation}
+
+\paragraph{Correction.}
+With the standard Pauli matrices and column-vector convention used in the
+notes, the corrected correspondence is
+\begin{equation}
+  e^{-i\vec n\cdot\vec\sigma/2}\longmapsto e^{+\vec n\cdot\vec R}.
+\end{equation}
+Equivalently, the printed Lorentz exponential corresponds to the spinor with
+opposite sign in its exponent.
+
+\paragraph{Why the correction is necessary.}
+For \(\vec n=(0,0,\theta)\), direct Pauli conjugation gives
+\begin{equation}
+  e^{-i\theta\sigma_3/2}\sigma_1e^{i\theta\sigma_3/2}
+   =\cos\theta\,\sigma_1+\sin\theta\,\sigma_2.
+\end{equation}
+The printed generator satisfies \(R_3\ket{1}=\ket{2}\), so this is the action
+of \(e^{+\theta R_3}\), whereas \(e^{-\theta R_3}\) rotates toward the
+negative second coordinate.
+
+\paragraph{Classification.}
+This is a genuine source sign error.  The formal theorem follows the actual
+congruence action; the boost formula in the same equation is unchanged.
+
 \section{The two boundary errors in Theorem~6.3}
 \label{sec:theorem-6-3}
 

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -373,17 +373,30 @@ so that the cited formal statements are available from the main project import.
 * `Wolf.spinorMatrix_isSpecialOrthochronousLorentz` — the spinor image obeys
   all three conditions printed in Equation (2.42): determinant one,
   `L η Lᵀ = η`, and `L₀₀ > 0` ✓
-* `Wolf.spinorMatrix_neg` — `X` and `-X` induce the same congruence action ✓.
-  Surjectivity onto `SO⁺(1,3)` and the assertion that every fibre has exactly
-  these two elements remain pending
+* `Wolf.spinorMatrix_neg` — `X` and `-X` induce the same congruence action ✓
+* `Wolf.specialOrthochronousLorentzGroup` / `Wolf.spinorCoverHom` — the
+  special orthochronous Lorentz matrices as a group and the bundled
+  homomorphism `SL(2, ℂ) →* SO⁺(1,3)` ✓
+* `Wolf.exists_sl2_spinorMatrix_eq` / `Wolf.spinorCoverHom_surjective` — every
+  special orthochronous Lorentz matrix has a spinor preimage, constructed by
+  the canonical boost followed by an `SU(2)` lift of the residual `SO(3)`
+  rotation ✓
+* `Wolf.spinorCoverHom_eq_iff_eq_or_eq_neg` /
+  `Wolf.spinorCoverHom_eq_one_iff` — every fibre is exactly `{X, -X}` and the
+  kernel is exactly `{1, -1}` ✓
 * `Wolf.pauliTransferMatrix_two_sided_filtering` — Equation (2.43) over the
   complex Pauli transfer matrix, in the exact order `L₂ T̂ L₁` ✓
 * `Wolf.coe_pauliTransferMatrixReal_of_preservesHermiticity` /
   `Wolf.pauliTransferMatrixReal_slFiltering` — identification with the real
   transfer matrix for Hermiticity-preserving maps and the bundled
   `SLFiltering` specialization of Equation (2.43) ✓
-* **Equation (2.44)** (rotation and boost exponential formulas) remains
-  pending and is not inferred from the three-dimensional `SU(2)` spin cover
+* `Wolf.spinorMatrix_boostExpSL2` — the boost formula in Equation (2.44),
+  `exp(t n·σ/2) ↦ exp(t n·B)`, including the identification of the Lorentz
+  exponential with the canonical rapidity boost ✓
+* `Wolf.spinorMatrix_rotationExpSL2` — the rotation formula in Equation
+  (2.44), with the corrected congruence-action sign
+  `exp(-i t n·σ/2) ↦ exp(+t n·R)` ✓. Wolf's printed negative Lorentz sign is
+  documented in `docs/paper-gaps/wolf_ch2_spinor_rotation_sign.tex`
 * `IsLorentzDiagonal` — diagonal Lorentz normal form (Wolf Proposition 2.11 case 1) ✓
 * `IsLorentzNonDiagonal` — non-diagonal Lorentz normal form (case 2) ✓
 * `IsLorentzSingular` — singular Lorentz normal form (case 3) ✓
@@ -472,6 +485,12 @@ so that the cited formal statements are available from the main project import.
   `Wolf.det_pauliMatrixOfMinkowski` |
 | Spinor Lorentz action | `LorentzNormalForm/SpinorAction.lean` |
   `Wolf.spinorMatrix_isSpecialOrthochronousLorentz` |
+| Spinor epimorphism and exact two-point fibres |
+  `LorentzNormalForm/SpinorCover.lean` |
+  `Wolf.spinorCoverHom_surjective`, `Wolf.spinorCoverHom_eq_iff_eq_or_eq_neg` |
+| Spinor boost and rotation exponentials |
+  `LorentzNormalForm/SpinorExponential.lean` |
+  `Wolf.spinorMatrix_boostExpSL2`, `Wolf.spinorMatrix_rotationExpSL2` |
 | Filtered Pauli transfer action | `LorentzNormalForm/SpinorAction.lean` |
   `Wolf.pauliTransferMatrixReal_slFiltering` |
 | Diagonal Lorentz form | `LorentzNormalForm.lean` | `IsLorentzDiagonal` |
@@ -497,10 +516,6 @@ so that the cited formal statements are available from the main project import.
   available. The proof still needs the Lorentz-orbit classification, the
   necessity of the parameter bounds, and the final trace-preserving
   normalization. |
-| Section 2.4 full spinor double cover and Equation (2.44) | Image inclusion,
-  multiplicativity, and the equality `L(-X) = L(X)` are available. Surjectivity,
-  exact two-point fibres, and the rotation/boost exponential formulas remain
-  pending. |
 | Section 2.4 Sorted singular values | Current SVD is unsorted; later uses want sorted values |
 
 ### References


### PR DESCRIPTION
## Summary

- bundle the concrete spinor homomorphism $\mathrm{SL}(2,\mathbb C) \to \mathrm{SO}^+(1,3)$ and prove surjectivity by Wolf's canonical boost--rotation decomposition
- transfer the reviewed $\mathrm{SU}(2) \to \mathrm{SO}(3)$ Euler-angle cover, construct the Lorentz boost lift, and prove the exact fibres $L_X=L_Y \iff X=Y$ or $X=-Y$
- prove the boost and rotation exponential formulas in Wolf Eq. (2.44), using the corrected positive Lorentz rotation sign, and document the printed sign mismatch
- synchronize the blueprint, Wolf numbering coverage, module aggregators, and lecture-note errata

## Verification

- `lake env lean QICLean/Channel/LorentzNormalForm/SpinorExponential.lean`
- `lake build QICLean.Channel.LorentzNormalForm.SpinorExponential QICLean.Channel.LorentzNormalForm QICLean.Channel QICLean`
- `leanblueprint pdf`
- `leanblueprint web`
- `leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --diff-base origin/main --changed-files QICLean/Channel/LorentzNormalForm/SpinorExponential.lean QICLean/Channel/LorentzNormalForm.lean QICLean/Channel.lean`
- `texra-blueprint --root . paper-gaps check`
- targeted `#print axioms` audit: only `propext`, `Classical.choice`, and `Quot.sound`
- forbidden-token scan: no `sorry`, `admit`, `native_decide`, `unsafeCast`, or new `axiom`

Closes #377
