### PR TITLE
docs(blueprint): record Pauli–Minkowski dependency of boost positivity

### DIFF
--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -1001,7 +1001,7 @@ This section states the existence theorems from
         Wolf.spinorCoverHom_eq_iff_eq_or_eq_neg,
         Wolf.spinorCoverHom_eq_one_iff}
     \leanok
-    \uses{def:spinor_cover_homomorphism}
+    \uses{def:spinor_cover_homomorphism, thm:pauli_minkowski_determinant}
     The homomorphism $\Lambda$ in
     (\ref{eq:representations_spinor_cover_hom}) is surjective.  Its fibres
     contain exactly two points: for all $X,Y\in\SL(2,\C)$,


### PR DESCRIPTION
## Summary

- add `thm:pauli_minkowski_determinant` to the `\uses` of `thm:spinor_epimorphism_two_point_fibres`, recording the direct call `Wolf.boostSpinor_posDef → Wolf.posSemidef_pauliMatrixOfMinkowski_iff` in the dependency graph
- the omission landed with #434; it was caught by the independent exact-head review of the (superseded, now closed) parallel PR #435, whose verdict required exactly this dependency to be recorded
- one-line blueprint change; no Lean code touched

## Verification

- `lake exe checkdecls blueprint/lean_decls` passes (after regenerating `lean_decls`)
- `python3 scripts/blueprint_lean_sync.py --root . --ci` passes (100% sync)

Refs #433