### PR TITLE
feat(channel): add normalized decomposable witnesses

### DIFF
--- a/QICLean/Channel/DecomposableWitness.lean
+++ b/QICLean/Channel/DecomposableWitness.lean
@@ -6,6 +6,8 @@ Authors: TNLean contributors
 import QICLean.Channel.ChoiRectangular
 import QICLean.Channel.KrausCPTP
 import QICLean.Channel.PartialTranspose
+import QICLean.Channel.SchmidtNumberCompact
+import QICLean.Algebra.PositiveSemidefiniteNormalization
 
 /-!
 # Decomposable witnesses and the trace-adjoint Choi bridge
@@ -30,6 +32,13 @@ here; those are separate ingredients in Wolf Proposition 3.5.
 * `Matrix.IsDecomposableWitness` -- the explicit cone in Wolf Equation (3.15).
 * `Matrix.convex_setOf_isDecomposableWitness` -- convexity of the explicit
   decomposable-witness cone used in Wolf Proposition 3.5.
+* `Matrix.IsNormalizedDecomposableWitness` -- the trace-one compact base
+  `a P₁ + (1-a) P₂^{T₁}` used in the primary proof of the witness theorem.
+* `Matrix.isCompact_setOf_isNormalizedDecomposableWitness` and
+  `Matrix.convex_setOf_isNormalizedDecomposableWitness` -- compactness and
+  convexity of that normalized base.
+* `Matrix.trace_partialTransposeLeft_mul` -- first-factor partial transpose is
+  self-adjoint for the bilinear trace pairing.
 * `Matrix.traceAdjointMap_transposeLinearMapComplex` -- transposition is
   self-adjoint for the bilinear trace pairing.
 * `ChoiRectangular.choiMatrix_transposeLinearMapComplex_comp` -- transposing
@@ -41,9 +50,12 @@ here; those are separate ingredients in Wolf Proposition 3.5.
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
   Equations (3.13) and (3.15)][Wolf2012QChannels]
+* M. Lewenstein, B. Kraus, J. I. Cirac, and P. Horodecki,
+  *Optimization of entanglement witnesses*, Theorem 3,
+  arXiv:quant-ph/0005014.
 -/
 
-open scoped Matrix ComplexOrder MatrixOrder
+open scoped BigOperators Matrix ComplexOrder MatrixOrder
 
 namespace Matrix
 
@@ -71,6 +83,231 @@ theorem convex_setOf_isDecomposableWitness :
   ext p q
   simp [partialTransposeLeft_apply, Matrix.add_apply, Matrix.smul_apply]
   ring
