### PR TITLE
feat(channel): formalize the diagonal qubit representative

### DIFF
--- a/QICLean/Channel/LorentzNormalForm/CanonicalQubitChannels.lean
+++ b/QICLean/Channel/LorentzNormalForm/CanonicalQubitChannels.lean
@@ -8,12 +8,16 @@ import QICLean.Channel.KrausRank
 import QICLean.Channel.LorentzNormalForm.SpinorAction
 
 /-!
-# Canonical non-diagonal and singular qubit channels
+# Canonical qubit-channel representatives
 
-This module formalizes the two non-generic channel representatives displayed in
+This module formalizes the three channel representatives displayed in
 Verstraete--Verschelde, *On Quantum Channels*, arXiv:quant-ph/0202124v2,
 Theorem 8, Equations (17)--(19), and repeated in Wolf, Proposition 2.11
 (`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 1021--1035).
+The non-diagonal and singular rank statements also appear in cases 2 and 3
+of Wolf--Cirac, *Dividing Quantum Channels*, arXiv:math-ph/0611057v3,
+Theorem 18.  The diagonal rank formula below instead follows directly from
+the Bell family in Verstraete--Verschelde, Equation (18).
 
 Only the displayed representatives are treated here.  In particular, this file
 does not prove that every qubit channel has one of these forms, does not derive
@@ -23,9 +27,20 @@ The Pauli-transfer convention is Wolf's
 `T̂ᵢⱼ = tr[σᵢ T(σⱼ)] / 2`.  QICLean's Choi matrix is normalized, so
 for a trace-preserving qubit map
 `tau = (1/4) sum i j, T̂ᵢⱼ σᵢ ⊗ σⱼᵀ`.  Consequently a raw Pauli
-correlation matrix of `tau` has the extra sign in its `σ₂` input column
-coming from `σ₂ᵀ = -σ₂`; no raw-correlation matrix is identified with
-the transfer matrix below.
+correlation matrix of `tau` satisfies
+`R_raw(tau) = T̂ * diag(1, 1, -1, 1)`; the extra sign in its `σ₂` input
+column comes from `σ₂ᵀ = -σ₂`.  Verstraete--Verschelde instead define
+`R_Φ` from their first-factor-partially-transposed dual state and use it in the Bloch
+action `(1, x') = R_Φ (1, x)`.  Thus their `R_Φ` is the transfer matrix
+corresponding to `T̂`, not the raw correlation matrix of `tau`.
+
+Verstraete--Verschelde, Theorem 8 nevertheless prints the constraint
+`1 - s₁ - s₂ - s₃ ≥ 0`.  This is inconsistent with their preceding transfer
+convention: the identity channel has `R_Φ = diag(1, 1, 1, 1)` and violates that
+printed inequality.  The weights below are therefore obtained directly by applying
+the Equation (18) Pauli family in Wolf's transfer convention.  In particular the
+last weight is `(1 - s₁ - s₂ + s₃) / 4`, in agreement with Wolf's
+Equation (2.40); no parameter conversion from the printed all-minus inequality is used.
 -/
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
@@ -37,6 +52,230 @@ namespace Wolf
 
 private abbrev QubitMatrix := Matrix (Fin 2) (Fin 2) ℂ
 private abbrev QubitMap := QubitMatrix →ₗ[ℂ] QubitMatrix
+
+/-! ## The diagonal (bistochastic) representative -/
+
+/-- The four candidate Bell-diagonal weights obtained by inverting the Pauli action of
+the Equation (18) family in Wolf's transfer convention.  Under the nonnegativity
+hypothesis used below, they are the squared source amplitudes `pᵢ²`.  The final
+`+s₃` is the direct Pauli-family sign, not Verstraete--Verschelde's inconsistent
+printed all-minus constraint. -/
+def diagonalBellWeight (s₁ s₂ s₃ : ℝ) : Fin 4 → ℝ
+  | 0 => (1 + s₁ + s₂ + s₃) / 4
+  | 1 => (1 + s₁ - s₂ - s₃) / 4
+  | 2 => (1 - s₁ + s₂ - s₃) / 4
+  | 3 => (1 - s₁ - s₂ + s₃) / 4
+
+/-- The diagonal entries of the Pauli transfer matrix, including the
+trace-preserving entry `s₀ = 1`. -/
+def diagonalPauliEigenvalue (s₁ s₂ s₃ : ℝ) : Fin 4 → ℝ
+  | 0 => 1
+  | 1 => s₁
+  | 2 => s₂
+  | 3 => s₃
+
+/-- Square-root coefficients for the diagonal Pauli family.  When the four
+weights are nonnegative, these are the coefficients `pᵢ` in the Equation (18)
+family `{p₀ σ₀, p₁ σ₁, p₂ σ₂, p₃ σ₃}`, specialized to `A = B = I` and
+related to the transfer parameters by the direct Pauli-action calculation above. -/
+def diagonalKrausCoefficient (s₁ s₂ s₃ : ℝ) (i : Fin 4) : ℝ :=
+  Real.sqrt (diagonalBellWeight s₁ s₂ s₃ i)
+
+/-- The four-operator Pauli family built from `diagonalKrausCoefficient`.
+Under nonnegative weights it is the diagonal representative in
+Verstraete--Verschelde, Theorem 8, Equation (18), with `A = B = I`. -/
+def diagonalKraus (s₁ s₂ s₃ : ℝ) : Fin 4 → QubitMatrix :=
+  fun i ↦ (diagonalKrausCoefficient s₁ s₂ s₃ i : ℂ) • pauliMatrices i
+
+/-- The completely positive Kraus map built from `diagonalKraus`.
+
+If a candidate weight is negative, `Real.sqrt` clips it to zero.  Therefore
+the theorems identifying this map with the source diagonal representative and
+its parameters explicitly assume that every weight is nonnegative. -/
+def diagonalMap (s₁ s₂ s₃ : ℝ) : QubitMap :=
+  Kraus.mapLM (diagonalKraus s₁ s₂ s₃)
+
+/-- Indices of the nonzero candidate Bell-diagonal weights. -/
+abbrev diagonalBellSupport (s₁ s₂ s₃ : ℝ) :=
+  {i : Fin 4 // diagonalBellWeight s₁ s₂ s₃ i ≠ 0}
+
+/-- The four candidate Bell-diagonal weights sum to one. -/
+theorem sum_diagonalBellWeight (s₁ s₂ s₃ : ℝ) :
+    ∑ i : Fin 4, diagonalBellWeight s₁ s₂ s₃ i = 1 := by
+  simp [diagonalBellWeight, Fin.sum_univ_four]
+  ring
+
+/-- Simultaneous nonnegativity of the four Bell weights is equivalent to the
+four displayed linear inequalities. -/
+theorem diagonalBellWeight_nonneg_iff (s₁ s₂ s₃ : ℝ) :
+    (∀ i, 0 ≤ diagonalBellWeight s₁ s₂ s₃ i) ↔
+      0 ≤ 1 + s₁ + s₂ + s₃ ∧
+      0 ≤ 1 + s₁ - s₂ - s₃ ∧
+      0 ≤ 1 - s₁ + s₂ - s₃ ∧
+      0 ≤ 1 - s₁ - s₂ + s₃ := by
+  constructor
+  · intro h
+    have h₀ := h (0 : Fin 4)
+    have h₁ := h (1 : Fin 4)
+    have h₂ := h (2 : Fin 4)
+    have h₃ := h (3 : Fin 4)
+    simp [diagonalBellWeight] at h₀ h₁ h₂ h₃
+    exact ⟨by linarith, by linarith, by linarith, by linarith⟩
+  · rintro ⟨h₀, h₁, h₂, h₃⟩ i
+    fin_cases i <;> simp [diagonalBellWeight] <;> linarith
+
+/-- Under Wolf's ordered diagonal convention, the single displayed
+Fujiwara--Algoet inequality supplies all four nonnegative Bell-diagonal
+eigenvalues. -/
+theorem diagonalBellWeight_nonneg_of_ordered
+    {s₁ s₂ s₃ : ℝ} (hs₁ : s₁ ≤ 1) (hs₂ : s₂ ≤ s₁)
+    (hs₃ : |s₃| ≤ s₂) (hcp : s₁ + s₂ ≤ 1 + s₃) :
+    ∀ i, 0 ≤ diagonalBellWeight s₁ s₂ s₃ i := by
+  rw [diagonalBellWeight_nonneg_iff]
+  constructor
+  · nlinarith [le_abs_self s₃, neg_abs_le s₃]
+  constructor
+  · nlinarith [le_abs_self s₃, neg_abs_le s₃]
+  constructor
+  · nlinarith [le_abs_self s₃, neg_abs_le s₃]
+  · linarith
+
+/-- The source Pauli family is trace preserving whenever its Bell-diagonal
+eigenvalues are nonnegative. -/
+theorem diagonalKraus_isTP {s₁ s₂ s₃ : ℝ}
+    (hweight : ∀ i, 0 ≤ diagonalBellWeight s₁ s₂ s₃ i) :
+    Kraus.IsTP (diagonalKraus s₁ s₂ s₃) := by
+  have hsqrt (i : Fin 4) :
+      Real.sqrt (diagonalBellWeight s₁ s₂ s₃ i) ^ 2 =
+        diagonalBellWeight s₁ s₂ s₃ i :=
+    Real.sq_sqrt (hweight i)
+  have hsqrtℂ (i : Fin 4) :
+      (diagonalKrausCoefficient s₁ s₂ s₃ i : ℂ) *
+          (diagonalKrausCoefficient s₁ s₂ s₃ i : ℂ) =
+        (diagonalBellWeight s₁ s₂ s₃ i : ℂ) := by
+    exact_mod_cast (show
+      diagonalKrausCoefficient s₁ s₂ s₃ i *
+          diagonalKrausCoefficient s₁ s₂ s₃ i =
+        diagonalBellWeight s₁ s₂ s₃ i by
+      simpa [diagonalKrausCoefficient, pow_two] using hsqrt i)
+  have hsumℂ :
+      ∑ i : Fin 4, (diagonalBellWeight s₁ s₂ s₃ i : ℂ) = 1 := by
+    exact_mod_cast sum_diagonalBellWeight s₁ s₂ s₃
+  rw [Kraus.IsTP]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [diagonalKraus, pauliMatrices,
+      Fin.sum_univ_four, Matrix.mul_apply, Matrix.conjTranspose_apply,
+      hsqrtℂ]
+  all_goals simpa [Fin.sum_univ_four] using hsumℂ
+
+/-- The source Pauli family defines a diagonal qubit channel. -/
+theorem diagonalMap_isChannel {s₁ s₂ s₃ : ℝ}
+    (hweight : ∀ i, 0 ≤ diagonalBellWeight s₁ s₂ s₃ i) :
+    IsChannel (diagonalMap s₁ s₂ s₃) :=
+  Kraus.isChannel_mapLM _ (diagonalKraus_isTP hweight)
+
+/-- Each Pauli matrix is an eigenvector of the diagonal representative. -/
+theorem diagonalMap_pauli {s₁ s₂ s₃ : ℝ}
+    (hweight : ∀ i, 0 ≤ diagonalBellWeight s₁ s₂ s₃ i) (j : Fin 4) :
+    diagonalMap s₁ s₂ s₃ (pauliMatrices j) =
+      (diagonalPauliEigenvalue s₁ s₂ s₃ j : ℂ) • pauliMatrices j := by
+  have hsqrtℂ (i : Fin 4) :
+      (diagonalKrausCoefficient s₁ s₂ s₃ i : ℂ) *
+          (diagonalKrausCoefficient s₁ s₂ s₃ i : ℂ) =
+        (diagonalBellWeight s₁ s₂ s₃ i : ℂ) := by
+    exact_mod_cast (show
+      diagonalKrausCoefficient s₁ s₂ s₃ i *
+          diagonalKrausCoefficient s₁ s₂ s₃ i =
+        diagonalBellWeight s₁ s₂ s₃ i by
+      simpa [diagonalKrausCoefficient, pow_two] using Real.sq_sqrt (hweight i))
+  have hsqrtPowℂ (i : Fin 4) :
+      (diagonalKrausCoefficient s₁ s₂ s₃ i : ℂ) ^ 2 =
+        (diagonalBellWeight s₁ s₂ s₃ i : ℂ) := by
+    simpa [pow_two] using hsqrtℂ i
+  fin_cases j <;> ext a b <;> fin_cases a <;> fin_cases b <;>
+    norm_num [diagonalMap, Kraus.map_apply, diagonalKraus, pauliMatrices,
+      diagonalPauliEigenvalue, Fin.sum_univ_four, Matrix.mul_apply,
+      Matrix.vecMul, dotProduct, Matrix.conjTranspose_apply, hsqrtℂ]
+  all_goals try simp [diagonalBellWeight]
+  case «2».«0».«1» =>
+    have h₀ := hsqrtPowℂ (0 : Fin 4)
+    have h₁ := hsqrtPowℂ (1 : Fin 4)
+    have h₂ := hsqrtPowℂ (2 : Fin 4)
+    have h₃ := hsqrtPowℂ (3 : Fin 4)
+    simp [diagonalBellWeight] at h₀ h₁ h₂ h₃
+    linear_combination -Complex.I * h₀ + Complex.I * h₁ -
+      Complex.I * h₂ + Complex.I * h₃
+  case «2».«1».«0» =>
+    have h₀ := hsqrtPowℂ (0 : Fin 4)
+    have h₁ := hsqrtPowℂ (1 : Fin 4)
+    have h₂ := hsqrtPowℂ (2 : Fin 4)
+    have h₃ := hsqrtPowℂ (3 : Fin 4)
+    simp [diagonalBellWeight] at h₀ h₁ h₂ h₃
+    linear_combination Complex.I * h₀ - Complex.I * h₁ +
+      Complex.I * h₂ - Complex.I * h₃
+  all_goals ring
+
+/-- Exact Pauli-transfer matrix of the diagonal representative. -/
+theorem pauliTransferMatrix_diagonalMap {s₁ s₂ s₃ : ℝ}
+    (hweight : ∀ i, 0 ≤ diagonalBellWeight s₁ s₂ s₃ i) :
+    pauliTransferMatrix (diagonalMap s₁ s₂ s₃) =
+      Matrix.diagonal (fun i ↦ (diagonalPauliEigenvalue s₁ s₂ s₃ i : ℂ)) := by
+  ext i j
+  rw [pauliTransferMatrix, pauliTransferEntry, diagonalMap_pauli hweight]
+  fin_cases i <;> fin_cases j <;>
+    norm_num [diagonalPauliEigenvalue, pauliMatrices, Matrix.diagonal_apply,
+      Matrix.trace_fin_two, Matrix.mul_apply]
+  all_goals ring_nf
+  all_goals try rw [Complex.I_sq]
+  all_goals ring
+
+/-- The source-displayed Pauli channel satisfies the diagonal normal-form
+predicate.  This does not assert existence of such a representative in every
+filtering orbit. -/
+theorem isLorentzDiagonal_diagonalMap {s₁ s₂ s₃ : ℝ}
+    (hweight : ∀ i, 0 ≤ diagonalBellWeight s₁ s₂ s₃ i) :
+    IsLorentzDiagonal (diagonalMap s₁ s₂ s₃) := by
+  refine ⟨diagonalMap_isChannel hweight, ?_, ?_⟩
+  · have hpauli : pauliMatrices (0 : Fin 4) = (1 : QubitMatrix) := by
+      ext i j
+      fin_cases i <;> fin_cases j <;> norm_num [pauliMatrices]
+    have h := diagonalMap_pauli hweight (0 : Fin 4)
+    rw [hpauli] at h
+    simpa [diagonalPauliEigenvalue] using h
+  · intro i j hij
+    have h := congrArg (fun M : Matrix (Fin 4) (Fin 4) ℂ ↦ M i j)
+      (pauliTransferMatrix_diagonalMap hweight)
+    simpa [pauliTransferMatrix, Matrix.diagonal_apply, hij] using h
+
+private theorem pauliMatrices_linearIndependent :
+    LinearIndependent ℂ pauliMatrices := by
+  rw [Fintype.linearIndependent_iff]
+  intro g hg i
+  have h₀₀ := congrArg (fun M : QubitMatrix ↦ M 0 0) hg
+  have h₁₁ := congrArg (fun M : QubitMatrix ↦ M 1 1) hg
+  have h₀₁ := congrArg (fun M : QubitMatrix ↦ M 0 1) hg
+  have h₁₀ := congrArg (fun M : QubitMatrix ↦ M 1 0) hg
+  have h₀₀' : g 0 + g 3 = 0 := by
+    simpa [Fin.sum_univ_four, pauliMatrices] using h₀₀
+  have h₁₁' : g 0 + -g 3 = 0 := by
+    simpa [Fin.sum_univ_four, pauliMatrices] using h₁₁
+  have h₀₁' : g 1 + -(g 2 * Complex.I) = 0 := by
+    simpa [Fin.sum_univ_four, pauliMatrices] using h₀₁
+  have h₁₀' : g 1 + g 2 * Complex.I = 0 := by
+    simpa [Fin.sum_univ_four, pauliMatrices] using h₁₀
+  have hg₀ : g 0 = 0 := by linear_combination (h₀₀' + h₁₁') / 2
+  have hg₃ : g 3 = 0 := by linear_combination (h₀₀' - h₁₁') / 2
+  have hg₁ : g 1 = 0 := by linear_combination (h₀₁' + h₁₀') / 2
+  have hg₂ : g 2 = 0 := by
+    have hI : g 2 * Complex.I = 0 := by
+      linear_combination (h₁₀' - h₀₁') / 2
+    exact (mul_eq_zero.mp hI).resolve_right Complex.I_ne_zero
+  fin_cases i
+  · exact hg₀
+  · exact hg₁
+  · exact hg₂
+  · exact hg₃
 
 /-! ## The non-diagonal representative -/
 
@@ -60,8 +299,8 @@ used only when certifying that this family is trace preserving. -/
 def nonDiagonalKraus (x : ℝ) : Fin 3 → QubitMatrix :=
   fun i ↦ (nonDiagonalKrausCoefficient x i : ℂ) • nonDiagonalKrausBase i
 
-/-- The canonical non-diagonal completely positive map displayed in
-Verstraete--Verschelde, Theorem 8. -/
+/-- The canonical non-diagonal completely positive map whose Pauli-transfer
+matrix is the second normal form in Verstraete--Verschelde, Equation (17). -/
 def nonDiagonalMap (x : ℝ) : QubitMap :=
   Kraus.mapLM (nonDiagonalKraus x)
 
@@ -226,19 +465,19 @@ theorem isLorentzNonDiagonal_nonDiagonalMap {x : ℝ}
 /-! ## Choi/Kraus ranks of the displayed family -/
 
 private theorem rank_sum_vecMulVec_eq_card_of_linearIndependent
-    {n : Type*} [Fintype n] {r : ℕ} (v : Fin r → n → ℂ)
+    {n ι : Type*} [Fintype n] [Fintype ι] (v : ι → n → ℂ)
     (hv : LinearIndependent ℂ v) :
-    (∑ i : Fin r, Matrix.vecMulVec (v i) (star (v i))).rank = r := by
-  let C : Matrix n (Fin r) ℂ := fun p i ↦ v i p
+    (∑ i : ι, Matrix.vecMulVec (v i) (star (v i))).rank = Fintype.card ι := by
+  let C : Matrix n ι ℂ := fun p i ↦ v i p
   have hsum :
-      ∑ i : Fin r, Matrix.vecMulVec (v i) (star (v i)) = C * Cᴴ := by
+      ∑ i : ι, Matrix.vecMulVec (v i) (star (v i)) = C * Cᴴ := by
     ext p q
     rw [Matrix.sum_apply, Matrix.mul_apply]
-    change (∑ i : Fin r, v i p * star (v i q)) =
-      ∑ i : Fin r, v i p * star (v i q)
+    change (∑ i : ι, v i p * star (v i q)) =
+      ∑ i : ι, v i p * star (v i q)
     rfl
   rw [hsum, Matrix.rank_self_mul_conjTranspose, Matrix.rank_eq_finrank_span_cols]
-  change Module.finrank ℂ (Submodule.span ℂ (Set.range v)) = r
+  change Module.finrank ℂ (Submodule.span ℂ (Set.range v)) = Fintype.card ι
   simpa using finrank_span_eq_card hv
 
 private theorem choiRank_mapLM_eq_card_of_linearIndependent {r : ℕ}
@@ -264,7 +503,101 @@ private theorem choiRank_mapLM_eq_card_of_linearIndependent {r : ℕ}
       (mul_eq_zero.mp hentry).resolve_left hc
   change (ChoiJamiolkowski.choiMatrix (Kraus.mapLM K)).rank = r
   rw [Channel.choiMatrix_mapLM_eq_sum_vecMulVec]
-  exact rank_sum_vecMulVec_eq_card_of_linearIndependent v hv
+  change (∑ i : Fin r, Matrix.vecMulVec (v i) (star (v i))).rank = r
+  simpa using rank_sum_vecMulVec_eq_card_of_linearIndependent v hv
+
+/-- The diagonal representative's Choi/Kraus rank is exactly the number of
+nonzero Bell-diagonal eigenvalues.  This includes every rank-drop boundary,
+rather than assuming the generic rank-four case. -/
+theorem choiRank_diagonalMap {s₁ s₂ s₃ : ℝ}
+    (hweight : ∀ i, 0 ≤ diagonalBellWeight s₁ s₂ s₃ i) :
+    Channel.choiRank (diagonalMap s₁ s₂ s₃) =
+      Fintype.card (diagonalBellSupport s₁ s₂ s₃) := by
+  classical
+  let c : ℂ := 1 / ((2 : ℝ).sqrt : ℂ)
+  let v : Fin 4 → (Fin 2 × Fin 2) → ℂ :=
+    fun j p ↦ c * diagonalKraus s₁ s₂ s₃ j p.1 p.2
+  let supportV : diagonalBellSupport s₁ s₂ s₃ → (Fin 2 × Fin 2) → ℂ :=
+    fun j ↦ v j.1
+  have hc : c ≠ 0 := by
+    dsimp [c]
+    positivity
+  have hcoeff : ∀ i : diagonalBellSupport s₁ s₂ s₃,
+      ((diagonalKrausCoefficient s₁ s₂ s₃ i.1 : ℝ) : ℂ) ≠ 0 := by
+    intro i
+    apply Complex.ofReal_ne_zero.mpr
+    rw [diagonalKrausCoefficient, Real.sqrt_ne_zero']
+    exact lt_of_le_of_ne (hweight i.1) (Ne.symm i.2)
+  have hK : LinearIndependent ℂ
+      (fun i : diagonalBellSupport s₁ s₂ s₃ ↦
+        diagonalKraus s₁ s₂ s₃ i.1) := by
+    have hrestricted := pauliMatrices_linearIndependent.comp
+      (fun i : diagonalBellSupport s₁ s₂ s₃ ↦ i.1) Subtype.val_injective
+    rw [Fintype.linearIndependent_iff] at hrestricted ⊢
+    intro g hg i
+    have hproduct := hrestricted
+      (fun j ↦ g j * (diagonalKrausCoefficient s₁ s₂ s₃ j.1 : ℂ)) (by
+        calc
+          ∑ j, (g j * (diagonalKrausCoefficient s₁ s₂ s₃ j.1 : ℂ)) •
+              pauliMatrices j.1 =
+              ∑ j, g j • diagonalKraus s₁ s₂ s₃ j.1 := by
+                apply Finset.sum_congr rfl
+                intro j _
+                change (g j * (diagonalKrausCoefficient s₁ s₂ s₃ j.1 : ℂ)) •
+                    pauliMatrices j.1 =
+                  g j • ((diagonalKrausCoefficient s₁ s₂ s₃ j.1 : ℂ) •
+                    pauliMatrices j.1)
+                rw [smul_smul]
+          _ = 0 := hg) i
+    exact (mul_eq_zero.mp hproduct).resolve_right (hcoeff i)
+  have hv : LinearIndependent ℂ supportV := by
+    rw [Fintype.linearIndependent_iff] at hK ⊢
+    intro g hg i
+    apply hK g _ i
+    apply Matrix.ext
+    intro a b
+    have hab := congrFun hg (a, b)
+    have hentry :
+        c * (∑ j, g j * diagonalKraus s₁ s₂ s₃ j.1 a b) = 0 := by
+      simpa [supportV, v, Finset.mul_sum, mul_comm, mul_left_comm, mul_assoc] using hab
+    rw [Matrix.sum_apply, show (0 : QubitMatrix) a b = 0 by rfl]
+    simpa only [Matrix.smul_apply, smul_eq_mul] using
+      (mul_eq_zero.mp hentry).resolve_left hc
+  have hsum :
+      ∑ i : Fin 4, Matrix.vecMulVec (v i) (star (v i)) =
+        ∑ i : diagonalBellSupport s₁ s₂ s₃,
+          Matrix.vecMulVec (supportV i) (star (supportV i)) := by
+    let f : Fin 4 → Matrix (Fin 2 × Fin 2) (Fin 2 × Fin 2) ℂ :=
+      fun i ↦ Matrix.vecMulVec (v i) (star (v i))
+    have hfiltered :
+        ∑ i ∈ Finset.univ.filter
+              (fun i ↦ diagonalBellWeight s₁ s₂ s₃ i ≠ 0), f i =
+          ∑ i : Fin 4, f i := by
+      apply Finset.sum_subset (Finset.filter_subset _ _)
+      intro i _ hi
+      have hzero : diagonalBellWeight s₁ s₂ s₃ i = 0 := by
+        simpa using hi
+      ext p q
+      simp [f, v, diagonalKraus, diagonalKrausCoefficient, hzero,
+        Matrix.vecMulVec_apply]
+    calc
+      ∑ i : Fin 4, Matrix.vecMulVec (v i) (star (v i)) = ∑ i : Fin 4, f i := rfl
+      _ = ∑ i ∈ Finset.univ.filter
+            (fun i ↦ diagonalBellWeight s₁ s₂ s₃ i ≠ 0), f i := hfiltered.symm
+      _ = ∑ i : diagonalBellSupport s₁ s₂ s₃, f i.1 := by
+        simpa [diagonalBellSupport] using
+          (Finset.sum_subtype
+            (Finset.univ.filter
+              (fun i ↦ diagonalBellWeight s₁ s₂ s₃ i ≠ 0))
+            (fun i ↦ by simp) f)
+      _ = ∑ i : diagonalBellSupport s₁ s₂ s₃,
+          Matrix.vecMulVec (supportV i) (star (supportV i)) := rfl
+  change (ChoiJamiolkowski.choiMatrix
+    (Kraus.mapLM (diagonalKraus s₁ s₂ s₃))).rank = _
+  rw [Channel.choiMatrix_mapLM_eq_sum_vecMulVec]
+  change (∑ i : Fin 4, Matrix.vecMulVec (v i) (star (v i))).rank = _
+  rw [hsum]
+  exact rank_sum_vecMulVec_eq_card_of_linearIndependent supportV hv
 
 private theorem nonDiagonalKrausBase_linearIndependent :
     LinearIndependent ℂ nonDiagonalKrausBase := by
@@ -365,7 +698,8 @@ def singularKraus : Fin 2 → QubitMatrix
   | 0 => !![1, 0; 0, 0]
   | 1 => !![0, 1; 0, 0]
 
-/-- The singular qubit channel of Wolf, Proposition 2.11 case 3. -/
+/-- The singular qubit channel from the third normal form in
+Verstraete--Verschelde, Equation (17), and Wolf, Proposition 2.11 case 3. -/
 def singularMap : QubitMap :=
   Kraus.mapLM singularKraus
 

--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -846,10 +846,24 @@ recorded in \cite{gap:qiclean_minkowski_canonical_pair_dependency}.
     Trace preservation supplies the first row of the displayed matrix.
 \end{definition}
 
-\begin{theorem}[Displayed non-diagonal and singular representatives]
+\begin{theorem}[Displayed canonical representatives and ranks]
     \label{thm:lorentz_displayed_qubit_representatives}
-    \uses{def:lorentz_non_diagonal, def:lorentz_singular}
-    \lean{Wolf.nonDiagonalKrausBase,
+    \uses{def:lorentz_diagonal, def:lorentz_non_diagonal, def:lorentz_singular}
+    \lean{Wolf.diagonalBellWeight,
+        Wolf.diagonalPauliEigenvalue,
+        Wolf.diagonalKrausCoefficient,
+        Wolf.diagonalKraus,
+        Wolf.diagonalMap,
+        Wolf.sum_diagonalBellWeight,
+        Wolf.diagonalBellWeight_nonneg_iff,
+        Wolf.diagonalBellWeight_nonneg_of_ordered,
+        Wolf.diagonalKraus_isTP,
+        Wolf.diagonalMap_isChannel,
+        Wolf.diagonalMap_pauli,
+        Wolf.pauliTransferMatrix_diagonalMap,
+        Wolf.isLorentzDiagonal_diagonalMap,
+        Wolf.choiRank_diagonalMap,
+        Wolf.nonDiagonalKrausBase,
         Wolf.nonDiagonalKrausCoefficient,
         Wolf.nonDiagonalKraus,
         Wolf.nonDiagonalMap,
@@ -872,6 +886,47 @@ recorded in \cite{gap:qiclean_minkowski_canonical_pair_dependency}.
         Wolf.isLorentzSingular_singularMap,
         Wolf.choiRank_singularMap}
     \leanok
+    Put $q_i=p_i^2$ for the Pauli coefficients in
+    \cite[Theorem~8, Eq.~(18)]{VerstraeteVerschelde2002QuantumChannels},
+    specialized to $A=B=\Id$.  Direct conjugation of the Pauli basis gives
+    \begin{align}
+        s_1 & =q_0+q_1-q_2-q_3, &
+        s_2 & =q_0-q_1+q_2-q_3, \\
+        s_3 & =q_0-q_1-q_2+q_3, &
+        1   & =q_0+q_1+q_2+q_3.
+    \end{align}
+    Thus, in Wolf's Pauli-transfer convention, the four candidate Bell weights
+    are
+    \begin{align}
+        q_0 & =\frac{1+s_1+s_2+s_3}{4}, &
+        q_1 & =\frac{1+s_1-s_2-s_3}{4},   \\
+        q_2 & =\frac{1-s_1+s_2-s_3}{4}, &
+        q_3 & =\frac{1-s_1-s_2+s_3}{4}.
+    \end{align}
+    Verstraete--Verschelde instead print
+    $1-s_1-s_2-s_3\geq0$ in Theorem~8.  Their preceding Equation~(16) uses
+    $R_\Phi$ as the Bloch transfer matrix, so the identity channel has
+    $R_\Phi=\operatorname{diag}(1,1,1,1)$ and violates the printed inequality.
+    The all-minus sign is therefore inconsistent with their own convention;
+    it is not used in this construction and no silent change of the parameter
+    $s_3$ is made.
+    They sum to one.  If every $q_i$ is nonnegative, put $p_i=\sqrt{q_i}$.
+    Then the source family
+    $\{p_0\sigma_0,p_1\sigma_1,p_2\sigma_2,p_3\sigma_3\}$ from
+    \cite[Theorem~8, Eq.~(18)]{VerstraeteVerschelde2002QuantumChannels},
+    specialized to $A=B=\Id$, defines a
+    bistochastic channel whose Pauli transfer matrix is
+    $\operatorname{diag}(1,s_1,s_2,s_3)$.  Its Choi rank is exactly
+    $\#\{i\mid q_i\ne0\}$, so all diagonal rank-drop boundaries are retained.
+    Simultaneous nonnegativity of the four weights is equivalent to
+    nonnegativity of their four displayed numerators.  This construction shows
+    that those inequalities suffice for the displayed Pauli family to be a
+    channel; it makes no converse assertion for a separately specified
+    diagonal map.
+    Under the ordered convention
+    $1\geq s_1\geq s_2\geq\lvert s_3\rvert$, Wolf's
+    $s_1+s_2\leq1+s_3$ from Equation~(2.40) implies all four.
+
     For every $x\in[0,1]$, the three Kraus operators displayed in
     \cite[Theorem~8, Eq.~(19)]{VerstraeteVerschelde2002QuantumChannels}
     define the non-diagonal representative
@@ -881,22 +936,32 @@ recorded in \cite{gap:qiclean_minkowski_canonical_pair_dependency}.
         &v&=(0,0,2/3).
     \end{align}
     Its Choi rank, equivalently its minimal Kraus rank, is $3$ when
-    $x<1$ and $2$ when $x=1$.  The singular representative is the
-    trace-to-state channel
+    $x<1$ and $2$ when $x=1$.  The third normal form in
+    \cite[Theorem~8, Eq.~(17)]{VerstraeteVerschelde2002QuantumChannels}
+    is the singular trace-to-state channel
     \begin{align}
         X\longmapsto \tr(X)\,\lvert0\rangle\!\langle0\rvert;
     \end{align}
     it has $\Delta=0$, $v=(0,0,1)$, and Choi/Kraus rank $2$.
 
-    These are constructions and rank calculations for the representatives
-    in \cite[Theorem~8, Eqs.~(17)--(19)]{VerstraeteVerschelde2002QuantumChannels}
-    and Wolf Proposition~2.11, not the Lorentz-orbit classification or the
-    derivation that the non-diagonal parameter must lie in $[0,1]$.
+    These are constructions and rank calculations for the representatives in
+    \cite[Theorem~8, Eqs.~(17)--(19)]{VerstraeteVerschelde2002QuantumChannels}.
+    The diagonal rank formula is the direct Bell-family calculation from
+    Equation~(18).  The non-diagonal and singular rank statements agree with
+    cases 2 and 3 of \cite[Theorem~18]{WolfCirac2008Dividing}.  This does not
+    prove the Lorentz-orbit classification or derive that the non-diagonal
+    parameter must lie in $[0,1]$.
     The normalized Choi convention is
     $\tau=\frac14\sum_{ij}\widehat T_{ij}\sigma_i\otimes\sigma_j^{\mathsf T}$;
-    hence a raw Pauli correlation matrix has a sign change in the
-    $\sigma_2$ input column and is not silently identified with
-    $\widehat T$.
+    hence its raw Pauli correlation matrix satisfies
+    $R_{\mathrm{raw}}(\tau)=\widehat T\operatorname{diag}(1,1,-1,1)$ because
+    $\sigma_2^{\mathsf T}=-\sigma_2$.  Verstraete--Verschelde define $R_\Phi$
+    only after taking the first-factor partial transpose of their dual state
+    and then use it as the Bloch transfer matrix.  Thus $R_\Phi$ corresponds
+    to $\widehat T$, not to $R_{\mathrm{raw}}(\tau)$; the displayed sign matrix
+    is the explicit bridge.  In particular, the partial-transpose sign has
+    already been absorbed before their Theorem~8 parameters are introduced and
+    cannot account for its printed all-minus constraint.
 \end{theorem}
 
 % Pending Lean formalization: there is currently no declaration for this theorem.
@@ -915,7 +980,7 @@ recorded in \cite{gap:qiclean_minkowski_canonical_pair_dependency}.
     map scalar $|c_1c_2|^2$; only the latter can normalize the resulting
     representative to a channel. A proof still requires this scalar
     normalization and the classification of Lorentz orbits.  The displayed
-    non-diagonal and singular representatives and their ranks are already
+    diagonal, non-diagonal, and singular representatives and their ranks are already
     supplied by Theorem~\ref{thm:lorentz_displayed_qubit_representatives}.
 \end{theorem}
 

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -38,6 +38,15 @@
   note         = {arXiv:quant-ph/0202124v2},
 }
 
+@unpublished{WolfCirac2008Dividing,
+  author       = {Wolf, Michael M. and Cirac, J. Ignacio},
+  title        = {Dividing Quantum Channels},
+  year         = {2008},
+  eprint       = {math-ph/0611057},
+  eprinttype   = {arxiv},
+  note         = {arXiv:math-ph/0611057v3},
+}
+
 @article{Yamagami1993Cyclic,
   author       = {Yamagami, Shigeru},
   title        = {Cyclic Inequalities},

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -15,6 +15,15 @@
   note         = {arXiv:quant-ph/0202124v2},
 }
 
+@unpublished{WolfCirac2008Dividing,
+  author       = {Wolf, Michael M. and Cirac, J. Ignacio},
+  title        = {Dividing Quantum Channels},
+  year         = {2008},
+  eprint       = {math-ph/0611057},
+  eprinttype   = {arxiv},
+  note         = {arXiv:math-ph/0611057v3},
+}
+
 @article{Yamagami1993Cyclic,
   author       = {Yamagami, Shigeru},
   title        = {Cyclic Inequalities},

--- a/docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex
+++ b/docs/paper-gaps/wolf_prop2_11_lorentz_scalar_filtering_gap.tex
@@ -94,26 +94,83 @@ $L_2\widehat T L_1$ are also formalized.\footnote{Formal declarations
 \leanid{Wolf.pauliMinkowskiEquiv},
 \leanid{Wolf.spinorMatrix_isSpecialOrthochronousLorentz}, and
 \leanid{Wolf.pauliTransferMatrixReal_slFiltering} in
-\doclink{QICLean/Channel/LorentzNormalForm/SpinorAction}.}  The theorem
+\doclink{QICLean/Channel/LorentzNormalForm/SpinorAction};
+\leanid{Wolf.spinorCoverHom_surjective},
+\leanid{Wolf.spinorCoverHom_eq_iff_eq_or_eq_neg}, and
+\leanid{Wolf.boostSpinor_posDef} in
+\doclink{QICLean/Channel/LorentzNormalForm/SpinorCover}; and
+\leanid{Wolf.spinorMatrix_boostExpSL2} and
+\leanid{Wolf.spinorMatrix_rotationExpSL2} in
+\doclink{QICLean/Channel/LorentzNormalForm/SpinorExponential}.}  The theorem
 asserting existence of a canonical representative for every qubit channel
 remains open.
 
-The two non-generic representatives themselves are now formalized directly
-from the source formulas in
+All three displayed representatives are now formalized directly from the
+source formulas in
 \cite[Theorem~8, Eqs.~(17)--(19)]{VerstraeteVerschelde2002QuantumChannels}.
+Verstraete--Verschelde define $R_\Phi$ from the first-factor-partially-transposed
+dual state and then use $(1,x')^{\mathsf T}=R_\Phi(1,x)^{\mathsf T}$, so
+$R_\Phi$ is their Bloch transfer matrix.  It corresponds to the local
+$\widehat T$, not to the raw Pauli correlation matrix of $\tau$.  In the
+normalized Choi convention and the local factor order, the latter satisfies
+$R_{\mathrm{raw}}(\tau)=\widehat T\operatorname{diag}(1,1,-1,1)$ because
+$\sigma_2^{\mathsf T}=-\sigma_2$.
+The partial-transpose sign is therefore already absorbed before the parameters
+in Theorem~8 are introduced.
+
+For the diagonal representative, put $q_i=p_i^2$ in the Equation~(18) Pauli
+family and specialize to $A=B=\one$.  Direct Pauli conjugation gives
+\begin{align}
+  s_1&=q_0+q_1-q_2-q_3,
+  &s_2&=q_0-q_1+q_2-q_3,\\
+  s_3&=q_0-q_1-q_2+q_3,
+  &1&=q_0+q_1+q_2+q_3.
+\end{align}
+Inverting these equations in Wolf's Pauli-transfer convention gives
+\begin{align}
+  q_0&=(1+s_1+s_2+s_3)/4,
+  &q_1&=(1+s_1-s_2-s_3)/4,\\
+  q_2&=(1-s_1+s_2-s_3)/4,
+  &q_3&=(1-s_1-s_2+s_3)/4.
+\end{align}
+Verstraete--Verschelde, Theorem~8 instead prints
+$1-s_1-s_2-s_3\geq0$.  This is inconsistent with Equation~(16): the identity
+channel has $R_\Phi=\operatorname{diag}(1,1,1,1)$ and violates that printed
+inequality.  It also cannot be explained by the partial-transpose bridge,
+because $R_\Phi$ is defined only after that transpose and already acts as the
+Bloch transfer matrix.  The formalization therefore records the all-minus
+condition as a printed sign inconsistency and does not use it.
+The formalization proves that the weights sum to one and that their simultaneous
+nonnegativity is equivalent to the four displayed numerator inequalities.
+Assuming that nonnegativity, the Equation~(18) amplitudes are $p_i=\sqrt{q_i}$
+when $A=B=\one$, and the resulting channel has Pauli transfer matrix
+$\operatorname{diag}(1,s_1,s_2,s_3)$ and Choi/Kraus rank
+$\#\{i\mid q_i\ne0\}$, retaining all rank-drop boundaries.  No necessity
+statement for complete positivity is formalized: the definition uses
+$\sqrt{q_i}$ and therefore clips a negative candidate weight to zero.
+Under $1\geq s_1\geq s_2\geq|s_3|$, Wolf's Equation~(2.40),
+$s_1+s_2\leq1+s_3$, supplies all four inequalities and agrees with the direct
+Equation~(18) calculation above.
 The exact non-diagonal three-Kraus family defines a channel for each assumed
 $x\in[0,1]$, has the Pauli data
 $\Delta=\operatorname{diag}(x/\sqrt3,x/\sqrt3,1/3)$ and
 $v=(0,0,2/3)$, and has Choi/Kraus rank three for $x<1$ and two at $x=1$.
-The singular two-Kraus family realizes
+The third normal form in Equation~(17) is realized by the singular two-Kraus
+family
 $X\mapsto\tr(X)\lvert0\rangle\!\langle0\rvert$ and has Choi/Kraus rank two.
-\footnote{Formal declarations
+The diagonal rank formula is the direct Bell-family calculation from
+Equation~(18).  The non-diagonal and singular rank statements are respectively
+cases 2 and 3 of \cite[Theorem~18]{WolfCirac2008Dividing}\footnote{Formal declarations
+\leanid{Wolf.diagonalMap},
+\leanid{Wolf.diagonalBellWeight_nonneg_iff},
+\leanid{Wolf.pauliTransferMatrix_diagonalMap},
+\leanid{Wolf.choiRank_diagonalMap},
 \leanid{Wolf.nonDiagonalMap},
 \leanid{Wolf.choiRank_nonDiagonalMap_eq_three},
 \leanid{Wolf.choiRank_nonDiagonalMap_one},
 \leanid{Wolf.singularMap}, and
 \leanid{Wolf.choiRank_singularMap} in
-\doclink{QICLean/Channel/LorentzNormalForm/CanonicalQubitChannels}.}
+\doclink{QICLean/Channel/LorentzNormalForm/CanonicalQubitChannels}.}.
 This bounded construction proves sufficiency for an already supplied
 $x\in[0,1]$; it does not derive that range or classify Lorentz orbits.
 
@@ -138,27 +195,30 @@ A source-faithful proof requires the following steps.
     transformation \leanid{Wolf.spinorMatrix}.  Its image satisfies the three
     defining conditions of $\mathrm{SO}^+(1,3)$, and two-sided filtering acts
     on Pauli transfer matrices in Wolf's order as $L_2\widehat T L_1$.
+  \item[\(\checkmark\)] The spinor homomorphism onto
+    $\mathrm{SO}^+(1,3)$ is surjective and has the exact two-point fibres
+    $\{S,-S\}$.  The explicit boost and rotation exponential identities from
+    Wolf's Equation~(2.44) are also formalized, so arbitrary source Lorentz
+    factors can be lifted by the proved spinor cover rather than extrapolating
+    from the $\mathrm{SU}(2)$ rotation case.
   \item Classify the resulting diagonal, non-diagonal, and singular Lorentz
-    orbits.  If this classification is transported through arbitrary elements
-    of $\mathrm{SO}^+(1,3)$, prove the required surjectivity of the spinor map
-    rather than importing it from the $\mathrm{SU}(2)$ case.  The present
-    formalization proves only image inclusion and $L(-S)=L(S)$; it does not
-    prove the full two-to-one assertion or the rotation and boost formulas of
-    Wolf's Equation~(2.44).
+    orbits using the source decomposition and its signed canonical-pair data.
   \item Choose the scalar factors so that the canonical representative is trace
     preserving, and derive the stated parameter bounds from the positive
-    two-qubit normal forms.  Once $x\in[0,1]$ is supplied, the exact Kraus
-    constructions, complete positivity, transfer data, and rank calculations
-    for the non-diagonal and singular representatives are already formalized.
+    two-qubit normal forms.  Once the Bell-diagonal eigenvalues are nonnegative and
+    $x\in[0,1]$ is supplied, the exact Kraus constructions, complete positivity,
+    transfer data, and rank calculations for all three representatives are
+    already formalized.
   \item Prove the three-case existence theorem using the general filters and link
     it to the existing canonical-form predicates.
 \end{enumerate}
 
 The discrepancy is an open gap: the canonical predicates, the exact
-non-generic representatives and their ranks, the generic minimisation theorem
-in square dimension, and the determinant-one Lorentz action are available,
-but the scalar-normalized Lorentz-orbit classification and necessity of the
-parameter range required by Proposition~2.11 have not yet been formalized.
+displayed representatives and their ranks, the generic minimisation theorem
+in square dimension, the determinant-one Lorentz action, and the full spinor
+cover are available, but the scalar-normalized Lorentz-orbit classification
+and necessity of the parameter range required by Proposition~2.11 have not
+yet been formalized.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -31,9 +31,11 @@ representations of quantum channels.
 The Lorentz-normal-form statements are recorded in
 `QICLean.Channel.LorentzNormalForm`.  The compactness/minimisation result is
 proved there, and the `SL(2, ℂ)` action on Pauli--Minkowski coordinates is
-formalized in `QICLean.Channel.LorentzNormalForm.SpinorAction`.  The remaining
-proof obligations for Proposition 2.11 are the Lorentz-orbit classification
-and the final scalar normalization.  This index imports the assembling module
+formalized in `QICLean.Channel.LorentzNormalForm.SpinorAction`.  The displayed
+diagonal, non-diagonal, and singular representatives and their exact
+Choi/Kraus ranks are formalized.  The remaining proof obligations for
+Proposition 2.11 are the Lorentz-orbit classification and the final scalar
+normalization.  This index imports the assembling module
 so that the cited formal statements are available from the main project import.
 
 ### Coverage summary
@@ -404,14 +406,33 @@ so that the cited formal statements are available from the main project import.
 * `IsLorentzDiagonal` — diagonal Lorentz normal form (Wolf Proposition 2.11 case 1) ✓
 * `IsLorentzNonDiagonal` — non-diagonal Lorentz normal form (case 2) ✓
 * `IsLorentzSingular` — singular Lorentz normal form (case 3) ✓
+  These are the same three transfer-matrix cases stated in Wolf--Cirac,
+  *Dividing Quantum Channels*, arXiv:math-ph/0611057v3, Theorem 18.  Its rank
+  statements concern only the non-diagonal and singular cases 2 and 3.
+* `Wolf.diagonalBellWeight` / `Wolf.diagonalKraus` / `Wolf.diagonalMap` —
+  the bistochastic Pauli family in Verstraete--Verschelde Theorem 8,
+  Equation (18), with its four Bell weights derived directly from Pauli
+  conjugation and with Pauli transfer matrix `diag(1, s₁, s₂, s₃)` under their
+  nonnegativity hypothesis. Verstraete--Verschelde's printed constraint
+  `1 - s₁ - s₂ - s₃ ≥ 0` is not used: their preceding Equation (16) makes
+  `R_Φ` the Bloch transfer matrix, so that constraint incorrectly excludes the
+  identity channel. The local final inequality
+  `1 - s₁ - s₂ + s₃ ≥ 0` is the direct Equation (18) calculation and agrees
+  with Wolf's Equation (2.40); the partial-transpose `σ₂` sign has already been
+  absorbed in `R_Φ` and does not provide a parameter conversion ✓
+* `Wolf.choiRank_diagonalMap` — the diagonal representative's Choi/Kraus
+  rank is the number of nonzero Bell weights, including ranks 1 through 4;
+  this is the direct Equation (18) Bell-family calculation, not a rank claim
+  from Wolf--Cirac Theorem 18 ✓
 * `Wolf.nonDiagonalKraus` / `Wolf.nonDiagonalMap` — the exact three-operator
   non-diagonal representative in Verstraete--Verschelde Theorem 8,
   Equation (19), with its arbitrary-matrix action and Pauli transfer matrix ✓
 * `Wolf.choiRank_nonDiagonalMap_eq_three` /
   `Wolf.choiRank_nonDiagonalMap_one` — the non-diagonal representative has
   Choi/Kraus rank 3 for `0 ≤ x < 1` and rank 2 at `x = 1` ✓
-* `Wolf.singularKraus` / `Wolf.singularMap` — the singular representative is
-  `X ↦ tr(X)|0⟩⟨0|`, has the stated Pauli transfer matrix, and satisfies
+* `Wolf.singularKraus` / `Wolf.singularMap` — the singular representative,
+  the third normal form in Verstraete--Verschelde Theorem 8, Equation (17),
+  realizes `X ↦ tr(X)|0⟩⟨0|`, has the stated Pauli transfer matrix, and satisfies
   `Wolf.choiRank_singularMap : Channel.choiRank singularMap = 2` ✓
 * `Wolf.infimum_is_attained` — **key compactness lemma**: trace minimisation
   over SL(d₁, ℂ) × SL(d₂, ℂ) filterings of a positive-definite operator on
@@ -440,9 +461,9 @@ so that the cited formal statements are available from the main project import.
   pending as an existence and orbit-classification theorem. The required
   general invertible Kraus-rank-one CP filters and their scalar freedom, the
   determinant-one spinor action, and its exact action on Pauli transfer
-  matrices are formalized. The source-displayed non-diagonal and singular
-  representatives, including their exact actions and Choi/Kraus ranks, are
-  also formalized. The Lorentz-orbit classification, necessity of the
+  matrices are formalized. The source-displayed diagonal, non-diagonal, and
+  singular representatives, including their exact actions and Choi/Kraus
+  ranks, are also formalized. The Lorentz-orbit classification, necessity of the
   non-diagonal parameter range, and final trace-preserving normalization have
   no Lean declaration yet. The former determinant-one `SLFiltering`
   formulation was false and was removed.
@@ -500,12 +521,12 @@ so that the cited formal statements are available from the main project import.
 | Diagonal Lorentz form | `LorentzNormalForm.lean` | `IsLorentzDiagonal` |
 | Non-diagonal Lorentz form | `LorentzNormalForm.lean` | `IsLorentzNonDiagonal` |
 | Singular Lorentz form | `LorentzNormalForm.lean` | `IsLorentzSingular` |
-| Canonical non-diagonal and singular representatives |
+| Canonical diagonal, non-diagonal, and singular representatives |
   `LorentzNormalForm/CanonicalQubitChannels.lean` |
-  `Wolf.nonDiagonalMap`, `Wolf.singularMap` |
+  `Wolf.diagonalMap`, `Wolf.nonDiagonalMap`, `Wolf.singularMap` |
 | Canonical representative Choi/Kraus ranks |
   `LorentzNormalForm/CanonicalQubitChannels.lean` |
-  `Wolf.choiRank_nonDiagonalMap_eq_three`,
+  `Wolf.choiRank_diagonalMap`, `Wolf.choiRank_nonDiagonalMap_eq_three`,
   `Wolf.choiRank_nonDiagonalMap_one`, `Wolf.choiRank_singularMap` |
 
 #### Not yet formalized
@@ -515,8 +536,8 @@ so that the cited formal statements are available from the main project import.
 | Section 2.4 Lorentz normal form (Proposition 2.11) | Correctly formulated
   statement and proof remain pending. The general invertible Kraus-rank-one
   filters, their scalar/SL decomposition, and the determinant-one Lorentz
-  action on Pauli transfer matrices are available. The displayed
-  non-diagonal and singular representatives and their ranks are also
+  action on Pauli transfer matrices are available. The displayed diagonal,
+  non-diagonal, and singular representatives and their ranks are also
   available. The proof still needs the Lorentz-orbit classification, the
   necessity of the parameter bounds, and the final trace-preserving
   normalization. |


### PR DESCRIPTION
## Summary

- formalize the candidate Bell weights for the diagonal Pauli-transfer family and their sum/inequality characterization;
- prove the corresponding Kraus-form sufficiency statement and rank-by-support calculation under nonnegative weights;
- record the exact bridge between the raw Choi correlation matrix and Verstraete--Verschelde's partially-transposed Bloch transfer matrix;
- synchronize the Blueprint, Wolf numbering coverage, and the remaining Lorentz-normal-form gap.

## Source boundary

This is the diagonal slice of Verstraete--Verschelde, arXiv:quant-ph/0202124v2, Equations (17)--(18), used in Wolf's qubit-channel normal-form discussion.

The source conventions are explicit:

- Verstraete--Verschelde define `R_Φ` after partial transpose and use it as the Bloch transfer matrix;
- the raw Choi correlation matrix has the extra `diag(1,1,-1,1)` from `σ₂ᵀ = -σ₂`;
- Verstraete--Verschelde Theorem 8 prints an all-minus inequality that is inconsistent with its own Bloch-transfer convention (it would exclude the identity channel); the local fourth weight `1 - s₁ - s₂ + s₃` is instead derived directly from the Equation (18) Pauli-conjugation Kraus family and agrees with Wolf Equation (2.40).

The Lean definition uses square roots of candidate weights, so negative values are clipped by `Real.sqrt`. Accordingly this PR does **not** claim complete-positivity necessity for the resulting map. It proves only the exact arithmetic weight characterization, CP sufficiency under nonnegative weights, and diagonal rank formula. The diagonal rank attribution is Equation (18)'s Bell family; Wolf--Cirac Theorem 18 is reserved for the non-diagonal/singular cases 2--3.

The full Lorentz SVD/orbit theorem remains blocked by #378, and issue #379 remains open.

## Validation

- focused and full `lake build`;
- import, style, declaration, and policy checks;
- Blueprint sync, web/PDF build, 30-page rendered-browser check, prose and coverage checks;
- paper-gap reference/PDF checks;
- explicit primary-source audit of the printed sign inconsistency and the corrected Equation (18) derivation.

No `sorry`, `admit`, new axiom, `native_decide`, `unsafeCast`, or equivalent bypass is introduced.

Refs #379
