### PR TITLE
docs(channel): restore Choi positivity source contract

### DIFF
--- a/QICLean/Channel/ChoiTypeMap.lean
+++ b/QICLean/Channel/ChoiTypeMap.lean
@@ -580,7 +580,7 @@ positive semidefinite matrix.
 **Scope restriction:** See
 `docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`.  This proves
 the case `n = d - 2` of the positivity assertion for every `d ≥ 3`, subsuming
-the earlier \(d=3,n=1\) case.  The remaining range \(1\le n\le d-3\) is still
+the earlier \(d=3,n=1\) case.  The remaining range \(2\le n\le d-3\) is still
 open; its classical proof is the variational argument of Yamagami
 [Proc. Amer. Math. Soc. 118 (1993), 521–527]. -/
 theorem choiTypeMap_isPositiveMap_sub_two (hd : 3 ≤ d) :

--- a/QICLean/Channel/ChoiTypeMap/Positivity.lean
+++ b/QICLean/Channel/ChoiTypeMap/Positivity.lean
@@ -26,6 +26,9 @@ The middle range \(2\le n\le d-3\) and indecomposability are not proved here.
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
   Example 3.1, equation (3.20)][Wolf2012QChannels]
+* [K. Tanahashi and J. Tomiyama, *Indecomposable positive maps in matrix
+  algebras*, Theorem 1 and Lemmas 2--3, pp. 309--311]
+  [TanahashiTomiyama1988Indecomposable]
 -/
 
 open scoped Matrix ComplexOrder InnerProductSpace
@@ -53,11 +56,14 @@ some coordinate vanishes, at most \(d-1\) summands are nonzero and each is at
 most \(1/(d-1)\), which proves the boundary case directly.
 
 This is the case \(n = 1\) of the positivity assertion of Wolf Chapter 3,
-Example 3.1, equation (3.20) (ch03 lines 357–365); that case is classical
-(Tanahashi–Tomiyama, *Indecomposable positive maps in matrix algebras*,
-Canad. Math. Bull. 31 (1988), 308–317).  The proof here is the
-elementary-symmetric expansion sketched above, not the variational argument
-of Yamagami needed for the middle of the range. -/
+Example 3.1, equation (3.20) (ch03 lines 357–365). The proof follows
+Tanahashi--Tomiyama, Theorem 1 and Lemmas 2--3 (pp. 309--311): their Lemma 3
+sets \(y_i=x_{i-1}/x_i\), groups the cleared-denominator coefficients by
+elementary degree, and bounds the corresponding symmetric sums at the
+product-one family; their Theorem 1 then applies the rank-one diagonal-minus-
+projector criterion of Lemma 2. The paper assumes every \(x_i>0\); the formal
+proof below additionally handles zero coordinates directly. This source route
+is distinct from Yamagami's variational argument for the middle of the range. -/
 
 /-- Each variable appears in the same number of `k`-subsets of the index
 type, so the product of all `k`-subset monomials of a product-one family is

--- a/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
@@ -14,10 +14,11 @@ middle range $2\le n\le d-3$ and the indecomposability assertion remain open.
 The missing general positivity step is a cyclic reciprocal estimate for the
 weights in the rank-one reduction; it does not follow merely from equality of
 the total numerator and denominator weights. The general estimate is
-classical: the case $n=d-2$ is due to Ando, the case $n=1$ to Tanahashi and
-Tomiyama~\cite{TanahashiTomiyama1988Indecomposable}, and the whole range to
-Yamagami~\cite{Yamagami1993Cyclic}, whose proof is a variational argument on
-the boundary of a projective simplex.
+classical: the case $n=d-2$ is due to Ando, while the case $n=1$ is Theorem~1
+of Tanahashi and Tomiyama~\cite[pp.~309--311]{TanahashiTomiyama1988Indecomposable}.
+Their Lemmas~2--3 use the same rank-one and product-one coefficient argument
+formalized below. The whole range is due to Yamagami~\cite{Yamagami1993Cyclic},
+whose proof is a variational argument on the boundary of a projective simplex.
 
 \begin{definition}[Choi-type map]
     \label{def:choi_type_map}
@@ -159,10 +160,12 @@ the boundary of a projective simplex.
 
 \begin{proof}
     \leanok
-    First suppose that every $x_i$ is positive and set
+    Following Tanahashi--Tomiyama, Lemma~3, first suppose that every $x_i$ is
+    positive and set
     $y_i=x_{i-1}/x_i$. Then $\prod_i y_i=1$, and the sum becomes
-    $\sum_i 1/(d-1+y_i)$. Clearing its positive common denominator reduces the
-    desired estimate to
+    $\sum_i 1/(d-1+y_i)$. After clearing its positive common denominator,
+    multiply the resulting non-negative difference by the positive factor
+    $d-1$. The desired estimate then reduces to
     \begin{align}
         \sum_{k=0}^{d}(k-1)(d-1)^{d-k}e_k(y)
          & \ge0,
