### PR TITLE
feat(analysis): add Nowosad coordinate prerequisites

### DIFF
--- a/QICLean/Analysis.lean
+++ b/QICLean/Analysis.lean
@@ -54,6 +54,7 @@ import QICLean.Analysis.MatrixSqrt
 import QICLean.Analysis.MatrixTraceInequalities
 import QICLean.Analysis.MeanErgodic
 import QICLean.Analysis.NeumannInverse
+import QICLean.Analysis.Nowosad
 import QICLean.Analysis.OperatorConvexity
 import QICLean.Analysis.OperatorNormConvergence
 import QICLean.Analysis.PosSemidefCommute

--- a/QICLean/Analysis/Nowosad.lean
+++ b/QICLean/Analysis/Nowosad.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import Mathlib.Analysis.Normed.Module.FiniteDimension
+import Mathlib.Topology.Order.LocalExtr
+
+/-!
+# Finite-coordinate prerequisites for Nowosad's extremum theorem
+
+This file records the source-facing finite-coordinate infrastructure needed for
+Yamagami's use of Nowosad's Theorem 1.8.  For a real linear operator `T` on
+`Fin d → ℝ`, the functional is
+
+`functional T x = ∑ i, (T x) i / x i`.
+
+Nowosad's original statement is oriented toward local minima.  Yamagami's
+Theorem 1 uses the corresponding local-maximum form.  The passage is exactly
+`T ↦ -T`, since `functional (-T) = -functional T`; it is made explicit below.
+
+The file also discharges two finite-dimensional specializations used in the
+source proof: every coordinate linear operator is continuous, and every point
+derivation of the coordinate algebra vanishes.  The latter is proved directly
+from the coordinate idempotent, replacing the Singer--Wermer step in the
+general Banach-algebra argument.
+
+This is only prerequisite infrastructure.  It does not claim Nowosad's
+Laurent-algebra constancy theorem or Yamagami's Lemma 3.
+-/
+
+open scoped BigOperators
+
+namespace Nowosad
+
+variable {d : ℕ}
+
+/-- The strictly positive part of the real coordinate algebra. -/
+def positiveDomain : Set (Fin d → ℝ) :=
+  {x | ∀ i, 0 < x i}
+
+/-- The finite-coordinate specialization of Nowosad's functional
+`x ↦ φ (x⁻¹ T(x))`, for the sum-of-coordinates positive functional `φ`. -/
+noncomputable def functional
+    (T : (Fin d → ℝ) →ₗ[ℝ] (Fin d → ℝ)) (x : Fin d → ℝ) : ℝ :=
+  ∑ i, (T x) i / x i
+
+/-- Negating the operator negates Nowosad's functional. -/
+@[simp] theorem functional_neg
+    (T : (Fin d → ℝ) →ₗ[ℝ] (Fin d → ℝ)) (x : Fin d → ℝ) :
+    functional (-T) x = -functional T x := by
+  simp only [functional, LinearMap.neg_apply, Pi.neg_apply, neg_div]
+  rw [Finset.sum_neg_distrib]
+
+/-- Nowosad's functional is invariant under a nonzero scalar rescaling of its
+coordinate argument. -/
+theorem functional_smul
+    (T : (Fin d → ℝ) →ₗ[ℝ] (Fin d → ℝ)) (c : ℝ) (x : Fin d → ℝ)
+    (hc : c ≠ 0) :
+    functional T (c • x) = functional T x := by
+  simp only [functional, LinearMap.map_smul, Pi.smul_apply, smul_eq_mul]
+  refine Finset.sum_congr rfl fun i _ ↦ ?_
+  exact mul_div_mul_left _ _ hc
+
+/-- Explicit sign bridge from Nowosad's local-minimum orientation to the
+local-maximum orientation used by Yamagami. -/
+theorem isLocalMinOn_functional_neg_iff_isLocalMaxOn
+    (T : (Fin d → ℝ) →ₗ[ℝ] (Fin d → ℝ)) (a : Fin d → ℝ) :
+    IsLocalMinOn (functional (-T)) (positiveDomain (d := d)) a ↔
+      IsLocalMaxOn (functional T) (positiveDomain (d := d)) a := by
+  constructor
+  · intro h
+    simpa using h.neg
+  · intro h
+    rw [show functional (-T) = fun x ↦ -functional T x by
+      funext x
+      exact functional_neg T x]
+    exact h.neg
+
+/-- A linear operator on the finite coordinate space is automatically a
+bounded linear operator for the Euclidean norm. -/
+noncomputable def continuousLinearMap
+    (T : (Fin d → ℝ) →ₗ[ℝ] (Fin d → ℝ)) :
+    (Fin d → ℝ) →L[ℝ] (Fin d → ℝ) :=
+  ⟨T, T.continuous_of_finiteDimensional⟩
+
+@[simp] theorem continuousLinearMap_apply
+    (T : (Fin d → ℝ) →ₗ[ℝ] (Fin d → ℝ)) (x : Fin d → ℝ) :
+    continuousLinearMap T x = T x :=
+  rfl
+
+/-- A point derivation at coordinate `i`: the coordinate evaluation is the
+character appearing in the Leibniz rule. -/
+def IsPointDerivationAt
+    (D : (Fin d → ℝ) →ₗ[ℝ] ℝ) (i : Fin d) : Prop :=
+  ∀ x y, D (x * y) = x i * D y + y i * D x
+
+/-- Every point derivation on the finite coordinate algebra vanishes.  The
+proof uses the coordinate idempotent directly, which is the finite-coordinate
+specialization of the derivation-vanishing step in Nowosad's argument. -/
+theorem pointDerivation_eq_zero
+    (D : (Fin d → ℝ) →ₗ[ℝ] ℝ) (i : Fin d)
+    (hD : IsPointDerivationAt D i) :
+    D = 0 := by
+  apply LinearMap.ext
+  intro x
+  let e : Fin d → ℝ := Pi.single i 1
+  have hei : e i = 1 := by simp [e]
+  have hee : e * e = e := by
+    ext j
+    simp [e, Pi.single_apply]
+  have hDe_formula := hD e e
+  have hDe : D e = 0 := by
+    rw [hee, hei] at hDe_formula
+    linarith
+  have hex : e * x = x i • e := by
+    ext j
+    by_cases hji : j = i
+    · subst j
+      simp [e, smul_eq_mul]
+    · simp [e, smul_eq_mul, hji]
+  have hDx_formula := hD e x
+  rw [hex, D.map_smul, hDe, smul_zero, hei, one_mul, mul_zero, add_zero] at hDx_formula
+  simpa using hDx_formula.symm
+
+end Nowosad

