### PR TITLE
feat(channel): derive indecomposable maps from PPT entanglement

### DIFF
--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -86,6 +86,7 @@ import QICLean.Channel.POVM
 import QICLean.Channel.POVM.RankOneNaimark
 import QICLean.Channel.POVM.SIC
 import QICLean.Channel.POVM.Uniqueness
+import QICLean.Channel.PPTIndecomposable
 import QICLean.Channel.PSDConeAutomorphism
 import QICLean.Channel.PartialTrace
 import QICLean.Channel.PartialTranspose

--- a/QICLean/Channel/Basic.lean
+++ b/QICLean/Channel/Basic.lean
@@ -31,9 +31,12 @@ Chapters 3 and 6 of Wolf's lecture notes.
 * `IsCPMap`: a linear map that admits a Kraus representation
 * `IsKrausCP`: a linear map between possibly different matrix algebras that
   admits a rectangular Kraus representation
-* `IsCompletelyCopositiveMap`: a map whose composition with transposition is CP
-* `IsDecomposablePositiveMap`: a sum of a CP map and a completely copositive map
+* `IsCompletelyCopositiveMap`: a possibly rectangular map whose composition
+  with input transposition is CP
+* `IsDecomposablePositiveMap`: a possibly rectangular sum of a CP map and a
+  completely copositive map
 * `IsIndecomposablePositiveMap`: a positive map that is not decomposable
+* `IsKrausCP.isPositiveMap`: rectangular Kraus CP maps are positive
 * `IsCPMap.isPositiveMap`: completely positive maps are positive
 * `IsChannel`: completely positive + trace-preserving (CPTP)
 * `Matrix.transposeLinearMapComplex_isPositiveMap`: matrix transposition is positive
@@ -145,47 +148,55 @@ end Matrix
 
 section PositiveMap
 
-variable {n : Type*} [Fintype n]
+variable {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
 
 /-- A map is **completely copositive** if composing it with transposition gives a
 completely positive map.
 
 This is the convention used in Wolf Chapter 3: a decomposable positive map is
 written as a completely positive map plus a map `F` for which `F ∘ transpose` is
-completely positive. -/
-def IsCompletelyCopositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
-  IsCPMap (E.comp (Matrix.transposeLinearMapComplex n))
+completely positive. Thus Wolf's summand `T₂ ∘ θ` is represented by
+`F = T₂ ∘ θ`, since `F ∘ θ = T₂`. -/
+def IsCompletelyCopositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ) : Prop :=
+  IsKrausCP (E.comp (Matrix.transposeLinearMapComplex n))
 
 /-- A **decomposable positive map** is a sum of a completely positive map and a
-completely copositive map.  This is the class used in Wolf Chapter 3 to describe
-positive maps that cannot detect PPT entanglement. -/
-def IsDecomposablePositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
-  ∃ Ecp Eccp : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ,
-    IsCPMap Ecp ∧ IsCompletelyCopositiveMap Eccp ∧ E = Ecp + Eccp
+completely copositive map. This is Wolf Equation (3.2),
+`T = T₁ + T₂ ∘ θ`, for a possibly rectangular map `T : M_d → M_{d'}`. -/
+def IsDecomposablePositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ) : Prop :=
+  ∃ Ecp Eccp : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ,
+    IsKrausCP Ecp ∧ IsCompletelyCopositiveMap Eccp ∧ E = Ecp + Eccp
 
 /-- An **indecomposable positive map** is positive but not decomposable. -/
-def IsIndecomposablePositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
+def IsIndecomposablePositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ) : Prop :=
   IsPositiveMap E ∧ ¬ IsDecomposablePositiveMap E
 
-/-- A completely positive map is positive. -/
-theorem IsCPMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
-    (h : IsCPMap E) : IsPositiveMap E := by
+/-- A completely positive map in rectangular Kraus form is positive. -/
+theorem IsKrausCP.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ}
+    (h : IsKrausCP E) : IsPositiveMap E := by
   obtain ⟨r, K, hK⟩ := h
   intro X hX
   rw [hK]
   exact Matrix.posSemidef_sum (s := Finset.univ) (x := fun i => K i * X * (K i)ᴴ)
     (fun i _ => by simpa [Matrix.mul_assoc] using hX.mul_mul_conjTranspose_same (B := K i))
 
