### PR TITLE
chore(channel): make Ha scalar reductions explicit

### DIFF
--- a/QICLean/Channel/ChoiTypeMap/HaBlockTranspose.lean
+++ b/QICLean/Channel/ChoiTypeMap/HaBlockTranspose.lean
@@ -413,13 +413,18 @@ private theorem haCyclicProjectorSum_apply_forward_diag (hd : 3 ≤ d)
   have hm1sq : (Real.sqrt ((d : ℝ) - 1)) ^ 2 = (d : ℝ) - 1 :=
     Real.sq_sqrt hdm1
   have hne := haCyclicSucc_ne hd i
-  simp [add_apply, haVectorProjector, vecMulVec_apply, Pi.star_apply,
-    haUVector, haVVector, haTensorBasis, hne]
-  apply Complex.ext <;> simp [pow_two]
-  rw [Nat.cast_sub (by omega : 1 ≤ d), Nat.cast_one]
-  field_simp
-  ring_nf at hdsq hm1sq ⊢
-  nlinarith
+  have hscalar :
+      γ / Real.sqrt d * (γ / Real.sqrt d) +
+          Real.sqrt ((d : ℝ) - 1) / Real.sqrt d *
+            (Real.sqrt ((d : ℝ) - 1) / Real.sqrt d) =
+        (d : ℝ)⁻¹ * (γ ^ 2 + (d - 1 : ℕ)) := by
+    rw [Nat.cast_sub (by omega : 1 ≤ d), Nat.cast_one]
+    field_simp
+    ring_nf at hdsq hm1sq ⊢
+    nlinarith
+  simpa [add_apply, haVectorProjector, vecMulVec_apply, Pi.star_apply,
+    haUVector, haVVector, haTensorBasis, hne, pow_two] using
+      congrArg (fun x : ℝ ↦ (x : ℂ)) hscalar
 
 private theorem haCyclicProjectorSum_apply_reverse_diag (hd : 3 ≤ d)
     {γ : ℝ} (hγ : 0 < γ) (i : Fin d) :
@@ -430,19 +435,22 @@ private theorem haCyclicProjectorSum_apply_reverse_diag (hd : 3 ≤ d)
   have hdpos : 0 < (d : ℝ) := by nlinarith
   have hspos : 0 < Real.sqrt d := Real.sqrt_pos.2 hdpos
   have hdsq : (Real.sqrt d) ^ 2 = (d : ℝ) := Real.sq_sqrt hdpos.le
-  have hdsq4 : (Real.sqrt d) ^ 4 = (d : ℝ) ^ 2 := by
-    rw [show (Real.sqrt d) ^ 4 = ((Real.sqrt d) ^ 2) ^ 2 by ring, hdsq]
   have hm1sq : (Real.sqrt (-1 + (d : ℝ))) ^ 2 = -1 + (d : ℝ) := by
     convert Real.sq_sqrt (show 0 ≤ -1 + (d : ℝ) by nlinarith)
   have hne := haCyclicSucc_ne hd i
-  simp [add_apply, haVectorProjector, vecMulVec_apply, Pi.star_apply,
-    haUVector, haVVector, haTensorBasis, hne]
-  apply Complex.ext <;> simp [pow_two]
-  rw [Nat.cast_sub (by omega : 1 ≤ d), Nat.cast_one]
-  field_simp
-  ring_nf
-  rw [hdsq4, hm1sq, hdsq]
-  ring
+  have hscalar :
+      γ⁻¹ * (Real.sqrt d)⁻¹ * (γ⁻¹ * (Real.sqrt d)⁻¹) +
+          Real.sqrt ((d : ℝ) - 1) / Real.sqrt d *
+            (Real.sqrt ((d : ℝ) - 1) / Real.sqrt d) =
+        (d : ℝ)⁻¹ * ((γ ^ 2)⁻¹ + (d - 1 : ℕ)) := by
+    rw [Nat.cast_sub (by omega : 1 ≤ d), Nat.cast_one]
+    field_simp
+    ring_nf
+    rw [hm1sq, hdsq]
+    ring
+  simpa [add_apply, haVectorProjector, vecMulVec_apply, Pi.star_apply,
+    haUVector, haVVector, haTensorBasis, hne, pow_two] using
+      congrArg (fun x : ℝ ↦ (x : ℂ)) hscalar
 
 private theorem haCyclicProjectorSum_apply_forward_reverse (hd : 3 ≤ d)
     {γ : ℝ} (hγ : 0 < γ) (i : Fin d) :
