### PR TITLE
docs(channel): clarify Ha witness indexing

### DIFF
--- a/QICLean/Channel/ChoiTypeMap/Indecomposable.lean
+++ b/QICLean/Channel/ChoiTypeMap/Indecomposable.lean
@@ -50,8 +50,9 @@ variable {d : ℕ} [NeZero d]
 
 /-! ## Ha's roots and two-simple vectors -/
 
-/-- Ha's integer
-\(m_k=\frac32(3^{k-1}-1)\), in zero-based indexing.
+/-- Ha's one-based integer is
+\(m_k=\frac32(3^{k-1}-1)\).  With the zero-based Lean index below, this is
+\(m_k=\frac32(3^k-1)\).
 
 This is the exponent introduced on Ha 1998, p. 593, immediately before
 equation (2.2). -/
@@ -87,8 +88,9 @@ noncomputable def haPhaseVector (d : ℕ) [NeZero d]
   fun p ↦ (haRootOfUnity d i)⁻¹ ^ haExponent k *
     haRootOfUnity d i ^ haExponent p
 
-/-- The phase-vector relation `a_{i,k} = ω_i ^ (-m_k) • a_{i,1}` from
-Ha 1998, p. 593. -/
+/-- The zero-based phase-vector relation
+`a_{i,k} = ω_i ^ (-m_k) • a_{i,0}`, corresponding to Ha's one-based
+relation with base vector `a_{i,1}` on p. 593. -/
 theorem haPhaseVector_eq_smul_zero (i : Fin (3 ^ d)) (k : Fin d) :
     haPhaseVector d i k =
       (haRootOfUnity d i)⁻¹ ^ haExponent k • haPhaseVector d i 0 := by
@@ -120,7 +122,8 @@ noncomputable def haTwoSimpleVector (d : ℕ) [NeZero d]
     else haPhaseVector d i p.2 p.1
 
 /-- Each `z_{r,i}` is 2-simple in Ha's terminology: its coefficient-matrix
-columns lie in the span of `a_{i,1}` and `c_r ∘ a_{i,r}`.
+columns lie in the span of the zero-based vectors `a_{i,0}` and
+`c_r ∘ a_{i,r}`.
 
 This is the first substantive step of Ha 1998, p. 594. -/
 theorem haTwoSimpleVector_hasSchmidtRankLE_two

--- a/docs/paper-gaps/ha98_choi_type_witness_scope.tex
+++ b/docs/paper-gaps/ha98_choi_type_witness_scope.tex
@@ -81,14 +81,17 @@ computes
 
 \section{Formalized part}
 
-The root family, the integers $m_k=\frac32(3^{k-1}-1)$, the vectors
-$a_{i,k}$, $c_r$, $b_{r,i,j}$, and $z_{r,i}$, and the averages in
-(\ref{eq:ha98_root_average}) are now defined with zero-based indices. The
-cyclic coordinates use $\mathbb Z/d\mathbb Z$, so the shift convention agrees
-with Wolf's equation (2.24) and Ha's rotation $S e_i=e_{i+1}$.
+Ha's source uses the one-based integers
+$m_k=\frac32(3^{k-1}-1)$ and base vector $a_{i,1}$. The formalization shifts
+all indices to zero-based notation, so its corresponding formula is
+$m_k=\frac32(3^k-1)$ and its base vector is $a_{i,0}$. The root family, the
+vectors $a_{i,k}$, $c_r$, $b_{r,i,j}$, and $z_{r,i}$, and the averages in
+(\ref{eq:ha98_root_average}) are defined with this convention. The cyclic
+coordinates use $\mathbb Z/d\mathbb Z$, so the shift convention agrees with
+Wolf's equation (2.24) and Ha's rotation $S e_i=e_{i+1}$.
 
 For fixed $r$ and $i$, every column of $z_{r,i}$ other than column $r$ is a
-scalar multiple of $a_{i,1}$, while column $r$ is $c_r\circ a_{i,r}$.
+scalar multiple of $a_{i,0}$, while column $r$ is $c_r\circ a_{i,r}$.
 Consequently the coefficient matrix has rank at most two. Averaging the
 corresponding rank-one projectors proves
 \begin{align}


### PR DESCRIPTION
## Correction

PR #444's final rebased head omitted a documentation correction found during its independent source review. The Lean definition and Blueprint already use a zero-based index, but two landed prose passages still describe Ha's one-based formula as zero-based.

This patch makes the translation explicit:

- Ha's source: `m_k = 3/2 (3^(k-1) - 1)` and base vector `a_{i,1}` with one-based `k`;
- QICLean/Blueprint: `m_k = 3/2 (3^k - 1)` and base vector `a_{i,0}` with zero-based `k`.

It also changes the affected column-span description to use the zero-based base vector. No definition or proof changes.

## Source

Kil-Chan Ha, *Atomic Positive Linear Maps in Matrix Algebras* (1998), pp. 593–594, immediately before Equation (2.2) and in the construction of the two-simple vectors.

## Validation

- focused build of `QICLean.Channel.ChoiTypeMap.Indecomposable`;
- Blueprint regeneration and 2363/2363 synchronization;
- reader-facing prose, paper-gap references, and diff checks.

Refs #18 and #444.