+omit [DecidableEq n] in
+/-- A square completely positive map is positive. -/
+theorem IsCPMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    (h : IsCPMap E) : IsPositiveMap E := by
+  classical
+  exact IsKrausCP.isPositiveMap h
+
 /-- Completely copositive maps are positive. -/
 theorem IsCompletelyCopositiveMap.isPositiveMap
-    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ}
     (h : IsCompletelyCopositiveMap E) : IsPositiveMap E := by
   intro X hX
   have hXt : (Matrix.transposeLinearMapComplex n X).PosSemidef :=
     Matrix.transposeLinearMapComplex_isPositiveMap X hX
-  have hcp : IsCPMap (E.comp (Matrix.transposeLinearMapComplex n)) := h
+  have hcp : IsKrausCP (E.comp (Matrix.transposeLinearMapComplex n)) := h
   have hEXt :=
-    IsCPMap.isPositiveMap hcp (Matrix.transposeLinearMapComplex n X) hXt
+    IsKrausCP.isPositiveMap hcp (Matrix.transposeLinearMapComplex n X) hXt
   have hdouble :
       Matrix.transposeLinearMapComplex n (Matrix.transposeLinearMapComplex n X) = X := by
     ext i j
@@ -198,13 +209,14 @@ theorem IsCompletelyCopositiveMap.isPositiveMap
 
 /-- Decomposable positive maps are positive. -/
 theorem IsDecomposablePositiveMap.isPositiveMap
-    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ}
     (h : IsDecomposablePositiveMap E) : IsPositiveMap E := by
   obtain ⟨Ecp, Eccp, hcp, hccp, rfl⟩ := h
   intro X hX
   simpa [LinearMap.add_apply] using
     (hcp.isPositiveMap X hX).add (hccp.isPositiveMap X hX)
 
+omit [DecidableEq n] in
 /-- A channel is a positive map (derived from complete positivity). -/
 theorem IsChannel.pos {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
     (hE : IsChannel E) : IsPositiveMap E := hE.cp.isPositiveMap

--- a/QICLean/Channel/DecomposablePPT.lean
+++ b/QICLean/Channel/DecomposablePPT.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import QICLean.Channel.Schwarz.TwoPositive
 import QICLean.Channel.PartialTranspose
 import QICLean.Channel.TensorMap
+import QICLean.Channel.LocalizedKrausCPTP
 
 /-!
 # Decomposable positive maps preserve positivity on PPT states
@@ -25,8 +26,9 @@ and nondecomposable entanglement witnesses.
 * `Matrix.tensorMapId_comp_transposeLinearMapComplex` -- ampliating a map
   precomposed with transposition equals ampliating the map itself after taking the
   first-factor partial transpose of the input.
-* `IsCPMap.tensorMapId_posSemidef` -- the ampliation of a completely positive map
-  sends positive semidefinite bipartite matrices to positive semidefinite matrices.
+* `IsKrausCP.tensorMapId_posSemidef` -- the ampliation of a rectangular
+  completely positive map sends positive semidefinite bipartite matrices to
+  positive semidefinite matrices.
 * `IsDecomposablePositiveMap.tensorMapId_posSemidef_of_isPPT` -- the ampliation of
   a decomposable positive map sends PPT states to positive semidefinite matrices.
 * `not_isDecomposablePositiveMap_of_isPPT_not_tensorMapId_posSemidef` -- a PPT
@@ -34,13 +36,14 @@ and nondecomposable entanglement witnesses.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  Equation (3.2) and Proposition 3.5][Wolf2012QChannels]
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
 open Matrix
 
