### PR TITLE
docs(channel): cite primary PPT dual-cone equation

### DIFF
--- a/docs/paper-gaps/wolf_prop3_5_reverse_implication.tex
+++ b/docs/paper-gaps/wolf_prop3_5_reverse_implication.tex
@@ -47,7 +47,9 @@ Its difficult direction separates a nondecomposable witness from the closed
 convex cone of decomposable witnesses. The earlier Horodecki--Horodecki--
 Horodecki cone calculation writes the dual of the PPT cone as the functionals
 represented by $B+C^{T_2}$ with $B,C\geq0$
-\cite[arXiv v2, Appendix Eq.~(50)]{HorodeckiHorodeckiHorodecki1996Separability}.
+\cite[arXiv v2 PDF, Appendix Eq.~(27)]{HorodeckiHorodeckiHorodecki1996Separability}.
+The generated arXiv HTML retags this display as Equation~(50); Equation~(27)
+is the number printed in the primary PDF.
 That paper transposes the second factor; Wolf's displayed Equation~(3.15)
 transposes the first.
 


### PR DESCRIPTION
## Summary

- cite the Horodecki--Horodecki--Horodecki dual PPT-cone display by the equation number printed in the primary arXiv v2 PDF: Appendix Equation (27);
- record that arXiv's generated HTML retags the same display as Equation (50), which caused the post-review citation regression.

The mathematical formula and factor convention are unchanged: the paper writes `B + C^{T₂}`, while Wolf Equation (3.15) uses the first-factor transpose.

## Validation

- primary PDF text checked directly at the Appendix display;
- paper-gap reference check passes;
- all paper-gap PDFs build successfully;
- `chktex` has only the pre-existing shared-command/footnote warnings;
- `git diff --check` passes.

Refs #22
