### PR TITLE
feat(channel): formalize decomposable witness cone

### DIFF
--- a/QICLean/Algebra/MatrixTracePairing.lean
+++ b/QICLean/Algebra/MatrixTracePairing.lean
@@ -43,6 +43,7 @@ linear map between matrix algebras.
 * `Matrix.exists_identity_traceless_basis` — an identity-plus-traceless basis
 * `Matrix.trace_traceAdjointMap_mul` — the adjoint satisfies `tr(E*(ρ) X) = tr(ρ E(X))`
 * `Matrix.traceAdjointMap_apply_apply` — the entries of the adjoint against matrix units
+* `Matrix.traceAdjointMap_add` — the trace-pairing adjoint preserves sums
 * `Matrix.traceAdjointMap_traceAdjointMap` — the trace-pairing adjoint is involutive
 * `Matrix.traceAdjointMap_comp` — the trace-pairing adjoint reverses composition
 -/
@@ -314,6 +315,15 @@ theorem traceAdjointMap_apply_apply {n m : Type*} [Finite n] [Fintype m]
   have hsingle := Matrix.trace_mul_single (traceAdjointMap E ρ) j i (1 : ℂ)
   rw [trace_traceAdjointMap_mul] at hsingle
   simpa using hsingle.symm
+
+/-- The trace-pairing adjoint preserves addition of linear maps. -/
+@[simp]
+theorem traceAdjointMap_add {n m : Type*} [Fintype m]
+    (E F : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ) :
+    traceAdjointMap (E + F) = traceAdjointMap E + traceAdjointMap F := by
+  classical
+  ext ρ i j
+  simp [traceAdjointMap, Matrix.mul_add]
 
 /-- The trace-pairing adjoint is involutive.
 

--- a/QICLean/Channel.lean
+++ b/QICLean/Channel.lean
@@ -21,6 +21,7 @@ import QICLean.Channel.ChoiTypeMap.Positivity
 import QICLean.Channel.ComplementaryWeylTwirl
 import QICLean.Channel.CompletelyPositiveBridge
 import QICLean.Channel.DecomposablePPT
+import QICLean.Channel.DecomposableWitness
 import QICLean.Channel.DensityRetract
 import QICLean.Channel.DetailedBalance
 import QICLean.Channel.Determinant

