### PR TITLE
fix(channel): certify canonical boost positivity

### DIFF
--- a/QICLean/Channel/LorentzNormalForm/SpinorAction.lean
+++ b/QICLean/Channel/LorentzNormalForm/SpinorAction.lean
@@ -828,11 +828,16 @@ theorem spinorMatrix_eq_one_iff (X : SL(2, ℂ)) :
       exact self_eq_neg.mp h01e.symm
     have h10 : X.1 1 0 = 0 := by
       have h10e := congrFun (congrFun (hcomm 3) 1) 0
-      simp [pauliMatrices, Matrix.mul_apply, Fin.sum_univ_two] at h10e
+      simp only [pauliMatrices, Fin.isValue, Matrix.mul_apply, Matrix.of_apply,
+        Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_fin_one, Fin.sum_univ_two,
+        mul_one, Matrix.cons_val_one, mul_zero, add_zero, zero_mul, neg_mul, one_mul,
+        zero_add] at h10e
       exact self_eq_neg.mp h10e
     have hdiag : X.1 0 0 = X.1 1 1 := by
       have he := congrFun (congrFun (hcomm 1) 0) 1
-      simp [pauliMatrices, Matrix.mul_apply, Fin.sum_univ_two] at he
+      simp only [pauliMatrices, Fin.isValue, Matrix.mul_apply, Matrix.of_apply,
+        Matrix.cons_val', Matrix.cons_val_one, Matrix.cons_val_fin_one, Fin.sum_univ_two,
+        Matrix.cons_val_zero, mul_one, mul_zero, add_zero, zero_mul, one_mul, zero_add] at he
       exact he
     have hdet : X.1 0 0 * X.1 0 0 = 1 := by
       have hd := X.2

--- a/QICLean/Channel/LorentzNormalForm/SpinorCover.lean
+++ b/QICLean/Channel/LorentzNormalForm/SpinorCover.lean
@@ -34,6 +34,7 @@ gives the polar (Cartan) decomposition described by Wolf.
 * `Wolf.spinorMatrix_su2ToSL2` : the rotation lift, `1 ⊕ R(U)` for
   `U ∈ SU(2)`
 * `Wolf.boostSpinor` : the boost spinor `P = (M(u) + I)/√(2(1+u₀))`
+* `Wolf.boostSpinor_posDef` : the canonical boost spinor satisfies `P > 0`
 * `Wolf.spinorMatrix_boostSpinorSL2` : the boost lift,
   `spinorMatrix P_u = B_u`
 * `Wolf.exists_sl2_spinorMatrix_eq` : the spinor epimorphism; every
@@ -126,7 +127,9 @@ theorem IsSpecialOrthochronousLorentz.inv {L : Matrix (Fin 4) (Fin 4) ℝ}
     rw [hcancelt, hcancelt] at h2
     exact h2
   · rw [hLinv]
