### PR TITLE
feat(channel): prove rectangular Schmidt-number map criterion

### DIFF
--- a/QICLean/Channel/PositiveMapDetection.lean
+++ b/QICLean/Channel/PositiveMapDetection.lean
@@ -19,18 +19,15 @@ This file supplies the two correspondence steps that turn the witness into an
 
 ## The Choi correspondence as a linear isomorphism
 
-The Choi map `T ↦ τ = (T ⊗ id)(|Ω⟩⟨Ω|)` is a complex-linear map between the
-superoperator space `M_D(ℂ) → M_D(ℂ)` and the bipartite matrix space
-`M_{D·D}(ℂ)`.  Both spaces have complex dimension `D⁴`, and the map is injective
-(`ChoiJamiolkowski.choiMatrix_injective`), hence surjective: every bipartite matrix is the
-Choi matrix of a unique superoperator.  In particular the Hermitian witness `W` is the
-Choi matrix of some superoperator `T`.
+The rectangular Choi correspondence assigns to every operator on
+`ℂ^d ⊗ ℂ^{d'}` the map `P : M_{d'}(ℂ) → M_d(ℂ)` recovered by Wolf's inverse formula,
+`ChoiRectangular.mapOfChoiMatrix`. In particular the Hermitian witness `W` is the
+Choi matrix of a unique dimension-changing superoperator.
 
 ## The witness condition as the `n`-positivity criterion
 
-The `n`-positivity criterion
-`ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg`
-phrases `n`-positivity of `T` as nonnegativity of the Choi quadratic form
+The rectangular Schmidt-rank Choi criterion phrases `n`-positivity of `T` as
+nonnegativity of the Choi quadratic form
 `⟨ψ| τ |ψ⟩ = star ψ ⬝ᵥ (τ *ᵥ ψ)` over vectors ψ of Schmidt rank at most `n`.  For `τ = W`
 this quadratic form equals the witness expectation `Re tr(W |ψ⟩⟨ψ|)` (a real number, `W`
 being Hermitian), which the witness condition makes nonnegative.  So the superoperator
@@ -38,17 +35,17 @@ whose Choi matrix is the witness is `n`-positive.
 
 ## Detection through the trace-pairing adjoint
 
-The entanglement witness has negative expectation `Re tr(W ρ)` on ρ.  Writing `W = τ_T`
-and pushing `T` across the trace pairing of the ampliation onto its trace-pairing adjoint
-`T*` (`Matrix.trace_traceAdjointMap_mul`) turns this expectation into the Choi-vector
-quadratic form of the ampliation of `T*`:
+The entanglement witness has negative expectation `Re tr(W ρ)` on ρ. Writing `W = τ_P`
+and pushing `P` across the trace pairing of the ampliation onto its trace-pairing adjoint
+`P*` (`Matrix.trace_traceAdjointMap_mul`) turns this expectation into the Choi-vector
+quadratic form of the ampliation of `P*`:
 
-  `tr(W ρ) = ⟨Ω| (T* ⊗ id)(ρ) |Ω⟩`.
+  `tr(W ρ) = ⟨Ω| (P* ⊗ id)(ρ) |Ω⟩`.
 
 The trace-pairing adjoint of an `n`-positive map is again `n`-positive
-(`IsNPositiveMap.traceAdjointMap`), so `T*` is the `n`-positive map detecting ρ: the
-negative real part of `tr(W ρ)` forces `⟨Ω| (T* ⊗ id)(ρ) |Ω⟩` to have negative real part,
-which a positive semidefinite matrix cannot, so `(T* ⊗ id)(ρ)` is not positive
+(`IsNPositiveMap.traceAdjointMap`), so `P*` is the `n`-positive map detecting ρ: the
+negative real part of `tr(W ρ)` forces `⟨Ω| (P* ⊗ id)(ρ) |Ω⟩` to have negative real part,
+which a positive semidefinite matrix cannot, so `(P* ⊗ id)(ρ)` is not positive
 semidefinite.
 
 ## Main results
@@ -62,13 +59,17 @@ semidefinite.
   trace pairing of the Choi matrix with ρ equals the Choi-vector quadratic form of the
   trace-pairing-adjoint ampliation.
 * `Matrix.exists_isNPositiveMap_tensorMapId_not_posSemidef`: **Wolf Proposition 3.4 (if
-  direction)** — a trace-one Hermitian state of Schmidt number larger than `n` is detected
-  by an `n`-positive map whose ampliation makes the state not positive semidefinite.
+  direction)** — a trace-one Hermitian state on `ℂ^d ⊗ ℂ^{d'}` of Schmidt number larger
+  than `n` is detected by an `n`-positive map `M_d(ℂ) → M_{d'}(ℂ)`.
+* `Matrix.hasSchmidtNumberLE_iff_forall_isNPositiveMap_tensorMapId_posSemidef`:
+  **Wolf Proposition 3.4** — the rectangular source equivalence, combining the detector
+  with the general forward theorem.
 
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
-  Section 3.2, Proposition 3.4][Wolf2012QChannels]
+  Section 3.2, Proposition 3.4, lines 250--267, especially Equations (3.13)--(3.14)]
+  [Wolf2012QChannels]
 -/
 
 open scoped Matrix ComplexOrder
@@ -76,42 +77,22 @@ open Matrix
 
 namespace ChoiJamiolkowski
 
-variable {D : ℕ}
+variable {D d d' : ℕ}
 
 /-! ## Surjectivity of the Choi map -/
 
 /-- **The Choi map is surjective.**  Every bipartite matrix `W` on `M_{D·D}(ℂ)` is the
 Choi matrix `(T ⊗ id)(|Ω⟩⟨Ω|)` of some superoperator `T : M_D(ℂ) → M_D(ℂ)`.
 
-The Choi map is complex-linear (`choiMatrixLinearMap`) and injective
-(`choiMatrix_injective`); its domain (superoperators on `M_D(ℂ)`) and codomain
-(bipartite matrices on `M_{D·D}(ℂ)`) have equal complex dimension `D⁴`, so injectivity
-forces surjectivity. -/
+This square compatibility theorem now delegates to the explicit inverse
+`ChoiRectangular.mapOfChoiMatrix`, rather than recovering surjectivity indirectly from
+finite-dimensional dimension counting. -/
 theorem exists_choiMatrix_eq [NeZero D]
     (W : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) :
     ∃ T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ, choiMatrix T = W := by
-  -- Domain and codomain have equal complex dimension `D⁴`.
-  have hdom :
-      Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-        = D ^ 4 := by
-    rw [Module.finrank_linearMap, Module.finrank_matrix, Module.finrank_self,
-      Fintype.card_fin, mul_one]
-    ring
-  have hcod :
-      Module.finrank ℂ (Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) = D ^ 4 := by
-    rw [Module.finrank_matrix, Module.finrank_self, Fintype.card_prod, Fintype.card_fin,
-      mul_one]
-    ring
-  have hdim :
-      Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-        = Module.finrank ℂ (Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) := by
-    rw [hdom, hcod]
-  -- `choiMatrixLinearMap` is injective, so (equal finite dimensions) surjective.
-  have hinj : Function.Injective (choiMatrixLinearMap (D := D)) := choiMatrix_injective
-  have hsurj : Function.Surjective (choiMatrixLinearMap (D := D)) :=
-    (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hdim).1 hinj
-  obtain ⟨T, hT⟩ := hsurj W
-  exact ⟨T, hT⟩
+  refine ⟨ChoiRectangular.mapOfChoiMatrix W, ?_⟩
+  simpa only [ChoiRectangular.choiMatrix_eq_choiJamiolkowski] using
+    ChoiRectangular.choiMatrix_mapOfChoiMatrix W
 
 /-! ## The witness as the Choi matrix of an `n`-positive map -/
 
@@ -123,32 +104,37 @@ any matrix `W` and any vector ψ,
 This is the algebraic identity matching the entanglement-witness condition to the Choi
 `n`-positivity criterion. -/
 theorem trace_mul_vecMulVec_eq_dotProduct
-    (W : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) (ψ : Fin D × Fin D → ℂ) :
+    {ι : Type*} [Fintype ι]
+    (W : Matrix ι ι ℂ) (ψ : ι → ℂ) :
     (W * Matrix.vecMulVec ψ (star ψ)).trace = star ψ ⬝ᵥ (W *ᵥ ψ) := by
+  classical
   rw [Matrix.mul_vecMulVec, Matrix.trace_vecMulVec, dotProduct_comm]
 
-/-- **A Schmidt-`n` entanglement witness is the Choi matrix of an `n`-positive map.**
-A Hermitian operator `W` whose expectation on every pure state of Schmidt rank at most `n`
-is nonnegative is the Choi matrix `(T ⊗ id)(|Ω⟩⟨Ω|)` of an `n`-positive map `T`.
+/-- **A Schmidt-`n` entanglement witness is the rectangular Choi matrix of an
+`n`-positive map.** A Hermitian operator `W` on `ℂ^d ⊗ ℂ^{d'}` whose expectation
+on every pure state of Schmidt rank at most `n` is nonnegative is the Choi matrix
+of an `n`-positive map `P : M_{d'}(ℂ) → M_d(ℂ)`.
 
 This is the Choi–Jamiołkowski translation of the entanglement-witness criterion (Wolf
-Proposition 3.3) into an `n`-positive map (the map of Wolf Proposition 3.4).  Surjectivity
-of the Choi map (`exists_choiMatrix_eq`) gives a superoperator `T` with `choiMatrix T = W`;
-the witness condition `0 ≤ Re tr(W |ψ⟩⟨ψ|)`, which on the Hermitian `W` is the full
+Proposition 3.3) into the map `P = T*` of Wolf Proposition 3.4, Equation (3.13).
+The inverse Choi assignment `ChoiRectangular.mapOfChoiMatrix` gives `P` with
+`ChoiRectangular.choiMatrix P = W`; the witness condition
+`0 ≤ Re tr(W |ψ⟩⟨ψ|)`, which on the Hermitian `W` is the full
 (real, nonnegative) Choi quadratic form `0 ≤ star ψ ⬝ᵥ (W *ᵥ ψ)`, is exactly the