-variable {d : ℕ}
+variable {d d' k : ℕ}
 
 namespace Matrix
 
@@ -49,12 +52,12 @@ taking the first-factor partial transpose of the input. Both sides evaluate `F`
 on the matrix `X(j₁, i₂)(i₁, j₂)` at entry `(i₁, j₁)`: the left side transposes the
 `(i₂, j₂)`-slice of `X` before feeding it to `F`, and the right side reads that
 same transposed slice directly off `partialTransposeLeft X`. -/
-theorem tensorMapId_comp_transposeLinearMapComplex {d' : ℕ}
+theorem tensorMapId_comp_transposeLinearMapComplex
     (F : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
-    (X : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) :
+    (X : Matrix (Fin d × Fin k) (Fin d × Fin k) ℂ) :
     tensorMapId (F.comp (Matrix.transposeLinearMapComplex (Fin d))) X
       = tensorMapId F (partialTransposeLeft X) := by
-  have hslice : ∀ i₂ j₂ : Fin d,
+  have hslice : ∀ i₂ j₂ : Fin k,
       (bipartiteSlice X i₂ j₂)ᵀ = bipartiteSlice (partialTransposeLeft X) i₂ j₂ := by
     intro i₂ j₂
     ext i₁ j₁
@@ -64,17 +67,23 @@ theorem tensorMapId_comp_transposeLinearMapComplex {d' : ℕ}
       = (F (bipartiteSlice (partialTransposeLeft X) i₂ j₂)) i₁ j₁
   rw [hslice]
 
-/-- The ampliation of a completely positive map sends positive semidefinite
-bipartite matrices to positive semidefinite matrices: this is exactly the
-statement that `E` is `d`-positive, unfolded at the ancilla dimension matching
-`E`'s domain. -/
-theorem _root_.IsCPMap.tensorMapId_posSemidef
+end Matrix
+
+/-- The ampliation of a rectangular Kraus completely positive map sends positive
+semidefinite bipartite matrices to positive semidefinite matrices. -/
+theorem IsKrausCP.tensorMapId_posSemidef
+    {E : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hE : IsKrausCP E)
+    {ρ : Matrix (Fin d × Fin k) (Fin d × Fin k) ℂ} (hρ : ρ.PosSemidef) :
+    (Matrix.tensorMapId E ρ).PosSemidef :=
+  Matrix.tensorMapId_posSemidef_of_isKrausCP hE hρ
+
+/-- Square compatibility form of `IsKrausCP.tensorMapId_posSemidef`. -/
+theorem IsCPMap.tensorMapId_posSemidef
     {E : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ} (hE : IsCPMap E)
     {ρ : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ} (hρ : ρ.PosSemidef) :
-    (tensorMapId E ρ).PosSemidef :=
-  hE.isNPositiveMap d ρ hρ
-
-end Matrix
+    (Matrix.tensorMapId E ρ).PosSemidef :=
+  IsKrausCP.tensorMapId_posSemidef hE hρ
 
 /-- **Decomposable maps cannot detect PPT entanglement (Wolf Ch. 3).** If `E` is a
 decomposable positive map and `ρ` is a PPT state (positive semidefinite with
@@ -83,9 +92,9 @@ semidefinite. The completely positive summand preserves positivity of `ρ`
 directly; the completely copositive summand preserves positivity of `ρ`'s
 partial transpose, which is exactly the PPT hypothesis. -/
 theorem IsDecomposablePositiveMap.tensorMapId_posSemidef_of_isPPT
-    {E : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
+    {E : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
     (hE : IsDecomposablePositiveMap E)
-    {ρ : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ}
+    {ρ : Matrix (Fin d × Fin k) (Fin d × Fin k) ℂ}
     (hρ : ρ.PosSemidef) (hPPT : Matrix.IsPPT ρ) :
     (Matrix.tensorMapId E ρ).PosSemidef := by
   obtain ⟨Ecp, Eccp, hcp, hccp, rfl⟩ := hE
@@ -109,9 +118,21 @@ witnesses that `E` is not decomposable, since decomposable maps preserve
 positivity on PPT states
 (`IsDecomposablePositiveMap.tensorMapId_posSemidef_of_isPPT`). -/
 theorem not_isDecomposablePositiveMap_of_isPPT_not_tensorMapId_posSemidef
-    {E : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
-    {ρ : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ}
+    {E : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    {ρ : Matrix (Fin d × Fin k) (Fin d × Fin k) ℂ}
     (hρ : ρ.PosSemidef) (hPPT : Matrix.IsPPT ρ)
     (hneg : ¬ (Matrix.tensorMapId E ρ).PosSemidef) :
     ¬ IsDecomposablePositiveMap E :=
   fun hE => hneg (hE.tensorMapId_posSemidef_of_isPPT hρ hPPT)
+
+/-- A positive map detected by a PPT state is indecomposable. This is the map-side
+contrapositive of the preservation theorem above. -/
+theorem IsPositiveMap.isIndecomposablePositiveMap_of_isPPT_not_tensorMapId_posSemidef
+    {E : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hE : IsPositiveMap E)
+    {ρ : Matrix (Fin d × Fin k) (Fin d × Fin k) ℂ}
+    (hρ : ρ.PosSemidef) (hPPT : Matrix.IsPPT ρ)
+    (hneg : ¬ (Matrix.tensorMapId E ρ).PosSemidef) :
+    IsIndecomposablePositiveMap E :=
+  ⟨hE, not_isDecomposablePositiveMap_of_isPPT_not_tensorMapId_posSemidef
+    hρ hPPT hneg⟩

--- a/QICLean/Channel/PPTIndecomposable.lean
+++ b/QICLean/Channel/PPTIndecomposable.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Channel.DecomposablePPT
+import QICLean.Channel.PositiveMapDetection
+
+/-!
+# PPT entangled states yield indecomposable positive maps
+
+This file proves the source-faithful easy direction of Wolf, Chapter 3,
+Proposition 3.5: a PPT entangled density operator on
+`ℂ^d ⊗ ℂ^{d'}` yields an indecomposable positive map
+`T : M_d(ℂ) → M_{d'}(ℂ)`.
+
+Wolf says this implication follows from Proposition 3.3. In the formalization,
+the exact rectangular detector is Proposition 3.4:
+`Matrix.exists_isNPositiveMap_tensorMapId_not_posSemidef` at `n = 1` produces
+a positive map whose ampliation detects the entangled state. The contrapositive
+of rectangular decomposable-PPT preservation then proves that this map is
+indecomposable.
+
+The reverse implication in Proposition 3.5 is not claimed here. It requires the
+closed convex cone of Wolf Equation (3.15), its trace-pairing duality, and the
+separating-hyperplane argument used in Lewenstein--Kraus--Cirac--Horodecki,
+arXiv:quant-ph/0005014v3, Theorem 3.
+The exact remaining boundary is recorded in
+`docs/paper-gaps/wolf_prop3_5_reverse_implication.tex`.
+
+## Main result
+
+* `Matrix.exists_isIndecomposablePositiveMap_of_isPPT_not_isSeparable` -- a
+  PPT entangled density operator yields a rectangular indecomposable positive
+  map.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  Proposition 3.5][Wolf2012QChannels]
+* M. Lewenstein, B. Kraus, J. I. Cirac, and P. Horodecki,
+  *Optimization of entanglement witnesses*, arXiv:quant-ph/0005014v3,
+  Theorem 3.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace Matrix
+
+variable {d d' : ℕ}
+
+/-- **PPT entanglement gives an indecomposable positive map (Wolf Proposition 3.5,
+easy direction).** If `ρ` is a density operator on `ℂ^d ⊗ ℂ^{d'}`, has positive
+first-factor partial transpose, and is not separable, then there is an
+indecomposable positive map `T : M_d(ℂ) → M_{d'}(ℂ)`.
+
+The map is the `n = 1` detector from the rectangular positive-map criterion
+(Wolf Proposition 3.4). One-positivity is positivity, and decomposable maps
+preserve positivity on PPT states, so a map detected by `ρ` cannot be
+decomposable. -/
+theorem exists_isIndecomposablePositiveMap_of_isPPT_not_isSeparable [NeZero d']
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hρ : ρ.PosSemidef) (hρtr : ρ.trace = 1) (hPPT : IsPPT ρ)
+    (hentangled : ¬ IsSeparable ρ) :
+    ∃ T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ,
+      IsIndecomposablePositiveMap T := by
+  rw [← hasSchmidtNumberLE_one_iff_isSeparable] at hentangled
+  obtain ⟨T, hT, hneg⟩ :=
+    exists_isNPositiveMap_tensorMapId_not_posSemidef 1 hρ.isHermitian hρtr hentangled
+  refine ⟨T, ?_⟩
+  exact (isNPositiveMap_one_iff_isPositiveMap.mp hT)
+    |>.isIndecomposablePositiveMap_of_isPPT_not_tensorMapId_posSemidef hρ hPPT hneg
+
+end Matrix

--- a/QICLean/Channel/PositiveExamples.lean
+++ b/QICLean/Channel/PositiveExamples.lean
@@ -169,7 +169,9 @@ composition with transposition has Choi matrix \(D^{-1}(1-F)\), which is positiv
 semidefinite. -/
 theorem reductionMap_one_isCompletelyCopositiveMap [NeZero D] :
     IsCompletelyCopositiveMap (reductionMap D 1) := by
-  rw [IsCompletelyCopositiveMap, ChoiJamiolkowski.cp_iff_choi_posSemidef,
+  rw [IsCompletelyCopositiveMap]
+  change IsCPMap ((reductionMap D 1).comp (transposeLinearMapComplex (Fin D)))
+  rw [ChoiJamiolkowski.cp_iff_choi_posSemidef,
     ChoiJamiolkowski.choiMatrix_reductionMap_one_comp_transpose]
   exact (one_sub_swapMatrix_posSemidef D).smul (by positivity)
 

--- a/blueprint/src/chapter/ch02_channels_positive_map_and_channel_foundations.tex
+++ b/blueprint/src/chapter/ch02_channels_positive_map_and_channel_foundations.tex
@@ -110,10 +110,11 @@ consequences cited there: entrywise complete positivity and the associated
 abstract completely positive map.
 
 \begin{theorem}[CP maps are positive]\label{thm:cp_is_positive}
-    \lean{IsCPMap.isPositiveMap}
+    \lean{IsKrausCP.isPositiveMap, IsCPMap.isPositiveMap}
     \leanok
     \uses{def:cp_map, def:positive_map}
-    Every completely positive map is positive.
+    Every rectangular Kraus completely positive map is positive. In particular,
+    every square completely positive map is positive.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
@@ -406,7 +406,7 @@ positive map and a completely copositive map.
     \lean{IsCompletelyCopositiveMap, IsDecomposablePositiveMap,
         IsIndecomposablePositiveMap}
     \leanok
-    A map $\Phi\colon\MN{D}\to\MN{D}$ is completely copositive if
+    A map $\Phi\colon\MN{d}\to\MN{d'}$ is completely copositive if
     $\Phi\circ\theta$ is completely positive, where $\theta$ is transposition.
     It is decomposable if
     $\Phi=\Phi_{\mathrm{cp}}+\Phi_{\mathrm{ccp}}$ with
@@ -453,11 +453,13 @@ positive map and a completely copositive map.
 
 \begin{theorem}[Decomposable maps preserve positivity on PPT states]
     \label{thm:decomposable_map_tensor_id_ppt}
-    \lean{IsDecomposablePositiveMap.tensorMapId_posSemidef_of_isPPT}
+    \lean{Matrix.tensorMapId_comp_transposeLinearMapComplex,
+        IsKrausCP.tensorMapId_posSemidef, IsCPMap.tensorMapId_posSemidef,
+        IsDecomposablePositiveMap.tensorMapId_posSemidef_of_isPPT}
     \leanok
     \uses{def:decomposable_positive_map, def:is_ppt}
-    If $\Phi\colon\MN{D}\to\MN{D}$ is decomposable and $\rho$ is a positive
-    semidefinite matrix on $\C^{D}\otimes\C^{D}$ with the PPT property, then
+    If $\Phi\colon\MN{d}\to\MN{d'}$ is decomposable and $\rho$ is a positive
+    semidefinite matrix on $\C^{d}\otimes\C^{k}$ with the PPT property, then
     $(\Phi\otimes\id)(\rho)\ge0$.
 \end{theorem}
 
@@ -484,20 +486,53 @@ positive map and a completely copositive map.
     images is positive.
 \end{proof}
 
+\begin{theorem}[PPT entanglement yields an indecomposable positive map]
+    \label{thm:ppt_entangled_state_gives_indecomposable_map}
+    \lean{Matrix.exists_isIndecomposablePositiveMap_of_isPPT_not_isSeparable}
+    \leanok
+    \uses{def:decomposable_positive_map, def:is_ppt,
+        thm:has_schmidt_number_le_one_iff_separable,
+        thm:exists_isNPositiveMap_detects, thm:decomposable_map_tensor_id_ppt}
+    Let $\rho$ be a PPT entangled density operator on
+    $\C^d\otimes\C^{d'}$. Then there is an indecomposable positive map
+    $T\colon\MN{d}\to\MN{d'}$.
+    This is the PPT-state-to-map direction of Wolf's Proposition~3.5; the
+    remaining reverse implication is recorded in
+    \cite{gap:wolf_prop3_5_reverse_implication}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    By Theorem~\ref{thm:has_schmidt_number_le_one_iff_separable}, entanglement
+    means that $\rho$ has Schmidt number larger than one. The rectangular
+    detector in Theorem~\ref{thm:exists_isNPositiveMap_detects}, at $n=1$,
+    gives a positive map $T\colon\MN{d}\to\MN{d'}$ for which
+    $(T\otimes\id)(\rho)$ is not positive semidefinite. If $T$ were
+    decomposable, Theorem~\ref{thm:decomposable_map_tensor_id_ppt} would make
+    this ampliation positive because $\rho$ is PPT, a contradiction.
+
+    The reverse implication of Proposition~3.5 is not claimed here; it needs
+    Wolf's decomposable-witness cone in Equation~(3.15), its closedness and
+    trace-pairing duality, and a separating-hyperplane argument.
+\end{proof}
+
 \begin{theorem}[A PPT state detected by an ampliation witnesses indecomposability]
     \label{thm:indecomposable_of_ppt_witness}
-    \lean{not_isDecomposablePositiveMap_of_isPPT_not_tensorMapId_posSemidef}
+    \lean{not_isDecomposablePositiveMap_of_isPPT_not_tensorMapId_posSemidef,
+        IsPositiveMap.isIndecomposablePositiveMap_of_isPPT_not_tensorMapId_posSemidef}
     \leanok
     \uses{def:decomposable_positive_map, def:is_ppt,
         thm:decomposable_map_tensor_id_ppt}
-    Let $\Phi\colon\MN{D}\to\MN{D}$ be a linear map. If some positive
-    semidefinite matrix $\rho$ on $\C^{D}\otimes\C^{D}$ with the PPT property
-    has $(\Phi\otimes\id)(\rho)$ not positive semidefinite, then $\Phi$ is not
-    decomposable.
+    Let $\Phi\colon\MN{d}\to\MN{d'}$ be a positive map. If some positive
+    semidefinite matrix $\rho$ on $\C^{d}\otimes\C^{k}$ with the PPT property
+    has $(\Phi\otimes\id)(\rho)$ not positive semidefinite, then $\Phi$ is
+    indecomposable. The detection hypothesis alone, without positivity of
+    $\Phi$, still implies that $\Phi$ is not decomposable.
 \end{theorem}
 
 \begin{proof}
     \leanok
     This is the contrapositive of
-    Theorem~\ref{thm:decomposable_map_tensor_id_ppt}.
+    Theorem~\ref{thm:decomposable_map_tensor_id_ppt}. Together with the assumed
+    positivity of $\Phi$, it is exactly indecomposability.
 \end{proof}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -321,6 +321,16 @@
   note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_prop3_1_exact_schmidt_rank_scope.pdf}},
 }
 
+@techreport{gap:wolf_prop3_5_reverse_implication,
+  author      = {The {QICLean} contributors},
+  title       = {{Wolf} Proposition 3.5: The Remaining Reverse Implication},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_prop3\_5\_reverse\_implication},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_prop3_5_reverse_implication.pdf}},
+}
+
 @techreport{gap:wolf_slater_attainment_conditions,
   author      = {The {QICLean} contributors},
   title       = {Slater Strong Duality: Finiteness Conditions for Attainment},

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -46,3 +46,28 @@
   pages        = {73--83},
   year         = {1991},
 }
+
+@article{LewensteinKrausCiracHorodecki2000,
+  author       = {Lewenstein, Maciej and Kraus, Barbara and Cirac, J. Ignacio
+                  and Horodecki, Pawel},
+  title        = {Optimization of Entanglement Witnesses},
+  journal      = {Physical Review A},
+  volume       = {62},
+  pages        = {052310},
+  year         = {2000},
+  doi          = {10.1103/PhysRevA.62.052310},
+  eprint       = {quant-ph/0005014},
+  eprinttype   = {arxiv},
+}
+
+@article{HorodeckiHorodeckiHorodecki1996Separability,
+  author       = {Horodecki, Michal and Horodecki, Pawel and Horodecki, Ryszard},
+  title        = {Separability of Mixed States: Necessary and Sufficient Conditions},
+  journal      = {Physics Letters A},
+  volume       = {223},
+  pages        = {1--8},
+  year         = {1996},
+  doi          = {10.1016/S0375-9601(96)00706-2},
+  eprint       = {quant-ph/9605038},
+  eprinttype   = {arxiv},
+}

--- a/docs/paper-gaps/wolf_prop3_5_reverse_implication.tex
+++ b/docs/paper-gaps/wolf_prop3_5_reverse_implication.tex
@@ -1,0 +1,120 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Remaining Direction of Wolf's PPT--Indecomposable Existence Equivalence}
+\author{}
+\date{2026-08-24}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{wip}
+
+\section{The source equivalence}
+
+For fixed dimensions $d,d'$, Wolf's Proposition~3.5 states the existence
+equivalence
+\begin{align}
+  &\text{there is an indecomposable positive map }
+      T:\MN{d}\longrightarrow\MN{d'}
+  \notag\\
+  &\qquad\Longleftrightarrow\qquad
+  \text{there is an entangled density operator }
+      \rho\in\MN{d}\otimes\MN{d'}
+      \text{ with }\rho^{T_1}\geq 0.
+  \tag{Wolf Proposition 3.5}
+\end{align}
+Immediately before the proposition, the decomposable witnesses are written in
+the first-factor convention
+\begin{align}
+  W=P_1+P_2^{T_1},\qquad P_1,P_2\geq0.
+  \tag{Wolf 3.15}
+\end{align}
+The local source is
+\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex}, lines
+276--303.
+\footnote{Tracked by \ghissue{22}.}
+
+The matching primary witness result is Theorem~3 of
+Lewenstein--Kraus--Cirac--Horodecki: a witness is nondecomposable if and only
+if it detects a PPT entangled state \cite{LewensteinKrausCiracHorodecki2000}.
+Its difficult direction separates a nondecomposable witness from the closed
+convex cone of decomposable witnesses. The earlier Horodecki--Horodecki--
+Horodecki cone calculation writes the dual of the PPT cone as the functionals
+represented by $B+C^{T_2}$ with $B,C\geq0$
+\cite[arXiv v2, Appendix Eq.~(50)]{HorodeckiHorodeckiHorodecki1996Separability}.
+That paper transposes the second factor; Wolf's displayed Equation~(3.15)
+transposes the first.
+
+\section{The formalized direction}
+
+The formal development now proves
+\begin{align}
+  &\rho\geq0,\quad \tr(\rho)=1,\quad \rho^{T_1}\geq0,
+      \quad \rho\text{ not separable}
+  \notag\\
+  &\qquad\Longrightarrow\qquad
+  \exists T:\MN{d}\longrightarrow\MN{d'}\text{ positive and indecomposable}.
+  \tag{formalized direction}
+\end{align}
+This is the source's PPT-state-to-map implication, not a substitute theorem.
+Schmidt number one is separability, so the rectangular positive-map criterion
+at level one supplies a positive $T$ for which
+$(T\otimes\operatorname{id}_{d'})(\rho)$ is not positive semidefinite. A
+decomposable map cannot have this property: writing
+$T=T_1+T_2\theta$ gives
+\begin{align}
+  (T\otimes\operatorname{id})(\rho)
+    &=(T_1\otimes\operatorname{id})(\rho)
+      +(T_2\otimes\operatorname{id})(\rho^{T_1})\geq0.
+\end{align}
+Thus the detecting map is indecomposable.
+
+The formal theorem is
+\leanid{Matrix.exists_isIndecomposablePositiveMap_of_isPPT_not_isSeparable}.
+\footnote{Formal declarations:
+\leanid{Matrix.exists_isIndecomposablePositiveMap_of_isPPT_not_isSeparable}
+in \doclink{QICLean/Channel/PPTIndecomposable}, and
+\leanid{IsDecomposablePositiveMap.tensorMapId_posSemidef_of_isPPT}
+in \doclink{QICLean/Channel/DecomposablePPT}.}
+The decomposability predicates and preservation theorem are rectangular, with
+the same input-to-output orientation $\MN{d}\to\MN{d'}$ as Wolf.
+
+\section{The remaining direction}
+
+The converse required for the full proposition begins with an
+indecomposable positive map and must produce a PPT entangled density
+operator. The current formal development does not claim that implication.
+Following Wolf and the primary witness proof requires all of the following:
+\begin{align}
+  &\text{the exact cone }\{P_1+P_2^{T_1}:P_1,P_2\geq0\},\notag\\
+  &\text{the rectangular map--witness correspondence in the adjoint
+    orientation of Wolf Proposition 3.4},\notag\\
+  &\text{closedness and convexity of that cone},\notag\\
+  &\tr\!\left(P_2^{T_1}R\right)
+      =\tr\!\left(P_2R^{T_1}\right),\notag\\
+  &\text{and separation followed by positivity, PPT, trace normalization,
+    and entanglement of the separator.}\notag
+\end{align}
+Defining a decomposable witness merely as a functional nonnegative on every
+PPT operator would hide rather than prove Equation~(3.15), so that route is
+not used.
+
+\section{Conclusion}
+
+The verdict is a live scope restriction. The PPT-entangled-state-to-
+indecomposable-map direction of Wolf Proposition~3.5 is formalized with the
+printed rectangular dimensions and first-factor transpose convention. The
+reverse direction, and hence the source's existence equivalence, remains open
+until the Equation~(3.15) cone and its trace-pairing separation argument are
+formalized.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -585,6 +585,26 @@ so that the cited formal statements are available from the main project import.
 - `Matrix.hasSchmidtNumberLE_iff_forall_isNPositiveMap_tensorMapId_posSemidef`
   — the full rectangular equivalence in Proposition 3.4 for density operators ✓
 
+#### Wolf Proposition 3.5 — ONE DIRECTION FORMALIZED (RECTANGULAR FORM)
+
+- `IsCompletelyCopositiveMap`, `IsDecomposablePositiveMap`, and
+  `IsIndecomposablePositiveMap` — Wolf Equation (3.2), now for maps
+  `T : M_d(ℂ) → M_{d'}(ℂ)` rather than only square endomorphisms ✓
+- `IsDecomposablePositiveMap.tensorMapId_posSemidef_of_isPPT` — a rectangular
+  decomposable map preserves positivity on a PPT input, with an independent
+  bystander dimension ✓
+- `Matrix.exists_isIndecomposablePositiveMap_of_isPPT_not_isSeparable` — a PPT
+  entangled density operator on `ℂ^d ⊗ ℂ^{d'}` yields an indecomposable positive
+  map `T : M_d(ℂ) → M_{d'}(ℂ)`, by Proposition 3.4 at `n = 1` and the
+  contrapositive of decomposable-PPT preservation ✓
+- The reverse implication remains open. It requires the explicit
+  decomposable-witness cone `W = P₁ + P₂^{T₁}` from Equation (3.15), the
+  rectangular map--witness equivalence, closedness of that cone,
+  self-adjointness of partial transpose for the trace pairing, and the
+  separating-hyperplane argument. Proposition 3.5 is therefore not recorded
+  as fully formalized; see
+  `docs/paper-gaps/wolf_prop3_5_reverse_implication.tex`.
+
 #### Wolf Example 3.1, Equation (3.20) (Choi-type maps) — PARTIALLY FORMALIZED
 
 - `Matrix.choiTypeMap` and `Matrix.choiTypeMap_vecMulVec` formalize the map


### PR DESCRIPTION
Refs #22.

## Scope

This is the first, source-faithful implication of Wolf Proposition 3.5:

\[
\text{PPT entangled density operator on }\mathbb C^d\otimes\mathbb C^{d'}
\Longrightarrow
\text{an indecomposable positive map }M_d\to M_{d'}.
\]

It is partial progress only. The reverse closed-cone/separation implication remains open, this PR does not mark the displayed iff `leanok`, and it does not close #22.

## Summary

- generalize the completely-copositive, decomposable-positive, and indecomposable-positive predicates from square endomorphisms to rectangular maps `M_d → M_{d'}` while preserving square compatibility;
- generalize decomposable-map preservation of PPT inputs to the same rectangular orientation;
- add `Matrix.exists_isIndecomposablePositiveMap_of_isPPT_not_isSeparable`;
- derive it from the existing rectangular Proposition 3.4 detector at `n = 1`, one-positivity, and the contrapositive of decomposable-PPT preservation;
- synchronize imports, Blueprint, Wolf coverage, references, and an explicit paper-gap note for the reverse implication.

## Source contract

- Wolf Chapter 3, Equation (3.2), lines 57–67: `T = T₁ + T₂ θ`;
- Wolf Equation (3.15) and Proposition 3.5, lines 276–303, with first-factor partial transpose;
- Lewenstein–Kraus–Cirac–Horodecki, arXiv:quant-ph/0005014v3, Theorem 3;
- Horodecki–Horodecki–Horodecki, arXiv:quant-ph/9605038v2, Appendix Equation (27) in the primary PDF (the generated arXiv HTML retags it as Equation (50)), with its second-factor convention explicitly distinguished from Wolf’s first-factor convention.

The unproved reverse direction is not replaced by a tautological dual-cone definition: its Equation-(3.15) cone, closedness, trace-pairing duality, and separation work remain recorded as an open gap.

## Validation

- focused DecomposablePPT/PPTIndecomposable builds and full `lake build` (9,273 jobs);
- style lint, policy, import-aggregator, oversized-file, forbidden-token, and axiom audits;
- Blueprint PDF/web/checkdecls/sync and changed-declaration reverse coverage (2,298/2,298);
- all 42 paper-gap references/PDFs, bibliography, `chktex`, and `git diff --check`.

