### PR TITLE
feat(algebra): signed sip blocks and Minkowski-selfadjoint block data for canonical pairs

### DIFF
--- a/QICLean/Algebra.lean
+++ b/QICLean/Algebra.lean
@@ -40,6 +40,7 @@ import QICLean.Algebra.MatrixSpectralDecomp
 import QICLean.Algebra.MatrixTracePairing
 import QICLean.Algebra.MatrixTracePowerContinuity
 import QICLean.Algebra.MatrixUnitaryBetween
+import QICLean.Algebra.MinkowskiCanonicalPair
 import QICLean.Algebra.NewtonGirard
 import QICLean.Algebra.OperatorBlock
 import QICLean.Algebra.OperatorSchmidt

--- a/QICLean/Algebra/MinkowskiCanonicalPair.lean
+++ b/QICLean/Algebra/MinkowskiCanonicalPair.lean
@@ -252,6 +252,54 @@ theorem mul_permMatrix_apply' {n : Type*} [Fintype n] [DecidableEq n]
   rw [Matrix.vecMul_permMatrix]
   rfl
 
+
+/-! ## Real-eigenvalue Jordan blocks -/
+
+/-- The real Jordan block of size `n` and eigenvalue `a`, with ones on the first
+superdiagonal. This is the orientation used in GLR Theorem 5.3. -/
+def realJordanBlock (n : ℕ) (a : ℝ) : Matrix (Fin n) (Fin n) ℝ := fun i j =>
+  if i = j then a else if i.val + 1 = j.val then 1 else 0
+
+/-- A real Jordan block is selfadjoint for its unsigned sip matrix. -/
+theorem sipMatrix_mul_realJordanBlock (n : ℕ) (a : ℝ) :
+    sipMatrix n ℝ * realJordanBlock n a =
+      (realJordanBlock n a).transpose * sipMatrix n ℝ := by
+  ext i j
+  change (((finReversePerm n).permMatrix ℝ * realJordanBlock n a) i j) =
+    ((realJordanBlock n a).transpose * (finReversePerm n).permMatrix ℝ) i j
+  rw [permMatrix_mul_apply', mul_permMatrix_apply']
+  simp only [transpose_apply, finReversePerm_apply]
+  change realJordanBlock n a i.rev j = realJordanBlock n a j.rev i
+  have hdiag : i.rev = j ↔ j.rev = i := by
+    constructor
+    · intro h
+      rw [← h]
+      simp
+    · intro h
+      rw [← h]
+      simp
+  have hsuper : n - (i.val + 1) + 1 = j.val ↔
+      n - (j.val + 1) + 1 = i.val := by
+    omega
+  simp only [realJordanBlock]
+  by_cases hd : i.rev = j
+  · have hd' : j.rev = i := hdiag.mp hd
+    simp [hd, hd']
+  · have hd' : j.rev ≠ i := fun h ↦ hd (hdiag.mpr h)
+    simp only [Fin.val_rev]
+    by_cases hs : n - (i.val + 1) + 1 = j.val
+    · have hs' : n - (j.val + 1) + 1 = i.val := hsuper.mp hs
+      simp [hd, hd', hs, hs']
+    · have hs' : n - (j.val + 1) + 1 ≠ i.val := fun h ↦ hs (hsuper.mpr h)
+      simp [hd, hd', hs, hs']
+
+/-- A real Jordan block is selfadjoint for either sign of its signed sip metric. -/
+theorem signedSipMatrix_mul_realJordanBlock (ε : GLRSign) (n : ℕ) (a : ℝ) :
+    signedSipMatrix ε n * realJordanBlock n a =
+      (realJordanBlock n a).transpose * signedSipMatrix ε n := by
+  simp only [signedSipMatrix, Matrix.smul_mul, Matrix.mul_smul]
+  rw [sipMatrix_mul_realJordanBlock]
+
 /-- The real conjugate-pair Jordan block is selfadjoint for its unsigned sip metric.
 
 This verifies the block identity `H A = Aᵀ H` from GLR Section 5.1. It also records why no sign
@@ -297,5 +345,74 @@ theorem complexPairSipMatrix_mul_realConjugatePairJordanBlock
       simp [hd, hd', hs, hs', one_fin_two_rev_apply]
     · have hs' : m - (j.val + 1) + 1 ≠ i.val := fun h ↦ hs (hsuperNat.mpr h)
       simp [hd, hd', hs, hs']
+
+
+/-! ## Four-dimensional Minkowski selfadjointness -/
+
+/-- The matrix of the Minkowski form of inertia `(1, 3)` in the ordered Pauli basis.
+
+This is the matrix denoted `M` in the proof of Verstraete--Dehaene--De Moor, Theorem 3,
+arXiv:quant-ph/0011111v1, lines 175--196. -/
+def minkowskiMetric : Matrix (Fin 4) (Fin 4) ℝ := diagonal ![1, -1, -1, -1]
+
+@[simp]
+theorem minkowskiMetric_transpose : minkowskiMetric.transpose = minkowskiMetric := by
+  simp [minkowskiMetric]
+
+@[simp]
+theorem minkowskiMetric_mul_self : minkowskiMetric * minkowskiMetric = 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [minkowskiMetric, Matrix.mul_apply, Fin.sum_univ_four]
+
+/-- The four-dimensional Minkowski metric is invertible and is its own inverse. -/
+theorem minkowskiMetric_isUnit : IsUnit minkowskiMetric := by
+  rw [isUnit_iff_exists_inv]
+  exact ⟨minkowskiMetric, minkowskiMetric_mul_self⟩
+
+/-- A real matrix is selfadjoint for a symmetric metric `H` when `Aᵀ H = H A`.
+
+This fixes the transpose orientation used in GLR Section 5.1 and in the proof of VDDM
+Theorem 3. -/
+def IsSelfAdjointFor {n : Type*} [Fintype n] (H A : Matrix n n ℝ) : Prop :=
+  A.transpose * H = H * A
+
+/-- Four-dimensional selfadjointness for the Minkowski metric of inertia `(1, 3)`. -/
+def IsMinkowskiSelfAdjoint (A : Matrix (Fin 4) (Fin 4) ℝ) : Prop :=
+  IsSelfAdjointFor minkowskiMetric A
+
+/-- The equation `Aᵀ M = M A` is equivalently symmetry of `M A`. -/
+theorem isMinkowskiSelfAdjoint_iff_mul_transpose_eq (A : Matrix (Fin 4) (Fin 4) ℝ) :
+    IsMinkowskiSelfAdjoint A ↔ (minkowskiMetric * A).transpose = minkowskiMetric * A := by
+  simp only [IsMinkowskiSelfAdjoint, IsSelfAdjointFor, Matrix.transpose_mul,
+    minkowskiMetric_transpose]
+
+/-! ## Source-indexed four-dimensional block patterns -/
+
+/-- The four block patterns listed after the use of Sylvester's law in the proof of VDDM
+Theorem 3, arXiv:quant-ph/0011111v1, lines 188--196.
+
+The `conjugatePair` constructor is the source's "orthogonal `2 × 2` block": it denotes one real
+block for a non-real conjugate eigenvalue pair, not a Euclidean orthogonal matrix. This datatype
+records the four target alternatives; exhaustiveness is the still-missing consequence of the GLR
+canonical-pair existence theorem and Sylvester's law. -/
+inductive GLRFourDimensionalPattern where
+  | fourRealSingletons
+  | conjugatePairAndTwoRealSingletons
+  | realJordanTwoAndTwoRealSingletons
+  | realJordanThreeAndRealSingleton
+  deriving DecidableEq
+
+/-- Real dimensions of the blocks in each VDDM four-dimensional pattern. -/
+def GLRFourDimensionalPattern.blockDimensions : GLRFourDimensionalPattern → List ℕ
+  | .fourRealSingletons => [1, 1, 1, 1]
+  | .conjugatePairAndTwoRealSingletons => [2, 1, 1]
+  | .realJordanTwoAndTwoRealSingletons => [2, 1, 1]
+  | .realJordanThreeAndRealSingleton => [3, 1]
+
+/-- Every source-listed block pattern has total real dimension four. -/
+theorem GLRFourDimensionalPattern.sum_blockDimensions (p : GLRFourDimensionalPattern) :
+    p.blockDimensions.sum = 4 := by
+  cases p <;> rfl
 
 end Matrix

--- a/QICLean/Algebra/MinkowskiCanonicalPair.lean
+++ b/QICLean/Algebra/MinkowskiCanonicalPair.lean
@@ -124,6 +124,31 @@ def sipBasisThree : Matrix (Fin 3) (Fin 3) ℝ := !![1, 0, 1; 0, 1, 0; 1, 0, -1]
 def sipBasisFour : Matrix (Fin 4) (Fin 4) ℝ :=
   !![1, 0, 1, 0; 0, 1, 0, 1; 0, 1, 0, -1; 1, 0, -1, 0]
 
+/-- The explicit two-dimensional sip-diagonalizing basis is invertible. -/
+theorem sipBasisTwo_isUnit : IsUnit sipBasisTwo := by
+  rw [isUnit_iff_exists_inv]
+  refine ⟨(2 : ℝ)⁻¹ • sipBasisTwo, ?_⟩
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [sipBasisTwo, Matrix.mul_apply, Fin.sum_univ_two] <;> norm_num
+
+/-- The explicit three-dimensional sip-diagonalizing basis is invertible. -/
+theorem sipBasisThree_isUnit : IsUnit sipBasisThree := by
+  rw [isUnit_iff_exists_inv]
+  refine ⟨!![(2 : ℝ)⁻¹, 0, (2 : ℝ)⁻¹; 0, 1, 0;
+      (2 : ℝ)⁻¹, 0, -(2 : ℝ)⁻¹], ?_⟩
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [sipBasisThree, Matrix.mul_apply, Fin.sum_univ_three] <;> norm_num
+
+/-- The explicit four-dimensional sip-diagonalizing basis is invertible. -/
+theorem sipBasisFour_isUnit : IsUnit sipBasisFour := by
+  rw [isUnit_iff_exists_inv]
+  refine ⟨(2 : ℝ)⁻¹ • sipBasisFour.transpose, ?_⟩
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [sipBasisFour, Matrix.mul_apply, Fin.sum_univ_four] <;> norm_num
+
 /-- The two-dimensional sip matrix has one positive and one negative square after congruence. -/
 theorem sipBasisTwo_congr :
     sipBasisTwo.transpose * sipMatrix 2 ℝ * sipBasisTwo = diagonal ![2, -2] := by
@@ -138,6 +163,16 @@ theorem sipBasisThree_congr :
   ext i j
   fin_cases i <;> fin_cases j <;>
     simp [sipBasisThree, sipMatrix, finReversePerm, Matrix.mul_apply,
+      Fin.sum_univ_three, Fin.rev] <;> norm_num
+
+/-- The negative three-dimensional sip matrix has one positive and two negative squares after
+congruence. -/
+theorem sipBasisThree_negative_congr :
+    sipBasisThree.transpose * signedSipMatrix .negative 3 * sipBasisThree =
+      diagonal ![-2, -1, 2] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [sipBasisThree, signedSipMatrix, sipMatrix, finReversePerm, Matrix.mul_apply,
       Fin.sum_univ_three, Fin.rev] <;> norm_num
 
 /-- The four-dimensional sip matrix has two positive and two negative squares after congruence. -/

--- a/QICLean/Algebra/MinkowskiCanonicalPair.lean
+++ b/QICLean/Algebra/MinkowskiCanonicalPair.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import Mathlib.LinearAlgebra.Matrix.Notation
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+import Mathlib.LinearAlgebra.Matrix.Permutation
+
+/-!
+# Canonical metric blocks for Minkowski-selfadjoint matrices
+
+This file develops the signed reversal matrices and real conjugate-pair blocks used in the real
+canonical-pair theorem for selfadjoint matrices in an indefinite scalar product.
+
+The conventions follow Gohberg--Lancaster--Rodman, *Matrices and Indefinite Scalar Products*
+(1983), Part I, Chapter 5, Section 5.1, Theorem 5.3 (statement near p. 89, proof pp. 91--92).
+Their ``sip'' matrix is the reversal permutation matrix. A sign `+1` or `-1` is attached to each
+real-eigenvalue Jordan block, while a block for a non-real conjugate pair carries an unsigned
+even-dimensional sip matrix. These are also the blocks denoted `N_J` in the proof of Theorem 3
+of Verstraete--Dehaene--De Moor, arXiv:quant-ph/0011111v1, lines 175--196.
+
+No channel or quantum-state definitions are used here.
+-/
+
+open Matrix
+
+namespace Matrix
+
+/-- Reversal of the ordered basis `0, ..., n - 1`, viewed as a permutation.
+
+This is the permutation underlying the ``standard involutory permutation (sip) matrix'' in
+GLR Theorem 5.3, Part I, Chapter 5, Section 5.1. -/
+def finReversePerm (n : ℕ) : Equiv.Perm (Fin n) where
+  toFun := Fin.rev
+  invFun := Fin.rev
+  left_inv := Fin.rev_rev
+  right_inv := Fin.rev_rev
+
+@[simp]
+theorem finReversePerm_apply {n : ℕ} (i : Fin n) : finReversePerm n i = i.rev :=
+  rfl
+
+@[simp]
+theorem finReversePerm_inv (n : ℕ) : (finReversePerm n)⁻¹ = finReversePerm n := by
+  ext i
+  rfl
+
+@[simp]
+theorem finReversePerm_mul_self (n : ℕ) : finReversePerm n * finReversePerm n = 1 := by
+  ext i
+  simp [finReversePerm]
+
+/-- The `n × n` sip matrix `P_n`, with ones on the anti-diagonal.
+
+GLR Theorem 5.3 uses `P_n` for the metric block paired with a Jordan block. -/
+def sipMatrix (n : ℕ) (R : Type*) [Zero R] [One R] : Matrix (Fin n) (Fin n) R :=
+  (finReversePerm n).permMatrix R
+
+@[simp]
+theorem sipMatrix_transpose (n : ℕ) (R : Type*) [Zero R] [One R] :
+    (sipMatrix n R).transpose = sipMatrix n R := by
+  simp [sipMatrix]
+
+@[simp]
+theorem sipMatrix_mul_self (n : ℕ) (R : Type*) [Semiring R] :
+    sipMatrix n R * sipMatrix n R = 1 := by
+  calc
+    (finReversePerm n).permMatrix R * (finReversePerm n).permMatrix R =
+        (finReversePerm n * finReversePerm n).permMatrix R :=
+      (Matrix.permMatrix_mul (R := R) (finReversePerm n) (finReversePerm n)).symm
+    _ = 1 := by simp
+
+/-- A sign in the sign characteristic of a real-eigenvalue block in GLR Theorem 5.3. -/
+inductive GLRSign where
+  | positive
+  | negative
+  deriving DecidableEq
+
+/-- The real scalar represented by a GLR sign. -/
+def GLRSign.toReal : GLRSign → ℝ
+  | .positive => 1
+  | .negative => -1
+
+@[simp] theorem GLRSign.toReal_positive : GLRSign.positive.toReal = 1 := rfl
+@[simp] theorem GLRSign.toReal_negative : GLRSign.negative.toReal = -1 := rfl
+
+@[simp]
+theorem GLRSign.toReal_sq (ε : GLRSign) : ε.toReal ^ 2 = 1 := by
+  cases ε <;> norm_num
+
+/-- The signed sip block `ε P_n` attached to a real-eigenvalue Jordan block.
+
+By GLR's convention, this construction is not used for non-real conjugate-pair blocks: those use
+an unsigned even-dimensional `sipMatrix`. -/
+def signedSipMatrix (ε : GLRSign) (n : ℕ) : Matrix (Fin n) (Fin n) ℝ :=
+  ε.toReal • sipMatrix n ℝ
+
+@[simp]
+theorem signedSipMatrix_transpose (ε : GLRSign) (n : ℕ) :
+    (signedSipMatrix ε n).transpose = signedSipMatrix ε n := by
+  simp [signedSipMatrix]
+
+@[simp]
+theorem signedSipMatrix_mul_self (ε : GLRSign) (n : ℕ) :
+    signedSipMatrix ε n * signedSipMatrix ε n = 1 := by
+  rw [signedSipMatrix, Matrix.smul_mul, Matrix.mul_smul, sipMatrix_mul_self]
+  have hε : ε.toReal * ε.toReal = 1 := by
+    nlinarith [GLRSign.toReal_sq ε]
+  rw [← mul_smul, hε, one_smul]
+
+/-- Every signed sip block is invertible; it is its own inverse. -/
+theorem signedSipMatrix_isUnit (ε : GLRSign) (n : ℕ) : IsUnit (signedSipMatrix ε n) := by
+  rw [isUnit_iff_exists_inv]
+  exact ⟨signedSipMatrix ε n, signedSipMatrix_mul_self ε n⟩
+
+/-- An explicit change of basis diagonalizing the two-dimensional sip quadratic form. -/
+def sipBasisTwo : Matrix (Fin 2) (Fin 2) ℝ := !![1, 1; 1, -1]
+
+/-- An explicit change of basis diagonalizing the three-dimensional sip quadratic form. -/
+def sipBasisThree : Matrix (Fin 3) (Fin 3) ℝ := !![1, 0, 1; 0, 1, 0; 1, 0, -1]
+
+/-- An explicit change of basis diagonalizing the four-dimensional sip quadratic form. -/
+def sipBasisFour : Matrix (Fin 4) (Fin 4) ℝ :=
+  !![1, 0, 1, 0; 0, 1, 0, 1; 0, 1, 0, -1; 1, 0, -1, 0]
+
+/-- The two-dimensional sip matrix has one positive and one negative square after congruence. -/
+theorem sipBasisTwo_congr :
+    sipBasisTwo.transpose * sipMatrix 2 ℝ * sipBasisTwo = diagonal ![2, -2] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [sipBasisTwo, sipMatrix, finReversePerm, Matrix.mul_apply,
+      Fin.sum_univ_two, Fin.rev] <;> norm_num
+
+/-- The three-dimensional sip matrix has two positive and one negative square after congruence. -/
+theorem sipBasisThree_congr :
+    sipBasisThree.transpose * sipMatrix 3 ℝ * sipBasisThree = diagonal ![2, 1, -2] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [sipBasisThree, sipMatrix, finReversePerm, Matrix.mul_apply,
+      Fin.sum_univ_three, Fin.rev] <;> norm_num
+
+/-- The four-dimensional sip matrix has two positive and two negative squares after congruence. -/
+theorem sipBasisFour_congr :
+    sipBasisFour.transpose * sipMatrix 4 ℝ * sipBasisFour = diagonal ![2, 2, -2, -2] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [sipBasisFour, sipMatrix, finReversePerm, Matrix.mul_apply,
+      Fin.sum_univ_four, Fin.rev] <;> norm_num
+
+end Matrix

--- a/QICLean/Algebra/MinkowskiCanonicalPair.lean
+++ b/QICLean/Algebra/MinkowskiCanonicalPair.lean
@@ -148,4 +148,154 @@ theorem sipBasisFour_congr :
     simp [sipBasisFour, sipMatrix, finReversePerm, Matrix.mul_apply,
       Fin.sum_univ_four, Fin.rev] <;> norm_num
 
+
+/-! ## Real blocks for non-real conjugate eigenvalues -/
+
+/-- The real `2 × 2` block representing the conjugate eigenvalues `a ± τ i`.
+
+This is the block displayed in GLR Example 5.2 immediately before Theorem 5.3. The parameter
+`τ` is nonzero when the eigenvalues are genuinely non-real; the definition is total because its
+algebraic identities do not require that hypothesis. -/
+def realConjugatePairBlock (a τ : ℝ) : Matrix (Fin 2) (Fin 2) ℝ := !![a, τ; -τ, a]
+
+/-- The basic realification block is selfadjoint for the unsigned two-dimensional sip metric. -/
+theorem sipMatrix_two_mul_realConjugatePairBlock (a τ : ℝ) :
+    sipMatrix 2 ℝ * realConjugatePairBlock a τ =
+      (realConjugatePairBlock a τ).transpose * sipMatrix 2 ℝ := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [sipMatrix, finReversePerm, realConjugatePairBlock, Matrix.mul_apply,
+      Fin.sum_univ_two, Fin.rev]
+
+/-- Reversing the row coordinate of the basic realification block is equivalent to reversing its
+column coordinate after transposition. -/
+theorem realConjugatePairBlock_rev_apply (a τ : ℝ) (i j : Fin 2) :
+    realConjugatePairBlock a τ i.rev j = realConjugatePairBlock a τ j.rev i := by
+  fin_cases i <;> fin_cases j <;> simp [realConjugatePairBlock, Fin.rev]
+
+/-- The identity matrix on the realification coordinate has the same reversal symmetry. -/
+theorem one_fin_two_rev_apply (i j : Fin 2) :
+    (1 : Matrix (Fin 2) (Fin 2) ℝ) i.rev j = (1 : Matrix (Fin 2) (Fin 2) ℝ) j.rev i := by
+  simp only [Matrix.one_apply]
+  congr 1
+  apply propext
+  constructor
+  · intro h
+    rw [← h]
+    simp
+  · intro h
+    rw [← h]
+    simp
+
+/-- Reversal of both the Jordan-chain index and the realification index.
+
+Under the lexicographic identification `(Fin m × Fin 2) ≃ Fin (2m)`, its permutation matrix is
+the unsigned even-dimensional sip block prescribed by GLR Theorem 5.3 for a non-real conjugate
+pair. -/
+def complexPairReversePerm (m : ℕ) : Equiv.Perm (Fin m × Fin 2) :=
+  (finReversePerm m).prodCongr (finReversePerm 2)
+
+@[simp]
+theorem complexPairReversePerm_inv (m : ℕ) :
+    (complexPairReversePerm m)⁻¹ = complexPairReversePerm m := by
+  apply Equiv.ext
+  intro i
+  rfl
+
+/-- The unsigned metric block for a length-`m` real Jordan chain associated with `a ± τ i`. -/
+def complexPairSipMatrix (m : ℕ) : Matrix (Fin m × Fin 2) (Fin m × Fin 2) ℝ :=
+  (complexPairReversePerm m).permMatrix ℝ
+
+@[simp]
+theorem complexPairSipMatrix_transpose (m : ℕ) :
+    (complexPairSipMatrix m).transpose = complexPairSipMatrix m := by
+  simp [complexPairSipMatrix]
+
+@[simp]
+theorem complexPairSipMatrix_mul_self (m : ℕ) :
+    complexPairSipMatrix m * complexPairSipMatrix m = 1 := by
+  change (complexPairReversePerm m).permMatrix ℝ *
+      (complexPairReversePerm m).permMatrix ℝ = 1
+  calc
+    _ = (complexPairReversePerm m * complexPairReversePerm m).permMatrix ℝ :=
+      (Matrix.permMatrix_mul (R := ℝ) (complexPairReversePerm m)
+        (complexPairReversePerm m)).symm
+    _ = 1 := by
+      have h : complexPairReversePerm m * complexPairReversePerm m = 1 := by
+        ext i <;> simp [complexPairReversePerm]
+      rw [h]
+      exact Matrix.permMatrix_one
+
+/-- A real Jordan block for the conjugate pair `a ± τ i`, written in `2 × 2` blocks.
+
+The diagonal blocks are `[[a, τ], [-τ, a]]`, the first block superdiagonal consists of `I₂`,
+and all remaining blocks vanish. This is GLR's real Jordan form convention in Theorem 5.3. -/
+def realConjugatePairJordanBlock (m : ℕ) (a τ : ℝ) :
+    Matrix (Fin m × Fin 2) (Fin m × Fin 2) ℝ := fun i j =>
+  if i.1 = j.1 then realConjugatePairBlock a τ i.2 j.2
+  else if i.1.val + 1 = j.1.val then (1 : Matrix (Fin 2) (Fin 2) ℝ) i.2 j.2
+  else 0
+
+/-- Left multiplication by a permutation matrix permutes matrix rows. -/
+theorem permMatrix_mul_apply' {n : Type*} [Fintype n] [DecidableEq n]
+    (σ : Equiv.Perm n) (A : Matrix n n ℝ) (i j : n) :
+    (σ.permMatrix ℝ * A) i j = A (σ i) j := by
+  change (σ.permMatrix ℝ *ᵥ fun k => A k j) i = _
+  rw [Matrix.permMatrix_mulVec]
+  rfl
+
+/-- Right multiplication by a permutation matrix permutes matrix columns by the inverse. -/
+theorem mul_permMatrix_apply' {n : Type*} [Fintype n] [DecidableEq n]
+    (σ : Equiv.Perm n) (A : Matrix n n ℝ) (i j : n) :
+    (A * σ.permMatrix ℝ) i j = A i (σ.symm j) := by
+  change ((fun k => A i k) ᵥ* σ.permMatrix ℝ) j = _
+  rw [Matrix.vecMul_permMatrix]
+  rfl
+
+/-- The real conjugate-pair Jordan block is selfadjoint for its unsigned sip metric.
+
+This verifies the block identity `H A = Aᵀ H` from GLR Section 5.1. It also records why no sign
+is attached to a non-real block: its canonical metric is the unsigned even-dimensional sip block. -/
+theorem complexPairSipMatrix_mul_realConjugatePairJordanBlock
+    (m : ℕ) (a τ : ℝ) :
+    complexPairSipMatrix m * realConjugatePairJordanBlock m a τ =
+      (realConjugatePairJordanBlock m a τ).transpose * complexPairSipMatrix m := by
+  ext i j
+  change (((complexPairReversePerm m).permMatrix ℝ *
+      realConjugatePairJordanBlock m a τ) i j) =
+    ((realConjugatePairJordanBlock m a τ).transpose *
+      (complexPairReversePerm m).permMatrix ℝ) i j
+  rw [permMatrix_mul_apply', mul_permMatrix_apply']
+  simp only [transpose_apply]
+  change realConjugatePairJordanBlock m a τ (i.1.rev, i.2.rev) j =
+    realConjugatePairJordanBlock m a τ (j.1.rev, j.2.rev) i
+  rcases i with ⟨i, ii⟩
+  rcases j with ⟨j, jj⟩
+  change (if i.rev = j then realConjugatePairBlock a τ ii.rev jj
+      else if i.rev.val + 1 = j.val then (1 : Matrix (Fin 2) (Fin 2) ℝ) ii.rev jj
+      else 0) =
+    if j.rev = i then realConjugatePairBlock a τ jj.rev ii
+      else if j.rev.val + 1 = i.val then (1 : Matrix (Fin 2) (Fin 2) ℝ) jj.rev ii
+      else 0
+  have hdiag : i.rev = j ↔ j.rev = i := by
+    constructor
+    · intro h
+      rw [← h]
+      simp
+    · intro h
+      rw [← h]
+      simp
+  have hsuperNat : m - (i.val + 1) + 1 = j.val ↔
+      m - (j.val + 1) + 1 = i.val := by
+    omega
+  by_cases hd : i.rev = j
+  · have hd' : j.rev = i := hdiag.mp hd
+    simp [hd, hd', realConjugatePairBlock_rev_apply]
+  · have hd' : j.rev ≠ i := fun h ↦ hd (hdiag.mpr h)
+    by_cases hs : m - (i.val + 1) + 1 = j.val
+    · have hs' : m - (j.val + 1) + 1 = i.val := hsuperNat.mp hs
+      simp [hd, hd', hs, hs', one_fin_two_rev_apply]
+    · have hs' : m - (j.val + 1) + 1 ≠ i.val := fun h ↦ hs (hsuperNat.mpr h)
+      simp [hd, hd', hs, hs']
+
 end Matrix

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -165,7 +165,7 @@ $\varepsilon\in\{1,-1\}$, the matrix $\varepsilon P_n$ is the signed
 metric block attached to a real-eigenvalue Jordan block in the sign
 characteristic of Gohberg--Lancaster--Rodman, Theorem~5.3.
 
-\begin{definition}[Signed sip metric blocks]
+\begin{definition}[Signed sip metric blocks]\label{def:signed_sip_metric_blocks}
     \lean{Matrix.GLRSign, Matrix.sipMatrix, Matrix.signedSipMatrix}
     \leanok
     The \emph{sip matrix} of size $n$ is $P_n$.  A signed sip block is
@@ -173,10 +173,11 @@ characteristic of Gohberg--Lancaster--Rodman, Theorem~5.3.
     Each such block is symmetric, invertible, and its own inverse.
 \end{definition}
 
-\begin{definition}[Real canonical Jordan blocks]
+\begin{definition}[Real canonical Jordan blocks]\label{def:real_canonical_jordan_blocks}
     \lean{Matrix.realJordanBlock, Matrix.realConjugatePairBlock,
         Matrix.realConjugatePairJordanBlock, Matrix.complexPairSipMatrix}
     \leanok
+    \uses{def:signed_sip_metric_blocks}
     A real-eigenvalue block is the ordinary real Jordan block $J_n(a)$
     with eigenvalue $a$ and ones on its first superdiagonal.  If
     $a\pm\tau i$ is a non-real conjugate pair, put
@@ -192,9 +193,11 @@ characteristic of Gohberg--Lancaster--Rodman, Theorem~5.3.
 \end{definition}
 
 \begin{theorem}[Canonical blocks are selfadjoint for their metric blocks]
+    \label{thm:canonical_blocks_metric_selfadjoint}
     \lean{Matrix.signedSipMatrix_mul_realJordanBlock,
         Matrix.complexPairSipMatrix_mul_realConjugatePairJordanBlock}
     \leanok
+    \uses{def:signed_sip_metric_blocks, def:real_canonical_jordan_blocks}
     For every sign $\varepsilon$ and every real Jordan block,
     \begin{align}
         (\varepsilon P_n)J_n(a)
@@ -204,7 +207,16 @@ characteristic of Gohberg--Lancaster--Rodman, Theorem~5.3.
     analogous identity with its unsigned $2m$-dimensional reversal metric.
 \end{theorem}
 
+\begin{proof}\leanok
+    For a real-eigenvalue block, reversal changes the first superdiagonal
+    of $J_n(a)$ into the first subdiagonal of $J_n(a)^{\mathsf T}$; the
+    scalar sign multiplies both sides.  For a conjugate pair, simultaneous
+    reversal of the chain and realification coordinates also changes
+    $B(a,\tau)$ into $B(a,\tau)^{\mathsf T}$, giving the unsigned identity.
+\end{proof}
+
 \begin{definition}[Four-dimensional Minkowski selfadjointness]
+    \label{def:four_dimensional_minkowski_selfadjoint}
     \lean{Matrix.minkowskiMetric, Matrix.IsMinkowskiSelfAdjoint}
     \leanok
     Let
@@ -215,9 +227,10 @@ characteristic of Gohberg--Lancaster--Rodman, Theorem~5.3.
     $C^{\mathsf T}M=MC$.
 \end{definition}
 
-\begin{definition}[The four VDDM block patterns]
+\begin{definition}[The four VDDM block patterns]\label{def:vddm_four_block_patterns}
     \lean{Matrix.GLRFourDimensionalPattern}
     \leanok
+    \uses{def:real_canonical_jordan_blocks}
     The four source-indexed patterns are: four real one-dimensional
     blocks; one two-dimensional non-real conjugate-pair block and two real
     one-dimensional blocks; one real Jordan block of size two and two real

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -157,6 +157,88 @@ This section states the existence theorems from
 % QICLean/Channel/LorentzNormalForm.lean. The correctly formulated Proposition 2.11
 % has no Lean declaration yet; declaration tags are omitted for pending results.
 
+\subsection{Canonical metric blocks for the Minkowski reduction}
+
+Let $P_n$ be the reversal permutation matrix, so that
+$(P_n)_{ij}=1$ exactly when $i+j=n+1$.  For a sign
+$\varepsilon\in\{1,-1\}$, the matrix $\varepsilon P_n$ is the signed
+metric block attached to a real-eigenvalue Jordan block in the sign
+characteristic of Gohberg--Lancaster--Rodman, Theorem~5.3.
+
+\begin{definition}[Signed sip metric blocks]
+    \lean{Matrix.GLRSign, Matrix.sipMatrix, Matrix.signedSipMatrix}
+    \leanok
+    The \emph{sip matrix} of size $n$ is $P_n$.  A signed sip block is
+    $\varepsilon P_n$, where $\varepsilon=1$ or $\varepsilon=-1$.
+    Each such block is symmetric, invertible, and its own inverse.
+\end{definition}
+
+\begin{definition}[Real canonical Jordan blocks]
+    \lean{Matrix.realJordanBlock, Matrix.realConjugatePairBlock,
+        Matrix.realConjugatePairJordanBlock, Matrix.complexPairSipMatrix}
+    \leanok
+    A real-eigenvalue block is the ordinary real Jordan block $J_n(a)$
+    with eigenvalue $a$ and ones on its first superdiagonal.  If
+    $a\pm\tau i$ is a non-real conjugate pair, put
+    \begin{align}
+        B(a,\tau)&=\begin{pmatrix}a&\tau\\-\tau&a\end{pmatrix}.
+    \end{align}
+    Its real Jordan chain of length $m$ has $B(a,\tau)$ on the block
+    diagonal and $I_2$ on the first block superdiagonal.  On the product
+    indexing of this $2m$-dimensional real block, its unsigned metric
+    reverses both the chain coordinate and the two-dimensional
+    realification coordinate.  No sign characteristic is attached to a
+    non-real block.
+\end{definition}
+
+\begin{theorem}[Canonical blocks are selfadjoint for their metric blocks]
+    \lean{Matrix.signedSipMatrix_mul_realJordanBlock,
+        Matrix.complexPairSipMatrix_mul_realConjugatePairJordanBlock}
+    \leanok
+    For every sign $\varepsilon$ and every real Jordan block,
+    \begin{align}
+        (\varepsilon P_n)J_n(a)
+        &=J_n(a)^{\mathsf T}(\varepsilon P_n).
+    \end{align}
+    The real Jordan chain for a non-real conjugate pair satisfies the
+    analogous identity with its unsigned $2m$-dimensional reversal metric.
+\end{theorem}
+
+\begin{definition}[Four-dimensional Minkowski selfadjointness]
+    \lean{Matrix.minkowskiMetric, Matrix.IsMinkowskiSelfAdjoint}
+    \leanok
+    Let
+    \begin{align}
+        M&=\operatorname{diag}(1,-1,-1,-1).
+    \end{align}
+    A real matrix $C\in M_4(\mathbb R)$ is \emph{$M$-selfadjoint} when
+    $C^{\mathsf T}M=MC$.
+\end{definition}
+
+\begin{definition}[The four VDDM block patterns]
+    \lean{Matrix.GLRFourDimensionalPattern}
+    \leanok
+    The four source-indexed patterns are: four real one-dimensional
+    blocks; one two-dimensional non-real conjugate-pair block and two real
+    one-dimensional blocks; one real Jordan block of size two and two real
+    one-dimensional blocks; or one real Jordan block of size three and one
+    real one-dimensional block.
+\end{definition}
+
+The load-bearing existence statement is still open.  It must construct, for
+every $M$-selfadjoint $C$, an invertible $X$, a real canonical Jordan matrix
+$J$, and its signed metric $N_J$ satisfying
+\begin{align}
+    C&=X^{-1}JX,
+    &XMX^{\mathsf T}&=N_J,
+\end{align}
+and then derive exhaustiveness of the four patterns from inertia $(1,3)$.
+The present library has neither real Jordan-form existence nor the simultaneous
+similarity--congruence theorem controlling the sign characteristic.  The exact
+formalization boundary and the required transpose and inverse translations are
+recorded in
+\path{docs/paper-gaps/qiclean_minkowski_canonical_pair_dependency.tex}.
+
 \begin{definition}[Pauli transfer matrix]\label{def:pauli_transfer_matrix}
     \lean{Wolf.pauliMatrices, Wolf.pauliTransferEntry,
         Wolf.pauliTransferMatrix, Wolf.pauliTransferMatrixReal}

--- a/docs/paper-gaps/qiclean_minkowski_canonical_pair_dependency.tex
+++ b/docs/paper-gaps/qiclean_minkowski_canonical_pair_dependency.tex
@@ -1,0 +1,133 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Minkowski Canonical-Pair Dependency in Four Real Dimensions}
+\author{}
+\date{2026-08-24}
+
+\begin{document}
+\maketitle
+\gapnote{open-gap}{wip}
+
+\section{The required assertion}
+
+Let
+\begin{align}
+  M&=\operatorname{diag}(1,-1,-1,-1),
+\end{align}
+and let $C\in M_4(\mathbb R)$ satisfy
+\begin{align}
+  C^{\mathsf T}M&=MC.
+  \label{eq:m-selfadjoint}
+\end{align}
+The proof of Theorem~3 of Verstraete--Dehaene--De Moor invokes
+Gohberg--Lancaster--Rodman, Part~I, Chapter~5, Section~5.1,
+Theorem~5.3, to obtain an invertible real matrix $X$, a real Jordan
+matrix $J$, and a canonical metric $N_J$ such that
+\begin{align}
+  C&=X^{-1}JX,
+  &XMX^{\mathsf T}&=N_J.
+  \label{eq:canonical-pair}
+\end{align}
+For a real-eigenvalue Jordan block of size $n$, the corresponding metric
+block is $\varepsilon P_n$, where $\varepsilon\in\{1,-1\}$ and $P_n$ is
+the reversal permutation matrix. A block for a non-real conjugate pair
+has real dimension $2m$ and carries an unsigned reversal metric; no sign
+characteristic is attached to that block.
+
+The GLR convention is commonly written
+\begin{align}
+  C&=S^{-1}JS,
+  &M&=S^{\mathsf T}N_JS.
+\end{align}
+Putting $X=S^{-\mathsf T}$ gives the second identity in
+\eqref{eq:canonical-pair}; transposing the similarity convention, and if
+necessary conjugating each Jordan chain by its reversal, gives the Jordan
+orientation used in the VDDM display. These inverse and transpose changes
+must be retained explicitly: replacing them by an ordinary Euclidean singular
+value decomposition does not prove \eqref{eq:canonical-pair}.
+
+\section{The four-dimensional inertia restriction}
+
+The reversal form $P_n$ has positive and negative indices
+\begin{align}
+  \left(\left\lceil\frac n2\right\rceil,
+        \left\lfloor\frac n2\right\rfloor\right),
+\end{align}
+with the two indices interchanged when the sign $\varepsilon$ is negative.
+An unsigned conjugate-pair block of real dimension $2m$ has indices $(m,m)$.
+Consequently, total inertia $(1,3)$ excludes a real Jordan block of size four,
+a conjugate-pair chain of real dimension four, and two blocks of dimension two.
+The remaining dimension patterns are exactly those listed in the proof of VDDM
+Theorem~3:
+\begin{enumerate}
+  \item four real one-dimensional blocks;
+  \item one two-dimensional non-real conjugate-pair block and two real
+        one-dimensional blocks;
+  \item one real Jordan block of size two and two real one-dimensional blocks;
+  \item one real Jordan block of size three and one real one-dimensional block.
+\end{enumerate}
+The source's phrase ``orthogonal $2\times2$ block'' in the second item denotes
+the real block for a non-real conjugate eigenvalue pair. It does not assert
+that this block is an orthogonal matrix for the Euclidean scalar product.
+
+\section{Formalized infrastructure}
+
+The reversal matrices, their signed variants, and explicit congruences exposing
+the signatures of $P_2$, $P_3$, and $P_4$ are formalized. The development also
+contains real Jordan blocks, realifications of non-real conjugate-pair Jordan
+chains, and direct proofs of the block identities
+\begin{align}
+  (\varepsilon P_n)J_n(a)
+    &=J_n(a)^{\mathsf T}(\varepsilon P_n),\\
+  P_{2m}J_m(a,\tau)
+    &=J_m(a,\tau)^{\mathsf T}P_{2m}.
+\end{align}
+Finally, the matrix $M$, Equation~\eqref{eq:m-selfadjoint}, and the four target
+block patterns are represented directly.\footnote{Formal declarations in
+\doclink{QICLean/Algebra/MinkowskiCanonicalPair.lean} include
+\leanid{Matrix.signedSipMatrix}, \leanid{Matrix.realJordanBlock},
+\leanid{Matrix.realConjugatePairJordanBlock},
+\leanid{Matrix.signedSipMatrix_mul_realJordanBlock},
+\leanid{Matrix.complexPairSipMatrix_mul_realConjugatePairJordanBlock},
+\leanid{Matrix.minkowskiMetric}, \leanid{Matrix.IsMinkowskiSelfAdjoint}, and
+\leanid{Matrix.GLRFourDimensionalPattern}.}
+
+\section{The remaining obstruction}
+
+The formal library has no real Jordan canonical-form existence theorem from
+which to construct $J$ and a similarity matrix for an arbitrary real
+$4\times4$ matrix. More importantly, it has no formal version of the GLR
+canonical-pair theorem that simultaneously controls that similarity and the
+congruence class of the indefinite metric, including the sign characteristic.
+Sylvester's law for quadratic forms is available, but it applies only after the
+canonical metric $N_J$ and the congruence in \eqref{eq:canonical-pair} have been
+constructed; it cannot supply the missing simultaneous reduction.
+
+Thus no theorem with additional hypotheses is being presented as the cited
+result. The exact existence identities in \eqref{eq:canonical-pair} and the
+exhaustiveness of the four cases remain unformalized. Eliminating this gap
+requires a source-faithful real Jordan theorem followed by the finite-dimensional
+proof of GLR Theorem~5.3, or a direct four-dimensional proof that retains the
+same block, sign, transpose, and inverse conventions. Before fixing the final
+formal signature, the exact existence clause of the cited edition must also be
+transcribed verbatim from the source; the currently recorded convention
+translation is a high-confidence reconstruction from the statement context and
+proof, not a verbatim quotation.
+
+\section{Conclusion}
+
+This is an open formalization dependency, not a correction to either cited
+source. The canonical blocks and all presently asserted algebraic identities
+are proved, but the simultaneous similarity--congruence existence theorem is
+the load-bearing missing result. Numerical orbit enumeration, Euclidean SVD,
+and a generic indefinite-SVD assumption would bypass rather than close this
+gap.
+
+\end{document}

--- a/docs/paper-gaps/qiclean_minkowski_canonical_pair_dependency.tex
+++ b/docs/paper-gaps/qiclean_minkowski_canonical_pair_dependency.tex
@@ -41,17 +41,43 @@ the reversal permutation matrix. A block for a non-real conjugate pair
 has real dimension $2m$ and carries an unsigned reversal metric; no sign
 characteristic is attached to that block.
 
-The GLR convention is commonly written
+The passage from the GLR convention to \eqref{eq:canonical-pair}
+requires applying GLR to $C^{\mathsf T}$, not directly to $C$.  Indeed,
+\eqref{eq:m-selfadjoint} and $M^2=I$ imply
 \begin{align}
-  C&=S^{-1}JS,
-  &M&=S^{\mathsf T}N_JS.
+  CM&=MC^{\mathsf T},
 \end{align}
-Putting $X=S^{-\mathsf T}$ gives the second identity in
-\eqref{eq:canonical-pair}; transposing the similarity convention, and if
-necessary conjugating each Jordan chain by its reversal, gives the Jordan
-orientation used in the VDDM display. These inverse and transpose changes
-must be retained explicitly: replacing them by an ordinary Euclidean singular
-value decomposition does not prove \eqref{eq:canonical-pair}.
+so $C^{\mathsf T}$ is also $M$-selfadjoint.  GLR then gives
+\begin{align}
+  C^{\mathsf T}&=S^{-1}JS,
+  &M&=S^{\mathsf T}P_{\varepsilon,J}S.
+\end{align}
+After transposing the first identity and setting $X=S^{-\mathsf T}$, one
+obtains
+\begin{align}
+  C&=S^{\mathsf T}J^{\mathsf T}S^{-\mathsf T}
+    =X^{-1}J^{\mathsf T}X,\\
+  XMX^{\mathsf T}
+    &=S^{-\mathsf T}MS^{-1}=P_{\varepsilon,J}.
+  \label{eq:glr-vddm-translation}
+\end{align}
+It remains only to restore the chosen upper-Jordan orientation.  On every
+real Jordan block, reversal gives
+\begin{align}
+  P_kJ_k(\lambda)^{\mathsf T}P_k&=J_k(\lambda),
+  &P_k^2&=I.
+\end{align}
+The simultaneous reversal of the chain and realification coordinates gives
+the analogous identity for a non-real conjugate-pair block.  Let $R$ be the
+direct sum of these blockwise reversals.  Replacing $J^{\mathsf T}$ by
+$RJ^{\mathsf T}R$ and $X$ by $RX$ preserves the similarity in
+\eqref{eq:glr-vddm-translation}.  It also preserves every metric block:
+$R(\varepsilon P_k)R^{\mathsf T}=\varepsilon P_k$ for a real block, and the
+same calculation holds for an unsigned conjugate-pair block.  Hence
+$N_J:=P_{\varepsilon,J}$ has exactly the VDDM orientation and sign convention.
+These inverse, transpose, and reversal changes must be retained explicitly:
+replacing them by an ordinary Euclidean singular value decomposition does not
+prove \eqref{eq:canonical-pair}.
 
 \section{The four-dimensional inertia restriction}
 


### PR DESCRIPTION
## Summary

This is a bounded infrastructure slice for the canonical-pair theorem invoked in Verstraete--Dehaene--De Moor, Theorem 3, through Gohberg--Lancaster--Rodman, Part I, Chapter 5, Section 5.1, Theorem 5.3.

It adds a quantum-independent module `QICLean/Algebra/MinkowskiCanonicalPair.lean` containing:

- reversal permutations and sip matrices `P_k`, with symmetry, involutivity, and invertibility;
- signed real sip blocks and explicit congruence certificates for `P₂`, `P₃`, `-P₃`, and `P₄`;
- ordinary real Jordan blocks and realification blocks for non-real conjugate pairs;
- the source block identities saying the canonical blocks are selfadjoint for their metric blocks;
- the Minkowski metric `M = diag(1,-1,-1,-1)` and `Matrix.IsMinkowskiSelfAdjoint` (`Cᵀ M = M C`);
- a source-indexed datatype recording the four block patterns listed by VDDM.

## Exact dependency boundary

The paper-gap note `docs/paper-gaps/qiclean_minkowski_canonical_pair_dependency.tex` records the GLR-to-VDDM transpose, inverse, reversal, and realification conventions.

The corrected orientation applies GLR to `Cᵀ`. From `Cᵀ M = M C` and `M² = I`, one obtains `C M = M Cᵀ`; after GLR gives

```text
Cᵀ = S⁻¹ J S,      M = Sᵀ P S,
```

setting `X = S⁻ᵀ`, transposing, and reversing the Jordan blocks yields the VDDM-facing orientation while preserving the sip metrics.

This PR does **not** prove the simultaneous similarity--congruence existence theorem, real Jordan-form existence, Sylvester-inertia exhaustiveness of the four patterns, or the Lorentz singular-value decomposition. The locally available GLR page is OCR-degraded, so the exact existence-clause transcription still requires confirmation from a legible primary copy before #426 freezes that theorem statement. The Lean declarations here are only the checked block data and identities needed by that later proof.

## Blueprint and source synchronization

The five new Blueprint entries have stable labels and minimal statement/proof dependencies. The paper-gap note remains an open WIP dependency record; it is not marked resolved and the full VDDM theorem is not marked `\leanok`.

## Verification

- focused and full `lake build`;
- Lean style, oversized-file, numbered-file, module-policy, and import-aggregator checks;
- Blueprint declaration regeneration, `checkdecls`, sync, labels, and web build;
- paper-gap references and reader-facing prose checks;
- `git diff --check`, forbidden-token scan, and public-declaration axiom audit.

The axiom audit reports only `propext`, `Classical.choice`, and `Quot.sound`. No `sorry`, `admit`, new axiom, `native_decide`, `unsafeCast`, or equivalent bypass is introduced.

Refs #426
