### PR TITLE
feat(channel): add the detailed-balance diagonalizing basis

### DIFF
--- a/QICLean/Channel/DetailedBalance.lean
+++ b/QICLean/Channel/DetailedBalance.lean
@@ -22,6 +22,9 @@ detailed balance controls the Jordan condition number.
 * `Matrix.PosDef.inv_sqrt_mul_mul_sqrt_isHermitian_of_detailedBalance`: conjugating
   by the positive square root in the detailed-balance identity gives a
   Hermitian matrix.
+* `Matrix.PosDef.exists_sqrt_mul_unitary_diagonalization_of_detailedBalance`:
+  Wolf's resulting diagonalizing similarity is `S¹/² U`, and its condition
+  factor is `sqrt (‖S‖ ‖S⁻¹‖)`.
 
 ## References
 
@@ -29,7 +32,7 @@ detailed balance controls the Jordan condition number.
   Proposition “Jordan condition number and detailed balance”][Wolf2012Quantum]
 -/
 
-open scoped Matrix MatrixOrder ComplexOrder Kronecker
+open scoped Matrix MatrixOrder ComplexOrder Kronecker Matrix.Norms.L2Operator
 
 variable {D : ℕ}
 
@@ -146,5 +149,97 @@ theorem PosDef.inv_sqrt_mul_mul_sqrt_isHermitian_of_detailedBalance
   change ((R⁻¹ * A * R)ᴴ = R⁻¹ * A * R)
   rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul, hRstar, hRinvstar]
   simpa only [Matrix.mul_assoc] using hcore
