### PR TITLE
docs(wolf): correct unitary comparison hypothesis

### DIFF
--- a/blueprint/src/chapter/ch06_operator_convexity_schwarz_and_jensen.tex
+++ b/blueprint/src/chapter/ch06_operator_convexity_schwarz_and_jensen.tex
@@ -618,3 +618,28 @@ matrix-order tools used independently of the Fundamental Theorem.
 \begin{proof}\leanok
     Direct application of Theorem~\ref{thm:posMap_log_concave_jensen}.
 \end{proof}
+
+\section{Source boundary for Wolf's unitary comparison}
+
+Wolf's Proposition~5.3 claims that, for arbitrary Hermitian $A,B$, there is
+one unitary $U$ such that
+\begin{align}
+    f(A)\le U f(B)U^\dagger
+    \tag{Wolf (5.57)}
+\end{align}
+for every scalar non-decreasing function $f$ on an interval containing both
+spectra.  The statement is false without the hypothesis $A\le B$: in
+dimension one, $A=[1]$, $B=[0]$, and $f(x)=x$ would give $1\le0$.
+
+The corrected proposition assumes $A\le B$.  This is precisely the hypothesis
+of Weyl monotonicity in the immediately preceding Equation~(5.56), which gives
+$\lambda_j^\downarrow(A)\le\lambda_j^\downarrow(B)$ for each decreasingly
+ordered eigenvalue.  Applying $f$ entrywise and aligning the two ordered
+eigenbases proves the unitary comparison, with the same unitary for every
+$f$.  The exact correction and source proof route are recorded in
+\cite{gap:wolf_ch5_unitary_comparison_missing_order}.
+
+This result is not yet marked as formalized.  The current development has
+unitary covariance of functional calculus, but not the required cross-matrix
+Weyl monotonicity theorem for the Loewner order.  That spectral theorem is the
+remaining dependency; no alternate proof route is asserted here.

--- a/blueprint/src/chapter/ch06_operator_convexity_schwarz_and_jensen.tex
+++ b/blueprint/src/chapter/ch06_operator_convexity_schwarz_and_jensen.tex
@@ -639,7 +639,7 @@ eigenbases proves the unitary comparison, with the same unitary for every
 $f$.  The exact correction and source proof route are recorded in
 \cite{gap:wolf_ch5_unitary_comparison_missing_order}.
 
-This result is not yet marked as formalized.  The current development has
-unitary covariance of functional calculus, but not the required cross-matrix
-Weyl monotonicity theorem for the Loewner order.  That spectral theorem is the
-remaining dependency; no alternate proof route is asserted here.
+% Formalization status: the current development has unitary covariance of
+% functional calculus, but not the required cross-matrix Weyl monotonicity
+% theorem for the Loewner order.  That spectral theorem is the remaining
+% dependency; no alternate proof route is asserted here.

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -345,6 +345,16 @@
   note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_ch01_operator_system_extension_matrix_scope.pdf}},
 }
 
