### PR TITLE
docs(wolf): correct Corollary 5.2 logarithm scope

### DIFF
--- a/QICLean/Analysis/LiebConcavity.lean
+++ b/QICLean/Analysis/LiebConcavity.lean
@@ -291,8 +291,10 @@ private lemma positiveMap_rpowIntegrand₁₂_cfcₙ_jensen
 For a positive subunital map `T` and `p ∈ [0, 1]`:
   `T(A ^ p) ≤ (T A) ^ p`.
 
-Follows from operator concavity of `rpow` (Bhatia, Chapter V) combined with
-the Hansen--Pedersen operator Jensen inequality for positive subunital maps.
+The proof integrates the finite-POVM resolvent inequality for Wolf's
+Löwner-integral real-power integrand.  It establishes this special-function
+instance directly, without assuming a packaged general Hansen--Pedersen
+operator Jensen theorem.
 
 References:
 * Wolf, Theorem 5.13
@@ -447,8 +449,10 @@ private lemma tendsto_rpow_exponent_two {M : Mat} (hM : 0 ≤ M) :
 For a positive subunital map `T` and `p ∈ [1, 2]`:
   `(T A) ^ p ≤ T(A ^ p)`.
 
-Follows from operator convexity of `rpow` (Bhatia, Chapter V) combined with
-the Hansen--Pedersen operator Jensen inequality for positive subunital maps.
+The proof integrates the reversed finite-POVM resolvent inequality for the
+convex Löwner integrand and obtains the endpoint `p = 2` by continuity.  It
+establishes this special-function instance directly, without assuming a
+packaged general Hansen--Pedersen operator Jensen theorem.
 
 References:
 * Wolf, Theorem 5.11
@@ -551,10 +555,12 @@ Follows by applying the concave real-power theorem to `(A ^ p - 1) / p` for
 `CFC.tendsto_cfc_rpow_sub_one_log`. Requires unitality (`T 1 = 1`), not merely
 subunitality.
 
-**Local fix (unital logarithm inequality):** Wolf Corollary 5.2(3) states the
-result for a positive subunital map, but that statement fails because `log` is
-unbounded below at zero. The present theorem uses the necessary unital
-hypothesis. This correction is documented in
+**Source correction (unital logarithm inequality):** Wolf Corollary 5.2(3)
+states the result for a positive subunital map.  That hypothesis is
+insufficient: in dimension one, `T(x) = c * x` with `0 < c < 1` and `A = 1`
+would give `0 = T(log A) ≤ log(T A) = log c`, which is false.  The present
+result uses the unital hypothesis under which the inequality is proved.  This
+correction is documented in
 `docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`.
 
 References:

--- a/QICLean/Channel/Schwarz/OperatorConvexity.lean
+++ b/QICLean/Channel/Schwarz/OperatorConvexity.lean
@@ -10,11 +10,12 @@ import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Order
 
 /-!
-# Operator Jensen inequality for positive subunital maps
+# Special-function operator Jensen inequalities for positive maps
 
-This file states the **operator Jensen inequality** (also known as the
-Choi--Davis--Jensen or Hansen--Pedersen inequality) specialized to the
-functions `x ↦ x ^ p` and `log`, for positive subunital maps on matrices.
+This file states **operator Jensen inequalities** (also known as
+Choi--Davis--Jensen or Hansen--Pedersen inequalities) specialized to
+`x ↦ x ^ p` and `log`.  The real-power results use positive subunital maps;
+the logarithmic result uses a positive unital map.
 
 ### Background
 
@@ -27,25 +28,30 @@ and every `t ∈ [0, 1]`:
 in the Loewner order, where `f` is applied via the continuous functional
 calculus. *Operator concavity* reverses the inequality.
 
-The **operator Jensen inequality** for a positive subunital map `T`
-(`T(1) ≤ 1`) then says:
+The subunital form of the **operator Jensen inequality** for `T`
+(`T(1) ≤ 1`) requires the corresponding boundary sign at zero and says:
 
-* **convex** `f`: `f(T(A)) ≤ T(f(A))`;
-* **concave** `f`: `T(f(A)) ≤ f(T(A))`.
+* **convex** `f` with `f(0) ≤ 0`: `f(T(A)) ≤ T(f(A))`;
+* **concave** `f` with `f(0) ≥ 0`: `T(f(A)) ≤ f(T(A))`.
 