+
+/-- Wolf's explicit diagonalizing similarity in the detailed-balance proof.
+If `S > 0` and `S A† = A S`, there is a unitary `U` such that the change of
+basis `S¹/² U` diagonalizes `A`.  Its inverse is `U† S⁻¹/²`, and its
+condition factor is exactly `sqrt (‖S‖ ‖S⁻¹‖)`.
+
+This is the chosen-basis statement used in Wolf's proof.  It does not define
+or replace Wolf's Jordan condition number `κ_T`, which is an infimum over
+Jordan changes of basis; the passage from this factor to `κ_T` remains a
+separate Jordan-API prerequisite.
+
+Source: Wolf (2012), Chapter 8, proof of the proposition “Jordan condition
+number and detailed balance”, lines 1288--1292 of
+`Notes/WolfNoteTexSource/ch08_distance_measures.tex`. -/
+theorem PosDef.exists_sqrt_mul_unitary_diagonalization_of_detailedBalance
+    {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+    {S A : Matrix n n ℂ} (hS : S.PosDef) (hdb : S * Aᴴ = A * S) :
+    ∃ (U : unitary (Matrix n n ℂ)) (d : n → ℝ),
+      A = (CFC.sqrt S * (U : Matrix n n ℂ)) *
+          diagonal (fun i ↦ (d i : ℂ)) *
+          ((star U : Matrix n n ℂ) * (CFC.sqrt S)⁻¹) ∧
+      (CFC.sqrt S * (U : Matrix n n ℂ)) *
+          ((star U : Matrix n n ℂ) * (CFC.sqrt S)⁻¹) = 1 ∧
+      ((star U : Matrix n n ℂ) * (CFC.sqrt S)⁻¹) *
+          (CFC.sqrt S * (U : Matrix n n ℂ)) = 1 ∧
+      ‖CFC.sqrt S * (U : Matrix n n ℂ)‖ *
+          ‖(star U : Matrix n n ℂ) * (CFC.sqrt S)⁻¹‖ =
+        Real.sqrt (‖S‖ * ‖S⁻¹‖) := by
+  let R := CFC.sqrt S
+  let B := R⁻¹ * A * R
+  have hB : B.IsHermitian := by
+    simpa [B, R] using
+      hS.inv_sqrt_mul_mul_sqrt_isHermitian_of_detailedBalance hdb
+  let U := hB.eigenvectorUnitary
+  let d := hB.eigenvalues
+  have hRdet : IsUnit R.det := by
+    simpa [R] using hS.isUnit_det_cfc_sqrt
+  have hRinv_mul : R⁻¹ * R = 1 := Matrix.nonsing_inv_mul R hRdet
+  have hRmul_inv : R * R⁻¹ = 1 := Matrix.mul_nonsing_inv R hRdet
+  have hUstar_mul : (star U : Matrix n n ℂ) * (U : Matrix n n ℂ) = 1 :=
+    Unitary.coe_star_mul_self U
+  have hUmul_star : (U : Matrix n n ℂ) * (star U : Matrix n n ℂ) = 1 :=
+    Unitary.coe_mul_star_self U
+  have hBspec :
+      B = (U : Matrix n n ℂ) * diagonal (fun i ↦ (d i : ℂ)) *
+        (star U : Matrix n n ℂ) := by
+    simpa [U, d, Unitary.conjStarAlgAut_apply, Function.comp_def] using
+      hB.spectral_theorem
+  refine ⟨U, d, ?_, ?_, ?_, ?_⟩
+  · calc
+      A = (R * R⁻¹) * A * (R * R⁻¹) := by
+        rw [hRmul_inv, Matrix.one_mul, Matrix.mul_one]
+      _ = R * B * R⁻¹ := by
+        change (R * R⁻¹) * A * (R * R⁻¹) =
+          R * (R⁻¹ * A * R) * R⁻¹
+        simp only [Matrix.mul_assoc]
+      _ = R * ((U : Matrix n n ℂ) * diagonal (fun i ↦ (d i : ℂ)) *
+          (star U : Matrix n n ℂ)) * R⁻¹ := by rw [hBspec]
+      _ = (R * (U : Matrix n n ℂ)) * diagonal (fun i ↦ (d i : ℂ)) *
+          ((star U : Matrix n n ℂ) * R⁻¹) := by simp only [Matrix.mul_assoc]
+      _ = (CFC.sqrt S * (U : Matrix n n ℂ)) *
+          diagonal (fun i ↦ (d i : ℂ)) *
+          ((star U : Matrix n n ℂ) * (CFC.sqrt S)⁻¹) := by rfl
+  · calc
+      (CFC.sqrt S * (U : Matrix n n ℂ)) *
+          ((star U : Matrix n n ℂ) * (CFC.sqrt S)⁻¹) =
+          R * ((U : Matrix n n ℂ) * (star U : Matrix n n ℂ)) * R⁻¹ := by
+            simp only [R, Matrix.mul_assoc]
+      _ = 1 := by rw [hUmul_star, Matrix.mul_one, hRmul_inv]
+  · calc
+      ((star U : Matrix n n ℂ) * (CFC.sqrt S)⁻¹) *
+          (CFC.sqrt S * (U : Matrix n n ℂ)) =
+          (star U : Matrix n n ℂ) * (R⁻¹ * R) * (U : Matrix n n ℂ) := by
+            simp only [R, Matrix.mul_assoc]
+      _ = 1 := by rw [hRinv_mul, Matrix.mul_one, hUstar_mul]
+  · have hRinv_sqrt : R⁻¹ = CFC.sqrt S⁻¹ := by
+      simpa [R, Matrix.nonsing_inv_eq_ringInverse] using
+        (CFC.sqrt_ringInverse (a := S)).symm
+    have hSinv_nonneg : 0 ≤ S⁻¹ := by
+      rw [Matrix.nonsing_inv_eq_ringInverse]
+      exact hS.isStrictlyPositive.ringInverse.nonneg
+    have hnormQ :
+        ‖star (U : Matrix n n ℂ) * R⁻¹‖ = ‖R⁻¹‖ := by
+      rw [← Unitary.coe_star]
+      exact CStarRing.norm_coe_unitary_mul (star U) R⁻¹
+    change ‖R * (U : Matrix n n ℂ)‖ *
+        ‖(star U : Matrix n n ℂ) * R⁻¹‖ = Real.sqrt (‖S‖ * ‖S⁻¹‖)
+    rw [CStarRing.norm_mul_coe_unitary R U,
+      hnormQ, hRinv_sqrt,
+      CFC.norm_sqrt S hS.posSemidef.nonneg,
+      CFC.norm_sqrt S⁻¹ hSinv_nonneg]
+    exact (Real.sqrt_mul (norm_nonneg S) ‖S⁻¹‖).symm
 
 end Matrix

--- a/blueprint/src/chapter/ch09_channel_asymptotics_detailed_balance.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_detailed_balance.tex
@@ -11,7 +11,7 @@
     $\Sigma T^*=T\Sigma$, then
     \begin{align}
         \widehat\Sigma\,\widehat T^\dagger
-          =\widehat T\,\widehat\Sigma.
+        =\widehat T\,\widehat\Sigma.
     \end{align}
 \end{theorem}
 
@@ -33,7 +33,7 @@
     $\Sigma(X)=\sqrt\sigma\,X\sqrt\sigma$, then
     \begin{align}
         \widehat\Sigma
-          =\overline{\sqrt\sigma}\otimes\sqrt\sigma>0.
+        =\overline{\sqrt\sigma}\otimes\sqrt\sigma>0.
     \end{align}
 \end{theorem}
 
@@ -63,6 +63,44 @@
     $R^{-1}$ gives
     $RA^\dagger R^{-1}=R^{-1}AR$, which says exactly that
     $R^{-1}AR$ is Hermitian.
+\end{proof}
+
+\begin{theorem}[The source diagonalizing similarity]
+    \label{thm:detailed_balance_diagonalizing_similarity}
+    \lean{Matrix.PosDef.exists_sqrt_mul_unitary_diagonalization_of_detailedBalance}
+    \leanok
+    This is the chosen change of basis in the proof of
+    \cite[Chapter~8, Proposition ``Jordan condition number and detailed balance'']{Wolf2012Quantum}.
+    Let $S,A\in M_n(\mathbb C)$, with $S>0$ and
+    $SA^\dagger=AS$.  There are a unitary $U$ and a real diagonal matrix
+    $D$ such that, for
+    \begin{align}
+        P=S^{1/2}U,
+        \qquad
+        Q=U^\dagger S^{-1/2},
+    \end{align}
+    one has
+    \begin{align}
+        PQ=QP=\Id,
+        \qquad
+        A=PDQ,
+        \qquad
+        \lVert P\rVert_\infty\lVert Q\rVert_\infty
+        =\sqrt{\lVert S\rVert_\infty\lVert S^{-1}\rVert_\infty}.
+    \end{align}
+    This is a statement about Wolf's displayed, chosen diagonalizing basis;
+    it does not identify that factor with the infimum $\kappa_T$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:detailed_balance_hermitian_representative}
+    The preceding theorem makes $B=S^{-1/2}AS^{1/2}$ Hermitian.  Diagonalize
+    it unitarily as $B=UDU^\dagger$ and conjugate back to obtain $A=PDQ$.
+    Unitarity gives the two inverse identities and leaves the operator norm
+    unchanged.  Finally the isometric functional calculus gives
+    $\lVert S^{1/2}\rVert_\infty=\sqrt{\lVert S\rVert_\infty}$ and the
+    corresponding identity for $S^{-1/2}$.
 \end{proof}
 
 \begin{theorem}[Fixed point from the detailed-balance sandwich]