+
+/-! ## The normalized compact base -/
+
+/-- Partial transpose commutes with complex scalar multiplication. -/
+@[simp]
+theorem partialTransposeLeft_smul (c : ℂ)
+    (X : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    partialTransposeLeft (c • X) = c • partialTransposeLeft X := by
+  ext p q
+  simp [partialTransposeLeft_apply]
+
+/-- First-factor partial transpose is continuous on the finite-dimensional
+matrix space. -/
+theorem continuous_partialTransposeLeft :
+    Continuous
+      (partialTransposeLeft :
+        Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ →
+          Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) := by
+  refine continuous_matrix fun p q ↦ ?_
+  simp only [partialTransposeLeft_apply]
+  fun_prop
+
+/-- First-factor partial transpose is self-adjoint for the bilinear trace
+pairing:
+
+`tr(X^{T₁} Y) = tr(X Y^{T₁})`.
+
+This is the factor orientation used when the separator in the proof of Wolf
+Proposition 3.5 is tested against `Q^{T₁}`. -/
+@[simp]
+theorem trace_partialTransposeLeft_mul
+    (X Y : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    (partialTransposeLeft X * Y).trace =
+      (X * partialTransposeLeft Y).trace := by
+  classical
+  simp only [trace, diag, mul_apply, partialTransposeLeft_apply,
+    Fintype.sum_prod_type]
+  calc
+    ∑ i₁, ∑ k, ∑ i₂, ∑ l,
+        X (i₂, k) (i₁, l) * Y (i₂, l) (i₁, k) =
+      ∑ i₁, ∑ i₂, ∑ k, ∑ l,
+        X (i₂, k) (i₁, l) * Y (i₂, l) (i₁, k) := by
+          apply Finset.sum_congr rfl
+          intro i₁ _
+          rw [Finset.sum_comm]
+    _ = ∑ i₂, ∑ i₁, ∑ k, ∑ l,
+        X (i₂, k) (i₁, l) * Y (i₂, l) (i₁, k) := by
+          rw [Finset.sum_comm]
+    _ = ∑ i₂, ∑ k, ∑ i₁, ∑ l,
+        X (i₂, k) (i₁, l) * Y (i₂, l) (i₁, k) := by
+          apply Finset.sum_congr rfl
+          intro i₂ _
+          rw [Finset.sum_comm]
+    _ = _ := rfl
+
+/-- First-factor partial transpose is self-adjoint for the real trace pairing
+`(X,Y) ↦ Re tr(XY)`. -/
+@[simp]
+theorem trace_partialTransposeLeft_mul_re
+    (X Y : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    (partialTransposeLeft X * Y).trace.re =
+      (X * partialTransposeLeft Y).trace.re := by
+  rw [trace_partialTransposeLeft_mul]
+
+/-- Every positive semidefinite bipartite matrix has Schmidt number at most
+the dimension of its first tensor factor. -/
+theorem PosSemidef.hasSchmidtNumberLE_left
+    {X : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hX : X.PosSemidef) : HasSchmidtNumberLE d X := by
+  obtain ⟨m, u, rfl⟩ := posSemidef_iff_eq_sum_vecMulVec.mp hX
+  refine ⟨Fin m, inferInstance, u, ?_, rfl⟩
+  intro i
+  simpa [HasSchmidtRankLE] using schmidtRank_le_left (u i)
+
+/-- Positive semidefinite trace-one matrices on a rectangular bipartite index
+space form a compact set. This is the full Schmidt-number section
+`S_d`, since every vector has Schmidt rank at most `d`. -/
+theorem isCompact_setOf_posSemidef_trace_one :
+    IsCompact
+      {X : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ |
+        X.PosSemidef ∧ X.trace = 1} := by
+  have heq :
+      {X : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ |
+          X.PosSemidef ∧ X.trace = 1} =
+        {X : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ |
+          HasSchmidtNumberLE d X ∧ X.trace = 1} := by
+    ext X
+    constructor
+    · intro h
+      exact ⟨h.1.hasSchmidtNumberLE_left, h.2⟩
+    · intro h
+      exact ⟨h.1.posSemidef, h.2⟩
+  rw [heq]
+  exact isCompact_setOf_hasSchmidtNumberLE_trace_one d
+
+/-- A normalized decomposable witness in the form used by
+Lewenstein--Kraus--Cirac--Horodecki, Theorem 3:
+
+`W = a P₁ + (1-a) P₂^{T₁}`,
+
+where `0 ≤ a ≤ 1` and `P₁,P₂` are positive semidefinite matrices of
+trace one. The partial transpose is on Wolf's first tensor factor. -/
+def IsNormalizedDecomposableWitness
+    (W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) : Prop :=
+  ∃ a : ℝ, ∃ P₁ P₂ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ,
+    a ∈ Set.Icc 0 1 ∧ P₁.PosSemidef ∧ P₁.trace = 1 ∧
+      P₂.PosSemidef ∧ P₂.trace = 1 ∧
+        W = (a : ℂ) • P₁ + ((1 - a : ℝ) : ℂ) • partialTransposeLeft P₂
+
+/-- The normalized decomposable witnesses form a compact set. It is the
+continuous image of `[0,1] × D × D`, where `D` is the compact set of
+positive semidefinite trace-one matrices. -/
+theorem isCompact_setOf_isNormalizedDecomposableWitness :
+    IsCompact
+      {W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ |
+        IsNormalizedDecomposableWitness W} := by
+  let D : Set (Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :=
+    {P | P.PosSemidef ∧ P.trace = 1}
+  let K := (Set.Icc (0 : ℝ) 1 ×ˢ D) ×ˢ D
+  let f : ((ℝ × Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) ×
+      Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) →
+        Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ :=
+    fun z ↦ (z.1.1 : ℂ) • z.1.2 + ((1 - z.1.1 : ℝ) : ℂ) •
+      partialTransposeLeft z.2
+  have hD : IsCompact D := by
+    simpa only [D] using
+      (isCompact_setOf_posSemidef_trace_one (d := d) (d' := d'))
+  have hK : IsCompact K := (isCompact_Icc.prod hD).prod hD
+  have hf : Continuous f := by
+    dsimp only [f]
+    apply Continuous.add
+    · fun_prop
+    · have hpt : Continuous (fun z : ((ℝ ×
+          Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) ×
+            Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) ↦
+          partialTransposeLeft z.2) :=
+        continuous_partialTransposeLeft.comp continuous_snd
+      have hc : Continuous (fun z : ((ℝ ×
+          Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) ×
+            Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) ↦
+          ((1 - z.1.1 : ℝ) : ℂ)) := by
+        fun_prop
+      exact hc.smul hpt
+  have hEq :
+      {W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ |
+          IsNormalizedDecomposableWitness W} = f '' K := by
+    ext W
+    constructor
+    · rintro ⟨a, P₁, P₂, ha, hP₁, hP₁tr, hP₂, hP₂tr, rfl⟩
+      refine ⟨((a, P₁), P₂), ?_, ?_⟩
+      · exact ⟨⟨ha, hP₁, hP₁tr⟩, hP₂, hP₂tr⟩
+      · rfl
+    · rintro ⟨⟨⟨a, P₁⟩, P₂⟩, ⟨⟨ha, hP₁, hP₁tr⟩, hP₂, hP₂tr⟩, rfl⟩
+      exact ⟨a, P₁, P₂, ha, hP₁, hP₁tr, hP₂, hP₂tr, rfl⟩
+  rw [hEq]
+  exact hK.image hf
+
+/-- On nonzero tensor factors, the normalized formula is exactly the trace-one
+section of Wolf's explicit decomposable-witness cone. The zero-trace summands
+are normalized by the uniform density matrix, as their original summands then
+vanish. -/
+theorem isNormalizedDecomposableWitness_iff
+    [NeZero d] [NeZero d']
+    (W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    IsNormalizedDecomposableWitness W ↔
+      IsDecomposableWitness W ∧ W.trace = 1 := by
+  constructor
+  · rintro ⟨a, P₁, P₂, ha, hP₁, hP₁tr, hP₂, hP₂tr, rfl⟩
+    refine ⟨?_, ?_⟩
+    · refine ⟨(a : ℂ) • P₁, ((1 - a : ℝ) : ℂ) • P₂, ?_, ?_, ?_⟩
+      · exact hP₁.smul (by exact_mod_cast ha.1)
+      · exact hP₂.smul (by exact_mod_cast sub_nonneg.mpr ha.2)
+      · rw [partialTransposeLeft_smul]
+    · rw [trace_add, trace_smul, trace_smul, trace_partialTransposeLeft,
+        hP₁tr, hP₂tr]
+      simp only [smul_eq_mul]
+      push_cast
+      ring
+  · rintro ⟨⟨P₁, P₂, hP₁, hP₂, hW⟩, hWtr⟩
+    let x₀ : Fin d × Fin d' := (0, 0)
+    have hsum : P₁.trace.re + P₂.trace.re = 1 := by
+      have h := congrArg Complex.re hWtr
+      rw [hW, trace_add, trace_partialTransposeLeft] at h
+      simpa using h
+    refine ⟨P₁.trace.re, normalizePosSemidef x₀ P₁,
+      normalizePosSemidef x₀ P₂, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    · constructor
+      · exact (Complex.nonneg_iff.mp hP₁.trace_nonneg).1
+      · have hP₂trace_nonneg := (Complex.nonneg_iff.mp hP₂.trace_nonneg).1
+        linarith
+    · exact normalizePosSemidef_posSemidef x₀ hP₁
+    · exact normalizePosSemidef_trace x₀ hP₁
+    · exact normalizePosSemidef_posSemidef x₀ hP₂
+    · exact normalizePosSemidef_trace x₀ hP₂
+    · calc
+        W = P₁ + partialTransposeLeft P₂ := hW
+        _ = (P₁.trace.re : ℂ) • normalizePosSemidef x₀ P₁ +
+            partialTransposeLeft
+              ((P₂.trace.re : ℂ) • normalizePosSemidef x₀ P₂) := by
+                rw [trace_re_smul_normalizePosSemidef x₀ hP₁,
+                  trace_re_smul_normalizePosSemidef x₀ hP₂]
+        _ = (P₁.trace.re : ℂ) • normalizePosSemidef x₀ P₁ +
+            ((1 - P₁.trace.re : ℝ) : ℂ) •
+              partialTransposeLeft (normalizePosSemidef x₀ P₂) := by
+                rw [partialTransposeLeft_smul]
+                have hb : P₂.trace.re = 1 - P₁.trace.re := by linarith
+                rw [hb]
+
+/-- The normalized decomposable witnesses form a convex set. Equivalently,
+they are the trace-one section of the convex Equation-(3.15) cone. -/
+theorem convex_setOf_isNormalizedDecomposableWitness
+    [NeZero d] [NeZero d'] :
+    Convex ℝ
+      {W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ |
+        IsNormalizedDecomposableWitness W} := by
+  intro X hX Y hY a b ha hb hab
+  have hX' := (isNormalizedDecomposableWitness_iff X).mp hX
+  have hY' := (isNormalizedDecomposableWitness_iff Y).mp hY
+  apply (isNormalizedDecomposableWitness_iff _).mpr
+  constructor
+  · exact convex_setOf_isDecomposableWitness hX'.1 hY'.1 ha hb hab
+  · have htraceX : (a • X).trace = a • X.trace := Matrix.trace_smul a X
+    have htraceY : (b • Y).trace = b • Y.trace := Matrix.trace_smul b Y
+    rw [trace_add, htraceX, htraceY, hX'.2, hY'.2]
+    simpa [smul_eq_mul] using congrArg (fun t : ℝ ↦ (t : ℂ)) hab
 
 /-- Matrix transposition is self-adjoint for the bilinear trace pairing. -/
 @[simp]

--- a/QICLean/Channel/PPTIndecomposable.lean
+++ b/QICLean/Channel/PPTIndecomposable.lean
@@ -21,10 +21,13 @@ a positive map whose ampliation detects the entangled state. The contrapositive
 of rectangular decomposable-PPT preservation then proves that this map is
 indecomposable.
 
-The reverse implication in Proposition 3.5 is not claimed here. It requires the
-closed convex cone of Wolf Equation (3.15), its trace-pairing duality, and the
-separating-hyperplane argument used in Lewenstein--Kraus--Cirac--Horodecki,
-arXiv:quant-ph/0005014v3, Theorem 3.
+The reverse implication in Proposition 3.5 is not claimed here. The normalized
+compact convex set of decomposable witnesses and the trace-adjointness of
+first-factor partial transpose are formalized in
+`QICLean.Channel.DecomposableWitness`. What remains is normalization of the
+nonzero block-positive Choi witness and the separating-hyperplane argument
+used in Lewenstein--Kraus--Cirac--Horodecki, arXiv:quant-ph/0005014v3,
+Theorem 3.
 The exact remaining boundary is recorded in
 `docs/paper-gaps/wolf_prop3_5_reverse_implication.tex`.
 

--- a/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
@@ -566,6 +566,91 @@ positive map and a completely copositive map.
     Both matrices in parentheses are positive semidefinite.
 \end{proof}
 
+\begin{definition}[Normalized decomposable witnesses]
+    \label{def:normalized_decomposable_witness}
+    \lean{Matrix.IsNormalizedDecomposableWitness}
+    \leanok
+    \uses{def:decomposable_witness}
+    Following Lewenstein--Kraus--Cirac--Horodecki
+    \cite{LewensteinKrausCiracHorodecki2000}, a normalized decomposable witness is
+    an operator of the form
+    \begin{align}
+        D=aP_1+(1-a)P_2^{T_1},\qquad 0\leq a\leq1,
+        \qquad P_1,P_2\geq0,\quad
+        \tr(P_1)=\tr(P_2)=1.
+        \notag
+    \end{align}
+    The transpose remains on Wolf's first tensor factor.
+\end{definition}
+
+\begin{theorem}[The normalized decomposable set]
+    \label{thm:normalized_decomposable_witness_compact_convex}
+    \lean{Matrix.partialTransposeLeft_smul,
+        Matrix.continuous_partialTransposeLeft,
+        Matrix.PosSemidef.hasSchmidtNumberLE_left,
+        Matrix.isCompact_setOf_posSemidef_trace_one,
+        Matrix.isCompact_setOf_isNormalizedDecomposableWitness,
+        Matrix.isNormalizedDecomposableWitness_iff,
+        Matrix.convex_setOf_isNormalizedDecomposableWitness}
+    \leanok
+    \uses{def:normalized_decomposable_witness}
+    For $d,d'\geq1$, the normalized decomposable witnesses are precisely the
+    trace-one section of the cone in Equation~(3.15).  This set is compact
+    and convex.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:decomposable_witness_convex}
+    Let $\mathcal D$ be the set of positive semidefinite trace-one operators
+    on $\C^d\otimes\C^{d'}$.  Every positive semidefinite operator on this
+    space has Schmidt number at most $d$, because every vector in a
+    rank-one decomposition has Schmidt rank at most $d$.  Thus $\mathcal D$
+    is the compact Schmidt-number section $S_d$.  First-factor partial
+    transposition is a continuous coordinate permutation and commutes with
+    scalar multiplication.  The normalized decomposable set is therefore
+    the image of the compact set
+    $[0,1]\times\mathcal D\times\mathcal D$ under the continuous map
+    \begin{align}
+        (a,P_1,P_2)\longmapsto aP_1+(1-a)P_2^{T_1}.
+        \notag
+    \end{align}
+
+    This formula always gives a decomposable operator of trace one.
+    Conversely, write a trace-one decomposable operator as
+    $W=P_1+P_2^{T_1}$.  Positivity gives
+    $\tr(P_1),\tr(P_2)\geq0$, while
+    $\tr(P_1)+\tr(P_2)=1$.  Normalize each nonzero summand and use
+    $a=\tr(P_1)$.  A positive summand of trace zero vanishes, so in that case
+    it may be replaced by any fixed density operator.  This proves the
+    claimed identification.  Convexity now follows by intersecting the
+    convex cone of Theorem~\ref{thm:decomposable_witness_convex} with the
+    affine trace-one hyperplane.
+\end{proof}
+
+\begin{lemma}[Trace adjointness of first-factor partial transpose]
+    \label{lem:partial_transpose_left_trace_adjoint}
+    \lean{Matrix.trace_partialTransposeLeft_mul,
+        Matrix.trace_partialTransposeLeft_mul_re}
+    \leanok
+    \uses{def:partial_transpose_left}
+    For square operators $X,Y$ on $\C^d\otimes\C^{d'}$,
+    \begin{align}
+        \tr\!\left(X^{T_1}Y\right)
+        =\tr\!\left(XY^{T_1}\right).
+        \notag
+    \end{align}
+    Consequently, first-factor partial transpose is self-adjoint for the
+    real trace pairing $(X,Y)\mapsto\Re\tr(XY)$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expand the trace in product indices.  Both sides are the same finite
+    fourfold sum after interchanging the two first-factor indices.  Taking
+    real parts gives the assertion for the real trace pairing.
+\end{proof}
+
 \begin{theorem}[Rectangular decomposable map--witness correspondence]
     \label{thm:decomposable_map_iff_decomposable_witness}
     \lean{Matrix.traceAdjointMap_add,
@@ -671,11 +756,15 @@ positive map and a completely copositive map.
     decomposable, Theorem~\ref{thm:decomposable_map_tensor_id_ppt} would make
     this ampliation positive because $\rho$ is PPT, a contradiction.
 
-    The reverse implication of Proposition~3.5 is not claimed here. Although
-    Theorem~\ref{thm:decomposable_map_iff_decomposable_witness} now supplies
-    Wolf's explicit Equation~(3.15) cone and map--witness bridge, the reverse
-    implication still needs closedness of that cone, trace-pairing duality,
-    and a separating-hyperplane argument.
+    The reverse implication of Proposition~3.5 is not claimed here.
+    Theorem~\ref{thm:normalized_decomposable_witness_compact_convex} supplies
+    the compact convex trace-one set used in the primary witness proof, and
+    Lemma~\ref{lem:partial_transpose_left_trace_adjoint} supplies the required
+    trace identity.  What remains is to normalize the nonzero block-positive
+    Choi witness of an indecomposable map and to carry out the strict
+    separation argument, including positivity, the PPT property, trace
+    normalization, and entanglement of the separating operator.  No
+    closedness theorem for the full unbounded cone is needed for this route.
 \end{proof}
 
 \begin{theorem}[A PPT state detected by an ampliation witnesses indecomposability]

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -274,6 +274,19 @@
   eprinttype   = {arxiv},
 }
 
+@article{LewensteinKrausCiracHorodecki2000,
+  author       = {Lewenstein, Maciej and Kraus, Barbara and Cirac, J. Ignacio
+                  and Horodecki, Pawel},
+  title        = {Optimization of Entanglement Witnesses},
+  journal      = {Physical Review A},
+  volume       = {62},
+  pages        = {052310},
+  year         = {2000},
+  doi          = {10.1103/PhysRevA.62.052310},
+  eprint       = {quant-ph/0005014},
+  eprinttype   = {arxiv},
+}
+
 % -------------------------------------------------------------------------
 %  Paper-gap notes (cite as \cite{gap:<slug>}; the note field carries the
 %  published PDF of the note as a \url link, because the alpha bibliography

--- a/docs/paper-gaps/wolf_prop3_5_reverse_implication.tex
+++ b/docs/paper-gaps/wolf_prop3_5_reverse_implication.tex
@@ -24,9 +24,11 @@ equivalence
       T:\MN{d}\longrightarrow\MN{d'}
   \notag\\
   &\qquad\Longleftrightarrow\qquad
-  \text{there is an entangled density operator }
-      \rho\in\MN{d}\otimes\MN{d'}
-      \text{ with }\rho^{T_1}\geq 0.
+  \begin{gathered}
+    \text{there is an entangled density operator }\rho
+      \in\MN{d}\otimes\MN{d'}\\
+    \text{with }\rho^{T_1}\geq 0.
+  \end{gathered}
   \tag{Wolf Proposition 3.5}
 \end{align}
 Immediately before the proposition, the decomposable witnesses are written in
@@ -37,16 +39,22 @@ the first-factor convention
 \end{align}
 The local source is
 \path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex}, lines
-276--303.
-\footnote{Tracked by \ghissue{22}.}
+276--303.\footnote{Tracked by \ghissue{22}.}
 
 The matching primary witness result is Theorem~3 of
 Lewenstein--Kraus--Cirac--Horodecki: a witness is nondecomposable if and only
 if it detects a PPT entangled state \cite{LewensteinKrausCiracHorodecki2000}.
-Its difficult direction separates a nondecomposable witness from the closed
-convex cone of decomposable witnesses. The earlier Horodecki--Horodecki--
-Horodecki cone calculation writes the dual of the PPT cone as the functionals
-represented by $B+C^{T_2}$ with $B,C\geq0$
+That paper fixes $\tr(W)=1$ for witnesses and, unless stated otherwise, takes
+$P,Q\geq0$ to have trace one.  Its decomposable operators are therefore
+written
+\begin{align}
+  D=aP+(1-a)Q^T,\qquad 0\leq a\leq1.
+  \tag{LKCH normalized form}
+\end{align}
+The difficult direction of Theorem~3 separates a nondecomposable witness
+from this closed convex normalized set. The earlier
+Horodecki--Horodecki--Horodecki cone calculation writes the dual of the PPT
+cone as the functionals represented by $B+C^{T_2}$ with $B,C\geq0$
 \cite[arXiv v2 PDF, Appendix Eq.~(27)]{HorodeckiHorodeckiHorodecki1996Separability}.
 The generated arXiv HTML retags this display as Equation~(50); Equation~(27)
 is the number printed in the primary PDF.
@@ -78,8 +86,7 @@ $T=T_1+T_2\theta$ gives
 Thus the detecting map is indecomposable.
 
 The formal theorem is
-\leanid{Matrix.exists_isIndecomposablePositiveMap_of_isPPT_not_isSeparable}.
-\footnote{Formal declarations:
+\leanid{Matrix.exists_isIndecomposablePositiveMap_of_isPPT_not_isSeparable}.\footnote{Formal declarations:
 \leanid{Matrix.exists_isIndecomposablePositiveMap_of_isPPT_not_isSeparable}
 in \doclink{QICLean/Channel/PPTIndecomposable}, and
 \leanid{IsDecomposablePositiveMap.tensorMapId_posSemidef_of_isPPT}
@@ -87,14 +94,49 @@ in \doclink{QICLean/Channel/DecomposablePPT}.}
 The decomposability predicates and preservation theorem are rectangular, with
 the same input-to-output orientation $\MN{d}\to\MN{d'}$ as Wolf.
 
+\section{The normalized separation data}
+
+The source-shaped normalized set is now formalized directly.  In Wolf's
+first-factor convention it is
+\begin{align}
+  \mathcal D_1
+  =\left\{aP_1+(1-a)P_2^{T_1}:
+      0\leq a\leq1,\ P_1,P_2\geq0,\
+      \tr(P_1)=\tr(P_2)=1\right\}.
+  \tag{normalized decomposable set}
+\end{align}
+The predicate \leanid{Matrix.IsNormalizedDecomposableWitness} records this
+formula.  The development proves that $\mathcal D_1$ is compact and convex
+and, when both tensor factors are nonzero, that it is exactly the trace-one
+section of Wolf's Equation~(3.15) cone.  Compactness is proved as a continuous
+image of
+$[0,1]\times\mathcal S\times\mathcal S$, where $\mathcal S$ is the compact
+set of positive semidefinite trace-one operators on the rectangular product
+space.
+
+The first-factor trace identity needed after separation is also formalized:
+\begin{align}
+  \tr\!\left(X^{T_1}Y\right)
+    =\tr\!\left(XY^{T_1}\right).
+  \tag{partial-transpose trace identity}
+\end{align}
+Thus first-factor partial transpose is self-adjoint for the real trace
+pairing.\footnote{Formal declarations:
+\leanid{Matrix.isCompact_setOf_isNormalizedDecomposableWitness},
+\leanid{Matrix.convex_setOf_isNormalizedDecomposableWitness},
+\leanid{Matrix.isNormalizedDecomposableWitness_iff}, and
+\leanid{Matrix.trace_partialTransposeLeft_mul_re} in
+\doclink{QICLean/Channel/DecomposableWitness}.}
+
 \section{The remaining direction}
 
 The converse required for the full proposition begins with an
 indecomposable positive map and must produce a PPT entangled density
 operator. The current formal development does not claim that implication.
-The explicit cone, its convexity, and the rectangular adjoint bridge are now
-formalized as \leanid{Matrix.IsDecomposableWitness},
-\leanid{Matrix.convex_setOf_isDecomposableWitness}, and
+The explicit cone, its normalized compact section, and the rectangular
+adjoint bridge are now formalized as
+\leanid{Matrix.IsDecomposableWitness},
+\leanid{Matrix.IsNormalizedDecomposableWitness}, and
 \leanid{ChoiRectangular.isDecomposablePositiveMap_iff_choiMatrix_traceAdjointMap_isDecomposableWitness}:
 \begin{align}
   T\text{ decomposable}
@@ -103,24 +145,35 @@ formalized as \leanid{Matrix.IsDecomposableWitness},
   \text{ for some }P_1,P_2\geq0.
   \notag
 \end{align}
-Following Wolf and the primary witness proof still requires all of the
-following:
+The remaining proof should now follow the normalized route of
+Lewenstein--Kraus--Cirac--Horodecki.  Starting with an indecomposable positive
+map, one must first assemble its block-positive Choi witness, prove that this
+witness is nonzero and has positive trace, and normalize it to trace one.
+The resulting witness lies outside $\mathcal D_1$.
+
+One must then strictly separate this point from the compact convex set
+$\mathcal D_1$ in the real space of Hermitian operators.  Because both the
+witness and every member of $\mathcal D_1$ have trace one, the separating
+functional may be shifted by a multiple of the trace functional so that its
+value is negative on the witness and nonnegative on $\mathcal D_1$.
+Representing the shifted functional by a Hermitian operator $R$, the endpoint
+choices $a=1$ and $a=0$ give, respectively,
 \begin{align}
-  &\text{closedness of that cone},\notag\\
-  &\tr\!\left(P_2^{T_1}R\right)
-      =\tr\!\left(P_2R^{T_1}\right),\notag\\
-  &\text{and separation followed by positivity, PPT, trace normalization,
-    and entanglement of the separator.}\notag
+  \tr(RP)\geq0\quad&\text{for every positive trace-one }P,
+  \notag\\
+  \tr(RQ^{T_1})=\tr(R^{T_1}Q)\geq0\quad
+    &\text{for every positive trace-one }Q.
+  \notag
 \end{align}
-The intended source-faithful route to closedness starts from the trace-one
-decomposable operators $aP+(1-a)Q^{T_1}$ used by
-Lewenstein--Kraus--Cirac--Horodecki.  One must first prove that the normalized set
-is compact, then recover the unnormalized Equation~(3.15) cone through the radial
-map whose radius is its trace.  On the Lean side this still requires
-trace-bounded compactness for positive-semidefinite matrices on the product
-index and a proper-map argument for radial scaling.  Merely observing that
-$P_1+P_2^{T_1}$ is a continuous image of the closed product of two
-positive-semidefinite cones would not prove closedness.
+Self-duality of the positive cone then gives $R\geq0$ and
+$R^{T_1}\geq0$.  The strict negative pairing makes $R$ nonzero, so it has
+positive trace and can be normalized to a PPT density operator.  Finally,
+the same negative pairing with the block-positive witness proves that the
+normalized operator is entangled.  These normalization, separation, and
+identification steps remain to be formalized.
+
+Closedness of the full unbounded Equation~(3.15) cone, and a radial proper-map
+argument for that cone, are not prerequisites for this trace-one proof.
 
 Defining a decomposable witness merely as a functional nonnegative on every
 PPT operator would hide rather than prove Equation~(3.15), so that route is
@@ -128,13 +181,14 @@ not used.
 
 \section{Conclusion}
 
-The verdict is a live scope restriction. The PPT-entangled-state-to-
-indecomposable-map direction of Wolf Proposition~3.5 is formalized with the
+The verdict is a live scope restriction. The direction from a PPT entangled
+state to an indecomposable map in Wolf Proposition~3.5 is formalized with the
 printed rectangular dimensions and first-factor transpose convention. The
 reverse direction, and hence the source's existence equivalence, remains open
-until closedness of the now-explicit Equation~(3.15) cone, trace-adjointness of
-partial transpose for the trace pairing, and the separation argument are
-formalized.
+until normalization of the block-positive Choi witness and the separation,
+PPT, trace-normalization, and entanglement steps above are formalized.  The
+normalized decomposable set and trace-adjointness of first-factor partial
+transpose are no longer open ingredients.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -625,10 +625,33 @@ so that the cited formal statements are available from the main project import.
 - `Matrix.convex_setOf_isDecomposableWitness` — convexity of the explicit
   Equation (3.15) decomposable-witness cone, as used in the proof of
   Proposition 3.5 ✓
-- The reverse implication remains open. It requires closedness of the
-  decomposable-witness cone, self-adjointness of partial transpose for the
-  trace pairing, and the separating-hyperplane argument. Proposition 3.5 is
-  therefore not recorded as fully formalized; see
+- `Matrix.IsNormalizedDecomposableWitness` — the trace-one decomposable
+  operators `a P₁ + (1-a) P₂^{T₁}` of
+  Lewenstein–Kraus–Cirac–Horodecki Theorem 3, with `a ∈ [0,1]` and
+  positive trace-one `P₁,P₂` ✓
+- `Matrix.isCompact_setOf_isNormalizedDecomposableWitness`,
+  `Matrix.isNormalizedDecomposableWitness_iff`, and
+  `Matrix.convex_setOf_isNormalizedDecomposableWitness` — compactness and
+  convexity of the normalized set, and its identification with the trace-one
+  section of Wolf's Equation (3.15) cone in nonzero dimensions ✓
+- `Matrix.PosSemidef.hasSchmidtNumberLE_left` and
+  `Matrix.isCompact_setOf_posSemidef_trace_one` — the rectangular
+  positive-semidefinite trace-one section used in the compactness proof ✓
+- `Matrix.partialTransposeLeft_smul` and
+  `Matrix.continuous_partialTransposeLeft` — scalar compatibility and
+  continuity of Wolf's first-factor partial transpose, used for the compact
+  continuous-image description ✓
+- `Matrix.trace_partialTransposeLeft_mul` and
+  `Matrix.trace_partialTransposeLeft_mul_re` — self-adjointness of
+  first-factor partial transpose for the complex bilinear and real trace
+  pairings ✓
+- The reverse implication remains open. The remaining work is to normalize
+  the nonzero block-positive Choi witness of an indecomposable map and carry
+  out the strict separation argument, including positivity, the PPT
+  property, trace normalization, and entanglement of the separating
+  operator. Closedness of the full unbounded cone is not needed for this
+  trace-one route. Proposition 3.5 is therefore not recorded as fully
+  formalized; see
   `docs/paper-gaps/wolf_prop3_5_reverse_implication.tex`.
 
 #### Wolf Example 3.1, Equation (3.20) (Choi-type maps) — PARTIALLY FORMALIZED


### PR DESCRIPTION
## Summary

- formalize the trace-one decomposable operators used in Lewenstein--Kraus--Cirac--Horodecki Theorem 3 as
  \(aP_1+(1-a)P_2^{T_1}\), where \(a\in[0,1]\) and \(P_1,P_2\) are positive semidefinite operators of trace one;
- prove that this normalized set is compact and convex and, in nonzero dimensions, is exactly the trace-one section of Wolf's Equation (3.15) cone;
- prove the first-factor identity \(\operatorname{tr}(X^{T_1}Y)=\operatorname{tr}(XY^{T_1})\), including its real-trace-pairing form;
- synchronize the Chapter 4 blueprint, Wolf numbering coverage, and the dedicated Proposition 3.5 gap note with this normalized route.

The rectangular product orientation follows Wolf: partial transposition is on the first factor. The compactness proof uses the normalized set directly and does not assert closedness of the full unbounded decomposable cone.

The reverse implication of Wolf Proposition 3.5 remains open. In particular, this pull request does not claim the normalization of a nonzero block-positive Choi witness or the separating-hyperplane construction of a PPT entangled density operator.

Refs #22

## Verification

- `lake env lean QICLean/Channel/DecomposableWitness.lean`
- `lake env lean QICLean/Channel/PPTIndecomposable.lean`
- blueprint--Lean synchronization and changed-declaration coverage
- reader-facing prose check
- blueprint bibliography, `chktex`, and `latexindent`
- `texra-blueprint paper-gaps check`
- standalone compilation of `wolf_prop3_5_reverse_implication.tex`