-Note: the `log` variant requires unitality (`T(1) = 1`), not merely
-subunitality, because `log` is unbounded below.
+The printed common subunital hypothesis in Wolf Corollary 5.2 is insufficient
+for its logarithmic clause.  Already in dimension one, for `0 < c < 1`, the
+positive subunital map `T(x) = c * x` and `A = 1` would assert
+`0 = T(log A) ≤ log(T A) = log c`, which is false.  The theorem below therefore
+records the corrected unital statement.
 
 ### Status
 
-The three Jensen wrappers below are proved from the boundary declarations in
+The three Jensen wrappers below are proved from declarations in
 `TNLean.Analysis.LiebConcavity`.  The concave real-power theorem is proved
 there by the finite-POVM / compression integrand route, and the logarithmic
-theorem is proved from it by taking the right limit `p → 0+` in
+result is proved from it by taking the right limit `p → 0+` in
 `(A ^ p - 1) / p`.  The convex real-power wrapper is proved from the boundary
 declaration `posMap_rpow_convex_jensen` in the same module.
 
-These are consumed by the Corollary 5.2 proofs in `OperatorMonotone.lean`.
+These are the live special-function interfaces.  The former
+`OperatorMonotone.lean` corollary wrappers were removed as unused; no theorem in
+this file depends on an unproved declaration.
 
 ## References
 
@@ -108,14 +114,16 @@ For a positive **unital** map `T` and positive-definite `A`:
   `T(log A) ≤ log(T A)`.
 
 This is obtained as the right limit of the concave real-power Jensen theorem
-for positive subunital maps. Note: unlike the `rpow` variants, the `log`
-Jensen inequality requires unitality (`T 1 = 1`), not merely subunitality
-(`T 1 ≤ 1`).
+for positive subunital maps. Note: unlike the `rpow` variants, the available
+`log` Jensen inequality assumes unitality (`T 1 = 1`), not merely
+subunitality (`T 1 ≤ 1`).
 
-**Local fix (unital logarithm inequality):** Wolf Corollary 5.2(3) states the
-result for a positive subunital map, but that statement fails because `log` is
-unbounded below at zero. The present theorem uses the necessary unital
-hypothesis. This correction is documented in
+**Source correction (unital logarithm inequality):** Wolf Corollary 5.2(3)
+states the result for a positive subunital map.  That hypothesis is
+insufficient: the scalar map `T(x) = c * x`, with `0 < c < 1`, and `A = 1`
+would give the false inequality `0 ≤ log c`.  The present theorem uses the
+unital hypothesis under which the inequality is proved.  This correction is
+documented in
 `docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`.
 
 Proved from `posMap_log_concave_jensen` in `TNLean.Analysis.LiebConcavity`. -/

--- a/QICLean/Channel/Schwarz/OperatorJensenAux.lean
+++ b/QICLean/Channel/Schwarz/OperatorJensenAux.lean
@@ -11,12 +11,11 @@ import Mathlib.MeasureTheory.Integral.Bochner.Basic
 # Finite-POVM compression lemmas for operator Jensen
 
 This file states algebraic lemmas for the finite-POVM / compression route to
-operator Jensen inequalities. The main target is the concave real-power case in
-Wolf Corollary 5.2. The Löwner integral representation of `rpow` that this route
-feeds into is now available in Mathlib 4.31
+operator Jensen inequalities. Its first target is the concave real-power case
+behind Wolf Corollary 5.2. The Löwner integral representation of `rpow` that
+this route feeds into is available in Mathlib 4.31
 (`Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/IntegralRepresentation.lean`),
-so the outstanding gap is the operator Jensen step rather than the integral
-representation; see the status note below.
+and `QICLean.Analysis.LiebConcavity` performs the downstream integral assembly.
 
 ## Main statements
 
@@ -61,17 +60,18 @@ and `CFC.concaveOn_cfc_rpowIntegrand₀₁` records the operator concavity of ea
 integrand together with the resolvent form
 `cfc (Real.rpowIntegrand₀₁ p t) a = t ^ (p - 1) • 1 - t ^ p • (t • 1 + a)⁻¹`.
 