--- a/docs/paper-gaps/wolf_thm823_jordan_scaling_qualifications.tex
+++ b/docs/paper-gaps/wolf_thm823_jordan_scaling_qualifications.tex
@@ -104,6 +104,19 @@ limiting argument compatible with the chosen normalized Jordan form.  No such
 result is currently available in the imported Lean Jordan API, so the formal
 declaration does not assume a minimizing basis.
 
+For the detailed-balance hypothesis in Equation~(8.110),
+\leanid{Matrix.PosDef.exists_sqrt_mul_unitary_diagonalization_of_detailedBalance}
+in \doclink{QICLean/Channel/DetailedBalance.lean} now constructs exactly Wolf's
+chosen diagonalizing change of basis $S^{1/2}U$, its inverse
+$U^\dagger S^{-1/2}$, and the condition factor
+$\sqrt{\lVert S\rVert_\infty\lVert S^{-1}\rVert_\infty}$.  This supplies the
+source's unitary-diagonalization and norm calculation, but deliberately does
+not rename the chosen factor as $\kappa_T$.  Completing the printed
+$\kappa_T$ bound still requires the source-shaped infimum from issue~\#297
+and the bridge that this infimum is bounded by every admissible Jordan change
+of basis.  The detailed-balance assembly is tracked in
+\href{https://github.com/LionSR/QICLean/issues/298}{QICLean issue \#298}.
+
 \section{Verdict}
 
 \textbf{Verdict: source qualifications and missing Jordan-form

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -1832,3 +1832,25 @@ qualification, and a justified passage to Wolf's `κ_T` infimum. These are
 recorded in
 `docs/paper-gaps/wolf_thm823_jordan_scaling_qualifications.tex`; issue #297
 therefore remains open.
+
+### Proposition “Jordan condition number and detailed balance” (Equation 8.110) — SOURCE BASIS PREREQUISITE FORMALIZED
+
+In `QICLean.Channel.DetailedBalance`:
+
+* `transferMatrix_detailedBalance` translates `Σ T* = T Σ` to
+  `Σ̂ T̂† = T̂ Σ̂`.
+* `Matrix.PosDef.inv_sqrt_mul_mul_sqrt_isHermitian_of_detailedBalance`
+  proves that `Σ̂⁻¹/² T̂ Σ̂¹/²` is Hermitian.
+* `Matrix.PosDef.exists_sqrt_mul_unitary_diagonalization_of_detailedBalance`
+  constructs Wolf's particular diagonalizing similarity `Σ̂¹/² U`, its
+  inverse, and its condition factor
+  `sqrt (‖Σ̂‖∞ ‖Σ̂⁻¹‖∞)`.
+* `transferMatrix_sigmaSandwich_eq_kronecker_and_posDef` and
+  `fixedPoint_of_detailedBalance_sigmaSandwich` verify the square-root
+  sandwich specialization and Wolf's fixed-point observation.
+
+The final printed inequality `κ_T ≤ sqrt (κ(Σ̂))` is not yet marked
+formalized. It depends on issue #297's source-shaped Jordan condition number
+and a theorem bounding that infimum by the condition factor of each
+admissible Jordan basis. The current declarations retain Wolf's chosen basis
+instead of silently replacing its factor by `κ_T`; issue #298 remains open.


### PR DESCRIPTION
## Summary

- prove Wolf's detailed-balance conjugate `S⁻¹/² A S¹/²` is Hermitian;
- construct the exact source diagonalizing similarity `P = S¹/² U` with inverse `Q = U† S⁻¹/²` and `A = P D Q`;
- prove the chosen-basis condition factor
  `‖P‖∞ ‖Q‖∞ = sqrt (‖S‖∞ ‖S⁻¹‖∞)`;
- synchronize the Blueprint, Wolf numbering coverage, and the existing Jordan-scaling gap note.

## Source boundary

This is Wolf Chapter 8, lines 1288--1292, in the proof of the proposition “Jordan condition number and detailed balance” (Equation (8.110)). It formalizes Wolf's displayed unitary diagonalization and norm calculation.

It deliberately does **not** identify this chosen condition factor with Wolf's Jordan condition number `κ_T`. That quantity is an infimum over admissible Jordan changes of basis. Issue #297 must still supply the source-shaped family/infimum and the elementary bound of that infimum by every admissible member before the final `κ_T ≤ sqrt (κ(S))` statement can be assembled. Issue #298 therefore remains open.

## Validation

- focused and full `lake build`;
- Lean style lint and declaration checks;
- Blueprint sync, dependency graph, web/PDF rendering, and prose checks;
- paper-gap reference and PDF checks;
- independent proof review after the proof-level Blueprint dependency correction.

No `sorry`, `admit`, new axiom, `native_decide`, `unsafeCast`, or equivalent bypass is introduced.

Refs #298
