### PR TITLE
docs: use original statement terminology

### DIFF
--- a/QICLean/Algebra/KramersDegeneracy.lean
+++ b/QICLean/Algebra/KramersDegeneracy.lean
@@ -192,7 +192,7 @@ is exactly what Wolf's calculation needs and cannot be dropped (the eigenvalue `
 see the paper-gap note).
 
 **Local fix (Wolf ch03, lines 527–530):** the nonvanishing hypothesis
-`A *ᵥ star ψ ≠ 0` is added to the printed statement.  Counterexample and corrected
+`A *ᵥ star ψ ≠ 0` is added to the original statement.  Counterexample and corrected
 statement: `docs/paper-gaps/wolf_ch3_kramers_theorem_ii.tex`. -/
 theorem two_le_finrank_eigenspace_of_intertwiner_mulVec_star_ne_zero {H A : Matrix n n ℂ}
     (hH : H.IsHermitian) (hHA : H * A = A * Hᵀ) (hAanti : Aᵀ = -A)

--- a/QICLean/Analysis/SemidefiniteDuality.lean
+++ b/QICLean/Analysis/SemidefiniteDuality.lean
@@ -173,7 +173,7 @@ theorem weak_duality (F₀ : HermitianMatrix n) (F : ι → HermitianMatrix n)
 
 /-- **Primal-strict semidefinite Slater attainment, corrected.** Wolf's `X > 0` condition and a
 finite primal value give a dual optimizer. The finite-value hypothesis is the necessary correction
-to the printed statement at lines 100--105. -/
+to the original statement at lines 100--105. -/
 theorem exists_dualOptimizer_of_primalStrict_of_primalValue_eq_coe
     (F₀ : HermitianMatrix n) (F : ι → HermitianMatrix n) (b : EuclideanSpace ℝ ι) (p : ℝ)
     (hstrict : ∃ X : HermitianMatrix n, (toMatrix n X).PosDef ∧

--- a/QICLean/Channel/Irreducible/SpectralRadius.lean
+++ b/QICLean/Channel/Irreducible/SpectralRadius.lean
@@ -304,7 +304,7 @@ every positive eigenvalue with a nonzero positive semidefinite eigenvector
 equals `r`, and `r` is the spectral radius.
 
 The value is allowed to be zero exactly to retain the one-dimensional zero-map
-boundary case omitted in Wolf's printed statement. -/
+boundary case omitted in Wolf's original statement. -/
 theorem exists_wolfTheorem63_of_irreducible_positive [NeZero D]
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hT : IsPositiveMap T) (hIrr : IsIrreducibleMap T) :
@@ -355,7 +355,7 @@ theorem exists_wolfTheorem63_of_irreducible_positive [NeZero D]
 /-- **Wolf Theorem 6.3, source form.**  If the irreducible positive map is
 nonzero, the common Collatz--Wielandt value in
 `exists_wolfTheorem63_of_irreducible_positive` is strictly positive.  This is
-Wolf's printed statement with the necessary one-dimensional zero-map boundary
+Wolf's original statement with the necessary one-dimensional zero-map boundary
 excluded explicitly. -/
 theorem exists_wolfTheorem63_of_irreducible_positive_of_ne_zero [NeZero D]
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -23,7 +23,7 @@ formalization or by a paper-gap analysis required to state a formal theorem
 faithfully. It is not a general errata list for the lecture notes. Its main
 body records only formalization-derived corrections; the final appendix records
 three separately audited local PDF--transcription errors. Each item quotes the
-relevant printed statement, gives the locally correct replacement, and explains
+relevant original statement, gives the locally correct replacement, and explains
 why the correction is necessary.
 \end{abstract}
 
@@ -465,7 +465,7 @@ The correction and the exact source proof route are documented in
 corrected theorem is not yet formalized because the current dependency surface
 does not expose the required cross-matrix Weyl monotonicity theorem.
 