-This file now also proves the positive-map resolvent estimate obtained from
+This file also proves the positive-map resolvent estimate obtained from
 the spectral projections of the input matrix and `povm_resolvent_inv_le`, and
 uses it to prove the single-integrand Jensen inequality
 `T(cfc (Real.rpowIntegrand₀₁ p t) A) ≤ cfc (Real.rpowIntegrand₀₁ p t) (T A)`.
-The remaining unfinished step is therefore to integrate the pointwise
-positive-semidefinite bound obtained from
+The pointwise positive-semidefinite bound obtained from
 `cfc (Real.rpowIntegrand₀₁ p t) (T A) - T(cfc (Real.rpowIntegrand₀₁ p t) A)`
-through Mathlib's Löwner integral representation.  The matrix-valued
-positive-integral step is packaged below from Mathlib's ordered Bochner
-integral API and the local closed Loewner-order topology on finite matrices;
-order monotonicity itself is Mathlib's `integral_mono_ae`.
+is integrated in `QICLean.Analysis.LiebConcavity`, giving
+`posMap_rpow_concave_jensen`; the logarithmic theorem is then its right-limit
+consequence.  The matrix-valued positive-integral step is packaged below from
+Mathlib's ordered Bochner integral API and the local closed Loewner-order
+topology on finite matrices; order monotonicity itself is Mathlib's
+`integral_mono_ae`.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder

--- a/blueprint/src/chapter/ch06_operator_convexity_schwarz_and_jensen.tex
+++ b/blueprint/src/chapter/ch06_operator_convexity_schwarz_and_jensen.tex
@@ -595,8 +595,12 @@ matrix-order tools used independently of the Fundamental Theorem.
     \uses{def:positive_map, thm:posMap_rpow_concave_jensen}
     For a positive \emph{unital} map $T$ and positive-definite~$A$, one has
     $T(\log A)\le\log(T(A))$.
-    This is \cite[Theorem~5.13]{Wolf2012Quantum} for~$f=\log$.
-    Requires unitality ($T(\Id)=\Id$), not merely subunitality.
+    This is the corrected logarithmic specialization associated with
+    \cite[Corollary~5.2(3)]{Wolf2012Quantum}.  The printed common hypothesis
+    $T(\Id)\le\Id$ is insufficient: in dimension one, for $0<c<1$, the
+    positive subunital map $T(x)=cx$ and $A=1$ would give
+    $0=T(\log A)\le\log(T(A))=\log c$.  The formal theorem instead assumes
+    $T(\Id)=\Id$; see \cite{gap:wolf_ch5_operator_jensen_lieb}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -618,6 +622,23 @@ matrix-order tools used independently of the Fundamental Theorem.
 \begin{proof}\leanok
     Direct application of Theorem~\ref{thm:posMap_log_concave_jensen}.
 \end{proof}
+
+\subsection{Boundary of the source package}
+
+The preceding declarations prove the real-power instances and the corrected
+unital logarithm instance.  The former pass-through declarations which rewrote
+the real-power inequalities into the exact exponent-parameterization of
+Corollary~5.2(1)--(2) are not live declarations.  Nor do the results above
+package the full block of results in Wolf's Section~5.4: the integral
+characterization of operator-convex
+functions, L\"owner's operator-monotonicity theorem, the two general projection
+inequalities, Jensen's inequality for an arbitrary operator-convex function,
+the entropic operator inequality, the general positive-map monotonicity theorem,
+and the finite-family Jensen corollary remain outside the proved declarations
+listed here.  Thus the special-function slice is proved, while the complete
+source package remains partial by packaging and scope.  The false common
+subunital hypothesis in the printed logarithm clause and the exact formal
+boundary are recorded in \cite{gap:wolf_ch5_operator_jensen_lieb}.
 
 \section{Source boundary for Wolf's unitary comparison}
 

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -345,6 +345,16 @@
   note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/qiclean_minkowski_canonical_pair_dependency.pdf}},
 }
 