@@ -456,12 +464,16 @@ private theorem haCyclicProjectorSum_apply_forward_reverse (hd : 3 ≤ d)
   have hm1sq : (Real.sqrt ((d : ℝ) - 1)) ^ 2 = (d : ℝ) - 1 :=
     Real.sq_sqrt hdm1
   have hne := haCyclicSucc_ne hd i
-  simp [add_apply, haVectorProjector, vecMulVec_apply, Pi.star_apply,
-    haUVector, haVVector, haTensorBasis, hne]
-  apply Complex.ext <;> simp
-  field_simp
-  ring_nf at hdsq hm1sq ⊢
-  nlinarith
+  have hscalar :
+      γ / Real.sqrt d * (γ⁻¹ * (Real.sqrt d)⁻¹) +
+          Real.sqrt ((d : ℝ) - 1) / Real.sqrt d *
+            (Real.sqrt ((d : ℝ) - 1) / Real.sqrt d) = 1 := by
+    field_simp
+    ring_nf at hdsq hm1sq ⊢
+    nlinarith
+  simpa [add_apply, haVectorProjector, vecMulVec_apply, Pi.star_apply,
+    haUVector, haVVector, haTensorBasis, hne] using
+      congrArg (fun x : ℝ ↦ (x : ℂ)) hscalar
 
 private theorem haCyclicProjectorSum_apply_reverse_forward (hd : 3 ≤ d)
     {γ : ℝ} (hγ : 0 < γ) (i : Fin d) :
@@ -475,12 +487,16 @@ private theorem haCyclicProjectorSum_apply_reverse_forward (hd : 3 ≤ d)
   have hm1sq : (Real.sqrt ((d : ℝ) - 1)) ^ 2 = (d : ℝ) - 1 :=
     Real.sq_sqrt hdm1
   have hne := haCyclicSucc_ne hd i
-  simp [add_apply, haVectorProjector, vecMulVec_apply, Pi.star_apply,
-    haUVector, haVVector, haTensorBasis, hne]
-  apply Complex.ext <;> simp
-  field_simp
-  ring_nf at hdsq hm1sq ⊢
-  nlinarith
+  have hscalar :
+      (γ⁻¹ * (Real.sqrt d)⁻¹) * (γ / Real.sqrt d) +
+          Real.sqrt ((d : ℝ) - 1) / Real.sqrt d *
+            (Real.sqrt ((d : ℝ) - 1) / Real.sqrt d) = 1 := by
+    field_simp
+    ring_nf at hdsq hm1sq ⊢
+    nlinarith
+  simpa [add_apply, haVectorProjector, vecMulVec_apply, Pi.star_apply,
+    haUVector, haVVector, haTensorBasis, hne] using
+      congrArg (fun x : ℝ ↦ (x : ℂ)) hscalar
 
 private theorem haCyclicProjectorSum_apply_eq_zero (γ : ℝ)
     (p q : Fin d × Fin d)


### PR DESCRIPTION
## Summary

Follow-up to #453.

- replace the four flexible `simp`-then-rigid tactic transitions in Ha’s private projector-entry proofs with explicit real scalar identities;
- cast each proved real identity to `ℂ` and use a terminal `simpa` to unfold the projector entry;
- remove the now-unused local fourth-power identity;
- leave public statements, imports, documentation, and source claims unchanged.

## Exact scope

- base: `b48f652b42ac9e0298cd1c47fd4e581110b4a6a9`
- head: `6aadaec33398a705b9b81ca22012969aa0984d46`
- stable patch ID: `ad48a92683e3316d7ad66876b538c5e98d6fabfa`
- changed file: `QICLean/Channel/ChoiTypeMap/HaBlockTranspose.lean`

## Validation

- direct Lean elaboration of `QICLean/Channel/ChoiTypeMap/HaBlockTranspose.lean` passes without warning output;
- `lake exe lint_style --github` passes;
- `git diff --check origin/main...HEAD` passes;
- the patch contains no changed public/private declaration headers or imports;
- the source-facing statements and their kernel closures are unchanged from merged PR #453.

Fresh pull-request CI repeats the project build and Blueprint checks.

Refs #453.