### PR TITLE
docs(blueprint): link the canonical-pair gap note

### DIFF
--- a/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_normal_forms_and_determinant.tex
@@ -249,8 +249,7 @@ and then derive exhaustiveness of the four patterns from inertia $(1,3)$.
 The present library has neither real Jordan-form existence nor the simultaneous
 similarity--congruence theorem controlling the sign characteristic.  The exact
 formalization boundary and the required transpose and inverse translations are
-recorded in
-\path{docs/paper-gaps/qiclean_minkowski_canonical_pair_dependency.tex}.
+recorded in \cite{gap:qiclean_minkowski_canonical_pair_dependency}.
 
 \begin{definition}[Pauli transfer matrix]\label{def:pauli_transfer_matrix}
     \lean{Wolf.pauliMatrices, Wolf.pauliTransferEntry,

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -271,6 +271,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.pdf}},
 }
 
+@techreport{gap:qiclean_minkowski_canonical_pair_dependency,
+  author      = {The {QICLean} contributors},
+  title       = {The {Minkowski} Canonical-Pair Dependency in Four Real Dimensions},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {qiclean\_minkowski\_canonical\_pair\_dependency},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/qiclean_minkowski_canonical_pair_dependency.pdf}},
+}
+
 @techreport{gap:wolf_ch01_operator_system_extension_matrix_scope,
   author      = {The {QICLean} contributors},
   title       = {Wolf's Operator-System Extension: Matrix-Algebra Realization},


### PR DESCRIPTION
## Summary

Correct the unresolved Blueprint-link review finding left by merged PR #441:

- replace the repository-local `\path{...}` mention with the required `\cite{gap:qiclean_minkowski_canonical_pair_dependency}` citation;
- add the matching `gap:` bibliography record with the published QICLean paper-gap PDF URL.

This is documentation linkage only. It does not change the canonical-pair declarations or enlarge the deliberately open GLR/VDDM existence boundary.

## Validation

- `python3 scripts/blueprint_bibtex.py`;
- `texra-blueprint paper-gaps check` (43 referenced slugs);
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (2310/2310);
- `texra-blueprint web`;
- changed reader-facing prose check;
- `git diff --check`.

Follow-up to #441. Refs #426.