+@techreport{gap:wolf_ch5_operator_jensen_lieb,
+  author      = {The {QICLean} contributors},
+  title       = {{Wolf} Chapter 5: The Subunital Logarithm Clause and the Operator {Jensen} Boundary},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_ch5\_operator\_jensen\_lieb},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_ch5_operator_jensen_lieb.pdf}},
+}
+
 @techreport{gap:wolf_ch01_operator_system_extension_matrix_scope,
   author      = {The {QICLean} contributors},
   title       = {Wolf's Operator-System Extension: Matrix-Algebra Realization},

--- a/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
+++ b/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
@@ -9,24 +9,28 @@
 
 \title{Wolf Chapter~5 Operator Jensen and Lieb Concavity Boundary}
 \author{}
-\date{2026-06-23}
+\date{2026-08-24}
 
 \begin{document}
 \maketitle
-\gapnote{open-gap}{resolved}
+\gapnote{false-source}{resolved}
 
 \section{Scope}
 
-This note records the mathematical content of the Chapter~5
-operator-convexity boundary\footnote{%
+This note records three distinct parts of the Chapter~5
+operator-convexity boundary.  First, the special-function Jensen declarations
+are proved.\footnote{%
     The declarations are
     \leanid{posMap_rpow_concave_jensen}, \leanid{posMap_rpow_convex_jensen},
     \leanid{posMap_log_concave_jensen}, and \leanid{lieb_concavity_posDef} in
-    \doclink{QICLean/Analysis/LiebConcavity}; the first, third, and fourth are
-    now theorems (the Lieb declaration in its positive-definite, boundary-exponent
-    scope, see Section~\ref{sec:lieb}); none remains an axiom.}
-together with the cited sources, the precise gaps, and the first concrete step
-toward eliminating each remaining gap.  The positive-map Jensen declarations
+    \doclink{QICLean/Analysis/LiebConcavity}; all four are proved theorems and
+    none is an axiom.}
+Second, the common subunital hypothesis printed in Wolf Corollary~5.2 is false
+for its logarithmic clause and must be replaced there by unitality.  Third, the
+finite-dimensional Ando--Lieb theorem is proved in the full exponent range
+described in Section~\ref{sec:lieb}.  This note does not identify the proved
+special-function declarations with the full general function-theoretic package
+in Wolf's Section~5.4.  The positive-map Jensen declarations
 underlie \cite[Corollary~5.2]{Wolf2012Quantum} (the second corollary of Wolf's
 \S5.4) and rest on the operator-convexity and
 operator-monotonicity-versus-positive-maps results
@@ -58,21 +62,19 @@ and, for a positive \emph{unital} map $T$ and $A>0$,
 \end{align}
 These are the operator-valued Jensen inequalities behind Wolf
 Corollary~5.2.\footnote{%
-    They were consumed by
-    \leanid{cor52_item1_rpow_of_subunital},
-    \leanid{cor52_item2_rpow_of_subunital}, and
-    \leanid{cor52_item3_log_of_unital} in
-    \path{Channel/Schwarz/OperatorMonotone}, corollary wrappers since removed
-    as unused in
-    \href{https://github.com/LionSR/QICLean/pull/56}{QICLean PR \#56}.}
+    The live map-facing interfaces are
+    \leanid{IsPositiveMap.rpow_concave_jensen},
+    \leanid{IsPositiveMap.rpow_convex_jensen}, and
+    \leanid{IsPositiveMap.log_concave_jensen} in
+    \doclink{QICLean/Channel/Schwarz/OperatorConvexity}.}
 The first and third are concavity inequalities (for the operator-concave
 functions $x\mapsto x^p$ on $[0,1]$ and $x\mapsto\log x$); the second is a
 convexity inequality (for the operator-convex function $x\mapsto x^p$ on
-$[1,2]$).  The logarithmic case requires $T$ unital, not merely subunital: with
-$T$ only subunital the inequality fails because $\log$ is unbounded below near
-$0$.
+$[1,2]$).  The logarithmic case proved in the development assumes $T$ unital.
+The weaker common subunital hypothesis printed by Wolf is insufficient, as the
+scalar counterexample below shows.
 
-\subsection{The point at issue: the genuine gap is positive-map Jensen}
+\subsection{The proved special-function route and the general-package boundary}
 
 Mathlib~4.31 supplies the integral
 representation\footnote{%
@@ -88,13 +90,11 @@ $[1,2]$, is also now present as \leanid{CFC.convexOn_rpow} in
 inputs for the three Jensen declarations are available in the formal
 development.
 
-The remaining gap is the step \emph{from} operator concavity (a statement about a
-single operator) \emph{to} the Jensen inequality $T(fA)\le f(TA)$ for a positive
-map.  This is the Choi--Davis--Jensen inequality (the positive-map form of the
-Hansen--Pedersen operator Jensen inequality): for an operator-concave $f$ and a
-positive unital map $T$ one has $T(fA)\le f(TA)$, with the subunital version
-obtained by dilating $T$ to a unital map.  Mathlib~4.31 contains no such
-general theorem for positive maps.  The concave real-power case has now been
+The general step \emph{from} operator concavity (a statement about a single
+operator) \emph{to} the Jensen inequality $T(fA)\le f(TA)$ for a positive map is
+the Choi--Davis--Jensen inequality (the positive-map form of the
+Hansen--Pedersen operator Jensen inequality).  Mathlib~4.31 contains no such
+general theorem for positive maps.  The concave real-power case is nevertheless
 discharged by the special Löwner-integrand route recorded in
 \leanid{TNLean.OperatorJensen.positiveMap_rpowIntegrand₀₁_jensen}, together
 with ordered Bochner integral monotonicity.  The logarithmic case has also been
@@ -124,25 +124,32 @@ $\mathcal M_d$ (Wolf Prop.~1.7).  Thus no obstruction specific to maps that are
 positive but not completely positive survives, and the source corollary itself
 is stated for
 positive subunital maps, not for channels: \cite[Corollary~5.2]{Wolf2012Quantum}
-hypothesises a positive map with $T(\mathbf 1)\le\mathbf 1$, which is exactly the
-\leanid{IsPositiveMap} plus subunitality recorded in the two power companions
-\leanid{cor52_item1_rpow_of_subunital} and
-\leanid{cor52_item2_rpow_of_subunital}.
+hypothesises a positive map with $T(\mathbf 1)\le\mathbf 1$.  This is exactly the
+\leanid{IsPositiveMap} plus subunitality recorded in the two proved real-power
+declarations.
 
-\paragraph{Local fix (log unitality).}  The logarithmic companion
-\leanid{cor52_item3_log_of_unital} departs from this subunital hypothesis: it
-assumes $T$ \emph{unital}, $T(\mathbf 1)=\mathbf 1$, rather than $T(\mathbf
-1)\le\mathbf 1$.  This is a deliberate strengthening, not an exact match to the
-subunital form of the source corollary: as recorded in \S\ref{ssec:assertions},
-the subunital logarithmic inequality $T(\log A)\le\log(TA)$ fails because $\log$
-is unbounded below near $0$, so the unital restriction is the mathematically
-correct domain for the logarithmic case.  This is a local fix (a hypothesis
-sharpened to the regime where the inequality holds), documented here so the
-deviation from the verbatim subunital reading of
-\cite[Corollary~5.2]{Wolf2012Quantum} is auditable; the two power companions
-above retain the bare subunital hypothesis.
+\paragraph{False printed logarithm clause.}  The same common hypothesis is
+printed for item~3,
+\begin{align}
+  T(\log A) &\le \log(T(A)), & A&>0. \tag{printed item 3}
+\end{align}
+It is false for positive subunital maps.  Work in dimension one, fix
+$0<c<1$, take $T_c(x)=cx$, and set $A=1$.  Then $T_c$ is positive and
+$T_c(1)=c\le1$, while
+\begin{align}
+  T_c(\log 1) &=0,
+  &\log(T_c(1))&=\log c<0.
+\end{align}
+Thus the printed inequality would assert $0\le\log c$.  The unital theorem
+\leanid{IsPositiveMap.log_concave_jensen} instead assumes
+$T(\mathbf 1)=\mathbf 1$ and proves the corrected statement.  This is not a
+formalization-only scope choice: the source's common subunital hypothesis is
+mathematically insufficient for item~3.  The live real-power Jensen theorems
+retain Wolf's bare subunital hypothesis; the former pass-through declarations
+which repackaged them in the exact exponent-reparameterized form of items~1--2
+were removed as unused.
 
-The partial scaffold already present in the repository for the concave power
+The finite-POVM scaffold used for the concave power
 case\footnote{%
     \doclink{QICLean/Channel/Schwarz/OperatorJensenAux} (finite-POVM compression,
     Schur-complement inverse bound, and the resolvent inequality).}
@@ -172,8 +179,8 @@ Loewner inequality by the closedness of the finite-dimensional order graph.
 
 \subsection{Current formal inputs}\label{ssec:formal-inputs}
 
-The auxiliary ingredients needed before the remaining positive-map Jensen
-assemblies are now present.  The theorem \leanid{CFC.convexOn_rpow} supplies operator
+The auxiliary ingredients used by the proved positive-map Jensen assemblies
+are present.  The theorem \leanid{CFC.convexOn_rpow} supplies operator
 convexity of $x\mapsto x^p$ for $p\in[1,2]$, completing the scalar
 functional-calculus input for \leanid{posMap_rpow_convex_jensen}.
 
@@ -187,9 +194,10 @@ directly by the general ordered Bochner theorem \leanid{integral_mono_ae}.
 
 \subsection{Verdict}
 
-The three positive-map Jensen statements are mathematically standard
-\cite[Theorems~5.10--5.13 and Corollary~5.2]{Wolf2012Quantum}.  The concave
-real-power statement \leanid{posMap_rpow_concave_jensen} has been discharged by
+The two real-power Jensen theorems underlying
+\cite[Corollary~5.2]{Wolf2012Quantum} and the corrected unital logarithm theorem
+are proved.  The concave real-power statement
+\leanid{posMap_rpow_concave_jensen} is discharged by
 the finite-POVM resolvent scaffold, the pointwise integrand inequality, and
 ordered Bochner integral monotonicity.  The logarithmic statement
 \leanid{posMap_log_concave_jensen} has been discharged as the right limit of the
@@ -197,7 +205,20 @@ concave real-power result.  The convex real-power statement
 \leanid{posMap_rpow_convex_jensen} has likewise been discharged, by the same
 positive-map operator Jensen step applied to the convex integrand.
 The integral representation of the power integrand, previously named as the
-obstruction, is present.
+obstruction, is present.  The printed subunital logarithm clause remains false;
+its resolution is the source-facing unital correction above.
+
+These special-function theorems do not package Wolf's full Section~5.4 block.
+No source-level declaration has been identified for the general operator-convex
+integral criterion (Theorem~5.8), L\"owner's theorem (Theorem~5.9), the two
+general projection-inequality implications (Theorems~5.10--5.11), Jensen's
+inequality for an arbitrary operator-convex function and a unital positive map
+(Theorem~5.12), the entropic corollary, the general positive-map
+operator-monotonicity theorem (Theorem~5.13), or the finite-family Jensen
+corollary following Corollary~5.2.  The exact source package is therefore still
+partial by scope and packaging; in particular, the former pass-through wrappers
+for Corollary~5.2(1)--(2) are no longer live declarations.  The special
+real-power and corrected logarithm slice itself remains axiom-free.
 
 \section{The Lieb concavity theorem (boundary exponent)}\label{sec:lieb}
 

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -492,6 +492,54 @@ This is a genuine source error: the printed theorem is false, while its
 intended corrected statement follows by exactly the preceding argument once
 $A\le B$ is retained.
 
+\section{The subunital logarithm clause in Corollary~5.2}
+\label{sec:cor52-log}
+
+\paragraph{Formalization trigger.}
+The proved logarithmic Jensen declarations
+\leanid{posMap_log_concave_jensen} and
+\leanid{IsPositiveMap.log_concave_jensen}, in
+\doclink{QICLean/Analysis/LiebConcavity} and
+\doclink{QICLean/Channel/Schwarz/OperatorConvexity}, assume that the positive
+map is unital.  The discrepancy is documented in
+\path{docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex}.
+
+\paragraph{Original statement and its role.}
+Chapter~5, Corollary~5.2, in
+\path{Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex}, lines~761--769,
+places all three clauses under the common hypothesis that $T$ is positive and
+$T(\one)\le\one$.  Its third clause prints
+\begin{equation}\tag{printed item 3}
+  T(\log A)\le\log(T(A))\qquad(A>0).
+\end{equation}
+
+\paragraph{Correction.}
+The proved logarithmic statement replaces subunitality by unitality:
+\begin{equation}\tag{corrected item 3}
+  T(\one)=\one,\qquad A>0
+  \quad\Longrightarrow\quad
+  T(\log A)\le\log(T(A)).
+\end{equation}
+The two real-power clauses in the same corollary remain valid with Wolf's
+subunital hypothesis.  The live Jensen declarations from which they follow use
+that exact assumption; this correction does not alter either power clause.
+
+\paragraph{Why the correction is necessary.}
+In dimension one, fix $0<c<1$, take the positive map $T_c(x)=cx$, and set
+$A=1$.  Then $T_c(1)=c\le1$, but
+\begin{equation}
+  T_c(\log 1)=0>\log c=\log(T_c(1)).
+\end{equation}
+Thus the printed inequality fails even for a strictly positive scalar map.
+The boundary hypothesis in Wolf's preceding positive-map monotonicity theorem
+also signals the problem: it assumes a function on an interval containing zero
+with $f(0)\ge0$, whereas the logarithm is unbounded below at zero.
+
+\paragraph{Classification.}
+This is a genuine source error in the common hypothesis of Corollary~5.2.  The
+formal theorem proves the corrected unital clause and does not preserve the
+false subunital target.
+
 \section{Formalization gaps that are not source corrections}
 
 The following Wolf-specific paper-gap notes are intentionally \emph{not}
@@ -507,18 +555,17 @@ errata entries:
     Schmidt-number premise was a formalization dependency and is now resolved;
   \item \path{wolf_ex3_1_choi_positivity_subcase_scope.tex}: the development
     proves selected parameter families, not the full source range;
-  \item \path{wolf_ch5_operator_jensen_lieb.tex} and
-    \path{wolf_cor67_maximal_support_restriction.tex}: these describe
-    formalization boundaries and their resolution, not a false printed theorem.
+  \item \path{wolf_cor67_maximal_support_restriction.tex}: this describes a
+    formalization boundary and its resolution, not a false printed theorem.
 \end{itemize}
 
 \section{Conclusion}
 
-At present the formalization-derived record contains five false printed
-assertions (Sections~\ref{sec:lorentz},
-\ref{sec:pauli-block-truncation}, and the two corrections in
-Section~\ref{sec:theorem-6-3}, together with
-Section~\ref{sec:unitary-comparison}), one normalization typo
+At present the formalization-derived record contains source errors in
+Sections~\ref{sec:lorentz}, \ref{sec:kramers-ii},
+\ref{sec:pauli-block-truncation}, \ref{sec:spinor-rotation-sign},
+\ref{sec:theorem-6-3}, \ref{sec:unitary-comparison}, and
+\ref{sec:cor52-log}; one normalization typo
 (Section~\ref{sec:ordered-cp-inverse}), one explicit boundary convention
 (Section~\ref{sec:radon-nikodym}), and one local correction to a spectrum
 shorthand (Section~\ref{sec:two-pure-state-spectrum}). These are the


### PR DESCRIPTION
## Summary

- record that the common positive-subunital hypothesis in Wolf Corollary 5.2 is false for the logarithmic clause;
- give the scalar counterexample `T_c(x) = c x`, `0 < c < 1`, `A = 1`, which would force the false inequality `0 ≤ log c`;
- preserve the exact subunital hypotheses for the two real-power clauses and identify unitality as the corrected logarithmic hypothesis;
- align the live Lean docstrings, Chapter 6 Blueprint text and citation, the dedicated paper-gap note, and the shared Wolf errata.

The Lean changes are documentation-only: theorem statements, proof bodies, imports, and declarations are unchanged. The broader operator-convexity and monotonicity source package remains partial and its tracking hierarchy stays open.

## Exact scope

- base: `9a306bded45450fd4f390576940484576a335033`
- head: `6353a83c147a5e13f1b677942a97c2e874ac0409`
- stable patch ID: `39984cf36b662c461b1942e045c4f44db089cc69`
- changed files: 7

## Validation

- full `lake build QICLean` passed before the final terminology-only rebase; focused affected Lean modules pass at the exact head;
- `lake exe lint_style --github` passes;
- Blueprint declaration generation, sync, and `checkdecls` pass;
- `texra-blueprint bbl` passes;
- paper-gap registry check passes for all 45 referenced slugs;
- the full paper-gap LaTeX build passes;
- reader-facing prose and `git diff --check` pass.

Fresh pull-request CI repeats the project build and Blueprint checks.