-\paragraph{Printed statement and correction.}
+\paragraph{Original statement and correction.}
 Immediately after stating Weyl monotonicity for Hermitian matrices satisfying
 $A\le B$, Wolf's Proposition~5.3 drops that hypothesis and claims that for
 arbitrary Hermitian $A,B$ there is a unitary $U$ such that

--- a/docs/paper-gaps/wolf_schur_complement_tfae.tex
+++ b/docs/paper-gaps/wolf_schur_complement_tfae.tex
@@ -103,6 +103,6 @@ formalized without additional hypotheses. Condition (3) is false as printed;
 the scalar counterexample above is decisive. After adjoining the necessary
 left-support condition $\ker(P)\subseteq\ker(Q^\dagger)$, the three-way
 equivalence is formalized. Thus \href{https://github.com/LionSR/TNLean/issues/5501}{TNLean issue \#5501} is resolved by a source
-correction rather than by asserting the false printed statement.
+correction rather than by asserting the false original statement.
 
 \end{document}

--- a/docs/paper-gaps/wolf_theorem6_16_schwarz_orientation.tex
+++ b/docs/paper-gaps/wolf_theorem6_16_schwarz_orientation.tex
@@ -14,7 +14,7 @@
 \maketitle
 \gapnote{local-correction}{resolved}
 
-\section{The printed statement and the invoked theorem}
+\section{The original statement and the invoked theorem}
 
 Let $T:M_d(\mathbb C)\to M_d(\mathbb C)$ be positive and trace preserving,
 and write $T^*$ for its trace-pairing adjoint.  Wolf's Theorem~6.16 states

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -700,7 +700,7 @@ so that the cited formal statements are available from the main project import.
 
 #### Wolf Theorem 3.2 (Kramers' theorem II) — FALSE AS PRINTED; CORRECTED FORM FORMALIZED
 
-- The printed statement (`H` Hermitian, `Aᵀ = -A ≠ 0`, `H * A = A * Hᵀ` ⟹
+- The original statement (`H` Hermitian, `Aᵀ = -A ≠ 0`, `H * A = A * Hᵀ` ⟹
   every eigenvalue at least two-fold degenerate) is false: the partner
   `A *ᵥ star ψ` of an eigenvector can vanish. The counterexample
   (`H = diag(0,1,1)`, `A` the antisymmetric unit of the `1`-eigenspace) and
@@ -1258,7 +1258,7 @@ In `QICLean.Channel.FixedPoint.Algebra`:
 #### Wolf Theorem 6.10 (Brouwer's fixed point theorem) — FORMALIZED
 
 * `brouwer_fixedPoint_compactConvex` — `QICLean.Topology.CompactConvexFixedPoint`;
-  the printed statement for every nonempty compact convex
+  the original statement for every nonempty compact convex
   `S ⊆ Fin n → ℝ` and continuous self-map of `S`.
 * `fixedPoint_of_compact_convex` — coordinate-free form for finite-dimensional
   real inner-product spaces.


### PR DESCRIPTION
## Summary

- replace every case-insensitive exact phrase `printed statement` with `original statement`
- preserve capitalization and surrounding grammar across Lean docstrings, paper-gap notes, Wolf coverage, and the Chapter 5 errata entry
- leave distinct phrases such as `printed theorem`, `printed endpoint`, and `as printed` unchanged

## Scope check

- base occurrence count: 10
- head occurrence count: 0
- changed files: 7
- diff: 10 insertions, 10 deletions

## Validation

- `lake build QICLean.Algebra.KramersDegeneracy QICLean.Analysis.SemidefiniteDuality QICLean.Channel.Irreducible.SpectralRadius -q --log-level=info`
- `lake exe lint_style`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base 256dd8b5c3d1d479aba04ba6aa05a6d94b19451d --ci`
- `texra-blueprint paper-gaps check`
- `texra-blueprint --root . paper-gaps build`