+@techreport{gap:wolf_ch5_unitary_comparison_missing_order,
+  author      = {The {QICLean} contributors},
+  title       = {The Missing Order Hypothesis in {Wolf}'s Unitary Comparison},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_ch5\_unitary\_comparison\_missing\_order},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_ch5_unitary_comparison_missing_order.pdf}},
+}
+
 @techreport{gap:wolf_prop1_5_one_factor_scope,
   author      = {The {QICLean} contributors},
   title       = {Wolf Proposition 1.5: Factor and Coordinate Direct-Sum Scope Restrictions},

--- a/docs/paper-gaps/wolf_ch5_unitary_comparison_missing_order.tex
+++ b/docs/paper-gaps/wolf_ch5_unitary_comparison_missing_order.tex
@@ -1,0 +1,130 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Missing Order Hypothesis in Wolf's Unitary Comparison}
+\author{}
+\date{2026-08-24}
+
+\begin{document}
+\maketitle
+\gapnote{false-source}{open}
+
+\section{The assertion}
+
+Wolf's Proposition~5.3 follows a display of Weyl's monotonicity theorem for
+Hermitian matrices.  The preceding paragraph assumes $A\le B$ and states
+\begin{align}
+  \lambda_j^\downarrow(B)
+  \ge \lambda_j^\downarrow(A)+\lambda_d^\downarrow(B-A)
+  \qquad (1\le j\le d),
+  \tag{Wolf (5.56)}
+\end{align}
+where the eigenvalues are ordered decreasingly.  Since $B-A\ge0$, its
+smallest eigenvalue is nonnegative, so the paragraph concludes that
+$\lambda_j^\downarrow(A)\le\lambda_j^\downarrow(B)$ for every $j$.
+
+The proposition printed immediately afterward drops the order hypothesis:
+for arbitrary Hermitian $A,B\in M_d(\C)$ it claims that there is a unitary
+$U$, independent of $f$, such that
+\begin{align}
+  f(A)\le U f(B)U^\dagger
+  \tag{Wolf (5.57)}
+\end{align}
+for every non-decreasing function $f:I\to\mathbb R$ on an interval containing
+both spectra.\footnote{\cite[Proposition~5.3 and Equations~(5.56)--(5.57)]
+{Wolf2012Quantum}; local source
+\path{Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex},
+lines~1119--1135.  Tracked in \ghissue{27}.}
+
+\section{The point at issue}
+
+The printed proposition is false.  In dimension one take
+\begin{align}
+  A=[1],\qquad B=[0],\qquad I=[0,1],\qquad f(x)=x.
+\end{align}
+Every one-dimensional unitary is a scalar phase and therefore
+$Uf(B)U^\dagger=0$, whereas the claimed inequality becomes $1\le0$.
+
+The omission is also exposed by the source proof route itself: Equation~(5.56)
+is stated only for $A\le B$, and that condition is exactly what makes the
+ordered eigenvalues comparable.  Without it, the sentence ``one obtains
+immediately'' does not supply the hypothesis needed by the proposition.
+
+\section{The corrected statement and source proof}
+
+The source argument proves the following corrected proposition.
+
+Let $A,B\in M_d(\C)$ be Hermitian and assume $A\le B$.  Then there is a
+unitary $U\in M_d(\C)$ such that, for every non-decreasing
+$f:I\to\mathbb R$ on an interval $I$ containing the spectra of both $A$ and
+$B$,
+\begin{align}
+  f(A)\le U f(B)U^\dagger.
+  \tag{corrected Wolf (5.57)}
+\end{align}
+The quantifier order is unchanged: the same $U$ works for every such $f$.
+
+Indeed, choose eigenvector unitaries $V_A,V_B$ in decreasing eigenvalue order,
+so that
+\begin{align}
+  A&=V_A\operatorname{diag}
+      (\lambda_1^\downarrow(A),\ldots,\lambda_d^\downarrow(A))V_A^\dagger,\\
+  B&=V_B\operatorname{diag}
+      (\lambda_1^\downarrow(B),\ldots,\lambda_d^\downarrow(B))V_B^\dagger.
+\end{align}
+Equation~(5.56), positivity of $B-A$, and monotonicity of $f$ give
+\begin{align}
+  f(\lambda_j^\downarrow(A))
+  \le f(\lambda_j^\downarrow(B))
+  \qquad (1\le j\le d).
+\end{align}
+With $U=V_A V_B^\dagger$, functional calculus in these eigenbases yields
+\begin{align}
+  f(A)
+  &=V_A\operatorname{diag}
+      (f(\lambda_1^\downarrow(A)),\ldots,f(\lambda_d^\downarrow(A)))V_A^\dagger,\\
+  U f(B)U^\dagger
+  &=V_A\operatorname{diag}
+      (f(\lambda_1^\downarrow(B)),\ldots,f(\lambda_d^\downarrow(B)))V_A^\dagger.
+\end{align}
+The entrywise diagonal inequality, transported by the unitary congruence
+$X\mapsto V_A X V_A^\dagger$, is the corrected conclusion.
+
+\section{Formalization boundary}
+
+The current matrix API already provides decreasingly ordered Hermitian
+eigenvalues and unitary covariance of the continuous functional calculus.
+The latter is recorded as \leanid{Matrix.cfc_conj_unitary} in
+\doclink{QICLean/Analysis/CfcConjugation}.  What is not yet exposed by the
+current dependency surface is the cross-matrix Weyl step
+\begin{align}
+  A\le B
+  \Longrightarrow
+  \lambda_j^\downarrow(A)\le\lambda_j^\downarrow(B)
+  \quad\text{for every }j.
+\end{align}
+The available antitonicity theorem for the ordered list only compares indices
+within one fixed Hermitian matrix; it does not compare two matrices in the
+Loewner order.  Consequently no replacement proof of the corrected proposition
+is asserted here.  Formalizing Weyl monotonicity by its own finite-dimensional
+spectral route remains the exact open dependency.
+
+\section{Conclusion}
+
+Wolf's Proposition~5.3 is false as printed because it omits $A\le B$.  Adding
+that hypothesis makes the proposition an immediate consequence of the
+preceding Equation~(5.56), exactly as the source says: order the two spectra,
+apply the scalar monotonicity of $f$, and align the two eigenbases by one
+unitary.  The source correction is definitive; the formal Weyl-monotonicity
+dependency remains open.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -9,7 +9,7 @@
 
 \title{Formalization-Derived Corrections to Wolf's \emph{Quantum Channels \& Operations}}
 \author{}
-\date{2026-08-23}
+\date{2026-08-24}
 
 \begin{document}
 \sloppy
@@ -456,6 +456,42 @@ These are two local false-source corrections exposed by the positive-map
 formalization. They do not alter the proof for a nonzero irreducible map once
 the second global extremum is read as an infimum.
 
+\section{The missing order hypothesis in the unitary comparison}
+\label{sec:unitary-comparison}
+
+\paragraph{Formalization trigger.}
+The correction and the exact source proof route are documented in
+\path{docs/paper-gaps/wolf_ch5_unitary_comparison_missing_order.tex}.  The
+corrected theorem is not yet formalized because the current dependency surface
+does not expose the required cross-matrix Weyl monotonicity theorem.
+
+\paragraph{Printed statement and correction.}
+Immediately after stating Weyl monotonicity for Hermitian matrices satisfying
+$A\le B$, Wolf's Proposition~5.3 drops that hypothesis and claims that for
+arbitrary Hermitian $A,B$ there is a unitary $U$ such that
+\begin{align}
+  f(A)\le U f(B)U^\dagger
+\end{align}
+for every non-decreasing scalar function $f$ on an interval containing the two
+spectra.  In dimension one, $A=[1]$, $B=[0]$, and $f(x)=x$ contradict the
+printed claim.  The corrected proposition inserts $A\le B$.
+
+\paragraph{Source proof route.}
+Under $A\le B$, Equation~(5.56) gives
+$\lambda_j^\downarrow(A)\le\lambda_j^\downarrow(B)$ for every $j$ because
+the smallest eigenvalue of $B-A$ is nonnegative.  Monotonicity of $f$ preserves
+these scalar inequalities.  Choosing decreasingly ordered eigenvector
+unitaries $V_A,V_B$ and setting $U=V_A V_B^\dagger$ then transports the
+entrywise diagonal inequality to
+$f(A)\le Uf(B)U^\dagger$.  This unitary depends only on the two ordered
+eigenbases, so it works simultaneously for every admissible $f$, as required
+by the quantifier order of the printed proposition.
+
+\paragraph{Classification.}
+This is a genuine source error: the printed theorem is false, while its
+intended corrected statement follows by exactly the preceding argument once
+$A\le B$ is retained.
+
 \section{Formalization gaps that are not source corrections}
 
 The following Wolf-specific paper-gap notes are intentionally \emph{not}
@@ -478,14 +514,16 @@ errata entries:
 
 \section{Conclusion}
 
-At present the formalization-derived record contains four false printed
+At present the formalization-derived record contains five false printed
 assertions (Sections~\ref{sec:lorentz},
 \ref{sec:pauli-block-truncation}, and the two corrections in
-Section~\ref{sec:theorem-6-3}), one normalization typo
+Section~\ref{sec:theorem-6-3}, together with
+Section~\ref{sec:unitary-comparison}), one normalization typo
 (Section~\ref{sec:ordered-cp-inverse}), one explicit boundary convention
 (Section~\ref{sec:radon-nikodym}), and one local correction to a spectrum
 shorthand (Section~\ref{sec:two-pure-state-spectrum}). These are the
-corrections asserted by the Lean documentation itself.
+corrections exposed by the Lean development and its source-faithfulness
+audits.
 
 \appendix
 \section{Corrected errors in the local LaTeX transcription}


### PR DESCRIPTION
## Summary

- record that Wolf Proposition 5.3 / Equation (5.57) is false as printed because it drops the preceding hypothesis `A ≤ B`;
- give the one-dimensional counterexample `A = [1]`, `B = [0]`, `f(x) = x`;
- state the corrected proposition and preserve Wolf’s proof route exactly: Equation (5.56), ordered eigenvalue monotonicity, scalar monotonicity of `f`, and alignment of the two ordered eigenbases by one unitary;
- synchronize the Chapter 5 Blueprint, bibliography, shared Wolf errata, and a dedicated paper-gap note.

## Formalization boundary

No Lean theorem is invented here. The current API has unitary covariance of functional calculus, but not the exact cross-matrix Weyl theorem
`A ≤ B → λ↓_j(A) ≤ λ↓_j(B)`.
That is the precise remaining dependency. Issue #27 therefore remains open for this theorem and the rest of its source package.

## Verification

- focused `lake build QICLean.Analysis.CfcConjugation`
- Blueprint sync, prose, BibTeX, `chktex`, all paper-gap slugs, full paper-gap PDFs, and full Blueprint web render
- import aggregator, diff, and no-bypass checks
- stable patch ID `af71e9eab40652320e60895f3518317458c8d06f` preserved across rebases
- exact rebased source commit `d8d82b6db3de4abdf2964c97a3b16d6ef8f1316c` on base `958e3c812baaf24463476887b3d8150e626db3b0`
- review correction commit `7bdce0d` moves maintainer-only proof status into a LaTeX comment

Related umbrella: #27; remains open.