-`n`-positivity criterion for `T`. -/
-theorem exists_isNPositiveMap_choiMatrix_eq_of_witness [NeZero D] {n : ℕ}
-    {W : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hWherm : W.IsHermitian)
-    (hWpos : ∀ ψ : Fin D × Fin D → ℂ, Matrix.HasSchmidtRankLE n ψ →
+`n`-positivity criterion for `P`. -/
+theorem exists_isNPositiveMap_choiMatrix_eq_of_witness [NeZero d'] {n : ℕ}
+    {W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} (hWherm : W.IsHermitian)
+    (hWpos : ∀ ψ : Fin d × Fin d' → ℂ, Matrix.HasSchmidtRankLE n ψ →
       0 ≤ (W * Matrix.vecMulVec ψ (star ψ)).trace.re) :
-    ∃ T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
-      IsNPositiveMap n T ∧ choiMatrix T = W := by
-  obtain ⟨T, hT⟩ := exists_choiMatrix_eq W
-  refine ⟨T, ?_, hT⟩
-  rw [isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg]
+    ∃ P : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ,
+      IsNPositiveMap n P ∧ ChoiRectangular.choiMatrix P = W := by
+  let P := ChoiRectangular.mapOfChoiMatrix W
+  refine ⟨P, ?_, ChoiRectangular.choiMatrix_mapOfChoiMatrix W⟩
+  rw [isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg_rectangular]
   intro ψ hψ
   -- The Choi quadratic form for ψ is the witness expectation, a nonnegative real.
-  rw [hT]
+  rw [show ChoiRectangular.choiMatrix P = W from
+    ChoiRectangular.choiMatrix_mapOfChoiMatrix W]
   have hreal : (W * Matrix.vecMulVec ψ (star ψ)).trace = star ψ ⬝ᵥ (W *ᵥ ψ) :=
     trace_mul_vecMulVec_eq_dotProduct W ψ
   -- `star ψ ⬝ᵥ (W *ᵥ ψ)` is real (W Hermitian) with nonnegative real part.
@@ -162,33 +148,37 @@ theorem exists_isNPositiveMap_choiMatrix_eq_of_witness [NeZero D] {n : ℕ}
 
 /-! ## Detection through the trace-pairing adjoint -/
 
-/-- The trace pairing of the Choi matrix with ρ is the Choi-vector quadratic form of the
-trace-pairing-adjoint ampliation:
+/-- The trace pairing of the rectangular Choi matrix of
+`P : M_{d'}(ℂ) → M_d(ℂ)` with `ρ` on `ℂ^d ⊗ ℂ^{d'}` is the quadratic form of
+the trace-pairing-adjoint ampliation on the maximally entangled vector of the
+`d'`-dimensional factor:
 
-  `tr(τ_T ρ) = ⟨Ω| (T* ⊗ id)(ρ) |Ω⟩`.
+  `tr(τ_P ρ) = ⟨Ω| (P* ⊗ id)(ρ) |Ω⟩`.
 
-Here `T*` is the trace-pairing adjoint (`Matrix.traceAdjointMap`).  The identity moves `T`
-across the trace pairing of its `id`-ampliation (`Matrix.trace_traceAdjointMap_mul`,
+Here `P*` is the trace-pairing adjoint (`Matrix.traceAdjointMap`). The identity moves `P`
+across the trace pairing of its `id_{d'}`-ampliation (`Matrix.trace_traceAdjointMap_mul`,
 together with `nPositiveAmpliation_traceAdjointMap`) and reads the result as the quadratic
-form of `(T* ⊗ id)(ρ)` on the maximally entangled vector, using
-`τ_T = (T ⊗ id)(|Ω⟩⟨Ω|)` and `|Ω⟩⟨Ω| = |Ω⟩⟨Ω|`. -/
+form of `(P* ⊗ id_{d'})(ρ)` on `Ω_{d'}`. This is Wolf, Chapter 3,
+Equation (3.14), lines 262--265, with the factor order of Equation (3.13). -/
 theorem trace_choiMatrix_mul_eq_omegaVec_quadraticForm_traceAdjointMap
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) :
-    (choiMatrix T * ρ).trace
-      = star (omegaVec D) ⬝ᵥ (tensorMapId (Matrix.traceAdjointMap T) ρ *ᵥ omegaVec D) := by
-  -- `tr(τ_T ρ) = tr(ρ (T ⊗ id)(|Ω⟩⟨Ω|))`.
-  have h1 : (choiMatrix T * ρ).trace = (ρ * tensorMapId T (omegaProj D)).trace := by
-    rw [choiMatrix, Matrix.trace_mul_comm]
-  -- Move `T` onto its trace-pairing adjoint across the ampliation trace pairing.
-  have h2 : (ρ * tensorMapId T (omegaProj D)).trace
-      = (tensorMapId (Matrix.traceAdjointMap T) ρ * omegaProj D).trace := by
-    rw [tensorMapId_eq_nPositiveAmpliation T (omegaProj D),
-      show tensorMapId (Matrix.traceAdjointMap T) ρ
-          = nPositiveAmpliation D (Matrix.traceAdjointMap T) ρ from
+    (P : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ)
+    (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    (ChoiRectangular.choiMatrix P * ρ).trace =
+      star (omegaVec d') ⬝ᵥ
+        (tensorMapId (Matrix.traceAdjointMap P) ρ *ᵥ omegaVec d') := by
+  -- `tr(τ_P ρ) = tr(ρ (P ⊗ id)(|Ω⟩⟨Ω|))`.
+  have h1 : (ChoiRectangular.choiMatrix P * ρ).trace =
+      (ρ * tensorMapId P (omegaProj d')).trace := by
+    rw [ChoiRectangular.choiMatrix, Matrix.trace_mul_comm]
+  -- Move `P` onto its trace-pairing adjoint across the ampliation trace pairing.
+  have h2 : (ρ * tensorMapId P (omegaProj d')).trace =
+      (tensorMapId (Matrix.traceAdjointMap P) ρ * omegaProj d').trace := by
+    rw [tensorMapId_eq_nPositiveAmpliation P (omegaProj d'),
+      show tensorMapId (Matrix.traceAdjointMap P) ρ =
+          nPositiveAmpliation d' (Matrix.traceAdjointMap P) ρ from
         tensorMapId_eq_nPositiveAmpliation _ _,
       nPositiveAmpliation_traceAdjointMap,
-      Matrix.trace_traceAdjointMap_mul (nPositiveAmpliation D T) ρ (omegaProj D),
+      Matrix.trace_traceAdjointMap_mul (nPositiveAmpliation d' P) ρ (omegaProj d'),
       Matrix.trace_mul_comm]
   -- `tr(Y |Ω⟩⟨Ω|) = ⟨Ω| Y |Ω⟩`.
   rw [h1, h2, omegaProj, trace_mul_vecMulVec_eq_dotProduct]
@@ -199,10 +189,10 @@ namespace Matrix
 
 open ChoiJamiolkowski
 
-/-- **Positive maps detect high Schmidt number** (Wolf §3.2, Proposition 3.4, if
-direction).  A trace-one Hermitian bipartite state ρ on `ℂ^D ⊗ ℂ^D` of Schmidt number
-larger than `n` is detected by an `n`-positive map `T`: the ampliation `(T ⊗ id)(ρ)` is not
-positive semidefinite.
+/-- **Positive maps detect high Schmidt number** (Wolf §3.2, Proposition 3.4,
+lines 250--267, if direction). A trace-one Hermitian bipartite state `ρ` on
+`ℂ^d ⊗ ℂ^{d'}` of Schmidt number larger than `n` is detected by an `n`-positive
+map `T : M_d(ℂ) → M_{d'}(ℂ)`: `(T ⊗ id_{d'})(ρ)` is not positive semidefinite.
 
 The entanglement witness `W` of Wolf Proposition 3.3 (`Matrix.exists_isHermitian_witness`)
 is the Choi matrix of an `n`-positive map `P` (`exists_isNPositiveMap_choiMatrix_eq_of_witness`).
@@ -212,10 +202,10 @@ and the trace identity
 expectation `Re tr(W ρ) < 0` into a negative real part of `⟨Ω| (T ⊗ id)(ρ) |Ω⟩`.  A
 positive semidefinite matrix has nonnegative quadratic forms, so `(T ⊗ id)(ρ)` is not
 positive semidefinite. -/
-theorem exists_isNPositiveMap_tensorMapId_not_posSemidef [NeZero D] (n : ℕ)
-    {ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
+theorem exists_isNPositiveMap_tensorMapId_not_posSemidef [NeZero d'] (n : ℕ)
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
     (hρH : ρ.IsHermitian) (hρtr : ρ.trace = 1) (hρ : ¬ HasSchmidtNumberLE n ρ) :
-    ∃ T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
+    ∃ T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ,
       IsNPositiveMap n T ∧ ¬ (tensorMapId T ρ).PosSemidef := by
   -- The entanglement witness for ρ.
   obtain ⟨W, hWherm, hWρ, hWpos⟩ := exists_isHermitian_witness n hρH hρtr hρ
@@ -226,13 +216,37 @@ theorem exists_isNPositiveMap_tensorMapId_not_posSemidef [NeZero D] (n : ℕ)
   refine ⟨Matrix.traceAdjointMap P, hPpos.traceAdjointMap, ?_⟩
   intro hPSD
   -- A positive semidefinite matrix has a nonnegative Choi-vector quadratic form.
-  have hquad : 0 ≤ star (omegaVec D) ⬝ᵥ
-      (tensorMapId (Matrix.traceAdjointMap P) ρ *ᵥ omegaVec D) :=
-    hPSD.dotProduct_mulVec_nonneg (omegaVec D)
+  have hquad : 0 ≤ star (omegaVec d') ⬝ᵥ
+      (tensorMapId (Matrix.traceAdjointMap P) ρ *ᵥ omegaVec d') :=
+    hPSD.dotProduct_mulVec_nonneg (omegaVec d')
   -- But that quadratic form is `tr(W ρ)`, whose real part is negative.
   have hid := trace_choiMatrix_mul_eq_omegaVec_quadraticForm_traceAdjointMap P ρ
   rw [hPchoi] at hid
   rw [← hid] at hquad
   exact absurd ((Complex.nonneg_iff.mp hquad).1) (not_le.mpr hWρ)
+
+/-- **Wolf's rectangular positive-map characterization of Schmidt number**
+(Chapter 3, Proposition 3.4, lines 250--267). A density operator `ρ` on
+`ℂ^d ⊗ ℂ^{d'}` has Schmidt number at most `n` if and only if every `n`-positive
+map `T : M_d(ℂ) → M_{d'}(ℂ)` keeps `(T ⊗ id_{d'})(ρ)` positive semidefinite.
+
+The forward implication is `HasSchmidtNumberLE.tensorMapId_posSemidef`. For the
+converse, Equations (3.13)--(3.14) turn the entanglement witness for `ρ` into the
+Choi matrix of `P : M_{d'} → M_d`, and `T = P*` detects `ρ` on `omegaVec d'`. -/
+theorem hasSchmidtNumberLE_iff_forall_isNPositiveMap_tensorMapId_posSemidef
+    [NeZero d] [NeZero d'] (n : ℕ)
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hρ : ρ.PosSemidef) (hρtr : ρ.trace = 1) :
+    HasSchmidtNumberLE n ρ ↔
+      ∀ T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ,
+        IsNPositiveMap n T → (tensorMapId T ρ).PosSemidef := by
+  constructor
+  · intro hsn T hT
+    exact hsn.tensorMapId_posSemidef hT
+  · intro hT
+    by_contra hsn
+    obtain ⟨T, hTpos, hTdetects⟩ :=
+      exists_isNPositiveMap_tensorMapId_not_posSemidef n hρ.isHermitian hρtr hsn
+    exact hTdetects (hT T hTpos)
 
 end Matrix

--- a/QICLean/Channel/SchmidtNumber.lean
+++ b/QICLean/Channel/SchmidtNumber.lean
@@ -73,11 +73,8 @@ Wolf eq. (3.18) with its Schmidt-number premise.
   `T`, `(T ⊗ id)(|ψ⟩⟨ψ|) ≥ 0`.
 * `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef`: **Wolf Prop 3.4 (only if)** — a
   state of Schmidt number at most `n` has `(T ⊗ id)(ρ) ≥ 0` for every `n`-positive
-  map `T`, on the square system `ℂ^D ⊗ ℂ^D`.  The lift to a general bipartite system
-  `ℂ^d ⊗ ℂ^{d'}` with no relation between the factors lives in
-  `QICLean/Channel/SchmidtNumberFactors.lean`
-  (`Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general` and the two padding
-  directions it combines).
+  map `T : M_d(ℂ) → M_r(ℂ)`, on a general bipartite system
+  `ℂ^d ⊗ ℂ^{d'}` with independent input, output, and bystander dimensions.
 * `Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE`: the **pure-state step** at
   `T = T_n` — for ψ of Schmidt rank at most `n` (with `1 ≤ n < D`),
   `(T_n ⊗ id)(|ψ⟩⟨ψ|) ≥ 0`.
@@ -96,23 +93,17 @@ Wolf eq. (3.18) with its Schmidt-number premise.
 (complete positivity) is inherited through the maximal-overlap principle and is
 documented in `docs/paper-gaps/wolf_t_eta_top_index_scope.tex`.
 
-**Scope restriction (square system d = d' = D):** the `T_n`-specialized forward step
-and the full reduction criterion fix both tensor factors to a common dimension `D`,
-because the pure state is parametrized through the square maximally entangled vector;
-Wolf states eq. (3.18) for a general bipartite system `ℂ^d ⊗ ℂ^{d'}`, and the
-non-square case is documented in
-`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`.  The Schmidt-number
-predicate itself and its equivalence with separability carry no such restriction.
-The bare positive-semidefiniteness of the ampliation `(T ⊗ id)(ρ) ≥ 0` carries no
-restriction relating the two factors: the general forms live in
-`QICLean/Channel/SchmidtNumberFactors.lean`, holding for any second factor `d'` by
-padding the second factor when `d' ≤ d` and padding the first factor while extending
-`T` when `d ≤ d'`.
+**Scope restriction (square system d = d' = D):** only the `T_n`-specialized reduction
+criterion below fixes both tensor factors to a common dimension `D`. The bare
+positive-semidefiniteness of `(T ⊗ id)(ρ)` is rectangular in the map and general in
+the bystander dimension at `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef`.
+The later padding declarations in `QICLean/Channel/SchmidtNumberFactors.lean` remain
+as compatibility results for the reduction-criterion development.
 
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
-  Section 3.2, the *Detecting entanglement* paragraph and Example 3.1,
+  Section 3.2, Proposition 3.4, lines 250--267, and the later reduction criterion,
   equation (3.18)][Wolf2012QChannels]
 -/
 
@@ -120,6 +111,8 @@ open scoped BigOperators Matrix ComplexOrder MatrixOrder Kronecker
 open Matrix
 
 namespace Matrix
+
+open ChoiJamiolkowski
 
 variable {d d' D : ℕ}
 
@@ -330,12 +323,12 @@ theorem hasSchmidtNumberLE_one_iff_isSeparable
 
 /-! ## The forward reduction step -/
 
-/-- The full `id`-ampliation `tensorMapId T` on `M_D ⊗ M_D` coincides with the
-`D`-fold blockwise ampliation `nPositiveAmpliation D T`: both apply `T` to the
+/-- The full `id`-ampliation `tensorMapId T` on `M_d ⊗ M_k` coincides with the
+`k`-fold blockwise ampliation `nPositiveAmpliation k T`: both apply `T` to the
 `(i₂, j₂)` block and read off the `(i₁, j₁)` entry. -/
 theorem tensorMapId_eq_nPositiveAmpliation
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (X : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) :
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (X : Matrix (Fin d × Fin D) (Fin d × Fin D) ℂ) :
     tensorMapId T X = nPositiveAmpliation D T X := by
   -- Both sides unfold to `T` applied entrywise to the second tensor block while the
   -- first block index is carried through, so the two ampliations are definitionally
@@ -346,11 +339,12 @@ theorem tensorMapId_eq_nPositiveAmpliation
 factor: the pulled-back vector has Schmidt rank at most the rank of the right-factor
 matrix `X` (not merely at most the number of its columns). -/
 theorem rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE_rank {k : ℕ}
-    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
+    (X : Matrix (Fin d) (Fin k) ℂ) (η : Fin d' × Fin k → ℂ) :
     HasSchmidtRankLE X.rank
-      ((ChoiJamiolkowski.rightTensorMatrix X)ᴴ *ᵥ η) := by
+      ((ChoiJamiolkowski.rightTensorMatrix (d' := d') X)ᴴ *ᵥ η) := by
   have hrank :
-      (schmidtCoeffMatrix ((ChoiJamiolkowski.rightTensorMatrix X)ᴴ *ᵥ η)).rank
+      (schmidtCoeffMatrix
+        ((ChoiJamiolkowski.rightTensorMatrix (d' := d') X)ᴴ *ᵥ η)).rank
         ≤ X.rank := by
     rw [ChoiJamiolkowski.schmidtCoeffMatrix_rightTensorMatrix_conjTranspose_mulVec]
     calc
@@ -360,30 +354,24 @@ theorem rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE_rank {k : ℕ}
   simpa [HasSchmidtRankLE, schmidtRank] using hrank
 
 /-- **Positive maps and entanglement, only-if direction, pure-state step**
-(Wolf §3.2, Prop 3.4).  For a pure state `|ψ⟩⟨ψ|` with ψ of Schmidt rank at most `n`
-and any `n`-positive map `T`, the ampliation `(T ⊗ id)(|ψ⟩⟨ψ|)` is positive
-semidefinite.
+(Wolf §3.2, Proposition 3.4, lines 250--267). For a pure state `|ψ⟩⟨ψ|` on
+`ℂ^d ⊗ ℂ^k` with ψ of Schmidt rank at most `n` and any `n`-positive map
+`T : M_d(ℂ) → M_{d'}(ℂ)`, the ampliation `(T ⊗ id_k)(|ψ⟩⟨ψ|)` is positive
+semidefinite on `ℂ^{d'} ⊗ ℂ^k`.
 
-Writing ψ through the maximally entangled vector as a square right-factor matrix `X`
+Writing ψ through the maximally entangled vector as a rectangular right-factor matrix `X`
 of rank equal to the Schmidt rank of ψ, the ampliation is the right-factor Choi
 compression of `T` by `X`.  Its quadratic form on any vector is the Choi quadratic
 form of `T` on a vector of Schmidt rank at most the rank of `X`, hence at most `n`;
-the `n`-positivity of `T` makes that form nonnegative.
-
-**Scope restriction (square system d = d' = D):** both tensor factors are fixed to a
-common dimension `D`, because the pure state is parametrized through the square
-maximally entangled vector (`ChoiJamiolkowski.exists_squareCompression_of_vector`).
-Wolf states the criterion for a general bipartite system `ℂ^d ⊗ ℂ^{d'}`; the
-non-square case is documented in
-`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
-theorem tensorMapId_posSemidef_of_hasSchmidtRankLE [NeZero D] {n : ℕ}
-    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (hTpos : IsNPositiveMap n T) {ψ : Fin D × Fin D → ℂ} (hψ : HasSchmidtRankLE n ψ) :
+the `n`-positivity of `T` makes that form nonnegative. -/
+theorem tensorMapId_posSemidef_of_hasSchmidtRankLE [NeZero d] {n : ℕ}
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hTpos : IsNPositiveMap n T) {ψ : Fin d × Fin D → ℂ} (hψ : HasSchmidtRankLE n ψ) :
     (tensorMapId T (vecMulVec ψ (star ψ))).PosSemidef := by
   classical
-  -- Express ψ as a square compression of the maximally entangled vector.
+  -- Express ψ as a rectangular compression of the maximally entangled vector.
   obtain ⟨X, hXvec, hXrank⟩ :=
-    ChoiJamiolkowski.exists_squareCompression_of_vector (D := D) ψ
+    ChoiJamiolkowski.exists_compression_of_vector ψ
   have hXrank_le : X.rank ≤ n := by rw [hXrank]; exact hψ
   -- The ampliation of the pure state is the right-factor Choi compression.
   have hcomp :
@@ -394,28 +382,28 @@ theorem tensorMapId_posSemidef_of_hasSchmidtRankLE [NeZero D] {n : ℕ}
   -- Positivity via the Choi quadratic form on Schmidt-rank-≤n vectors.
   refine posSemidef_of_dotProduct_mulVec_nonneg_complex ?_
   intro η
-  rw [ChoiJamiolkowski.rightCompression_quadraticForm_eq_choiMatrix_quadraticForm]
+  rw [ChoiJamiolkowski.rightCompression_quadraticForm_eq_choiMatrix_quadraticForm_rectangular]
   have hrank :
-      HasSchmidtRankLE n ((ChoiJamiolkowski.rightTensorMatrix X)ᴴ *ᵥ η) :=
+      HasSchmidtRankLE n
+        ((ChoiJamiolkowski.rightTensorMatrix (d' := d') X)ᴴ *ᵥ η) :=
     (rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE_rank X η).mono hXrank_le
   exact
-    ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg.mp
+    isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg_rectangular.mp
       hTpos _ hrank
 
-/-- **Positive maps and entanglement, only-if direction** (Wolf §3.2, Prop 3.4).  A
-bipartite state of Schmidt number at most `n` satisfies `(T ⊗ id)(ρ) ≥ 0` for every
-`n`-positive map `T`.
+/-- **Positive maps and entanglement, only-if direction** (Wolf §3.2,
+Proposition 3.4, lines 250--267). A bipartite state on `ℂ^d ⊗ ℂ^k` of Schmidt
+number at most `n` satisfies `(T ⊗ id_k)(ρ) ≥ 0` for every `n`-positive map
+`T : M_d(ℂ) → M_{d'}(ℂ)`.
 
 The state is a finite sum of pure-state projectors of Schmidt rank at most `n`; the
-ampliation is linear, the pure-state step makes each summand positive semidefinite,
-and a finite sum of positive semidefinite matrices is positive semidefinite.
-
-**Scope restriction (square system d = d' = D):** inherited from the pure-state step;
-see `docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
-theorem HasSchmidtNumberLE.tensorMapId_posSemidef [NeZero D] {n : ℕ}
-    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+ampliation is linear, the rectangular pure-state step makes each summand positive
+semidefinite, and a finite sum of positive semidefinite matrices is positive
+semidefinite. -/
+theorem HasSchmidtNumberLE.tensorMapId_posSemidef [NeZero d] {n : ℕ}
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
     (hTpos : IsNPositiveMap n T)
-    {ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hρ : HasSchmidtNumberLE n ρ) :
+    {ρ : Matrix (Fin d × Fin D) (Fin d × Fin D) ℂ} (hρ : HasSchmidtNumberLE n ρ) :
     (tensorMapId T ρ).PosSemidef := by
   obtain ⟨ι, _, ψ, hψ, rfl⟩ := hρ
   rw [tensorMapId_sum]

--- a/QICLean/Channel/SchmidtNumberFactors.lean
+++ b/QICLean/Channel/SchmidtNumberFactors.lean
@@ -6,17 +6,17 @@ Authors: Sirui Lu
 import QICLean.Channel.SchmidtNumber
 
 /-!
-# General bipartite reduction forward step
+# General bipartite reduction criterion
 
-`SchmidtNumber.lean` establishes the forward step of Wolf's reduction criterion —
-that a bipartite state of Schmidt number at most `n` satisfies `(T ⊗ id)(ρ) ≥ 0`
-for every `n`-positive map `T` — on the **square** system `ℂ^D ⊗ ℂ^D`.  This file
-lifts that result to a general bipartite system `ℂ^d ⊗ ℂ^{d'}` with the first factor
-`d` equal to the map's dimension and **no relation imposed** between the two tensor
-factors (Wolf §3.2, eq. (3.18) step 1, Prop 3.4 only-if).
+`SchmidtNumber.lean` establishes the rectangular forward step of Wolf Proposition 3.4:
+a bipartite state of Schmidt number at most `n` satisfies `(T ⊗ id)(ρ) ≥ 0` for every
+`n`-positive map `T`, with independent input, output, and bystander dimensions. This
+file retains the two zero-padding constructions originally used to lift the square
+specialization, together with compatibility declarations and the dimension-general
+reduction criterion of Wolf Equation (3.18).
 
-The lift uses two zero-padding directions to reach the square system the square
-result needs.  When the second factor is the smaller, `d' ≤ d`, the second factor is
+The compatibility construction uses two zero-padding directions. When the second
+factor is the smaller, `d' ≤ d`, the second factor is
 padded up to `d` by zeros and the square result is restricted back to the `d × d'`
 corner.  When the second factor is the larger, `d ≤ d'`, the first factor is padded up
 to `d'` by zeros and the map `T` is extended to the larger square `M_{d'}` by the
@@ -39,9 +39,9 @@ raise its rank.
   factor `d ≤ d'`, by padding the first factor up to `d'` with zeros, extending `T` by
   the corner sandwich, and restricting back to the `d × d'` corner.
 * `Matrix.tensorMapId_posSemidef_of_hasSchmidtRankLE_general` and
-  `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general`: the **general bipartite
-  forward step** of Wolf Prop 3.4 (only if), with no relation imposed between the two
-  tensor factors, combining the two padding directions.
+  `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general`: square-map compatibility
+  aliases for the rectangular forward theorem, with no relation imposed between the
+  two tensor factors.
 * `Matrix.reductionCriterion_left_of_hasSchmidtNumberLE_general` and
   `Matrix.reductionCriterion_right_of_hasSchmidtNumberLE_general`: the **general
   bipartite reduction criterion** of Wolf eq. (3.18), composing the general forward
@@ -66,10 +66,9 @@ variable {d d' D : ℕ}
 
 /-! ## Padding the second factor to a square system
 
-The square forward step of `SchmidtNumber.lean` fixes both tensor factors to the
-map's dimension `d`.  To reach Wolf's general bipartite system `ℂ^d ⊗ ℂ^{d'}` we
-pad the second factor up to `d` by zeros (valid when `d' ≤ d`), apply the square
-result, and restrict back to the `d × d'` corner with `Matrix.PosSemidef.submatrix`.
+This compatibility construction pads the second factor up to `d` by zeros (valid
+when `d' ≤ d`), applies the square specialization of the forward theorem, and restricts
+back to the `d × d'` corner with `Matrix.PosSemidef.submatrix`.
 The padding is the standard zero-border dilation; it preserves Schmidt rank because
 appending zero columns to the coefficient matrix cannot raise its rank. -/
 
@@ -580,16 +579,13 @@ bipartite second factor** (Wolf §3.2, Prop 3.4, eq. (3.18) step 1).  For a pure
 ampliation `(T ⊗ id)(|ψ⟩⟨ψ|)` is positive semidefinite, with no relation imposed
 between the two tensor factors.
 
-The two padding directions cover the full range: when the second factor is the smaller,
-`d' ≤ d`, the second factor is padded up to `d`; when it is the larger, `d ≤ d'`, the
-first factor is padded up to `d'` and `T` is extended to the larger square. -/
+The source-facing theorem in `SchmidtNumber.lean` is now rectangular. This declaration
+keeps the former square-map API as a compatibility alias. -/
 theorem tensorMapId_posSemidef_of_hasSchmidtRankLE_general [NeZero d] [NeZero d'] {n : ℕ}
     {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
     (hTpos : IsNPositiveMap n T) {ψ : Fin d × Fin d' → ℂ} (hψ : HasSchmidtRankLE n ψ) :
-    (tensorMapId T (vecMulVec ψ (star ψ))).PosSemidef := by
-  rcases le_or_gt d' d with h | h
-  · exact tensorMapId_posSemidef_of_hasSchmidtRankLE' h hTpos hψ
-  · exact tensorMapId_posSemidef_of_hasSchmidtRankLE'' h.le hTpos hψ
+    (tensorMapId T (vecMulVec ψ (star ψ))).PosSemidef :=
+  tensorMapId_posSemidef_of_hasSchmidtRankLE hTpos hψ
 
 /-- **Positive maps and entanglement, only-if direction, general bipartite second
 factor** (Wolf §3.2, Prop 3.4, eq. (3.18) step 1).  A bipartite state on a general
@@ -597,18 +593,14 @@ system `ℂ^d ⊗ ℂ^{d'}` of Schmidt number at most `n`, with first factor `d`
 dimension of the `n`-positive map `T`, satisfies `(T ⊗ id)(ρ) ≥ 0`, with no relation
 imposed between the two tensor factors.
 
-This is the faithful bipartite forward step of Wolf eq. (3.18): the two padding
-directions of the pure-state step (`d' ≤ d` padding the second factor, `d ≤ d'` padding
-the first factor and extending `T`) jointly cover all `d'`, and the ampliation is
-linear over the finite pure-state decomposition. -/
+This square-map compatibility declaration now delegates to the rectangular forward
+theorem in `SchmidtNumber.lean`. It is retained for the reduction-criterion API below. -/
 theorem HasSchmidtNumberLE.tensorMapId_posSemidef_general [NeZero d] [NeZero d'] {n : ℕ}
     {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
     (hTpos : IsNPositiveMap n T)
     {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} (hρ : HasSchmidtNumberLE n ρ) :
-    (tensorMapId T ρ).PosSemidef := by
-  rcases le_or_gt d' d with h | h
-  · exact hρ.tensorMapId_posSemidef' h hTpos
-  · exact hρ.tensorMapId_posSemidef'' h.le hTpos
+    (tensorMapId T ρ).PosSemidef :=
+  hρ.tensorMapId_posSemidef hTpos
 
 /-! ## The general bipartite reduction criterion (Wolf eq. (3.18))
 

--- a/QICLean/Channel/Schwarz/ChoiCompression.lean
+++ b/QICLean/Channel/Schwarz/ChoiCompression.lean
@@ -523,20 +523,22 @@ theorem compressedOmegaVector_hasSchmidtRankLE
     compressedOmegaVector] using
     Matrix.rank_le_card_width (Matrix.schmidtCoeffMatrix (compressedOmegaVector X))
 
-/-- A square compression of rank at most `k` gives Schmidt rank at most `k`. -/
+/-- A right-factor compression of rank at most `r` gives Schmidt rank at most `r`. -/
 theorem compressedOmegaVector_hasSchmidtRankLE_of_rank_le [NeZero D]
-    {X : Matrix (Fin D) (Fin D) ℂ} {k : ℕ} (hX : X.rank ≤ k) :
+    {m k : ℕ} {X : Matrix (Fin D) (Fin m) ℂ} (hX : X.rank ≤ k) :
     Matrix.HasSchmidtRankLE k (compressedOmegaVector X) := by
   simpa [Matrix.HasSchmidtRankLE, compressedOmegaVector_schmidtRank_eq_rank] using hX
 
-/-- For `D > 0`, every vector in $\mathbb{C}^D\otimes\mathbb{C}^D$ is obtained
-from the maximally entangled vector by applying a square right-factor matrix,
-and the matrix rank agrees with the Schmidt rank of the vector. -/
-theorem exists_squareCompression_of_vector [NeZero D]
-    (ψ : Fin D × Fin D → ℂ) :
-    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+/-- For `D > 0`, every vector in $\mathbb{C}^D\otimes\mathbb{C}^k$ is obtained
+from the normalized maximally entangled vector by applying a `D × k` right-factor
+matrix, and the matrix rank agrees with the Schmidt rank of the vector. This is
+the rectangular right-factor parametrization used in the only-if direction of
+Wolf, Chapter 3, Proposition 3.4, lines 250--267. -/
+theorem exists_compression_of_vector [NeZero D]
+    (ψ : Fin D × Fin k → ℂ) :
+    ∃ X : Matrix (Fin D) (Fin k) ℂ,
       compressedOmegaVector X = ψ ∧ X.rank = Matrix.schmidtRank ψ := by
-  let X : Matrix (Fin D) (Fin D) ℂ :=
+  let X : Matrix (Fin D) (Fin k) ℂ :=
     fun a p => (((D : ℝ).sqrt : ℂ)) * ψ (a, p)
   have hDpos : 0 < (D : ℝ) := by
     exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
@@ -549,6 +551,13 @@ theorem exists_squareCompression_of_vector [NeZero D]
     field_simp [hsqrt_ne]
   refine ⟨X, hvec, ?_⟩
   simpa [hvec] using (compressedOmegaVector_schmidtRank_eq_rank (X := X)).symm
+
+/-- Square specialization of `exists_compression_of_vector`. -/
+theorem exists_squareCompression_of_vector [NeZero D]
+    (ψ : Fin D × Fin D → ℂ) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+      compressedOmegaVector X = ψ ∧ X.rank = Matrix.schmidtRank ψ :=
+  exists_compression_of_vector ψ
 
 /-- For `D > 0`, a square bipartite vector with Schmidt rank at most `r` has a
 square right-factor matrix representative of rank at most `r`. -/

--- a/blueprint/src/chapter/ch04_positive_not_cp_schmidt_number_and_entanglement.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_schmidt_number_and_entanglement.tex
@@ -60,7 +60,7 @@ in Section~\ref{sec:app_positive_not_cp_schmidt_number_geometry}.
     \lean{Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE}
     \leanok
     \uses{def:schmidt_rank, def:t_eta, def:tensor_map_id, thm:t_eta_threshold,
-        thm:square_schmidt_rank_exact_parametrization,
+        thm:schmidt_rank_exact_parametrization,
         lem:rank_one_ampliation_choi_compression,
         thm:choi_right_compression_quadratic_form, thm:schmidt_rank_choi_test_iff}
     For a pure state $\ket{\psi}\bra{\psi}$ on the square bipartite system
@@ -86,19 +86,20 @@ in Section~\ref{sec:app_positive_not_cp_schmidt_number_geometry}.
     \lean{Matrix.tensorMapId_posSemidef_of_hasSchmidtRankLE}
     \leanok
     \uses{def:schmidt_rank, def:tensor_map_id, def:k_positive_map,
-        def:choi_right_compression, thm:square_schmidt_rank_exact_parametrization,
+        def:choi_right_compression, thm:schmidt_rank_exact_parametrization,
         lem:rank_one_ampliation_choi_compression,
         thm:choi_right_compression_quadratic_form, thm:schmidt_rank_choi_test_iff}
-    For a pure state $\ket{\psi}\bra{\psi}$ on the square bipartite system
-    $\MN{D}\otimes\MN{D}$ with $\SR(\psi)\le n$ and any $n$-positive map
-    $T$, applying $T$ to the first factor keeps the result positive semidefinite:
-    $(T\otimes\id)(\ket{\psi}\bra{\psi})\ge 0$.
+    For a pure state $\ket{\psi}\bra{\psi}$ on
+    $\MN{d}\otimes\MN{k}$ with $\SR(\psi)\le n$ and any $n$-positive map
+    $T\colon\MN{d}\to\MN{r}$, applying $T$ to the first factor keeps the result
+    positive semidefinite:
+    $(T\otimes\id_k)(\ket{\psi}\bra{\psi})\ge 0$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Write $\psi$ through the maximally entangled vector as $\psi=\psi_X$ for a square
-    matrix $X$ on the right factor with
+    Write $\psi$ through the maximally entangled vector as $\psi=\psi_X$ for a
+    rectangular matrix $X\in M_{d\times k}(\C)$ with
     $\rank(X)=\SR(\psi)\le n$. Then
     $(T\otimes\id)(\ket{\psi}\bra{\psi})$ is the right-factor Choi compression of $T$
     by $X$, and its quadratic form on a vector $\eta$ equals the Choi quadratic form
@@ -114,11 +115,11 @@ in Section~\ref{sec:app_positive_not_cp_schmidt_number_geometry}.
     \leanok
     \uses{def:has_schmidt_number_le, def:tensor_map_id, def:k_positive_map,
         thm:tensor_map_id_sum, thm:tensor_map_id_posSemidef_pure}
-    A bipartite state on the square system $\MN{D}\otimes\MN{D}$ of Schmidt number at
-    most $n$ satisfies $(T\otimes\id)(\rho)\ge 0$ for every $n$-positive map $T$.
-    This is the square case $d=d'=D$ of the only-if direction of Wolf's
-    Proposition~3.4 for a general bipartite system
-    $\MN{d}\otimes\MN{d'}$ \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}.
+    A bipartite state on $\MN{d}\otimes\MN{k}$ of Schmidt number at most $n$
+    satisfies $(T\otimes\id_k)(\rho)\ge 0$ for every $n$-positive map
+    $T\colon\MN{d}\to\MN{r}$. This is the only-if direction of Wolf's
+    Proposition~3.4 \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}, with the
+    map output and innocent-bystander dimensions allowed to vary independently.
 \end{theorem}
 
 \begin{proof}
@@ -129,29 +130,23 @@ in Section~\ref{sec:app_positive_not_cp_schmidt_number_geometry}.
     positive semidefinite matrices is positive semidefinite.
 \end{proof}
 
-\begin{theorem}[Only-if direction for a general bipartite system]
+\begin{theorem}[Square-map compatibility form of the only-if direction]
     \label{thm:has_schmidt_number_le_tensor_map_id_general}
     \lean{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general}
     \leanok
     \uses{def:has_schmidt_number_le, def:tensor_map_id, def:k_positive_map,
         thm:has_schmidt_number_le_tensor_map_id}
-    On a general bipartite system $\MN{d}\otimes\MN{d'}$, with no relation imposed
-    between the two factors, a state of Schmidt number at most $n$ satisfies
-    $(T\otimes\id)(\rho)\ge 0$ for every $n$-positive map $T$ on $\MN{d}$.
-    This is the only-if direction of Wolf's Proposition~3.4, the first step of
-    eq.~(3.18) \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}, with no restriction
-    on the bipartite dimensions.
+    On $\MN{d}\otimes\MN{d'}$, with no relation imposed between the two factors, a
+    state of Schmidt number at most $n$ satisfies $(T\otimes\id)(\rho)\ge 0$ for
+    every $n$-positive endomorphism $T$ of $\MN{d}$. This compatibility declaration
+    is the specialization of Theorem~\ref{thm:has_schmidt_number_le_tensor_map_id}
+    used by the reduction criterion below.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Pad the bipartite state to the square system $\MN{D}\otimes\MN{D}$ with
-    $D=\max(d,d')$ by zero rows and columns: when $d'\le d$ the second factor is padded
-    up to $d$; when $d\le d'$ the first factor is padded up to $d'$ and $T$ is extended
-    to a map on $\MN{d'}$ that preserves $n$-positivity. Padding preserves the
-    Schmidt-number bound, the square result makes the padded ampliation positive
-    semidefinite, and the original ampliation is its principal submatrix, hence positive
-    semidefinite.
+    Apply Theorem~\ref{thm:has_schmidt_number_le_tensor_map_id} with output dimension
+    $r=d$ and bystander dimension $k=d'$.
 \end{proof}
 
 \begin{theorem}[Reduction step from the Schmidt-number premise]
@@ -226,9 +221,12 @@ proved in Section~\ref{sec:app_positive_not_cp_schmidt_number_geometry}.
         \re\bra{\psi}W\ket{\psi} & \ge 0.
         \notag
     \end{align}
-    This is Wolf's Proposition~3.3 \cite[Chapter~3, Proposition~3.3]{Wolf2012Quantum}: a
-    state has Schmidt number larger than $n$ exactly when it is detected by an
-    entanglement witness for $S_n$.
+    This is the corrected form of Wolf's Proposition~3.3
+    \cite[Chapter~3, Proposition~3.3]{Wolf2012Quantum}: a state has Schmidt number
+    larger than $n$ exactly when it is detected by an entanglement witness for $S_n$.
+    The source prints exact Schmidt rank $n$, while the convex set and proof require
+    Schmidt rank at most $n$; the defect is recorded in
+    \cite{gap:wolf_prop3_1_exact_schmidt_rank_scope}.
 \end{theorem}
 
 \begin{proof}
@@ -252,20 +250,50 @@ Section~\ref{sec:app_positive_not_cp_witness_choi}.
     \uses{def:k_positive_map, def:has_schmidt_number_le,
         thm:exists_entanglement_witness, thm:exists_isNPositiveMap_choiMatrix_eq,
         thm:k_positive_trace_pairing_adjoint, thm:trace_choiMatrix_omega_quadratic_adjoint}
-    Let $\rho$ be a trace-one Hermitian bipartite state on $\C^D\otimes\C^D$ whose Schmidt
-    number exceeds $n$. Then there is an $n$-positive map $T\colon\MN{D}\to\MN{D}$ such that
-    $(T\otimes\Id)(\rho)$ is not positive semidefinite. This is the if direction of Wolf's
-    Proposition~3.4 \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}.
+    Let $\rho$ be a trace-one Hermitian bipartite state on
+    $\C^d\otimes\C^{d'}$ whose Schmidt number exceeds $n$. Then there is an
+    $n$-positive map $T\colon\MN{d}\to\MN{d'}$ such that
+    $(T\otimes\Id_{d'})(\rho)$ is not positive semidefinite. This is the if
+    direction of Wolf's Proposition~3.4
+    \cite[Chapter~3, Proposition~3.4, Equations~(3.13)--(3.14)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
     \leanok
     The entanglement witness $W$ for $\rho$ (\ref{thm:exists_entanglement_witness}) is the
-    Choi matrix of an $n$-positive map $P$ (\ref{thm:exists_isNPositiveMap_choiMatrix_eq}).
+    Choi matrix of an $n$-positive map $P\colon\MN{d'}\to\MN{d}$
+    (\ref{thm:exists_isNPositiveMap_choiMatrix_eq}).
     Its trace-pairing adjoint $T=P^{*}$ is again $n$-positive
     (\ref{thm:k_positive_trace_pairing_adjoint}). By the Choi trace pairing through the
     trace-pairing adjoint (\ref{thm:trace_choiMatrix_omega_quadratic_adjoint}),
-    $\bra{\Omega}(T\otimes\Id)(\rho)\ket{\Omega}=\tr(W\rho)$, whose real part is
+    $\bra{\Omega_{d'}}(T\otimes\Id_{d'})(\rho)\ket{\Omega_{d'}}=\tr(W\rho)$,
+    whose real part is
     negative. A positive semidefinite matrix has non-negative quadratic forms, so
     $(T\otimes\Id)(\rho)$ is not positive semidefinite.
+\end{proof}
+
+\begin{theorem}[Positive maps and entanglement]
+    \label{thm:schmidt_number_iff_positive_maps}
+    \lean{Matrix.hasSchmidtNumberLE_iff_forall_isNPositiveMap_tensorMapId_posSemidef}
+    \leanok
+    \uses{def:k_positive_map, def:has_schmidt_number_le,
+        thm:has_schmidt_number_le_tensor_map_id, thm:exists_isNPositiveMap_detects}
+    Let $d,d'>0$ and let $\rho$ be a density operator on
+    $\C^d\otimes\C^{d'}$. Then $\rho$ has Schmidt number at most $n$ if and only if
+    \begin{align}
+        (T\otimes\Id_{d'})(\rho)&\ge0
+        &&\text{for every $n$-positive }T\colon\MN{d}\to\MN{d'}.
+        \notag
+    \end{align}
+    This is Wolf's rectangular Proposition~3.4
+    \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The forward implication is
+    Theorem~\ref{thm:has_schmidt_number_le_tensor_map_id}. For the converse, if the
+    Schmidt number exceeded $n$, Theorem~\ref{thm:exists_isNPositiveMap_detects}
+    would supply an $n$-positive $T\colon\MN{d}\to\MN{d'}$ for which the displayed
+    ampliation is not positive semidefinite, contradicting the universal hypothesis.
 \end{proof}

--- a/blueprint/src/chapter/ch04_positive_not_cp_supporting_results.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_supporting_results.tex
@@ -405,21 +405,20 @@ $\C^{d'}\otimes\C^k$.
     rank.
 \end{proof}
 
-\begin{theorem}[Square representative with exact Schmidt rank]
-    \label{thm:square_schmidt_rank_exact_parametrization}
-    \lean{ChoiJamiolkowski.exists_squareCompression_of_vector,
-        ChoiJamiolkowski.exists_squareCompression_of_hasSchmidtRankLE}
+\begin{theorem}[Rectangular representative with exact Schmidt rank]
+    \label{thm:schmidt_rank_exact_parametrization}
+    \lean{ChoiJamiolkowski.exists_compression_of_vector}
     \leanok
     \uses{def:schmidt_rank, def:choi_right_compression,
         thm:compressed_omega_schmidt_rank_eq_rank}
-    Assume $d>0$. For every $\psi\in\C^d\otimes\C^d$, there is
-    $X\in\MN{d}$ such that
+    Assume $d>0$. For every $\psi\in\C^d\otimes\C^k$, there is
+    $X\in M_{d\times k}(\C)$ such that
     \begin{align}
         \psi_{(i,p)}
          & =d^{-1/2}X_{i,p}, \notag \\
         \rank X
          & =\SR(\psi).
-        \label{eq:schwarz_square_schmidt_representative}
+        \label{eq:schwarz_schmidt_representative}
     \end{align}
     In particular, if $\SR(\psi)\le r$, then $X$ may be chosen with
     $\rank X\le r$.
@@ -438,7 +437,7 @@ $\C^{d'}\otimes\C^k$.
     \lean{ChoiJamiolkowski.hasSchmidtRankLE_iff_exists_rank_le_compressedOmegaVector}
     \leanok
     \uses{def:schmidt_rank, def:choi_right_compression,
-        thm:square_schmidt_rank_exact_parametrization}
+        thm:schmidt_rank_exact_parametrization}
     Assume $d>0$. A vector $\psi\in\C^d\otimes\C^d$ has Schmidt rank at most
     $k$ if and only if there is a matrix $X\in\MN{d}$ of rank at most $k$
     such that $\psi_{(i,j)}=d^{-1/2}X_{i,j}$.
@@ -447,7 +446,7 @@ $\C^{d'}\otimes\C^k$.
 \begin{proof}
     \leanok
     The forward direction is the bounded-rank part of
-    Theorem~\ref{thm:square_schmidt_rank_exact_parametrization}. Conversely,
+    Theorem~\ref{thm:schmidt_rank_exact_parametrization}. Conversely,
     if $\psi_{(i,j)}=d^{-1/2}X_{i,j}$, then
     $C_\psi=d^{-1/2}X$, so $\rank(C_\psi)=\rank(X)$ because multiplication
     by a nonzero scalar preserves rank.
@@ -939,7 +938,7 @@ Theorem~\ref{thm:exists_isNPositiveMap_detects}.
     \label{thm:exists_choiMatrix_eq}
     \lean{ChoiJamiolkowski.exists_choiMatrix_eq}
     \leanok
-    \uses{thm:cp_iff_choi_posSemidef}
+    \uses{thm:choi_rect_mutual_inverse}
     Assume $D>0$. Every bipartite matrix $W$ on $\C^D\otimes\C^D$ is the Choi matrix
     $\tau_T=(T\otimes\Id)(\ket{\Omega}\bra{\Omega})$ of some linear map
     $T\colon\MN{D}\to\MN{D}$.
@@ -947,21 +946,21 @@ Theorem~\ref{thm:exists_isNPositiveMap_detects}.
 
 \begin{proof}
     \leanok
-    The Choi correspondence $T\mapsto\tau_T$ is complex-linear and injective. Its domain,
-    the space of linear maps on $\MN{D}$, and its codomain, the bipartite matrix space on
-    $\C^D\otimes\C^D$, both have complex dimension $D^4$, so the injective map is also
-    surjective. Hence every $W$ is a Choi matrix.
+    Apply the explicit inverse $\tau\mapsto T$ from the rectangular Choi correspondence
+    (Theorem~\ref{thm:choi_rect_mutual_inverse}) to $W$. Its inverse law gives
+    $\tau_T=W$; the displayed square statement is the specialization $d=d'=D$.
 \end{proof}
 
 \begin{theorem}[A witness is the Choi matrix of an $n$-positive map]
     \label{thm:exists_isNPositiveMap_choiMatrix_eq}
     \lean{ChoiJamiolkowski.exists_isNPositiveMap_choiMatrix_eq_of_witness}
     \leanok
-    \uses{def:k_positive_map, def:schmidt_rank, thm:exists_choiMatrix_eq,
+    \uses{def:k_positive_map, def:schmidt_rank, thm:choi_rect_mutual_inverse,
         thm:schmidt_rank_choi_test_iff, thm:exists_entanglement_witness}
-    Assume $D>0$. Let $W$ be a Hermitian operator on $\C^D\otimes\C^D$ with
+    Assume $d'>0$. Let $W$ be a Hermitian operator on $\C^d\otimes\C^{d'}$ with
     $\re\bra{\psi}W\ket{\psi}\ge 0$ for every $\psi$ of Schmidt rank at most $n$.
-    Then $W$ is the Choi matrix of an $n$-positive map $T$. This is the
+    Then $W$ is the Choi matrix of an $n$-positive map
+    $P\colon\MN{d'}\to\MN{d}$. This is the
     Choi--Jamio\l kowski translation of the entanglement witness of Wolf's Proposition~3.3
     into the $n$-positive map of Wolf's Proposition~3.4
     \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}.
@@ -969,12 +968,12 @@ Theorem~\ref{thm:exists_isNPositiveMap_detects}.
 
 \begin{proof}
     \leanok
-    By the surjectivity of the Choi correspondence (\ref{thm:exists_choiMatrix_eq}) there
-    is a linear map $T$ with $\tau_T=W$. Because $W$ is Hermitian, the Choi quadratic form
+    The explicit rectangular inverse gives $P\colon\MN{d'}\to\MN{d}$ with $\tau_P=W$.
+    Because $W$ is Hermitian, the Choi quadratic form
     $\bra{\psi}W\ket{\psi}$ is real, and it equals the witness expectation
     $\tr(W\ket{\psi}\bra{\psi})$; the witness condition makes it non-negative on every
     vector of Schmidt rank at most $n$. This is exactly the Schmidt-rank Choi criterion
-    (\ref{thm:schmidt_rank_choi_test_iff}) for $n$-positivity of $T$.
+    (\ref{thm:schmidt_rank_choi_test_iff}) for $n$-positivity of $P$.
 \end{proof}
 
 \begin{theorem}[Choi trace pairing through the trace-pairing adjoint]
@@ -982,22 +981,25 @@ Theorem~\ref{thm:exists_isNPositiveMap_detects}.
     \lean{ChoiJamiolkowski.trace_choiMatrix_mul_eq_omegaVec_quadraticForm_traceAdjointMap}
     \leanok
     \uses{def:trace_pairing_adjoint, thm:trace_pairing_adjoint_ampliation}
-    For a linear map $T\colon\MN{D}\to\MN{D}$ with Choi matrix $\tau_T$ and any bipartite
-    matrix $\rho$ on $\C^D\otimes\C^D$,
+    For a linear map $P\colon\MN{d'}\to\MN{d}$ with Choi matrix $\tau_P$ and any bipartite
+    matrix $\rho$ on $\C^d\otimes\C^{d'}$,
     \begin{align}
-        \tr(\tau_T\,\rho)
-         & =\bra{\Omega}(T^{*}\otimes\Id)(\rho)\ket{\Omega},
+        \tr(\tau_P\,\rho)
+         & =\bra{\Omega_{d'}}(P^{*}\otimes\Id_{d'})(\rho)\ket{\Omega_{d'}},
         \notag
     \end{align}
-    where $T^{*}$ is the trace-pairing adjoint of $T$.
+    where $P^{*}\colon\MN{d}\to\MN{d'}$ is the trace-pairing adjoint of $P$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Since $\tau_T=(T\otimes\Id)(\ket{\Omega}\bra{\Omega})$, cyclicity of the trace gives
-    $\tr(\tau_T\rho)=\tr(\rho\,(T\otimes\Id)(\ket{\Omega}\bra{\Omega}))$. The
+    Since $\tau_P=(P\otimes\Id_{d'})(\ket{\Omega_{d'}}\bra{\Omega_{d'}})$, cyclicity
+    of the trace gives
+    $\tr(\tau_P\rho)=\tr(\rho\,(P\otimes\Id_{d'})(\ket{\Omega_{d'}}\bra{\Omega_{d'}}))$.
+    The
     $\Id$-ampliation of the trace-pairing adjoint is the trace-pairing adjoint of the
-    ampliation, so moving $T$ across the trace pairing replaces
-    $(T\otimes\Id)$ by $(T^{*}\otimes\Id)$ acting on $\rho$ and turns the pairing against
-    $\ket{\Omega}\bra{\Omega}$ into the quadratic form $\bra{\Omega} \cdot\,\ket{\Omega}$.
+    ampliation, so moving $P$ across the trace pairing replaces
+    $(P\otimes\Id_{d'})$ by $(P^{*}\otimes\Id_{d'})$ acting on $\rho$ and turns the
+    pairing against $\ket{\Omega_{d'}}\bra{\Omega_{d'}}$ into the quadratic form
+    $\bra{\Omega_{d'}} \cdot\,\ket{\Omega_{d'}}$.
 \end{proof}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -313,7 +313,7 @@
 
 @techreport{gap:wolf_prop3_1_exact_schmidt_rank_scope,
   author      = {The {QICLean} contributors},
-  title       = {Exact-Rank Wording in {Wolf}'s {Choi} Criterion},
+  title       = {Exact-Rank Wording in {Wolf}'s {Choi} and Witness Criteria},
   institution = {QICLean},
   type        = {Paper-gap note},
   number      = {wolf\_prop3\_1\_exact\_schmidt\_rank\_scope},

--- a/docs/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.tex
+++ b/docs/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.tex
@@ -7,9 +7,9 @@
 
 \input{command}
 
-\title{Exact-Rank Wording in Wolf's Choi Criterion}
+\title{Exact-Rank Wording in Wolf's Choi and Witness Criteria}
 \author{}
-\date{2026-08-23}
+\date{2026-08-24}
 
 \begin{document}
 \maketitle
@@ -90,13 +90,64 @@ matrices of rank exactly $k$ are dense among matrices of rank at most $k$, and
 the quadratic form is continuous. This argument is not the proof printed by
 Wolf and is not used in the formal criterion.
 
+\section{The same defect in Proposition~3.3}
+
+Wolf's Proposition~3.3 considers a density operator
+$\rho\in M_d(\C)\otimes M_{d'}(\C)$ and states that its Schmidt number is at
+least $n+1$ if and only if there is a Hermitian $W$ with
+$\tr(W\rho)<0$ and
+\begin{align}
+    \langle\psi,W\psi\rangle&\ge0
+    &&\text{for every $\psi$ with $\operatorname{SR}(\psi)=n$}.
+    \tag{Wolf 3.3}
+\end{align}
+The source then defines $S_n$ as the density operators of Schmidt number at
+most $n$ and separates $\rho$ from $S_n$; its converse says that $S_n$ is the
+closed convex hull of the same printed exact-rank set.
+\footnote{Source: \path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex},
+lines 229--243. Tracked by
+\href{https://github.com/LionSR/QICLean/issues/23}{QICLean issue \#23}.}
+
+This exact-rank wording again fails without the bound $n\le\min\{d,d'\}$.
+If $n>\min\{d,d'\}$, no vector has Schmidt rank exactly $n$, so the witness
+condition is vacuous. Taking $W=-\one$ then makes $\tr(W\rho)=-1<0$ for every
+density operator, whereas no such $\rho$ can have Schmidt number at least
+$n+1$. Thus the printed equivalence is false in precisely the range where its
+test set is empty.
+
+The dimension-generic correction is
+\begin{align}
+    \operatorname{sn}(\rho)>n
+    \quad\Longleftrightarrow\quad
+    \exists W=W^\dagger:\quad
+    \tr(W\rho)<0\quad\text{and}\quad
+    \langle\psi,W\psi\rangle&\ge0
+    &&\text{whenever }\operatorname{SR}(\psi)\le n.
+    \tag{corrected Wolf 3.3}
+\end{align}
+This is exactly the separating-hyperplane statement for $S_n$: each pure
+projector in a defining decomposition of $S_n$ has Schmidt rank at most $n$.
+It is formalized by
+\leanid{Matrix.not_hasSchmidtNumberLE_iff_exists_witness} in
+\doclink{QICLean/Channel/EntanglementWitness} and is the witness input to the
+rectangular positive-map characterization
+\leanid{Matrix.hasSchmidtNumberLE_iff_forall_isNPositiveMap_tensorMapId_posSemidef}
+in \doclink{QICLean/Channel/PositiveMapDetection}.
+
+When $n\le\min\{d,d'\}$, the exact-rank witness test can again be recovered
+from the bounded-rank test by the same density-and-continuity argument. That
+additional argument is not the separating-hyperplane proof printed in
+Proposition~3.3 and is not used by the formal theorem.
+
 \section{Conclusion}
 
-Wolf's exact-rank wording is false under the printed hypothesis $k\le d$.
-Replacing exact Schmidt rank by Schmidt rank at most $k$ gives the standard
-rectangular Choi criterion and matches the compression proof. The formal
-statement and the Blueprint use this corrected wording; no additional route
-is attributed to the source.
+Wolf's exact-rank wording in Proposition~3.1 is false under the printed
+hypothesis $k\le d$, and the same wording in Proposition~3.3 is false when
+$n>\min\{d,d'\}$. Replacing exact Schmidt rank by Schmidt rank at most the
+given bound yields the dimension-generic Choi and witness criteria and matches
+the proofs through compressions and the convex set $S_n$. The formal statements
+and the Blueprint use this corrected wording; no additional route is attributed
+to the source.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
+++ b/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
@@ -109,28 +109,35 @@ the map $T_n$ is $n$-positive for all $1\le n<D$.\footnote{Formal declaration:
     \doclink{QICLean/Channel/NPositivityChainStrict}, the reduction map being
     $T_\eta$ at $\eta=n$ by \leanid{Matrix.reductionMap_eq_tEta}.}
 
-The pure-state step writes $\psi$ through the maximally entangled vector as a
-\emph{square} right-factor matrix, so the $T_n$-specialised \emph{criterion} theorems
-still fix the two tensor factors to a common dimension $D$. The general bipartite
-\emph{forward step} itself, however, no longer carries that restriction: padding the
-bipartite state to the square system $\mathbb{C}^D\otimes\mathbb{C}^D$ with
-$D=\max(d,d')$ — padding the smaller factor by zero rows or columns and, when the
-first factor grows, extending the map by a corner sandwich that preserves
-$n$-positivity — reduces the general case to the square one. Thus
-$(T\otimes\operatorname{id})(\rho)\ge 0$ holds on a general
-$\mathbb{C}^d\otimes\mathbb{C}^{d'}$ for every $n$-positive map $T$, with no relation
-between the factors.\footnote{Formal declaration:
-    \leanid{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general} in
-    \doclink{QICLean/Channel/SchmidtNumberFactors}, with the $n$-positivity-preserving
-    corner extension \leanid{Matrix.isNPositiveMap_cornerExtendMap}.}
+The general forward step is now direct and rectangular. For
+$T:M_d(\mathbb{C})\to M_r(\mathbb{C})$ and
+$\psi\in\mathbb{C}^d\otimes\mathbb{C}^k$, write $\psi$ through the normalized
+maximally entangled vector as a rectangular right-factor matrix
+$X\in M_{d\times k}(\mathbb{C})$ with
+$\operatorname{rank}(X)=\operatorname{SR}(\psi)$. The ampliation of
+$\ketbra\psi\psi$ is the right-factor compression of the rectangular Choi
+matrix of $T$. Its quadratic form pulls back to a Choi quadratic form on a
+vector of Schmidt rank at most $\operatorname{rank}(X)$, so $n$-positivity gives
+the desired nonnegativity. Summing the pure projectors proves
+$(T\otimes\operatorname{id}_k)(\rho)\ge0$ with independent input, output, and
+bystander dimensions.\footnote{Formal declarations:
+    \leanid{Matrix.tensorMapId_posSemidef_of_hasSchmidtRankLE} and
+    \leanid{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef} in
+    \doclink{QICLean/Channel/SchmidtNumber}.}
+
+The older padding constructions and the square-endomorphism declarations
+\leanid{Matrix.tensorMapId_posSemidef_of_hasSchmidtRankLE_general} and
+\leanid{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general} remain as
+compatibility APIs in \doclink{QICLean/Channel/SchmidtNumberFactors}; the latter
+now delegates to the direct rectangular theorem. They are not needed to justify
+Wolf's source-facing positive-map characterization.
 
 \section{Classification}
 
 \emph{Resolved.} The general bipartite forward step
 $\operatorname{sn}(\rho)\le n\Rightarrow(T\otimes\operatorname{id})(\rho)\ge 0$ holds
-for every $n$-positive map $T$ on $\mathbb{C}^d\otimes\mathbb{C}^{d'}$ with no relation
-between the factors, at
-\leanid{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general}.
+for every $n$-positive map with independent input, output, and bystander dimensions at
+\leanid{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef}.
 
 The $T_n$-specialised reduction \emph{criterion} is likewise now general: the
 inequalities $n\,\mathbf 1\otimes\rho_2\ge\rho$ and $n\,\rho_1\otimes\mathbf 1\ge\rho$

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -533,6 +533,39 @@ so that the cited formal statements are available from the main project import.
   recorded in
   `docs/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.tex`.
 
+### Section 3.2 Detecting entanglement and Schmidt number
+
+#### Wolf Proposition 3.3 — FORMALIZED WITH A SOURCE WORDING CORRECTION
+
+- `Matrix.not_hasSchmidtNumberLE_iff_exists_witness` — a trace-one Hermitian
+  state lies outside `S_n` iff a Hermitian witness is negative on the state
+  and nonnegative on every vector of Schmidt rank at most `n` ✓
+- Wolf prints exact Schmidt rank `n`. This is vacuous when
+  `n > min(d,d')` and does not describe the pure generators of `S_n` used by
+  the separating-hyperplane proof. The counterexample, corrected statement,
+  and exact-rank scope are recorded alongside the same defect in Proposition
+  3.1 at `docs/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.tex`.
+
+#### Wolf Proposition 3.4 — FORMALIZED (RECTANGULAR FORM)
+
+- `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef` — the only-if direction
+  for an `n`-positive map `T : M_d(ℂ) → M_r(ℂ)`, with an independent
+  bystander dimension; the pure-state proof uses the rectangular
+  right-factor parametrization
+  `ChoiJamiolkowski.exists_compression_of_vector` ✓
+- `ChoiJamiolkowski.exists_isNPositiveMap_choiMatrix_eq_of_witness` — Equation
+  (3.13) in Wolf's orientation: a witness `W` on `ℂ^d ⊗ ℂ^{d'}` is the
+  rectangular Choi matrix of an `n`-positive map
+  `P : M_{d'}(ℂ) → M_d(ℂ)` ✓
+- `ChoiJamiolkowski.trace_choiMatrix_mul_eq_omegaVec_quadraticForm_traceAdjointMap`
+  — Equation (3.14), with `T = traceAdjointMap P` and the test vector
+  `omegaVec d'` ✓
+- `Matrix.exists_isNPositiveMap_tensorMapId_not_posSemidef` — if a trace-one
+  Hermitian state on `ℂ^d ⊗ ℂ^{d'}` lies outside `S_n`, an `n`-positive map
+  `T : M_d(ℂ) → M_{d'}(ℂ)` detects it ✓
+- `Matrix.hasSchmidtNumberLE_iff_forall_isNPositiveMap_tensorMapId_posSemidef`
+  — the full rectangular equivalence in Proposition 3.4 for density operators ✓
+
 ### Section 3.3 Transposition and time reversal
 
 #### Wolf Theorem 3.1 (Kramers' theorem) — FORMALIZED


### PR DESCRIPTION
## Summary

- generalize the Schmidt-number forward preservation theorem to a rectangular map `T : M_d(ℂ) → M_{d'}(ℂ)` with an independent bystander dimension
- implement Wolf's witness-to-map detector in the exact orientation `W = τ_P`, `P : M_{d'} → M_d`, `T = P*`, tested on `Ω_{d'}`
- prove the full rectangular positive-map characterization of Schmidt number and synchronize Blueprint, numbering coverage, and the source-correction notes

Closes #23

## Source contract

Wolf, *Quantum Channels & Operations*, Chapter 3, Proposition 3.4 and Equations (3.13)--(3.14), local source lines 250--267, states the rectangular equivalence for `ρ ∈ M_d ⊗ M_{d'}`. Chapter 2, Proposition 2.1, lines 60--105 supplies the normalized rectangular Choi convention.

The detector follows the printed factor order:

- `W : M_d ⊗ M_{d'}`
- `P = ChoiRectangular.mapOfChoiMatrix W : M_{d'} → M_d`
- `T = Matrix.traceAdjointMap P : M_d → M_{d'}`
- negativity is tested on `Matrix.omegaVec d'`

No square padding or finite-rank Choi-surjectivity argument is used. The square `exists_choiMatrix_eq` compatibility theorem now delegates to the explicit rectangular inverse.

## Source correction

Proposition 3.3 line 232 prints vectors of exact Schmidt rank `n`. That condition becomes vacuous above the maximal possible rank, while the displayed witness equivalence does not. The formal theorem consistently uses Schmidt rank at most `n`; the existing paper-gap note now records this correction explicitly.

## Main declarations

- `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef`
- `ChoiJamiolkowski.exists_isNPositiveMap_choiMatrix_eq_of_witness`
- `ChoiJamiolkowski.trace_choiMatrix_mul_eq_omegaVec_quadraticForm_traceAdjointMap`
- `Matrix.exists_isNPositiveMap_tensorMapId_not_posSemidef`
- `Matrix.hasSchmidtNumberLE_iff_forall_isNPositiveMap_tensorMapId_posSemidef`

Existing square applications remain available by inference, and the legacy named rank-bound argument `(k := ...)` remains compatible.

## Verification

- `lake build QICLean` (9,268 jobs, exact current base)
- focused rectangular modules (3,110 jobs)
- `lake exe lint_style`
- Blueprint PDF and web builds
- generated web test: 30 pages, 28,253 typeset fragments
- Blueprint sync and `checkdecls`: 2,258 / 2,258
- import-aggregator and module-policy checks
- paper-gap reference check and all paper-gap PDF builds
- reader-facing prose, `git diff --check`, forbidden-token scan, and legacy compatibility probes

## Axiom audit

The changed proof boundary reports only the repository-standard foundational axioms:

- `propext`
- `Classical.choice`
- `Quot.sound`