--- a/QICLean/Channel/DecomposableWitness.lean
+++ b/QICLean/Channel/DecomposableWitness.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Channel.ChoiRectangular
+import QICLean.Channel.KrausCPTP
+import QICLean.Channel.PartialTranspose
+
+/-!
+# Decomposable witnesses and the trace-adjoint Choi bridge
+
+Wolf Chapter 3, Equation (3.15) defines a decomposable witness on
+`ℂ^d ⊗ ℂ^{d'}` explicitly as
+
+`W = P₁ + P₂^{T₁}`, with `P₁, P₂ ≥ 0`.
+
+This file records that cone and proves its exact correspondence with
+decomposable maps `T : M_d(ℂ) → M_{d'}(ℂ)`. Following Wolf's map--witness
+orientation, the witness is the rectangular Choi matrix of the trace adjoint
+`T* : M_{d'}(ℂ) → M_d(ℂ)`. Because rectangular Choi matrices are indexed
+output-first, transposition on the output of `T*` is
+`Matrix.partialTransposeLeft`.
+
+No closedness, cone duality, or separating-hyperplane statement is asserted
+here; those are separate ingredients in Wolf Proposition 3.5.
+
+## Main declarations
+
+* `Matrix.IsDecomposableWitness` -- the explicit cone in Wolf Equation (3.15).
+* `Matrix.traceAdjointMap_transposeLinearMapComplex` -- transposition is
+  self-adjoint for the bilinear trace pairing.
+* `ChoiRectangular.choiMatrix_transposeLinearMapComplex_comp` -- transposing
+  a map's output transposes the output factor of its Choi matrix.
+* `ChoiRectangular.isDecomposablePositiveMap_iff_choiMatrix_traceAdjointMap_isDecomposableWitness`
+  -- the rectangular map--witness equivalence.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  Equations (3.13) and (3.15)][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+
+namespace Matrix
+
+variable {d d' : ℕ}
+
+/-- A **decomposable witness** in the explicit sense of Wolf Chapter 3,
+Equation (3.15): `W = P₁ + P₂^{T₁}` for positive semidefinite
+`P₁, P₂`. The first tensor factor is `Fin d`, matching the output-first
+ordering of the Choi matrix of `T* : M_{d'}(ℂ) → M_d(ℂ)`. -/
+def IsDecomposableWitness
+    (W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) : Prop :=
+  ∃ P₁ P₂ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ,
+    P₁.PosSemidef ∧ P₂.PosSemidef ∧ W = P₁ + partialTransposeLeft P₂
+
+/-- Matrix transposition is self-adjoint for the bilinear trace pairing. -/
+@[simp]
+theorem traceAdjointMap_transposeLinearMapComplex
+    (n : Type*) [Fintype n] :
+    traceAdjointMap (transposeLinearMapComplex n) = transposeLinearMapComplex n := by
+  classical
+  apply LinearMap.ext
+  intro X
+  ext i j
+  rw [traceAdjointMap_apply_apply]
+  simpa [transposeLinearMapComplex] using Matrix.trace_mul_single X i j (1 : ℂ)
+
+end Matrix
+
+namespace ChoiRectangular
+
+variable {d d' : ℕ}
+
+/-- Postcomposing a rectangular map with transposition transposes the output
+factor of its Choi matrix. The Choi matrix is indexed output-first, so this is
+`partialTransposeLeft`, not the input-factor partial transpose.
+
+This is the orientation used for the trace-adjoint map--witness bridge around
+Wolf, Chapter 3, Equation (3.15). -/
+@[simp]
+theorem choiMatrix_transposeLinearMapComplex_comp
+    (P : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    choiMatrix ((Matrix.transposeLinearMapComplex (Fin d')).comp P) =
+      Matrix.partialTransposeLeft (choiMatrix P) := by
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  simp [choiMatrix_apply, LinearMap.comp_apply, Matrix.transposeLinearMapComplex,
+    Matrix.partialTransposeLeft_apply]
+
+/-- **Decomposable-map/decomposable-witness correspondence** (Wolf Chapter 3,
+Equations (3.13) and (3.15)). A rectangular map `T : M_d(ℂ) → M_{d'}(ℂ)`
+is decomposable exactly when the output-first Choi matrix of its trace adjoint
+`T* : M_{d'}(ℂ) → M_d(ℂ)` belongs to the explicit cone
+`P₁ + P₂^{T₁}`, `P₁, P₂ ≥ 0`.
+
+Only the witness-side input dimension `d'` must be nonzero, as required for
+injectivity and positive surjectivity of the normalized rectangular Choi
+assignment. -/
+theorem isDecomposablePositiveMap_iff_choiMatrix_traceAdjointMap_isDecomposableWitness
+    [NeZero d']
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    IsDecomposablePositiveMap T ↔
+      Matrix.IsDecomposableWitness (choiMatrix (Matrix.traceAdjointMap T)) := by
+  constructor
+  · rintro ⟨T₁, Tccp, hT₁, hTccp, hT⟩
+    have hT₂ :
+        IsKrausCP (Tccp.comp (Matrix.transposeLinearMapComplex (Fin d))) := hTccp
+    refine ⟨choiMatrix (Matrix.traceAdjointMap T₁),
+      choiMatrix (Matrix.traceAdjointMap
+        (Tccp.comp (Matrix.transposeLinearMapComplex (Fin d)))),
+      (isKrausCP_iff_choiMatrix_posSemidef _).mp hT₁.traceAdjointMap,
+      (isKrausCP_iff_choiMatrix_posSemidef _).mp hT₂.traceAdjointMap, ?_⟩
+    have hccpAdj :
+        Matrix.traceAdjointMap Tccp =
+          (Matrix.transposeLinearMapComplex (Fin d)).comp
+            (Matrix.traceAdjointMap
+              (Tccp.comp (Matrix.transposeLinearMapComplex (Fin d)))) := by
+      rw [Matrix.traceAdjointMap_comp,
+        Matrix.traceAdjointMap_transposeLinearMapComplex]
+      ext X i j
+      simp [LinearMap.comp_apply, Matrix.transposeLinearMapComplex]
+    calc
+      choiMatrix (Matrix.traceAdjointMap T)
+          = choiMatrix (Matrix.traceAdjointMap T₁) +
+              choiMatrix (Matrix.traceAdjointMap Tccp) := by
+                rw [hT, Matrix.traceAdjointMap_add, choiMatrix_add]
+      _ = choiMatrix (Matrix.traceAdjointMap T₁) +
+            Matrix.partialTransposeLeft
+              (choiMatrix (Matrix.traceAdjointMap
+                (Tccp.comp (Matrix.transposeLinearMapComplex (Fin d))))) := by
+              rw [hccpAdj, choiMatrix_transposeLinearMapComplex_comp]
+  · rintro ⟨P₁, P₂, hP₁, hP₂, hW⟩
+    obtain ⟨Q₁, hQ₁, hQ₁choi⟩ :=
+      exists_isKrausCP_of_posSemidef (d := d') (d' := d) hP₁
+    obtain ⟨Q₂, hQ₂, hQ₂choi⟩ :=
+      exists_isKrausCP_of_posSemidef (d := d') (d' := d) hP₂
+    have hadjChoi :
+        choiMatrix (Matrix.traceAdjointMap T) =
+          choiMatrix (Q₁ + (Matrix.transposeLinearMapComplex (Fin d)).comp Q₂) := by
+      calc
+        choiMatrix (Matrix.traceAdjointMap T)
+            = P₁ + Matrix.partialTransposeLeft P₂ := hW
+        _ = choiMatrix Q₁ + Matrix.partialTransposeLeft (choiMatrix Q₂) := by
+              rw [hQ₁choi, hQ₂choi]
+        _ = choiMatrix
+              (Q₁ + (Matrix.transposeLinearMapComplex (Fin d)).comp Q₂) := by
+              rw [choiMatrix_add, choiMatrix_transposeLinearMapComplex_comp]
+    have hadj : Matrix.traceAdjointMap T =
+        Q₁ + (Matrix.transposeLinearMapComplex (Fin d)).comp Q₂ :=
+      eq_of_choiMatrix_eq hadjChoi
+    refine ⟨Matrix.traceAdjointMap Q₁,
+      (Matrix.traceAdjointMap Q₂).comp (Matrix.transposeLinearMapComplex (Fin d)),
+      hQ₁.traceAdjointMap, ?_, ?_⟩
+    · rw [IsCompletelyCopositiveMap]
+      have hcomp :
+          ((Matrix.traceAdjointMap Q₂).comp (Matrix.transposeLinearMapComplex (Fin d))).comp
+              (Matrix.transposeLinearMapComplex (Fin d)) =
+            Matrix.traceAdjointMap Q₂ := by
+        ext X i j
+        simp [LinearMap.comp_apply, Matrix.transposeLinearMapComplex]
+      rw [hcomp]
+      exact hQ₂.traceAdjointMap
+    · have hback := congrArg (fun S ↦ Matrix.traceAdjointMap S) hadj
+      simpa [Matrix.traceAdjointMap_traceAdjointMap, Matrix.traceAdjointMap_comp] using hback
+
+end ChoiRectangular

--- a/QICLean/Channel/DecomposableWitness.lean
+++ b/QICLean/Channel/DecomposableWitness.lean
@@ -28,6 +28,8 @@ here; those are separate ingredients in Wolf Proposition 3.5.
 ## Main declarations
 
 * `Matrix.IsDecomposableWitness` -- the explicit cone in Wolf Equation (3.15).
+* `Matrix.convex_setOf_isDecomposableWitness` -- convexity of the explicit
+  decomposable-witness cone used in Wolf Proposition 3.5.
 * `Matrix.traceAdjointMap_transposeLinearMapComplex` -- transposition is
   self-adjoint for the bilinear trace pairing.
 * `ChoiRectangular.choiMatrix_transposeLinearMapComplex_comp` -- transposing
@@ -55,6 +57,20 @@ def IsDecomposableWitness
     (W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) : Prop :=
   ∃ P₁ P₂ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ,
     P₁.PosSemidef ∧ P₂.PosSemidef ∧ W = P₁ + partialTransposeLeft P₂
+
+/-- The explicit decomposable-witness cone from Wolf Chapter 3, Equation
+(3.15), is convex, as used in the proof of Proposition 3.5. Convex
+combinations are taken componentwise in the two positive-semidefinite
+summands. -/
+theorem convex_setOf_isDecomposableWitness :
+    Convex ℝ {W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ |
+      IsDecomposableWitness W} := by
+  rintro X ⟨PX, QX, hPX, hQX, rfl⟩ Y ⟨PY, QY, hPY, hQY, rfl⟩ a b ha hb _hab
+  refine ⟨a • PX + b • PY, a • QX + b • QY,
+    (hPX.smul ha).add (hPY.smul hb), (hQX.smul ha).add (hQY.smul hb), ?_⟩
+  ext p q
+  simp [partialTransposeLeft_apply, Matrix.add_apply, Matrix.smul_apply]
+  ring
 
 /-- Matrix transposition is self-adjoint for the bilinear trace pairing. -/
 @[simp]

--- a/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
@@ -546,6 +546,26 @@ positive map and a completely copositive map.
     transposition on the first factor.
 \end{definition}
 
+\begin{theorem}[Convexity of decomposable witnesses]
+    \label{thm:decomposable_witness_convex}
+    \lean{Matrix.convex_setOf_isDecomposableWitness}
+    \leanok
+    \uses{def:decomposable_witness}
+    The set of decomposable witnesses in Equation~(3.15) is convex.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    If $W=P_1+P_2^{T_1}$ and $W'=Q_1+Q_2^{T_1}$, then for
+    $a,b\geq0$ with $a+b=1$,
+    \begin{align}
+        aW+bW'
+        &=(aP_1+bQ_1)+(aP_2+bQ_2)^{T_1}.
+        \notag
+    \end{align}
+    Both matrices in parentheses are positive semidefinite.
+\end{proof}
+
 \begin{theorem}[Rectangular decomposable map--witness correspondence]
     \label{thm:decomposable_map_iff_decomposable_witness}
     \lean{Matrix.traceAdjointMap_add,

--- a/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
@@ -532,6 +532,65 @@ positive map and a completely copositive map.
     $\Phi(X)\ge0$.
 \end{proof}
 
+\begin{definition}[Decomposable witnesses]
+    \label{def:decomposable_witness}
+    \lean{Matrix.IsDecomposableWitness}
+    \leanok
+    \uses{def:partial_transpose_left}
+    A witness $W$ on $\C^d\otimes\C^{d'}$ is \emph{decomposable} when
+    \begin{align}
+        W=P_1+P_2^{T_1},\qquad P_1,P_2\geq0.
+        \tag{Wolf 3.15}
+    \end{align}
+    This is the explicit cone in Wolf's Equation~(3.15), with partial
+    transposition on the first factor.
+\end{definition}
+
+\begin{theorem}[Rectangular decomposable map--witness correspondence]
+    \label{thm:decomposable_map_iff_decomposable_witness}
+    \lean{Matrix.traceAdjointMap_add,
+        Matrix.traceAdjointMap_transposeLinearMapComplex,
+        ChoiRectangular.choiMatrix_transposeLinearMapComplex_comp,
+        ChoiRectangular.isDecomposablePositiveMap_iff_choiMatrix_traceAdjointMap_isDecomposableWitness}
+    \leanok
+    \uses{def:decomposable_positive_map, def:decomposable_witness,
+        def:choi_matrix_rect, lem:choi_rect_linear,
+        thm:choi_rect_mutual_inverse, thm:choi_rect_cp}
+    Let $d'\geq1$ and let $T\colon\MN{d}\to\MN{d'}$. Then $T$ is
+    decomposable if and only if the output-first Choi matrix of its trace
+    adjoint $T^*\colon\MN{d'}\to\MN{d}$ is a decomposable witness:
+    \begin{align}
+        T\text{ decomposable}
+        \quad\Longleftrightarrow\quad
+        \tau(T^*)=P_1+P_2^{T_1}
+        \text{ for some }P_1,P_2\geq0.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write a decomposable map in Wolf's form
+    $T=T_1+T_2\circ\theta$, with $T_1,T_2$ completely positive. The trace
+    adjoint reverses composition and transposition is self-adjoint, so
+    \begin{align}
+        T^*=T_1^*+\theta\circ T_2^*.
+        \notag
+    \end{align}
+    Rectangular Choi matrices place the output factor first. Consequently,
+    postcomposition by $\theta$ becomes first-factor partial transposition:
+    \begin{align}
+        \tau(\theta\circ T_2^*)=\tau(T_2^*)^{T_1}.
+        \notag
+    \end{align}
+    The Choi matrices of $T_1^*$ and $T_2^*$ are positive semidefinite by
+    complete positivity, which proves the forward implication. Conversely,
+    reconstruct completely positive maps $Q_1,Q_2\colon\MN{d'}\to\MN{d}$
+    from $P_1,P_2\geq0$. Choi injectivity gives
+    $T^*=Q_1+\theta\circ Q_2$; taking trace adjoints again yields
+    $T=Q_1^*+Q_2^*\circ\theta$, a decomposable map.
+\end{proof}
+
 \begin{theorem}[Decomposable maps preserve positivity on PPT states]
     \label{thm:decomposable_map_tensor_id_ppt}
     \lean{Matrix.tensorMapId_comp_transposeLinearMapComplex,
@@ -592,9 +651,11 @@ positive map and a completely copositive map.
     decomposable, Theorem~\ref{thm:decomposable_map_tensor_id_ppt} would make
     this ampliation positive because $\rho$ is PPT, a contradiction.
 
-    The reverse implication of Proposition~3.5 is not claimed here; it needs
-    Wolf's decomposable-witness cone in Equation~(3.15), its closedness and
-    trace-pairing duality, and a separating-hyperplane argument.
+    The reverse implication of Proposition~3.5 is not claimed here. Although
+    Theorem~\ref{thm:decomposable_map_iff_decomposable_witness} now supplies
+    Wolf's explicit Equation~(3.15) cone and map--witness bridge, the reverse
+    implication still needs closedness of that cone, trace-pairing duality,
+    and a separating-hyperplane argument.
 \end{proof}
 
 \begin{theorem}[A PPT state detected by an ampliation witnesses indecomposability]

--- a/docs/paper-gaps/wolf_prop3_5_reverse_implication.tex
+++ b/docs/paper-gaps/wolf_prop3_5_reverse_implication.tex
@@ -92,11 +92,19 @@ the same input-to-output orientation $\MN{d}\to\MN{d'}$ as Wolf.
 The converse required for the full proposition begins with an
 indecomposable positive map and must produce a PPT entangled density
 operator. The current formal development does not claim that implication.
-Following Wolf and the primary witness proof requires all of the following:
+The explicit cone and rectangular adjoint bridge are now formalized as
+\leanid{Matrix.IsDecomposableWitness} and
+\leanid{ChoiRectangular.isDecomposablePositiveMap_iff_choiMatrix_traceAdjointMap_isDecomposableWitness}:
 \begin{align}
-  &\text{the exact cone }\{P_1+P_2^{T_1}:P_1,P_2\geq0\},\notag\\
-  &\text{the rectangular map--witness correspondence in the adjoint
-    orientation of Wolf Proposition 3.4},\notag\\
+  T\text{ decomposable}
+  \quad\Longleftrightarrow\quad
+  \operatorname{Choi}(T^*)=P_1+P_2^{T_1}
+  \text{ for some }P_1,P_2\geq0.
+  \notag
+\end{align}
+Following Wolf and the primary witness proof still requires all of the
+following:
+\begin{align}
   &\text{closedness and convexity of that cone},\notag\\
   &\tr\!\left(P_2^{T_1}R\right)
       =\tr\!\left(P_2R^{T_1}\right),\notag\\
@@ -113,7 +121,8 @@ The verdict is a live scope restriction. The PPT-entangled-state-to-
 indecomposable-map direction of Wolf Proposition~3.5 is formalized with the
 printed rectangular dimensions and first-factor transpose convention. The
 reverse direction, and hence the source's existence equivalence, remains open
-until the Equation~(3.15) cone and its trace-pairing separation argument are
+until closedness of the now-explicit Equation~(3.15) cone, trace-adjointness of
+partial transpose for the trace pairing, and the separation argument are
 formalized.
 
 \bibliographystyle{alpha}

--- a/docs/paper-gaps/wolf_prop3_5_reverse_implication.tex
+++ b/docs/paper-gaps/wolf_prop3_5_reverse_implication.tex
@@ -92,8 +92,9 @@ the same input-to-output orientation $\MN{d}\to\MN{d'}$ as Wolf.
 The converse required for the full proposition begins with an
 indecomposable positive map and must produce a PPT entangled density
 operator. The current formal development does not claim that implication.
-The explicit cone and rectangular adjoint bridge are now formalized as
-\leanid{Matrix.IsDecomposableWitness} and
+The explicit cone, its convexity, and the rectangular adjoint bridge are now
+formalized as \leanid{Matrix.IsDecomposableWitness},
+\leanid{Matrix.convex_setOf_isDecomposableWitness}, and
 \leanid{ChoiRectangular.isDecomposablePositiveMap_iff_choiMatrix_traceAdjointMap_isDecomposableWitness}:
 \begin{align}
   T\text{ decomposable}
@@ -105,12 +106,22 @@ The explicit cone and rectangular adjoint bridge are now formalized as
 Following Wolf and the primary witness proof still requires all of the
 following:
 \begin{align}
-  &\text{closedness and convexity of that cone},\notag\\
+  &\text{closedness of that cone},\notag\\
   &\tr\!\left(P_2^{T_1}R\right)
       =\tr\!\left(P_2R^{T_1}\right),\notag\\
   &\text{and separation followed by positivity, PPT, trace normalization,
     and entanglement of the separator.}\notag
 \end{align}
+The intended source-faithful route to closedness starts from the trace-one
+decomposable operators $aP+(1-a)Q^{T_1}$ used by
+Lewenstein--Kraus--Cirac--Horodecki.  One must first prove that the normalized set
+is compact, then recover the unnormalized Equation~(3.15) cone through the radial
+map whose radius is its trace.  On the Lean side this still requires
+trace-bounded compactness for positive-semidefinite matrices on the product
+index and a proper-map argument for radial scaling.  Merely observing that
+$P_1+P_2^{T_1}$ is a continuous image of the closed product of two
+positive-semidefinite cones would not prove closedness.
+
 Defining a decomposable witness merely as a functional nonnegative on every
 PPT operator would hide rather than prove Equation~(3.15), so that route is
 not used.

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -618,12 +618,14 @@ so that the cited formal statements are available from the main project import.
   entangled density operator on `ℂ^d ⊗ ℂ^{d'}` yields an indecomposable positive
   map `T : M_d(ℂ) → M_{d'}(ℂ)`, by Proposition 3.4 at `n = 1` and the
   contrapositive of decomposable-PPT preservation ✓
-- The reverse implication remains open. It requires the explicit
-  decomposable-witness cone `W = P₁ + P₂^{T₁}` from Equation (3.15), the
-  rectangular map--witness equivalence, closedness of that cone,
-  self-adjointness of partial transpose for the trace pairing, and the
-  separating-hyperplane argument. Proposition 3.5 is therefore not recorded
-  as fully formalized; see
+- `Matrix.IsDecomposableWitness` and
+  `ChoiRectangular.isDecomposablePositiveMap_iff_choiMatrix_traceAdjointMap_isDecomposableWitness`
+  — the explicit Equation (3.15) cone `W = P₁ + P₂^{T₁}` and its rectangular
+  trace-adjoint Choi correspondence with decomposable maps ✓
+- The reverse implication remains open. It requires closedness of the
+  decomposable-witness cone, self-adjointness of partial transpose for the
+  trace pairing, and the separating-hyperplane argument. Proposition 3.5 is
+  therefore not recorded as fully formalized; see
   `docs/paper-gaps/wolf_prop3_5_reverse_implication.tex`.
 
 #### Wolf Example 3.1, Equation (3.20) (Choi-type maps) — PARTIALLY FORMALIZED

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -622,6 +622,9 @@ so that the cited formal statements are available from the main project import.
   `ChoiRectangular.isDecomposablePositiveMap_iff_choiMatrix_traceAdjointMap_isDecomposableWitness`
   — the explicit Equation (3.15) cone `W = P₁ + P₂^{T₁}` and its rectangular
   trace-adjoint Choi correspondence with decomposable maps ✓
+- `Matrix.convex_setOf_isDecomposableWitness` — convexity of the explicit
+  Equation (3.15) decomposable-witness cone, as used in the proof of
+  Proposition 3.5 ✓
 - The reverse implication remains open. It requires closedness of the
   decomposable-witness cone, self-adjointness of partial transpose for the
   trace pairing, and the separating-hyperplane argument. Proposition 3.5 is


### PR DESCRIPTION
## Summary

- define Wolf's explicit decomposable-witness cone from Equation (3.15), `W = P₁ + P₂^{T₁}` with `P₁,P₂ ≥ 0`;
- prove the rectangular decomposable-map/decomposable-witness correspondence in Wolf's trace-adjoint orientation;
- prove convexity of the explicit cone directly from PSD conic closure and linearity of first-factor partial transpose;
- synchronize the Blueprint, Wolf numbering coverage, and the open Proposition 3.5 paper-gap boundary.

## Exact source and orientation

This follows Wolf Chapter 3, Equations (3.2), (3.13), and (3.15):

- `T : M_d(ℂ) → M_{d'}(ℂ)`;
- the witness is the normalized rectangular Choi matrix of `T* : M_{d'}(ℂ) → M_d(ℂ)`;
- rectangular Choi indices are output-first, `Fin d × Fin d'`;
- postcomposition of `T*` by transposition therefore becomes `Matrix.partialTransposeLeft`.

The `[NeZero d']` hypothesis is exactly the nonzero input dimension needed by the rectangular Choi inverse/CP-surjectivity step; no unnecessary `[NeZero d]` assumption is introduced.

## Deliberate boundary

This is a bounded dependency slice for the still-open reverse implication of Wolf Proposition 3.5. It does **not** assert closedness merely because the cone is a linear image of a closed product cone. It also does not claim trace-pairing self-adjointness of partial transpose, separation, positivity/PPT of a separator, normalization to a density operator, or entanglement.

The remaining source-shaped route is the normalized trace-one compact base used in the primary witness argument, followed by a radial/properness proof for the unnormalized cone, then the trace-pairing and separation steps. Issue #22 remains open.

## Validation

- focused `lake build QICLean.Channel.DecomposableWitness QICLean.Channel`;
- independent source/proof review against Wolf Equations (3.2), (3.13), and (3.15);
- Blueprint declaration regeneration and 2330/2330 entry sync;
- reverse coverage, reader-facing prose, paper-gap references, module policy, lint, diff, and forbidden-bypass checks.

The reverse-coverage scanner retains one known warning for the pre-existing helper `Matrix.traceAdjointMap_apply_apply` in a touched module; every new public declaration in this PR is covered. No `sorry`, `admit`, new axiom, `native_decide`, `unsafeCast`, or equivalent bypass is introduced.

Refs #22
