### PR TITLE
docs(blueprint): classify boost dependency in proof

### DIFF
--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -1001,7 +1001,7 @@ This section states the existence theorems from
         Wolf.spinorCoverHom_eq_iff_eq_or_eq_neg,
         Wolf.spinorCoverHom_eq_one_iff}
     \leanok
-    \uses{def:spinor_cover_homomorphism, thm:pauli_minkowski_determinant}
+    \uses{def:spinor_cover_homomorphism}
     The homomorphism $\Lambda$ in
     (\ref{eq:representations_spinor_cover_hom}) is surjective.  Its fibres
     contain exactly two points: for all $X,Y\in\SL(2,\C)$,
@@ -1016,7 +1016,7 @@ This section states the existence theorems from
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:spinor_image_special_orthochronous}
+    \uses{thm:spinor_image_special_orthochronous, thm:pauli_minkowski_determinant}
     Given $L\in\mathrm{SO}^+(1,3)$, set $u=Le_0$.  The Lorentz identities
     give $q(u)=1$ and $u_0>0$.  The canonical boost $B_u$, whose first column
     is $u$, has the positive-definite spinor lift


### PR DESCRIPTION
## Summary

- move `thm:pauli_minkowski_determinant` from the statement-level `\\uses` of `thm:spinor_epimorphism_two_point_fibres` to its proof-level `\\uses`
- preserve the real dependency introduced by #434 while classifying it according to `docs/blueprint_style_guide.md`
- address the valid unresolved Codex review thread on already-merged #436 with a narrow follow-up; no Lean code changes

## Verification

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `texra-blueprint web`
- `git diff --check origin/main...HEAD`

Refs #433