--- a/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
@@ -24,6 +24,73 @@ of Tanahashi and Tomiyama~\cite[pp.~309--311]{TanahashiTomiyama1988Indecomposabl
 Their Lemmas~2--3 use the same rank-one and product-one coefficient argument
 formalized below. The whole range is due to Yamagami~\cite{Yamagami1993Cyclic},
 whose proof is a variational argument on the boundary of a projective simplex.
+The finite-coordinate prerequisites for the interior uniqueness step are
+recorded next.  They make explicit the sign change between Nowosad's original
+local-minimum orientation and Yamagami's local maxima, but do not yet prove
+Nowosad's Laurent-algebra constancy theorem or Yamagami's Lemma~3.
+
+\subsection{Nowosad's finite-coordinate prerequisites}
+
+\begin{definition}[Nowosad's coordinate functional]
+    \label{def:nowosad_coordinate_functional}
+    \lean{Nowosad.positiveDomain, Nowosad.functional}
+    \leanok
+    For a real linear operator $T$ on $\mathbb R^d$, set
+    \begin{align}
+        \lambda_T(x)
+         &=\sum_i\frac{(Tx)_i}{x_i},
+         \qquad x_i>0.
+        \notag
+    \end{align}
+    This is the finite-coordinate specialization of
+    $x\mapsto\varphi(x^{-1}T(x))$ used by
+    Nowosad~\cite[Theorems~1.5 and~1.8]{Nowosad1968Isoperimetric}.
+\end{definition}
+
+\begin{theorem}[The Nowosad--Yamagami sign bridge]
+    \label{thm:nowosad_yamagami_sign_bridge}
+    \lean{Nowosad.functional_neg, Nowosad.functional_smul,
+        Nowosad.isLocalMinOn_functional_neg_iff_isLocalMaxOn,
+        Nowosad.continuousLinearMap,
+        Nowosad.continuousLinearMap_apply}
+    \leanok
+    \uses{def:nowosad_coordinate_functional}
+    One has $\lambda_{-T}=-\lambda_T$, so local minima of $\lambda_{-T}$ on
+    the strictly positive domain are exactly local maxima of $\lambda_T$.
+    Moreover $\lambda_T(cx)=\lambda_T(x)$ for $c\ne0$, and every linear
+    operator on $\mathbb R^d$ is bounded for its Euclidean norm.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Linearity gives $(-T)x=-(Tx)$ coordinatewise, and negation reverses local
+    minima and local maxima.  The scaling identity follows by cancelling the
+    common nonzero scalar in each quotient.  Continuity is automatic in finite
+    dimension.  Thus applying Nowosad's original local-minimum statement to
+    $-T$ gives precisely the local-maximum orientation used in Yamagami's
+    Theorem~1~\cite[p.~522]{Yamagami1993Cyclic}.
+\end{proof}
+
+\begin{theorem}[Point derivations of the coordinate algebra vanish]
+    \label{thm:nowosad_coordinate_point_derivation_zero}
+    \lean{Nowosad.IsPointDerivationAt, Nowosad.pointDerivation_eq_zero}
+    \leanok
+    If a linear functional $D$ satisfies
+    \begin{align}
+        D(xy)=x_iD(y)+y_iD(x)
+        \notag
+    \end{align}
+    at a fixed coordinate $i$, then $D=0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Let $e_i$ be the coordinate idempotent.  Applying the Leibniz identity to
+    $e_i^2=e_i$ gives $D(e_i)=2D(e_i)$, hence $D(e_i)=0$.  For arbitrary $x$,
+    the identity $e_ix=x_i e_i$ then gives $0=D(e_ix)=D(x)$.  This is the
+    finite-coordinate idempotent proof of the point-derivation vanishing step
+    used in Nowosad's argument.
+\end{proof}
 
 \begin{definition}[Yamagami's stride-one cyclic reciprocal data]
     \label{def:yamagami_stride_one_reciprocal}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -47,6 +47,17 @@
   note         = {arXiv:math-ph/0611057v3},
 }
 
+@article{Nowosad1968Isoperimetric,
+  author       = {Nowosad, Pedro},
+  title        = {Isoperimetric Eigenvalue Problems in Algebras},
+  journal      = {Communications on Pure and Applied Mathematics},
+  volume       = {21},
+  number       = {5},
+  pages        = {401--465},
+  year         = {1968},
+  doi          = {10.1002/cpa.3160210502},
+}
+
 @article{Yamagami1993Cyclic,
   author       = {Yamagami, Shigeru},
   title        = {Cyclic Inequalities},


### PR DESCRIPTION
## Summary

- add the finite-coordinate definition of Nowosad's functional `lambda_T(x) = sum_i (T x)_i / x_i`
- formalize the exact sign bridge `T -> -T` between the local-minimum and local-maximum orientations
- discharge the finite-dimensional continuity and coordinate point-derivation prerequisites used by the source argument
- synchronize the Blueprint and add the Nowosad bibliographic entry

## Source boundary

This is deliberately a prerequisite-only slice. It follows Yamagami's Theorem 1 orientation and the finite-coordinate specialization needed by issue #448, but it does **not** claim Nowosad's Laurent-algebra constancy theorem, Yamagami's Lemma 3, or the cyclic reciprocal inequality. Those source-dependent steps remain open.

Refs #448
Parent tracking issue: #19

## Validation

- `lake build QICLean.Analysis.Nowosad QICLean.Analysis`
- `lake exe lint_style`
- `lake exe checkdecls blueprint/lean_decls`
- `texra-blueprint bbl`
- `python3 scripts/blueprint_lean_sync.py --ci`
- Blueprint web render
- repository module/prose/paper-gap guards
- `git diff --check origin/main...HEAD`

Base: `9a306bded45450fd4f390576940484576a335033`
Head: `2e73ea6b0fb3ad4253117cb75e401e96dafc86da`
Stable patch ID: `0035af3120ccb0877f52e47f2a4c7938c790c96d`