-    simp [Matrix.mul_apply, minkowskiMetric, Matrix.diagonal_apply]
+    simp only [minkowskiMetric, Fin.isValue, Matrix.mul_apply, Matrix.diagonal_apply,
+      reduceIte, Matrix.transpose_apply, ite_mul, one_mul, zero_mul, sum_ite_eq,
+      mem_univ, mul_ite, mul_one, mul_neg, mul_zero, sum_ite_eq']
     exact h00
 
 /-- The time-row Minkowski norm identity from `L η Lᵀ = η`. -/
@@ -137,7 +140,7 @@ theorem row_norm_of_lorentz {L : Matrix (Fin 4) (Fin 4) ℝ}
   simp [Matrix.mul_apply, Matrix.transpose_apply, minkowskiMetric,
     Matrix.diagonal_apply, Fin.sum_univ_four] at h00
   rw [Fin.sum_univ_three]
-  show L 0 0 ^ 2 - (L 0 1 ^ 2 + L 0 2 ^ 2 + L 0 3 ^ 2) = 1
+  change L 0 0 ^ 2 - (L 0 1 ^ 2 + L 0 2 ^ 2 + L 0 3 ^ 2) = 1
   linarith [h00]
 
 /-- The time-column Minkowski norm identity from `Lᵀ η L = η`. -/
@@ -148,7 +151,7 @@ theorem col_norm_of_lorentz {L : Matrix (Fin 4) (Fin 4) ℝ}
   simp [Matrix.mul_apply, Matrix.transpose_apply, minkowskiMetric,
     Matrix.diagonal_apply, Fin.sum_univ_four] at h00
   rw [Fin.sum_univ_three]
-  show L 0 0 ^ 2 - (L 1 0 ^ 2 + L 2 0 ^ 2 + L 3 0 ^ 2) = 1
+  change L 0 0 ^ 2 - (L 1 0 ^ 2 + L 2 0 ^ 2 + L 3 0 ^ 2) = 1
   linarith [h00]
 
 theorem IsSpecialOrthochronousLorentz.mul {A B : Matrix (Fin 4) (Fin 4) ℝ}
@@ -164,7 +167,8 @@ theorem IsSpecialOrthochronousLorentz.mul {A B : Matrix (Fin 4) (Fin 4) ℝ}
       _ = A * minkowskiMetric * Aᵀ := by rw [hlorB]
       _ = minkowskiMetric := hlorA
   · have hrowA := row_norm_of_lorentz hlorA
-    have hcolB := col_norm_of_lorentz (IsSpecialOrthochronousLorentz.transpose_mul_metric_mul ⟨hdetB, hlorB, h00B⟩)
+    have hcolB := col_norm_of_lorentz
+      (IsSpecialOrthochronousLorentz.transpose_mul_metric_mul ⟨hdetB, hlorB, h00B⟩)
     have hSA : 0 ≤ ∑ k : Fin 3, A 0 k.succ ^ 2 :=
       Finset.sum_nonneg (fun k _ ↦ sq_nonneg (A 0 k.succ : ℝ))
     have hSB : 0 ≤ ∑ k : Fin 3, B k.succ 0 ^ 2 :=
@@ -252,7 +256,8 @@ def lorentzRotationBlock (R : Matrix (Fin 3) (Fin 3) ℝ) : Matrix (Fin 4) (Fin 
     lorentzRotationBlock R i.succ j.succ = R i j := by
   simp [lorentzRotationBlock, Matrix.of_apply, Fin.cons_succ]
 
-@[simp] theorem lorentzRotationBlock_one : lorentzRotationBlock (1 : Matrix (Fin 3) (Fin 3) ℝ) = 1 := by
+@[simp] theorem lorentzRotationBlock_one :
+    lorentzRotationBlock (1 : Matrix (Fin 3) (Fin 3) ℝ) = 1 := by
   ext i j
   rw [Matrix.one_apply]
   cases i using Fin.cases <;> cases j using Fin.cases <;>
@@ -353,7 +358,7 @@ theorem exists_so3_block_of_fixes_time {L : Matrix (Fin 4) (Fin 4) ℝ}
           L 1 i.succ * L 1 j.succ + L 2 i.succ * L 2 j.succ + L 3 i.succ * L 3 j.succ := by
         simp only [Matrix.mul_apply, Matrix.transpose_apply, Fin.sum_univ_three,
           Matrix.submatrix_apply]
-        show L 1 i.succ * L 1 j.succ + L 2 i.succ * L 2 j.succ + L 3 i.succ * L 3 j.succ =
+        change L 1 i.succ * L 1 j.succ + L 2 i.succ * L 2 j.succ + L 3 i.succ * L 3 j.succ =
           L 1 i.succ * L 1 j.succ + L 2 i.succ * L 2 j.succ + L 3 i.succ * L 3 j.succ
         rfl
       rw [Matrix.one_apply, hR]
@@ -606,6 +611,22 @@ theorem boostSpinor_isHermitian (u : MinkowskiSpace) :
     Matrix.conjTranspose_one]
   congr 1
   simp
+
+/-- The canonical boost spinor is positive definite.  This is the `P > 0`
+clause in Wolf's polar decomposition immediately before Equation (2.44)
+(`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 1067--1077). -/
+theorem boostSpinor_posDef (u : MinkowskiSpace) (hu : minkowskiQuadratic u = 1)
+    (hu0 : 0 < u 0) :
+    (boostSpinor u).PosDef := by
+  have hM : (pauliMatrixOfMinkowski u).PosSemidef :=
+    (posSemidef_pauliMatrixOfMinkowski_iff u).2 ⟨hu0.le, by rw [hu]; norm_num⟩
+  have hbase : (pauliMatrixOfMinkowski u + 1).PosDef :=
+    Matrix.PosDef.posSemidef_add hM Matrix.PosDef.one
+  have hc : 0 < Real.sqrt (2 * (1 + u 0)) := Real.sqrt_pos.2 (by linarith)
+  rw [boostSpinor, ← Complex.ofReal_inv]
+  change (((Real.sqrt (2 * (1 + u 0)))⁻¹ : ℝ) •
+    (pauliMatrixOfMinkowski u + 1)).PosDef
+  exact hbase.smul (inv_pos.mpr hc)
 
 /-- The determinant of `M(u) + I` is `2(1+u₀)` on the unit hyperboloid. -/
 theorem det_pauliMatrixOfMinkowski_add_one (u : MinkowskiSpace)

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -987,7 +987,15 @@ This section states the existence theorems from
 
 \begin{theorem}[Spinor epimorphism and two-point fibres]
     \label{thm:spinor_epimorphism_two_point_fibres}
-    \lean{Wolf.exists_sl2_spinorMatrix_eq,
+    \lean{Wolf.IsSpecialOrthochronousLorentz.inv,
+        Wolf.IsSpecialOrthochronousLorentz.mul,
+        Wolf.row_norm_of_lorentz,
+        Wolf.col_norm_of_lorentz,
+        Wolf.lorentzRotationBlock_one,
+        Wolf.exists_so3_block_of_fixes_time,
+        Wolf.boostSpinor_isHermitian,
+        Wolf.boostSpinor_posDef,
+        Wolf.exists_sl2_spinorMatrix_eq,
         Wolf.spinorCoverHom_surjective,
         Wolf.spinorMatrix_eq_one_iff,
         Wolf.spinorCoverHom_eq_iff_eq_or_eq_neg,
@@ -1011,8 +1019,10 @@ This section states the existence theorems from
     \uses{thm:spinor_image_special_orthochronous}
     Given $L\in\mathrm{SO}^+(1,3)$, set $u=Le_0$.  The Lorentz identities
     give $q(u)=1$ and $u_0>0$.  The canonical boost $B_u$, whose first column
-    is $u$, has the spinor lift
-    $P_u=(M(u)+I)/\sqrt{2(1+u_0)}$.  The matrix $B_u^{-1}L$ fixes $e_0$;
+    is $u$, has the positive-definite spinor lift
+    $P_u=(M(u)+I)/\sqrt{2(1+u_0)}>0$.  This is the $P>0$ condition in Wolf's
+    polar decomposition immediately before \cite[Eq.~(2.44)]{Wolf2012Quantum}.
+    The matrix $B_u^{-1}L$ fixes $e_0$;
     its Lorentz equations force the block form $1\oplus R$ with
     $R\in\mathrm{SO}(3)$.  Lift $R$ to $U\in\mathrm{SU}(2)$.  Multiplicativity
     then gives $\Lambda(P_uU)=B_u(1\oplus R)=L$.

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -384,6 +384,10 @@ so that the cited formal statements are available from the main project import.
 * `Wolf.spinorCoverHom_eq_iff_eq_or_eq_neg` /
   `Wolf.spinorCoverHom_eq_one_iff` — every fibre is exactly `{X, -X}` and the
   kernel is exactly `{1, -1}` ✓
+* `Wolf.boostSpinor_posDef` — the canonical boost lift
+  `P_u = (M(u) + I)/√(2(1+u₀))` satisfies `P_u > 0`, matching the
+  positive factor in Wolf's polar decomposition immediately before
+  Equation (2.44) (source lines 1067–1077) ✓
 * `Wolf.pauliTransferMatrix_two_sided_filtering` — Equation (2.43) over the
   complex Pauli transfer matrix, in the exact order `L₂ T̂ L₁` ✓
 * `Wolf.coe_pauliTransferMatrixReal_of_preservesHermiticity` /


### PR DESCRIPTION
Closes #433.

## Summary

- add the public theorem `Wolf.boostSpinor_posDef` for the canonical boost spinor;
- derive it from future-cone positivity of `M(u)`, positive definiteness of the identity summand, and the positive inverse-square-root scale;
- synchronize the Chapter 2/3 Blueprint presentation and Wolf numbering coverage with the theorem;
- mechanically clear the eight lint warnings landed with #431.

## Source contract

Wolf, *Quantum Channels & Operations*, `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 1067–1077 and Equation (2.44), requires the polar factor

\[
P=\exp(\vec m\cdot\vec\sigma/2)>0.
\]

This change certifies that exact `P > 0` clause for the existing canonical `boostSpinor`; it does not alter the spinor epimorphism or fibre proof and does not introduce a parallel boost construction.

## Validation

- focused `SpinorCover` and `SpinorExponential` builds;
- full `lake build QICLean` (9,272 jobs);
- style lint and all 16 file-policy tests;
- Blueprint/Lean sync and reverse coverage, `checkdecls` (2,269 references), and all 41 paper-gap references;
- `git diff --check`.

The large Blueprint file retains the same advisory `latexindent -k` result as the exact base; CI treats that check as advisory.