@@ -175,7 +178,9 @@ the boundary of a projective simplex.
     $e_k(y)=\binom{d}{k}$ gives equality by the binomial identity obtained at
     $y_i=1$.
 
-    If some $x_i$ vanishes, at most $d-1$ summands are nonzero. Every nonzero
+    Tanahashi--Tomiyama assume positive coordinates at this step. To obtain the
+    source's unrestricted positive-map statement, suppose instead that some
+    $x_i$ vanishes. Then at most $d-1$ summands are nonzero. Every nonzero
     summand is at most $1/(d-1)$ because
     $(d-1)x_i+x_{i-1}\ge(d-1)x_i$, so their sum is again at most $1$.
 \end{proof}

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -46,8 +46,12 @@ with zero-denominator summands read as $0$.  In the interior, put
 $y_i=x_{i-1}/x_i$, so that $\prod_i y_i=1$.  Clearing denominators expands the
 inequality in the elementary symmetric sums $e_k(y)$; AM--GM gives
 $e_k(y)\ge\binom{d}{k}$, and the resulting binomial expression is zero at the
-constant family.  On the boundary, if some $x_i$ vanishes, at most $d-1$
-summands are nonzero and each is at most $1/(d-1)$.\footnote{Formal
+constant family.  This is the proof route of Tanahashi--Tomiyama, Theorem~1
+and Lemmas~2--3~\cite[pp.~309--311]{TanahashiTomiyama1988Indecomposable}:
+Lemma~3 supplies the reciprocal estimate and Theorem~1 applies the rank-one
+diagonal-minus-projector criterion of Lemma~2.  Their argument assumes the
+coordinates are positive.  On the boundary, if some $x_i$ vanishes, at most
+$d-1$ summands are nonzero and each is at most $1/(d-1)$.\footnote{Formal
 declarations: \leanid{Matrix.choiType\_cyclic\_reciprocal\_one\_of\_nonneg},
 \leanid{Matrix.choiTypeMap\_vecMulVec\_posSemidef\_one}, and
 \leanid{Matrix.choiTypeMap\_isPositiveMap\_one} in
@@ -98,8 +102,9 @@ already extends any such rank-one statement to positivity of \(T_C\) on all
 positive semidefinite matrices.
 
 The remaining estimate is genuinely harder than the proved cases.  The now
-formalized case $n=1$ is due to Tanahashi and
-Tomiyama~\cite{TanahashiTomiyama1988Indecomposable}, and the full range
+formalized case $n=1$ is Tanahashi--Tomiyama's Theorem~1, whose Lemmas~2--3
+give the exact proof route used here~\cite[pp.~309--311]{TanahashiTomiyama1988Indecomposable},
+and the full range
 $1\le n\le d-1$ to Yamagami~\cite{Yamagami1993Cyclic}, whose proof is
 variational: it combines Nowosad's uniqueness theorem for critical points of
 \(x\mapsto\sum_i x_i/(Sx)_i\) on the positive cone, a spectral condition on


### PR DESCRIPTION
Refs #19. Follow-up to #427.

## Summary

- identify the landed `n = 1` Choi-positivity argument with Tanahashi–Tomiyama Theorem 1 and Lemmas 2–3, pp. 309–311;
- record the paper’s variables `y_i=x_{i-1}/x_i`, product-one symmetric-sum step, and rank-one diagonal-minus-projector criterion instead of presenting the route as locally invented;
- distinguish the paper’s positive-coordinate argument from QICLean’s necessary zero-coordinate boundary extension;
- record the positive factor `d-1` used after clearing denominators;
- correct the still-open range to `2 ≤ n ≤ d - 3` now that #427 has landed the complete `n = 1` slice.

## Source contract

- Wolf, *Quantum Channels & Operations*, Chapter 3, Example 3.1, Equation (3.20), local source lines 357–365;
- K. Tanahashi and J. Tomiyama, *Indecomposable Positive Maps in Matrix Algebras*, Theorem 1 and Lemmas 2–3, Canadian Mathematical Bulletin 31 (1988), pp. 309–311;
- Yamagami’s variational argument remains the cited route for the unresolved middle range.

This is a documentation/source-contract correction. It does not claim or close the full-range theorem in #19.

## Validation

- focused `lake build QICLean.Channel.ChoiTypeMap.Positivity` and full `lake build QICLean`;
- style lint, all 16 file-policy tests, import-aggregator checks, bibliography and forbidden-token checks;
- Blueprint PDF (327 pages), web render, and reader-facing browser check (30 pages; 28,426 typeset nodes);
- Blueprint/Lean sync at 100%, `checkdecls`, and all 41 paper-gap PDFs/references;
- `chktex`, `latexindent` advisory check, and `git diff --check`.
