### PR TITLE
feat(analysis): formalize Yamagami singular-boundary estimate

### DIFF
--- a/QICLean/Analysis.lean
+++ b/QICLean/Analysis.lean
@@ -94,3 +94,4 @@ import QICLean.Analysis.UnitarySchurTriangularization
 import QICLean.Analysis.UpperTriangularBound
 import QICLean.Analysis.WeightedCesaroMean
 import QICLean.Analysis.WeightedPositiveKernel
+import QICLean.Analysis.YamagamiBoundary

--- a/QICLean/Analysis/YamagamiBoundary.lean
+++ b/QICLean/Analysis/YamagamiBoundary.lean
@@ -1,0 +1,494 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Order.LiminfLimsup
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Positivity
+import Lean.Elab.Tactic.Omega
+
+/-!
+# Yamagami's singular-boundary estimate
+
+This file isolates the omitted simultaneous-singularity step in Shigeru
+Yamagami's proof of the cyclic inequalities.  We retain Yamagami's forward
+cyclic indexing.  Thus
+\[
+  f_{N,m,s}(x)=\sum_j
+    \frac{x_j}{(s-m)x_j+x_{j+1}+\cdots+x_{j+m}}.
+\]
+
+For the case called `l = 1` in the paper, a singular denominator gives a run
+of at least `m + 1` zero coordinates.  Starting at the first positive
+coordinate after this run, the preceding `m` summands tend to zero along
+strictly positive approximants.  Every other summand is at most
+`1 / (s - m)`.  The resulting single global count is
+`(N - m) / (s - m) ≤ N / s`; no decomposition into maximal zero blocks is
+used.
+
+The last theorem is deliberately conditional on the strictly positive
+inequality.  It only transfers such an inequality to Lean's totalized
+nonnegative value, where `0 / 0 = 0`; it does not establish the strictly
+positive theorem or the regular-boundary induction.
+
+## Source
+
+* S. Yamagami, *Cyclic inequalities*, Proc. Amer. Math. Soc. 118 (1993),
+  521--527, especially the singular-boundary paragraph on pp. 524--525.
+-/
+
+open scoped BigOperators Topology
+open Filter Finset
+
+namespace Yamagami
+
+section FiniteEstimate
+
+variable {α ι : Type*} [Fintype ι] [DecidableEq ι]
+
+/-- A finite limsup estimate separating the terms that tend to zero from the
+uniformly bounded terms.  This is the analytic form of Yamagami's global
+count at a singular boundary point. -/
+theorem limsup_sum_le_card_mul_of_tendsto_zero_on
+    {l : Filter α} [NeBot l] (u : α → ι → ℝ) (V : Finset ι) (c : ℝ)
+    (hzero : ∀ i ∈ V, Tendsto (fun t ↦ u t i) l (𝓝 0))
+    (hnonneg : ∀ᶠ t in l, ∀ i, 0 ≤ u t i)
+    (hle : ∀ᶠ t in l, ∀ i ∉ V, u t i ≤ c) :
+    limsup (fun t ↦ ∑ i, u t i) l ≤ (((Finset.univ \ V).card : ℕ) : ℝ) * c := by
+  have hzeroSum : Tendsto (fun t ↦ ∑ i ∈ V, u t i) l (𝓝 0) := by
+    simpa using tendsto_finsetSum V hzero
+  have hcomplement : ∀ᶠ t in l,
+      (∑ i ∈ Finset.univ \ V, u t i) ≤ (((Finset.univ \ V).card : ℕ) : ℝ) * c := by
+    filter_upwards [hle] with t ht
+    simpa [nsmul_eq_mul] using
+      (Finset.sum_le_card_nsmul (Finset.univ \ V) (u t) c fun i hi ↦
+        ht i (Finset.mem_sdiff.mp hi).2)
+  have hsplit : ∀ t,
+      (∑ i, u t i) = (∑ i ∈ V, u t i) + ∑ i ∈ Finset.univ \ V, u t i := by
+    intro t
+    rw [← Finset.sum_sdiff V.subset_univ, add_comm]
+  have hbelow : IsCoboundedUnder (· ≤ ·) l (fun t ↦ ∑ i, u t i) :=
+    isCoboundedUnder_le_of_eventually_le l
+      (hnonneg.mono fun t ht ↦ Finset.sum_nonneg fun i _ ↦ ht i)
+  have habove : IsBoundedUnder (· ≤ ·) l (fun t ↦ ∑ i, u t i) := by
+    refine isBoundedUnder_of_eventually_le
+      (a := 1 + (((Finset.univ \ V).card : ℕ) : ℝ) * c) ?_
+    filter_upwards [(tendsto_order.1 hzeroSum).2 1 zero_lt_one, hcomplement]
+      with t hsmall hrest
+    rw [hsplit]
+    linarith
+  rw [limsup_le_iff hbelow habove]
+  intro y hy
+  filter_upwards [
+      (tendsto_order.1 hzeroSum).2
+        (y - (((Finset.univ \ V).card : ℕ) : ℝ) * c) (sub_pos.mpr hy),
+      hcomplement] with t hsmall hrest
+  rw [hsplit]
+  linarith
+
+end FiniteEstimate
+
+section OneStepCyclicFunction
+
+variable {N : ℕ} [NeZero N]
+
+/-- The denominator of Yamagami's `f_{N,m,s}` for the case `l = 1`, with
+the forward cyclic window used in the paper. -/
+def fnmsDenominator (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (i : ZMod N) : ℝ :=
+  (s - (m : ℝ)) * x i + ∑ k ∈ Finset.Icc 1 m, x (i + (k : ZMod N))
+
+/-- One summand of Yamagami's `f_{N,m,s}`. -/
+noncomputable def fnmsTerm (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (i : ZMod N) : ℝ :=
+  x i / fnmsDenominator m s x i
+
+/-- Yamagami's `f_{N,m,s}` for the case `l = 1`.  Division is Lean's
+totalized real division, so a boundary term `0 / 0` has value zero. -/
+noncomputable def fnms (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) : ℝ :=
+  ∑ i, fnmsTerm m s x i
+
+/-- The `m` terms immediately preceding the first positive coordinate after
+the zero run singled out in Yamagami's singular-boundary argument. -/
+def precedingIndices (m : ℕ) (j : ZMod N) : Finset (ZMod N) :=
+  (Finset.Icc 1 m).image fun k : ℕ ↦ j - (k : ZMod N)
+
+/-- The exact zero-run witness noted in Yamagami's omitted
+multiple-singularity sentence: `a_j > 0` and
+`a_{j-m-1} = ... = a_{j-1} = 0`. -/
+def HasSingularRun (m : ℕ) (a : ZMod N → ℝ) (j : ZMod N) : Prop :=
+  0 < a j ∧ ∀ k ∈ Finset.Icc 1 (m + 1), a (j - (k : ZMod N)) = 0
+
+/-- Starting from a zero forward window, choose the first positive coordinate
+encountered after that window.  The preceding `m + 1` coordinates are zero.
+This is the finite cyclic first-positive step used in Yamagami's
+singular-boundary paragraph; it does not choose or decompose maximal zero
+blocks. -/
+theorem exists_hasSingularRun_of_zero_window
+    (m : ℕ) (a : ZMod N → ℝ) (i : ZMod N)
+    (ha : ∀ q, 0 ≤ a q) (hpos : ∃ q, 0 < a q)
+    (hwindow : ∀ k ∈ Finset.Icc 0 m, a (i + (k : ZMod N)) = 0) :
+    ∃ j, HasSingularRun m a j := by
+  have hex : ∃ r : ℕ, 0 < a (i + ((m + 1 + r : ℕ) : ZMod N)) := by
+    obtain ⟨q, hq⟩ := hpos
+    let b : ZMod N := i + ((m + 1 : ℕ) : ZMod N)
+    refine ⟨(q - b).val, ?_⟩
+    convert hq using 1
+    dsimp [b]
+    rw [Nat.cast_add, ZMod.natCast_zmod_val]
+    abel_nf
+  let r := Nat.find hex
+  have hrpos : 0 < a (i + ((m + 1 + r : ℕ) : ZMod N)) := Nat.find_spec hex
+  have hrmin : ∀ q < r, ¬ 0 < a (i + ((m + 1 + q : ℕ) : ZMod N)) := by
+    intro q hqr hqpos
+    exact (not_le_of_gt hqr) (Nat.find_min' hex hqpos)
+  refine ⟨i + ((m + 1 + r : ℕ) : ZMod N), hrpos, ?_⟩
+  intro k hk
+  rw [Finset.mem_Icc] at hk
+  by_cases hkr : k ≤ r
+  · have hindex :
+        i + ((m + 1 + r : ℕ) : ZMod N) - (k : ZMod N) =
+          i + ((m + 1 + (r - k) : ℕ) : ZMod N) := by
+      have hnat : m + 1 + r = (m + 1 + (r - k)) + k := by omega
+      rw [hnat, Nat.cast_add]
+      abel_nf
+    rw [hindex]
+    apply le_antisymm
+    · exact le_of_not_gt (hrmin (r - k) (by omega))
+    · exact ha _
+  · have hindex :
+        i + ((m + 1 + r : ℕ) : ZMod N) - (k : ZMod N) =
+          i + (((m + 1 + r) - k : ℕ) : ZMod N) := by
+      have hnat : m + 1 + r = (m + 1 + r - k) + k := by omega
+      conv_lhs => rw [hnat, Nat.cast_add]
+      abel_nf
+    rw [hindex]
+    apply hwindow
+    rw [Finset.mem_Icc]
+    omega
+
+omit [NeZero N] in
+/-- Before the cyclic indices wrap, the preceding set has exactly `m`
+members.  This is the combinatorial count in the `l = 1` proof. -/
+theorem card_precedingIndices (m : ℕ) (j : ZMod N) (hmN : m < N) :
+    (precedingIndices m j).card = m := by
+  unfold precedingIndices
+  rw [Finset.card_image_iff.mpr]
+  · simp
+  · intro a ha b hb hab
+    have hcast : (a : ZMod N) = (b : ZMod N) := sub_right_inj.mp hab
+    have haN : a < N := lt_of_le_of_lt (Finset.mem_Icc.mp ha).2 hmN
+    have hbN : b < N := lt_of_le_of_lt (Finset.mem_Icc.mp hb).2 hmN
+    have hval := congrArg ZMod.val hcast
+    simpa [ZMod.val_natCast_of_lt haN, ZMod.val_natCast_of_lt hbN] using hval
+
+omit [NeZero N] in
+/-- Every one of the `m` preceding indices has zero boundary numerator, and
+its forward denominator window contains the positive coordinate `j`. -/
+theorem precedingIndices_zero_and_reaches
+    (m : ℕ) (a : ZMod N → ℝ) (j i : ZMod N) (hrun : HasSingularRun m a j)
+    (hi : i ∈ precedingIndices m j) :
+    a i = 0 ∧ ∃ k ∈ Finset.Icc 1 m, i + (k : ZMod N) = j := by
+  rw [precedingIndices, Finset.mem_image] at hi
+  obtain ⟨k, hk, rfl⟩ := hi
+  constructor
+  · apply hrun.2 k
+    rw [Finset.mem_Icc] at hk ⊢
+    omega
+  · exact ⟨k, hk, by abel_nf⟩
+
+omit [NeZero N] in
+/-- At each of the `m` preceding indices, the limiting denominator is
+strictly positive because its forward window contains `a_j > 0`. -/
+theorem fnmsDenominator_pos_of_mem_preceding
+    (m : ℕ) (s : ℝ) (a : ZMod N → ℝ) (j i : ZMod N)
+    (ha : ∀ q, 0 ≤ a q) (hrun : HasSingularRun m a j)
+    (hi : i ∈ precedingIndices m j) :
+    0 < fnmsDenominator m s a i := by
+  obtain ⟨hizero, k, hk, hik⟩ := precedingIndices_zero_and_reaches m a j i hrun hi
+  rw [fnmsDenominator, hizero, mul_zero, zero_add]
+  have hsingle : a j ≤ ∑ q ∈ Finset.Icc 1 m, a (i + (q : ZMod N)) := by
+    rw [← hik]
+    exact Finset.single_le_sum (s := Finset.Icc 1 m)
+      (f := fun q : ℕ ↦ a (i + (q : ZMod N)))
+      (fun q _ ↦ ha (i + (q : ZMod N))) hk
+  exact hrun.1.trans_le hsingle
+
+omit [NeZero N] in
+/-- The cyclic denominator is continuous under coordinatewise convergence. -/
+theorem tendsto_fnmsDenominator
+    {α : Type*} {l : Filter α} (m : ℕ) (s : ℝ)
+    (x : α → ZMod N → ℝ) (a : ZMod N → ℝ)
+    (hx : Tendsto x l (𝓝 a)) (i : ZMod N) :
+    Tendsto (fun t ↦ fnmsDenominator m s (x t) i) l
+      (𝓝 (fnmsDenominator m s a i)) := by
+  unfold fnmsDenominator
+  exact (tendsto_const_nhds.mul ((tendsto_pi_nhds.1 hx) i)).add
+    (tendsto_finsetSum (Finset.Icc 1 m) fun k _ ↦
+      (tendsto_pi_nhds.1 hx) (i + (k : ZMod N)))
+
+omit [NeZero N] in
+/-- A nonsingular cyclic summand is continuous under coordinatewise
+convergence. -/
+theorem tendsto_fnmsTerm_of_denominator_ne
+    {α : Type*} {l : Filter α} (m : ℕ) (s : ℝ)
+    (x : α → ZMod N → ℝ) (a : ZMod N → ℝ)
+    (hx : Tendsto x l (𝓝 a)) (i : ZMod N)
+    (hi : fnmsDenominator m s a i ≠ 0) :
+    Tendsto (fun t ↦ fnmsTerm m s (x t) i) l (𝓝 (fnmsTerm m s a i)) := by
+  have hquot :=
+    (tendsto_pi_nhds.1 hx i).div (tendsto_fnmsDenominator m s x a hx i) hi
+  refine Tendsto.congr' ?_ hquot
+  exact Eventually.of_forall fun _ ↦ rfl
+
+omit [NeZero N] in
+/-- The `m` source-designated summands tend to zero along any approximating
+filter.  Their numerators tend to zero and their limiting denominators contain
+the fixed positive coordinate `a_j`. -/
+theorem tendsto_fnmsTerm_zero_of_mem_preceding
+    {α : Type*} {l : Filter α} (m : ℕ) (s : ℝ)
+    (x : α → ZMod N → ℝ) (a : ZMod N → ℝ) (j i : ZMod N)
+    (hx : Tendsto x l (𝓝 a)) (ha : ∀ q, 0 ≤ a q)
+    (hrun : HasSingularRun m a j) (hi : i ∈ precedingIndices m j) :
+    Tendsto (fun t ↦ fnmsTerm m s (x t) i) l (𝓝 0) := by
+  have hizero := (precedingIndices_zero_and_reaches m a j i hrun hi).1
+  have hdenom := fnmsDenominator_pos_of_mem_preceding m s a j i ha hrun hi
+  have hquot :=
+    (tendsto_pi_nhds.1 hx i).div (tendsto_fnmsDenominator m s x a hx i) hdenom.ne'
+  have hquotZero : Tendsto
+      ((fun t ↦ x t i) / fun t ↦ fnmsDenominator m s (x t) i) l (𝓝 0) := by
+    simpa [hizero] using hquot
+  refine Tendsto.congr' ?_ hquotZero
+  exact Eventually.of_forall fun _ ↦ rfl
+
+omit [NeZero N] in
+/-- On the strictly positive cone, every summand is nonnegative and is at
+most the common source coefficient `1 / (s - m)`. -/
+theorem fnmsTerm_nonneg_and_le
+    (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (hs : (m : ℝ) < s)
+    (hx : ∀ q, 0 < x q) (i : ZMod N) :
+    0 ≤ fnmsTerm m s x i ∧ fnmsTerm m s x i ≤ 1 / (s - (m : ℝ)) := by
+  have hc : 0 < s - (m : ℝ) := sub_pos.mpr hs
+  have hsum : 0 ≤ ∑ k ∈ Finset.Icc 1 m, x (i + (k : ZMod N)) :=
+    Finset.sum_nonneg fun k _ ↦ (hx (i + (k : ZMod N))).le
+  have hdenom : 0 < fnmsDenominator m s x i := by
+    unfold fnmsDenominator
+    exact add_pos_of_pos_of_nonneg (mul_pos hc (hx i)) hsum
+  constructor
+  · exact div_nonneg (hx i).le hdenom.le
+  · have hbase : (s - (m : ℝ)) * x i ≤ fnmsDenominator m s x i := by
+      unfold fnmsDenominator
+      exact le_add_of_nonneg_right hsum
+    calc
+      fnmsTerm m s x i = x i / fnmsDenominator m s x i := rfl
+      _ ≤ x i / ((s - (m : ℝ)) * x i) :=
+        div_le_div_of_nonneg_left (hx i).le (mul_pos hc (hx i)) hbase
+      _ = 1 / (s - (m : ℝ)) := by
+        field_simp [hc.ne', (hx i).ne']
+
+omit [NeZero N] in
+/-- With nonnegative coordinates and `s > m`, a zero cyclic denominator has
+zero numerator.  Hence its totalized boundary summand is `0 / 0 = 0`. -/
+theorem eq_zero_of_fnmsDenominator_eq_zero
+    (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (hs : (m : ℝ) < s)
+    (hx : ∀ q, 0 ≤ x q) (i : ZMod N)
+    (hi : fnmsDenominator m s x i = 0) : x i = 0 := by
+  by_contra hxi
+  have hxipos : 0 < x i := lt_of_le_of_ne (hx i) (Ne.symm hxi)
+  have hsum : 0 ≤ ∑ k ∈ Finset.Icc 1 m, x (i + (k : ZMod N)) :=
+    Finset.sum_nonneg fun k _ ↦ hx (i + (k : ZMod N))
+  have hdenom : 0 < fnmsDenominator m s x i := by
+    unfold fnmsDenominator
+    exact add_pos_of_pos_of_nonneg (mul_pos (sub_pos.mpr hs) hxipos) hsum
+  exact hdenom.ne' hi
+
+omit [NeZero N] in
+/-- A singular denominator is exactly a zero numerator followed by `m` zero
+coordinates.  This records the `m + 1` consecutive zeros from which
+Yamagami begins the singular-boundary count. -/
+theorem fnmsDenominator_eq_zero_iff
+    (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (hs : (m : ℝ) < s)
+    (hx : ∀ q, 0 ≤ x q) (i : ZMod N) :
+    fnmsDenominator m s x i = 0 ↔
+      x i = 0 ∧ ∀ k ∈ Finset.Icc 1 m, x (i + (k : ZMod N)) = 0 := by
+  constructor
+  · intro hi
+    have hxi := eq_zero_of_fnmsDenominator_eq_zero m s x hs hx i hi
+    refine ⟨hxi, ?_⟩
+    have hsum : (∑ k ∈ Finset.Icc 1 m, x (i + (k : ZMod N))) = 0 := by
+      simpa [fnmsDenominator, hxi] using hi
+    exact (Finset.sum_eq_zero_iff_of_nonneg
+      (s := Finset.Icc 1 m) (f := fun k : ℕ ↦ x (i + (k : ZMod N)))
+      (fun k _ ↦ hx (i + (k : ZMod N)))).mp hsum
+  · rintro ⟨hxi, hwindow⟩
+    rw [fnmsDenominator, hxi, mul_zero, zero_add]
+    exact Finset.sum_eq_zero hwindow
+
+/-- A singular denominator in a nonzero nonnegative vector supplies the
+zero run singled out in Yamagami's simultaneous-singularity sentence.  The
+positive endpoint is the first positive coordinate encountered after the
+denominator's zero forward window. -/
+theorem exists_hasSingularRun_of_fnmsDenominator_eq_zero
+    (m : ℕ) (s : ℝ) (a : ZMod N → ℝ) (i : ZMod N)
+    (hs : (m : ℝ) < s) (ha : ∀ q, 0 ≤ a q) (hne : a ≠ 0)
+    (hi : fnmsDenominator m s a i = 0) :
+    ∃ j, HasSingularRun m a j := by
+  apply exists_hasSingularRun_of_zero_window m a i ha
+  · by_contra hpos
+    apply hne
+    funext q
+    apply le_antisymm
+    · exact not_lt.mp (fun hq ↦ hpos ⟨q, hq⟩)
+    · exact ha q
+  · obtain ⟨hai, hforward⟩ :=
+      (fnmsDenominator_eq_zero_iff m s a hs ha i).mp hi
+    intro k hk
+    rw [Finset.mem_Icc] at hk
+    by_cases hk0 : k = 0
+    · simpa [hk0] using hai
+    · exact hforward k (Finset.mem_Icc.mpr ⟨Nat.one_le_iff_ne_zero.mpr hk0, hk.2⟩)
+
+/-- Yamagami's omitted simultaneous-singularity estimate for `l = 1`.
+The one source-designated zero run supplies all `m` vanishing summands at
+once, and the complement has `N - m` terms. -/
+theorem limsup_fnms_le_sub_ratio_of_singularRun
+    {α : Type*} {l : Filter α} [NeBot l]
+    (m : ℕ) (s : ℝ) (x : α → ZMod N → ℝ) (a : ZMod N → ℝ) (j : ZMod N)
+    (hmN : m < N) (hs : (m : ℝ) < s)
+    (hx : Tendsto x l (𝓝 a)) (hxpos : ∀ᶠ t in l, ∀ i, 0 < x t i)
+    (ha : ∀ i, 0 ≤ a i) (hrun : HasSingularRun m a j) :
+    limsup (fun t ↦ fnms m s (x t)) l ≤
+      ((N - m : ℕ) : ℝ) / (s - (m : ℝ)) := by
+  have hcard : (Finset.univ \ precedingIndices m j).card = N - m := by
+    rw [Finset.card_sdiff_of_subset (precedingIndices m j).subset_univ, Finset.card_univ,
+      ZMod.card, card_precedingIndices m j hmN]
+  have hlim := limsup_sum_le_card_mul_of_tendsto_zero_on
+    (u := fun t i ↦ fnmsTerm m s (x t) i) (V := precedingIndices m j)
+    (c := 1 / (s - (m : ℝ)))
+    (fun i hi ↦ tendsto_fnmsTerm_zero_of_mem_preceding m s x a j i hx ha hrun hi)
+    (hxpos.mono fun t ht i ↦ (fnmsTerm_nonneg_and_le m s (x t) hs ht i).1)
+    (hxpos.mono fun t ht i _ ↦ (fnmsTerm_nonneg_and_le m s (x t) hs ht i).2)
+  simpa [fnms, hcard, div_eq_mul_inv] using hlim
+
+/-- Yamagami's singular-boundary estimate stated from the boundary condition
+itself: at least one denominator vanishes in a nonzero nonnegative vector.
+The first-positive lemma constructs the source-designated zero run, after
+which the global `N - m` count applies. -/
+theorem limsup_fnms_le_sub_ratio_of_singularDenominator
+    {α : Type*} {l : Filter α} [NeBot l]
+    (m : ℕ) (s : ℝ) (x : α → ZMod N → ℝ) (a : ZMod N → ℝ)
+    (hmN : m < N) (hs : (m : ℝ) < s)
+    (hx : Tendsto x l (𝓝 a)) (hxpos : ∀ᶠ t in l, ∀ i, 0 < x t i)
+    (ha : ∀ i, 0 ≤ a i) (hne : a ≠ 0)
+    (hsingular : ∃ i, fnmsDenominator m s a i = 0) :
+    limsup (fun t ↦ fnms m s (x t)) l ≤
+      ((N - m : ℕ) : ℝ) / (s - (m : ℝ)) := by
+  obtain ⟨i, hi⟩ := hsingular
+  obtain ⟨j, hrun⟩ :=
+    exists_hasSingularRun_of_fnmsDenominator_eq_zero m s a i hs ha hne hi
+  exact limsup_fnms_le_sub_ratio_of_singularRun m s x a j hmN hs hx hxpos ha hrun
+
+omit [NeZero N] in
+/-- The elementary comparison displayed by Yamagami:
+`(N - m) / (s - m) ≤ N / s` when `N ≤ s`. -/
+theorem sub_ratio_le_card_ratio
+    (m N : ℕ) (s : ℝ) (hmN : m < N) (hs : (m : ℝ) < s)
+    (hNs : (N : ℝ) ≤ s) :
+    ((N - m : ℕ) : ℝ) / (s - (m : ℝ)) ≤ (N : ℝ) / s := by
+  have hc : 0 < s - (m : ℝ) := sub_pos.mpr hs
+  have hspos : 0 < s := lt_of_le_of_lt (Nat.cast_nonneg m) hs
+  rw [div_le_div_iff₀ hc hspos, Nat.cast_sub (Nat.le_of_lt hmN)]
+  nlinarith [(Nat.cast_nonneg m : (0 : ℝ) ≤ (m : ℝ))]
+
+/-- The singular-boundary limsup is at most the interior value `N / s`.
+This is equation (5) of Yamagami's proof, with the suppressed simultaneous
+`0 / 0` case supplied by `limsup_fnms_le_sub_ratio_of_singularRun`. -/
+theorem limsup_fnms_le_card_ratio_of_singularRun
+    {α : Type*} {l : Filter α} [NeBot l]
+    (m : ℕ) (s : ℝ) (x : α → ZMod N → ℝ) (a : ZMod N → ℝ) (j : ZMod N)
+    (hmN : m < N) (hs : (m : ℝ) < s) (hNs : (N : ℝ) ≤ s)
+    (hx : Tendsto x l (𝓝 a)) (hxpos : ∀ᶠ t in l, ∀ i, 0 < x t i)
+    (ha : ∀ i, 0 ≤ a i) (hrun : HasSingularRun m a j) :
+    limsup (fun t ↦ fnms m s (x t)) l ≤ (N : ℝ) / s :=
+  (limsup_fnms_le_sub_ratio_of_singularRun m s x a j hmN hs hx hxpos ha hrun).trans
+    (sub_ratio_le_card_ratio m N s hmN hs hNs)
+
+/-- Equation (5) in Yamagami's singular-boundary case, including the
+suppressed possibility of several vanishing denominators.  No zero-block
+decomposition is used: one singular denominator and the first positive
+coordinate after its window provide all `m` vanishing summands. -/
+theorem limsup_fnms_le_card_ratio_of_singularDenominator
+    {α : Type*} {l : Filter α} [NeBot l]
+    (m : ℕ) (s : ℝ) (x : α → ZMod N → ℝ) (a : ZMod N → ℝ)
+    (hmN : m < N) (hs : (m : ℝ) < s) (hNs : (N : ℝ) ≤ s)
+    (hx : Tendsto x l (𝓝 a)) (hxpos : ∀ᶠ t in l, ∀ i, 0 < x t i)
+    (ha : ∀ i, 0 ≤ a i) (hne : a ≠ 0)
+    (hsingular : ∃ i, fnmsDenominator m s a i = 0) :
+    limsup (fun t ↦ fnms m s (x t)) l ≤ (N : ℝ) / s :=
+  (limsup_fnms_le_sub_ratio_of_singularDenominator
+    m s x a hmN hs hx hxpos ha hne hsingular).trans
+      (sub_ratio_le_card_ratio m N s hmN hs hNs)
+
+/-- Conditional passage from an already established strictly positive
+inequality to the repository's direct nonnegative value.  The proof uses the
+uniform perturbation `x_i + 1 / (n + 1)`.  Nonsingular summands converge to
+their boundary values, while the omitted singular summands are nonnegative;
+Lean's totalized value of each omitted `0 / 0` term is zero.
+
+This theorem does not prove the strictly positive inequality supplied as
+`hpositive`. -/
+theorem fnms_le_of_strictlyPositive
+    (m : ℕ) (s B : ℝ) (x : ZMod N → ℝ) (hs : (m : ℝ) < s)
+    (hx : ∀ i, 0 ≤ x i)
+    (hpositive : ∀ y : ZMod N → ℝ, (∀ i, 0 < y i) → fnms m s y ≤ B) :
+    fnms m s x ≤ B := by
+  classical
+  let R : Finset (ZMod N) :=
+    Finset.univ.filter fun i ↦ fnmsDenominator m s x i ≠ 0
+  have hregular : fnms m s x = ∑ i ∈ R, fnmsTerm m s x i := by
+    rw [fnms, Finset.sum_subset (Finset.subset_univ R)]
+    intro i _ hi
+    have hdenom : fnmsDenominator m s x i = 0 := by
+      simp only [R, Finset.mem_filter, Finset.mem_univ, true_and] at hi
+      exact not_ne_iff.mp hi
+    have hxi := eq_zero_of_fnmsDenominator_eq_zero m s x hs hx i hdenom
+    simp [fnmsTerm, hxi, hdenom]
+  let y : ℕ → ZMod N → ℝ := fun n i ↦ x i + 1 / ((n : ℝ) + 1)
+  have hypos : ∀ n i, 0 < y n i := by
+    intro n i
+    exact add_pos_of_nonneg_of_pos (hx i) (one_div_pos.mpr (by positivity))
+  have hytend : Tendsto y atTop (𝓝 x) := by
+    apply tendsto_pi_nhds.2
+    intro i
+    simpa [y] using
+      tendsto_const_nhds.add (tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ))
+  have hregularTend :
+      Tendsto (fun n ↦ ∑ i ∈ R, fnmsTerm m s (y n) i) atTop (𝓝 (fnms m s x)) := by
+    rw [hregular]
+    exact tendsto_finsetSum R fun i hi ↦
+      tendsto_fnmsTerm_of_denominator_ne m s y x hytend i (Finset.mem_filter.mp hi).2
+  have hregular_le : ∀ n, (∑ i ∈ R, fnmsTerm m s (y n) i) ≤ B := by
+    intro n
+    have hsubset : (∑ i ∈ R, fnmsTerm m s (y n) i) ≤ fnms m s (y n) := by
+      rw [fnms]
+      exact Finset.sum_le_sum_of_subset_of_nonneg R.subset_univ fun i _ _ ↦
+        (fnmsTerm_nonneg_and_le m s (y n) hs (hypos n) i).1
+    exact hsubset.trans (hpositive (y n) (hypos n))
+  exact le_of_tendsto' hregularTend hregular_le
+
+/-- The direct `0 / 0 = 0` nonnegative cyclic inequality, conditional only
+on the corresponding strictly positive inequality. -/
+theorem fnms_le_card_ratio_of_strictlyPositive
+    (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (hs : (m : ℝ) < s)
+    (hx : ∀ i, 0 ≤ x i)
+    (hpositive : ∀ y : ZMod N → ℝ, (∀ i, 0 < y i) →
+      fnms m s y ≤ (N : ℝ) / s) :
+    fnms m s x ≤ (N : ℝ) / s :=
+  fnms_le_of_strictlyPositive m s ((N : ℝ) / s) x hs hx hpositive
+
+end OneStepCyclicFunction
+
+end Yamagami

--- a/QICLean/Analysis/YamagamiBoundary.lean
+++ b/QICLean/Analysis/YamagamiBoundary.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 QICLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: QICLean contributors
 -/
+import QICLean.Analysis.CyclicReciprocal
 import Mathlib.Analysis.SpecificLimits.Basic
-import Mathlib.Data.ZMod.Basic
 import Mathlib.Order.LiminfLimsup
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.FieldSimp
@@ -97,19 +97,23 @@ section OneStepCyclicFunction
 
 variable {N : ℕ} [NeZero N]
 
-/-- The denominator of Yamagami's `f_{N,m,s}` for the case `l = 1`, with
-the forward cyclic window used in the paper. -/
-def fnmsDenominator (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (i : ZMod N) : ℝ :=
-  (s - (m : ℝ)) * x i + ∑ k ∈ Finset.Icc 1 m, x (i + (k : ZMod N))
-
-/-- One summand of Yamagami's `f_{N,m,s}`. -/
-noncomputable def fnmsTerm (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (i : ZMod N) : ℝ :=
-  x i / fnmsDenominator m s x i
-
-/-- Yamagami's `f_{N,m,s}` for the case `l = 1`.  Division is Lean's
-totalized real division, so a boundary term `0 / 0` has value zero. -/
-noncomputable def fnms (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) : ℝ :=
-  ∑ i, fnmsTerm m s x i
+omit [NeZero N] in
+private theorem forwardDenominator_eq_Icc
+    (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (i : ZMod N) :
+    forwardDenominator N m s x i =
+      (s - (m : ℝ)) * x i + ∑ k ∈ Finset.Icc 1 m, x (i + (k : ZMod N)) := by
+  unfold forwardDenominator
+  congr 1
+  change (∑ k : Fin m, (fun q : ℕ ↦ x (i + ((q + 1 : ℕ) : ZMod N))) k) = _
+  rw [Fin.sum_univ_eq_sum_range (fun q : ℕ ↦ x (i + ((q + 1 : ℕ) : ZMod N))) m,
+    ← Nat.Ico_zero_eq_range,
+    Finset.sum_Ico_add' (fun k : ℕ ↦ x (i + (k : ZMod N))) 0 m 1]
+  apply Finset.sum_congr
+  · ext k
+    simp only [Finset.mem_Ico, Finset.mem_Icc]
+    omega
+  · intro k _
+    rfl
 
 /-- The `m` terms immediately preceding the first positive coordinate after
 the zero run singled out in Yamagami's singular-boundary argument. -/
@@ -203,13 +207,13 @@ theorem precedingIndices_zero_and_reaches
 omit [NeZero N] in
 /-- At each of the `m` preceding indices, the limiting denominator is
 strictly positive because its forward window contains `a_j > 0`. -/
-theorem fnmsDenominator_pos_of_mem_preceding
+theorem forwardDenominator_pos_of_mem_preceding
     (m : ℕ) (s : ℝ) (a : ZMod N → ℝ) (j i : ZMod N)
     (ha : ∀ q, 0 ≤ a q) (hrun : HasSingularRun m a j)
     (hi : i ∈ precedingIndices m j) :
-    0 < fnmsDenominator m s a i := by
+    0 < forwardDenominator N m s a i := by
   obtain ⟨hizero, k, hk, hik⟩ := precedingIndices_zero_and_reaches m a j i hrun hi
-  rw [fnmsDenominator, hizero, mul_zero, zero_add]
+  rw [forwardDenominator_eq_Icc, hizero, mul_zero, zero_add]
   have hsingle : a j ≤ ∑ q ∈ Finset.Icc 1 m, a (i + (q : ZMod N)) := by
     rw [← hik]
     exact Finset.single_le_sum (s := Finset.Icc 1 m)
@@ -219,47 +223,45 @@ theorem fnmsDenominator_pos_of_mem_preceding
 
 omit [NeZero N] in
 /-- The cyclic denominator is continuous under coordinatewise convergence. -/
-theorem tendsto_fnmsDenominator
+theorem tendsto_forwardDenominator
     {α : Type*} {l : Filter α} (m : ℕ) (s : ℝ)
     (x : α → ZMod N → ℝ) (a : ZMod N → ℝ)
     (hx : Tendsto x l (𝓝 a)) (i : ZMod N) :
-    Tendsto (fun t ↦ fnmsDenominator m s (x t) i) l
-      (𝓝 (fnmsDenominator m s a i)) := by
-  unfold fnmsDenominator
+    Tendsto (fun t ↦ forwardDenominator N m s (x t) i) l
+      (𝓝 (forwardDenominator N m s a i)) := by
+  unfold forwardDenominator
   exact (tendsto_const_nhds.mul ((tendsto_pi_nhds.1 hx) i)).add
-    (tendsto_finsetSum (Finset.Icc 1 m) fun k _ ↦
-      (tendsto_pi_nhds.1 hx) (i + (k : ZMod N)))
+    (tendsto_finsetSum Finset.univ fun k _ ↦
+      (tendsto_pi_nhds.1 hx) (i + ((k.1 + 1 : ℕ) : ZMod N)))
 
 omit [NeZero N] in
 /-- A nonsingular cyclic summand is continuous under coordinatewise
 convergence. -/
-theorem tendsto_fnmsTerm_of_denominator_ne
+theorem tendsto_summand_of_denominator_ne
     {α : Type*} {l : Filter α} (m : ℕ) (s : ℝ)
     (x : α → ZMod N → ℝ) (a : ZMod N → ℝ)
     (hx : Tendsto x l (𝓝 a)) (i : ZMod N)
-    (hi : fnmsDenominator m s a i ≠ 0) :
-    Tendsto (fun t ↦ fnmsTerm m s (x t) i) l (𝓝 (fnmsTerm m s a i)) := by
-  have hquot :=
-    (tendsto_pi_nhds.1 hx i).div (tendsto_fnmsDenominator m s x a hx i) hi
-  refine Tendsto.congr' ?_ hquot
-  exact Eventually.of_forall fun _ ↦ rfl
+    (hi : forwardDenominator N m s a i ≠ 0) :
+    Tendsto (fun t ↦ x t i / forwardDenominator N m s (x t) i) l
+      (𝓝 (a i / forwardDenominator N m s a i)) :=
+  (tendsto_pi_nhds.1 hx i).div (tendsto_forwardDenominator m s x a hx i) hi
 
 omit [NeZero N] in
 /-- The `m` source-designated summands tend to zero along any approximating
 filter.  Their numerators tend to zero and their limiting denominators contain
 the fixed positive coordinate `a_j`. -/
-theorem tendsto_fnmsTerm_zero_of_mem_preceding
+theorem tendsto_summand_zero_of_mem_preceding
     {α : Type*} {l : Filter α} (m : ℕ) (s : ℝ)
     (x : α → ZMod N → ℝ) (a : ZMod N → ℝ) (j i : ZMod N)
     (hx : Tendsto x l (𝓝 a)) (ha : ∀ q, 0 ≤ a q)
     (hrun : HasSingularRun m a j) (hi : i ∈ precedingIndices m j) :
-    Tendsto (fun t ↦ fnmsTerm m s (x t) i) l (𝓝 0) := by
+    Tendsto (fun t ↦ x t i / forwardDenominator N m s (x t) i) l (𝓝 0) := by
   have hizero := (precedingIndices_zero_and_reaches m a j i hrun hi).1
-  have hdenom := fnmsDenominator_pos_of_mem_preceding m s a j i ha hrun hi
+  have hdenom := forwardDenominator_pos_of_mem_preceding m s a j i ha hrun hi
   have hquot :=
-    (tendsto_pi_nhds.1 hx i).div (tendsto_fnmsDenominator m s x a hx i) hdenom.ne'
+    (tendsto_pi_nhds.1 hx i).div (tendsto_forwardDenominator m s x a hx i) hdenom.ne'
   have hquotZero : Tendsto
-      ((fun t ↦ x t i) / fun t ↦ fnmsDenominator m s (x t) i) l (𝓝 0) := by
+      ((fun t ↦ x t i) / fun t ↦ forwardDenominator N m s (x t) i) l (𝓝 0) := by
     simpa [hizero] using hquot
   refine Tendsto.congr' ?_ hquotZero
   exact Eventually.of_forall fun _ ↦ rfl
@@ -267,24 +269,24 @@ theorem tendsto_fnmsTerm_zero_of_mem_preceding
 omit [NeZero N] in
 /-- On the strictly positive cone, every summand is nonnegative and is at
 most the common source coefficient `1 / (s - m)`. -/
-theorem fnmsTerm_nonneg_and_le
+theorem summand_nonneg_and_le
     (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (hs : (m : ℝ) < s)
     (hx : ∀ q, 0 < x q) (i : ZMod N) :
-    0 ≤ fnmsTerm m s x i ∧ fnmsTerm m s x i ≤ 1 / (s - (m : ℝ)) := by
+    0 ≤ x i / forwardDenominator N m s x i ∧
+      x i / forwardDenominator N m s x i ≤ 1 / (s - (m : ℝ)) := by
   have hc : 0 < s - (m : ℝ) := sub_pos.mpr hs
   have hsum : 0 ≤ ∑ k ∈ Finset.Icc 1 m, x (i + (k : ZMod N)) :=
     Finset.sum_nonneg fun k _ ↦ (hx (i + (k : ZMod N))).le
-  have hdenom : 0 < fnmsDenominator m s x i := by
-    unfold fnmsDenominator
+  have hdenom : 0 < forwardDenominator N m s x i := by
+    rw [forwardDenominator_eq_Icc]
     exact add_pos_of_pos_of_nonneg (mul_pos hc (hx i)) hsum
   constructor
   · exact div_nonneg (hx i).le hdenom.le
-  · have hbase : (s - (m : ℝ)) * x i ≤ fnmsDenominator m s x i := by
-      unfold fnmsDenominator
+  · have hbase : (s - (m : ℝ)) * x i ≤ forwardDenominator N m s x i := by
+      rw [forwardDenominator_eq_Icc]
       exact le_add_of_nonneg_right hsum
     calc
-      fnmsTerm m s x i = x i / fnmsDenominator m s x i := rfl
-      _ ≤ x i / ((s - (m : ℝ)) * x i) :=
+      x i / forwardDenominator N m s x i ≤ x i / ((s - (m : ℝ)) * x i) :=
         div_le_div_of_nonneg_left (hx i).le (mul_pos hc (hx i)) hbase
       _ = 1 / (s - (m : ℝ)) := by
         field_simp [hc.ne', (hx i).ne']
@@ -292,16 +294,16 @@ theorem fnmsTerm_nonneg_and_le
 omit [NeZero N] in
 /-- With nonnegative coordinates and `s > m`, a zero cyclic denominator has
 zero numerator.  Hence its totalized boundary summand is `0 / 0 = 0`. -/
-theorem eq_zero_of_fnmsDenominator_eq_zero
+theorem eq_zero_of_forwardDenominator_eq_zero
     (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (hs : (m : ℝ) < s)
     (hx : ∀ q, 0 ≤ x q) (i : ZMod N)
-    (hi : fnmsDenominator m s x i = 0) : x i = 0 := by
+    (hi : forwardDenominator N m s x i = 0) : x i = 0 := by
   by_contra hxi
   have hxipos : 0 < x i := lt_of_le_of_ne (hx i) (Ne.symm hxi)
   have hsum : 0 ≤ ∑ k ∈ Finset.Icc 1 m, x (i + (k : ZMod N)) :=
     Finset.sum_nonneg fun k _ ↦ hx (i + (k : ZMod N))
-  have hdenom : 0 < fnmsDenominator m s x i := by
-    unfold fnmsDenominator
+  have hdenom : 0 < forwardDenominator N m s x i := by
+    rw [forwardDenominator_eq_Icc]
     exact add_pos_of_pos_of_nonneg (mul_pos (sub_pos.mpr hs) hxipos) hsum
   exact hdenom.ne' hi
 
@@ -309,32 +311,32 @@ omit [NeZero N] in
 /-- A singular denominator is exactly a zero numerator followed by `m` zero
 coordinates.  This records the `m + 1` consecutive zeros from which
 Yamagami begins the singular-boundary count. -/
-theorem fnmsDenominator_eq_zero_iff
+theorem forwardDenominator_eq_zero_iff
     (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (hs : (m : ℝ) < s)
     (hx : ∀ q, 0 ≤ x q) (i : ZMod N) :
-    fnmsDenominator m s x i = 0 ↔
+    forwardDenominator N m s x i = 0 ↔
       x i = 0 ∧ ∀ k ∈ Finset.Icc 1 m, x (i + (k : ZMod N)) = 0 := by
   constructor
   · intro hi
-    have hxi := eq_zero_of_fnmsDenominator_eq_zero m s x hs hx i hi
+    have hxi := eq_zero_of_forwardDenominator_eq_zero m s x hs hx i hi
     refine ⟨hxi, ?_⟩
     have hsum : (∑ k ∈ Finset.Icc 1 m, x (i + (k : ZMod N))) = 0 := by
-      simpa [fnmsDenominator, hxi] using hi
+      simpa [forwardDenominator_eq_Icc, hxi] using hi
     exact (Finset.sum_eq_zero_iff_of_nonneg
       (s := Finset.Icc 1 m) (f := fun k : ℕ ↦ x (i + (k : ZMod N)))
       (fun k _ ↦ hx (i + (k : ZMod N)))).mp hsum
   · rintro ⟨hxi, hwindow⟩
-    rw [fnmsDenominator, hxi, mul_zero, zero_add]
+    rw [forwardDenominator_eq_Icc, hxi, mul_zero, zero_add]
     exact Finset.sum_eq_zero hwindow
 
 /-- A singular denominator in a nonzero nonnegative vector supplies the
 zero run singled out in Yamagami's simultaneous-singularity sentence.  The
 positive endpoint is the first positive coordinate encountered after the
 denominator's zero forward window. -/
-theorem exists_hasSingularRun_of_fnmsDenominator_eq_zero
+theorem exists_hasSingularRun_of_forwardDenominator_eq_zero
     (m : ℕ) (s : ℝ) (a : ZMod N → ℝ) (i : ZMod N)
     (hs : (m : ℝ) < s) (ha : ∀ q, 0 ≤ a q) (hne : a ≠ 0)
-    (hi : fnmsDenominator m s a i = 0) :
+    (hi : forwardDenominator N m s a i = 0) :
     ∃ j, HasSingularRun m a j := by
   apply exists_hasSingularRun_of_zero_window m a i ha
   · by_contra hpos
@@ -344,7 +346,7 @@ theorem exists_hasSingularRun_of_fnmsDenominator_eq_zero
     · exact not_lt.mp (fun hq ↦ hpos ⟨q, hq⟩)
     · exact ha q
   · obtain ⟨hai, hforward⟩ :=
-      (fnmsDenominator_eq_zero_iff m s a hs ha i).mp hi
+      (forwardDenominator_eq_zero_iff m s a hs ha i).mp hi
     intro k hk
     rw [Finset.mem_Icc] at hk
     by_cases hk0 : k = 0
@@ -354,42 +356,43 @@ theorem exists_hasSingularRun_of_fnmsDenominator_eq_zero
 /-- Yamagami's omitted simultaneous-singularity estimate for `l = 1`.
 The one source-designated zero run supplies all `m` vanishing summands at
 once, and the complement has `N - m` terms. -/
-theorem limsup_fnms_le_sub_ratio_of_singularRun
+theorem limsup_functional_le_sub_ratio_of_singularRun
     {α : Type*} {l : Filter α} [NeBot l]
     (m : ℕ) (s : ℝ) (x : α → ZMod N → ℝ) (a : ZMod N → ℝ) (j : ZMod N)
     (hmN : m < N) (hs : (m : ℝ) < s)
     (hx : Tendsto x l (𝓝 a)) (hxpos : ∀ᶠ t in l, ∀ i, 0 < x t i)
     (ha : ∀ i, 0 ≤ a i) (hrun : HasSingularRun m a j) :
-    limsup (fun t ↦ fnms m s (x t)) l ≤
+    limsup (fun t ↦ functional N m s (x t)) l ≤
       ((N - m : ℕ) : ℝ) / (s - (m : ℝ)) := by
   have hcard : (Finset.univ \ precedingIndices m j).card = N - m := by
     rw [Finset.card_sdiff_of_subset (precedingIndices m j).subset_univ, Finset.card_univ,
       ZMod.card, card_precedingIndices m j hmN]
   have hlim := limsup_sum_le_card_mul_of_tendsto_zero_on
-    (u := fun t i ↦ fnmsTerm m s (x t) i) (V := precedingIndices m j)
+    (u := fun t i ↦ x t i / forwardDenominator N m s (x t) i)
+    (V := precedingIndices m j)
     (c := 1 / (s - (m : ℝ)))
-    (fun i hi ↦ tendsto_fnmsTerm_zero_of_mem_preceding m s x a j i hx ha hrun hi)
-    (hxpos.mono fun t ht i ↦ (fnmsTerm_nonneg_and_le m s (x t) hs ht i).1)
-    (hxpos.mono fun t ht i _ ↦ (fnmsTerm_nonneg_and_le m s (x t) hs ht i).2)
-  simpa [fnms, hcard, div_eq_mul_inv] using hlim
+    (fun i hi ↦ tendsto_summand_zero_of_mem_preceding m s x a j i hx ha hrun hi)
+    (hxpos.mono fun t ht i ↦ (summand_nonneg_and_le m s (x t) hs ht i).1)
+    (hxpos.mono fun t ht i _ ↦ (summand_nonneg_and_le m s (x t) hs ht i).2)
+  simpa [functional, hcard, div_eq_mul_inv] using hlim
 
 /-- Yamagami's singular-boundary estimate stated from the boundary condition
 itself: at least one denominator vanishes in a nonzero nonnegative vector.
 The first-positive lemma constructs the source-designated zero run, after
 which the global `N - m` count applies. -/
-theorem limsup_fnms_le_sub_ratio_of_singularDenominator
+theorem limsup_functional_le_sub_ratio_of_singularDenominator
     {α : Type*} {l : Filter α} [NeBot l]
     (m : ℕ) (s : ℝ) (x : α → ZMod N → ℝ) (a : ZMod N → ℝ)
     (hmN : m < N) (hs : (m : ℝ) < s)
     (hx : Tendsto x l (𝓝 a)) (hxpos : ∀ᶠ t in l, ∀ i, 0 < x t i)
     (ha : ∀ i, 0 ≤ a i) (hne : a ≠ 0)
-    (hsingular : ∃ i, fnmsDenominator m s a i = 0) :
-    limsup (fun t ↦ fnms m s (x t)) l ≤
+    (hsingular : ∃ i, forwardDenominator N m s a i = 0) :
+    limsup (fun t ↦ functional N m s (x t)) l ≤
       ((N - m : ℕ) : ℝ) / (s - (m : ℝ)) := by
   obtain ⟨i, hi⟩ := hsingular
   obtain ⟨j, hrun⟩ :=
-    exists_hasSingularRun_of_fnmsDenominator_eq_zero m s a i hs ha hne hi
-  exact limsup_fnms_le_sub_ratio_of_singularRun m s x a j hmN hs hx hxpos ha hrun
+    exists_hasSingularRun_of_forwardDenominator_eq_zero m s a i hs ha hne hi
+  exact limsup_functional_le_sub_ratio_of_singularRun m s x a j hmN hs hx hxpos ha hrun
 
 omit [NeZero N] in
 /-- The elementary comparison displayed by Yamagami:
@@ -405,30 +408,30 @@ theorem sub_ratio_le_card_ratio
 
 /-- The singular-boundary limsup is at most the interior value `N / s`.
 This is equation (5) of Yamagami's proof, with the suppressed simultaneous
-`0 / 0` case supplied by `limsup_fnms_le_sub_ratio_of_singularRun`. -/
-theorem limsup_fnms_le_card_ratio_of_singularRun
+`0 / 0` case supplied by `limsup_functional_le_sub_ratio_of_singularRun`. -/
+theorem limsup_functional_le_card_ratio_of_singularRun
     {α : Type*} {l : Filter α} [NeBot l]
     (m : ℕ) (s : ℝ) (x : α → ZMod N → ℝ) (a : ZMod N → ℝ) (j : ZMod N)
     (hmN : m < N) (hs : (m : ℝ) < s) (hNs : (N : ℝ) ≤ s)
     (hx : Tendsto x l (𝓝 a)) (hxpos : ∀ᶠ t in l, ∀ i, 0 < x t i)
     (ha : ∀ i, 0 ≤ a i) (hrun : HasSingularRun m a j) :
-    limsup (fun t ↦ fnms m s (x t)) l ≤ (N : ℝ) / s :=
-  (limsup_fnms_le_sub_ratio_of_singularRun m s x a j hmN hs hx hxpos ha hrun).trans
+    limsup (fun t ↦ functional N m s (x t)) l ≤ (N : ℝ) / s :=
+  (limsup_functional_le_sub_ratio_of_singularRun m s x a j hmN hs hx hxpos ha hrun).trans
     (sub_ratio_le_card_ratio m N s hmN hs hNs)
 
 /-- Equation (5) in Yamagami's singular-boundary case, including the
 suppressed possibility of several vanishing denominators.  No zero-block
 decomposition is used: one singular denominator and the first positive
 coordinate after its window provide all `m` vanishing summands. -/
-theorem limsup_fnms_le_card_ratio_of_singularDenominator
+theorem limsup_functional_le_card_ratio_of_singularDenominator
     {α : Type*} {l : Filter α} [NeBot l]
     (m : ℕ) (s : ℝ) (x : α → ZMod N → ℝ) (a : ZMod N → ℝ)
     (hmN : m < N) (hs : (m : ℝ) < s) (hNs : (N : ℝ) ≤ s)
     (hx : Tendsto x l (𝓝 a)) (hxpos : ∀ᶠ t in l, ∀ i, 0 < x t i)
     (ha : ∀ i, 0 ≤ a i) (hne : a ≠ 0)
-    (hsingular : ∃ i, fnmsDenominator m s a i = 0) :
-    limsup (fun t ↦ fnms m s (x t)) l ≤ (N : ℝ) / s :=
-  (limsup_fnms_le_sub_ratio_of_singularDenominator
+    (hsingular : ∃ i, forwardDenominator N m s a i = 0) :
+    limsup (fun t ↦ functional N m s (x t)) l ≤ (N : ℝ) / s :=
+  (limsup_functional_le_sub_ratio_of_singularDenominator
     m s x a hmN hs hx hxpos ha hne hsingular).trans
       (sub_ratio_le_card_ratio m N s hmN hs hNs)
 
@@ -440,22 +443,23 @@ Lean's totalized value of each omitted `0 / 0` term is zero.
 
 This theorem does not prove the strictly positive inequality supplied as
 `hpositive`. -/
-theorem fnms_le_of_strictlyPositive
+theorem functional_le_of_strictlyPositive
     (m : ℕ) (s B : ℝ) (x : ZMod N → ℝ) (hs : (m : ℝ) < s)
     (hx : ∀ i, 0 ≤ x i)
-    (hpositive : ∀ y : ZMod N → ℝ, (∀ i, 0 < y i) → fnms m s y ≤ B) :
-    fnms m s x ≤ B := by
+    (hpositive : ∀ y : ZMod N → ℝ, (∀ i, 0 < y i) → functional N m s y ≤ B) :
+    functional N m s x ≤ B := by
   classical
   let R : Finset (ZMod N) :=
-    Finset.univ.filter fun i ↦ fnmsDenominator m s x i ≠ 0
-  have hregular : fnms m s x = ∑ i ∈ R, fnmsTerm m s x i := by
-    rw [fnms, Finset.sum_subset (Finset.subset_univ R)]
+    Finset.univ.filter fun i ↦ forwardDenominator N m s x i ≠ 0
+  have hregular : functional N m s x =
+      ∑ i ∈ R, x i / forwardDenominator N m s x i := by
+    rw [functional, Finset.sum_subset (Finset.subset_univ R)]
     intro i _ hi
-    have hdenom : fnmsDenominator m s x i = 0 := by
+    have hdenom : forwardDenominator N m s x i = 0 := by
       simp only [R, Finset.mem_filter, Finset.mem_univ, true_and] at hi
       exact not_ne_iff.mp hi
-    have hxi := eq_zero_of_fnmsDenominator_eq_zero m s x hs hx i hdenom
-    simp [fnmsTerm, hxi, hdenom]
+    have hxi := eq_zero_of_forwardDenominator_eq_zero m s x hs hx i hdenom
+    simp [hxi, hdenom]
   let y : ℕ → ZMod N → ℝ := fun n i ↦ x i + 1 / ((n : ℝ) + 1)
   have hypos : ∀ n i, 0 < y n i := by
     intro n i
@@ -466,28 +470,31 @@ theorem fnms_le_of_strictlyPositive
     simpa [y] using
       tendsto_const_nhds.add (tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ))
   have hregularTend :
-      Tendsto (fun n ↦ ∑ i ∈ R, fnmsTerm m s (y n) i) atTop (𝓝 (fnms m s x)) := by
+      Tendsto (fun n ↦ ∑ i ∈ R, y n i / forwardDenominator N m s (y n) i)
+        atTop (𝓝 (functional N m s x)) := by
     rw [hregular]
     exact tendsto_finsetSum R fun i hi ↦
-      tendsto_fnmsTerm_of_denominator_ne m s y x hytend i (Finset.mem_filter.mp hi).2
-  have hregular_le : ∀ n, (∑ i ∈ R, fnmsTerm m s (y n) i) ≤ B := by
+      tendsto_summand_of_denominator_ne m s y x hytend i (Finset.mem_filter.mp hi).2
+  have hregular_le : ∀ n,
+      (∑ i ∈ R, y n i / forwardDenominator N m s (y n) i) ≤ B := by
     intro n
-    have hsubset : (∑ i ∈ R, fnmsTerm m s (y n) i) ≤ fnms m s (y n) := by
-      rw [fnms]
+    have hsubset : (∑ i ∈ R, y n i / forwardDenominator N m s (y n) i) ≤
+        functional N m s (y n) := by
+      rw [functional]
       exact Finset.sum_le_sum_of_subset_of_nonneg R.subset_univ fun i _ _ ↦
-        (fnmsTerm_nonneg_and_le m s (y n) hs (hypos n) i).1
+        (summand_nonneg_and_le m s (y n) hs (hypos n) i).1
     exact hsubset.trans (hpositive (y n) (hypos n))
   exact le_of_tendsto' hregularTend hregular_le
 
 /-- The direct `0 / 0 = 0` nonnegative cyclic inequality, conditional only
 on the corresponding strictly positive inequality. -/
-theorem fnms_le_card_ratio_of_strictlyPositive
+theorem functional_le_card_ratio_of_strictlyPositive
     (m : ℕ) (s : ℝ) (x : ZMod N → ℝ) (hs : (m : ℝ) < s)
     (hx : ∀ i, 0 ≤ x i)
     (hpositive : ∀ y : ZMod N → ℝ, (∀ i, 0 < y i) →
-      fnms m s y ≤ (N : ℝ) / s) :
-    fnms m s x ≤ (N : ℝ) / s :=
-  fnms_le_of_strictlyPositive m s ((N : ℝ) / s) x hs hx hpositive
+      functional N m s y ≤ (N : ℝ) / s) :
+    functional N m s x ≤ (N : ℝ) / s :=
+  functional_le_of_strictlyPositive m s ((N : ℝ) / s) x hs hx hpositive
 
 end OneStepCyclicFunction
 

--- a/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
@@ -94,8 +94,9 @@ middle range.
         Yamagami.exists_hasSingularRun_of_forwardDenominator_eq_zero}
     \leanok
     \uses{def:yamagami_stride_one_reciprocal}
-    Let $a\colon\Z/N\Z\to\R$ be nonnegative and nonzero.  If one forward
-    denominator vanishes, there is an index $j$ such that
+    Suppose that $N\ge1$ and $m<s$.  Let $a\colon\Z/N\Z\to\R$ be
+    nonnegative and nonzero.  If one forward denominator vanishes, there is
+    an index $j$ such that
     \begin{align}
         a_j&>0,
         &a_{j-m-1}=a_{j-m}=\cdots=a_{j-1}&=0.
@@ -162,11 +163,11 @@ middle range.
         Yamagami.functional_le_card_ratio_of_strictlyPositive}
     \leanok
     \uses{def:yamagami_stride_one_reciprocal}
-    If $f_{N,m,s}(y)\le B$ for every strictly positive vector $y$, then the
-    same inequality holds for every nonnegative vector when a literal
-    $0/0$ summand is assigned Lean's totalized value zero.  In particular,
-    the conclusion holds with $B=N/s$ once the strictly positive inequality
-    has been proved.
+    Suppose that $N\ge1$ and $m<s$.  If $f_{N,m,s}(y)\le B$ for every
+    strictly positive vector $y$, then the same inequality holds for every
+    nonnegative vector when a literal $0/0$ summand is assigned Lean's
+    totalized value zero.  In particular, the conclusion holds with $B=N/s$
+    once the strictly positive inequality has been proved.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
@@ -81,6 +81,107 @@ This spectral lemma is only one dependency of Yamagami's variational proof.
 It does not establish the cyclic reciprocal inequality or positivity in the
 middle range.
 
+\begin{lemma}[The first positive coordinate after a singular window]
+    \label{lem:yamagami_singular_zero_run}
+    \lean{Yamagami.precedingIndices,
+        Yamagami.HasSingularRun,
+        Yamagami.exists_hasSingularRun_of_zero_window,
+        Yamagami.card_precedingIndices,
+        Yamagami.precedingIndices_zero_and_reaches,
+        Yamagami.forwardDenominator_pos_of_mem_preceding,
+        Yamagami.eq_zero_of_forwardDenominator_eq_zero,
+        Yamagami.forwardDenominator_eq_zero_iff,
+        Yamagami.exists_hasSingularRun_of_forwardDenominator_eq_zero}
+    \leanok
+    \uses{def:yamagami_stride_one_reciprocal}
+    Let $a\colon\Z/N\Z\to\R$ be nonnegative and nonzero.  If one forward
+    denominator vanishes, there is an index $j$ such that
+    \begin{align}
+        a_j&>0,
+        &a_{j-m-1}=a_{j-m}=\cdots=a_{j-1}&=0.
+    \end{align}
+    If $m<N$, the $m$ indices $j-1,\ldots,j-m$ are distinct.  Each has zero
+    numerator, and its forward denominator contains the positive coordinate
+    $a_j$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    A zero denominator gives a forward window of $m+1$ zero coordinates.
+    Starting immediately after this window, take the first positive
+    coordinate encountered cyclically; it exists because $a$ is nonzero.
+    Minimality gives the displayed zero string.  Translation by $j$ is
+    injective on the natural indices $1,\ldots,m$ when $m<N$, which gives the
+    cardinality statement.  No decomposition into maximal zero blocks is
+    used.
+\end{proof}
+
+\begin{lemma}[Yamagami's simultaneous-singularity boundary estimate]
+    \label{lem:yamagami_simultaneous_singular_boundary}
+    \lean{Yamagami.limsup_sum_le_card_mul_of_tendsto_zero_on,
+        Yamagami.tendsto_forwardDenominator,
+        Yamagami.tendsto_summand_of_denominator_ne,
+        Yamagami.tendsto_summand_zero_of_mem_preceding,
+        Yamagami.summand_nonneg_and_le,
+        Yamagami.limsup_functional_le_sub_ratio_of_singularRun,
+        Yamagami.limsup_functional_le_sub_ratio_of_singularDenominator,
+        Yamagami.sub_ratio_le_card_ratio,
+        Yamagami.limsup_functional_le_card_ratio_of_singularRun,
+        Yamagami.limsup_functional_le_card_ratio_of_singularDenominator}
+    \leanok
+    \uses{def:yamagami_stride_one_reciprocal,
+        lem:yamagami_singular_zero_run}
+    Suppose that $m<N$, $m<s$, and $N\le s$.  Let strictly positive vectors
+    $x^{(r)}$ converge coordinatewise to a nonzero nonnegative vector $a$ with
+    at least one vanishing forward denominator.  Then
+    \begin{align}
+        \limsup_r f_{N,m,s}\bigl(x^{(r)}\bigr)
+          &\le\frac{N-m}{s-m}
+          \le\frac Ns.
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Choose $j$ from
+    Lemma~\ref{lem:yamagami_singular_zero_run}.  The $m$ summands immediately
+    preceding $j$ tend to zero: their numerators tend to zero, while their
+    limiting denominators contain $a_j>0$.  Every remaining positive summand
+    is nonnegative and at most $1/(s-m)$.  The complement has $N-m$ elements,
+    which gives the first bound; the second is elementary.  This one global
+    count covers any number of simultaneous vanishing denominators.  Yamagami
+    prints the single-singularity calculation and only indicates the
+    simultaneous case; the completed step and its precise attribution are
+    recorded in
+    \cite{gap:yamagami_simultaneous_singularity_boundary}.
+\end{proof}
+
+\begin{lemma}[Conditional passage to the totalized boundary value]
+    \label{lem:yamagami_conditional_totalized_boundary}
+    \lean{Yamagami.functional_le_of_strictlyPositive,
+        Yamagami.functional_le_card_ratio_of_strictlyPositive}
+    \leanok
+    \uses{def:yamagami_stride_one_reciprocal}
+    If $f_{N,m,s}(y)\le B$ for every strictly positive vector $y$, then the
+    same inequality holds for every nonnegative vector when a literal
+    $0/0$ summand is assigned Lean's totalized value zero.  In particular,
+    the conclusion holds with $B=N/s$ once the strictly positive inequality
+    has been proved.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Approximate $x\ge0$ by
+    $y_i^{(r)}=x_i+1/(r+1)$.  At every nonsingular limiting denominator the
+    summand converges to its direct boundary value.  The omitted singular
+    summands of the positive approximants are nonnegative, while their
+    totalized boundary values are zero.  Passing to the limit gives the
+    claim.  This lemma is conditional: it supplies neither the positive
+    interior inequality nor Yamagami's regular-boundary induction.  In
+    particular, the Nowosad interior-uniqueness input remains open, so the
+    full cyclic inequality is not asserted here.
+\end{proof}
+
 \begin{definition}[Choi-type map]
     \label{def:choi_type_map}
     \lean{Matrix.choiTypeMap}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -315,6 +315,16 @@
   note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/yamagami93_lemma6_endpoint.pdf}},
 }
 
+@techreport{gap:yamagami_simultaneous_singularity_boundary,
+  author      = {The {QICLean} contributors},
+  title       = {{Yamagami}'s Simultaneous-Singularity Boundary Count},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {yamagami93\_simultaneous\_singularity\_boundary},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/yamagami93_simultaneous_singularity_boundary.pdf}},
+}
+
 @techreport{gap:cpsv16_ssa_equality_hayashi_markov,
   author      = {The {TNLean} contributors},
   title       = {Closure Record for the Strong-Subadditivity Equality Characterization and {Hayashi}--{Markov} Decomposition},

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -136,3 +136,13 @@
   year        = {2026},
   note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/yamagami93_lemma6_endpoint.pdf}},
 }
+
+@techreport{gap:yamagami_simultaneous_singularity_boundary,
+  author      = {The {QICLean} contributors},
+  title       = {{Yamagami}'s Simultaneous-Singularity Boundary Count},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {yamagami93\_simultaneous\_singularity\_boundary},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/yamagami93_simultaneous_singularity_boundary.pdf}},
+}

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -128,12 +128,23 @@ printed endpoint and its stride-one correction are recorded separately in
 the unfinished Choi-type positivity proof.
 
 The accompanying definitions retain Yamagami's forward window and provide the
-explicit index-negation bridge to the backward Choi window.  This is not the
-cyclic reciprocal inequality: the
-Nowosad uniqueness step, Hessian identification, and regular and singular
-projective-boundary analysis are still missing.  In particular, Yamagami's
-boundary $0/0$ terms remain indeterminate limits in the source, whereas Lean's
-division in the algebraically total functional is zero at a literal $0/0$.
+explicit index-negation bridge to the backward Choi window.  The
+simultaneous-singularity part of the projective-boundary analysis is now
+formalized separately.  From any vanishing denominator at a nonzero
+nonnegative boundary vector, the first positive coordinate after its zero
+window supplies $m$ summands tending to zero; the complement count gives
+\((N-m)/(s-m)\le N/s\).  This is the single global count indicated, but not
+printed, after Yamagami's one-singularity calculation
+\cite[pp.~524--525]{Yamagami1993Cyclic}.  Its completion and attribution are
+recorded in
+\cite{gap:yamagami_simultaneous_singularity_boundary}.
+
+This is still not the cyclic reciprocal inequality.  The positive-interior
+uniqueness theorem, tracked by \ghissue{448}, and the separate
+regular-boundary induction remain missing.  The direct theorem for Lean's
+literal \(0/0=0\) functional is correspondingly conditional on an already
+proved strictly positive inequality; it does not discharge either missing
+input.
 
 Two verifiable computations locate the obstruction to elementary summand
 bounds in the remaining range.  First, the estimate is tight in two distinct

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -130,11 +130,12 @@ the unfinished Choi-type positivity proof.
 The accompanying definitions retain Yamagami's forward window and provide the
 explicit index-negation bridge to the backward Choi window.  The
 simultaneous-singularity part of the projective-boundary analysis is now
-formalized separately.  From any vanishing denominator at a nonzero
-nonnegative boundary vector, the first positive coordinate after its zero
-window supplies $m$ summands tending to zero; the complement count gives
-\((N-m)/(s-m)\le N/s\).  This is the single global count indicated, but not
-printed, after Yamagami's one-singularity calculation
+formalized separately.  Under $N\ge1$, $m<N$, and $N\le s$, any vanishing
+denominator at a nonzero nonnegative boundary vector yields a first positive
+coordinate after its zero window.  This supplies $m$ summands tending to
+zero, and the complement count gives \((N-m)/(s-m)\le N/s\).  This is the
+single global count indicated, but not printed, after Yamagami's
+one-singularity calculation
 \cite[pp.~524--525]{Yamagami1993Cyclic}.  Its completion and attribution are
 recorded in
 \cite{gap:yamagami_simultaneous_singularity_boundary}.

--- a/docs/paper-gaps/yamagami93_simultaneous_singularity_boundary.tex
+++ b/docs/paper-gaps/yamagami93_simultaneous_singularity_boundary.tex
@@ -26,10 +26,12 @@ For the case denoted by \(l=1\), Yamagami studies the cyclic function
       {(s-m)x_q+x_{q+1}+\cdots+x_{q+m}}.
   \tag{1}
 \end{align}
-Here the indices are cyclic and the interior argument assumes \(x_q>0\).
-Suppose that a positive family tends coordinatewise to a nonzero boundary
-vector \(a\ge0\).  The singular-boundary question is how to control (1) when
-one or more limiting denominators vanish.
+Here the indices are cyclic.  Throughout this boundary count, assume
+\(N\ge1\), \(m<N\), and \(N\le s\); in particular, \(m<s\) and \(s-m>0\).
+The interior argument assumes \(x_q>0\).  Suppose that a positive family
+tends coordinatewise to a nonzero boundary vector \(a\ge0\).  The
+singular-boundary question is how to control (1) when one or more limiting
+denominators vanish.
 
 A zero limiting denominator at an index \(i\) gives
 \begin{align}
@@ -50,8 +52,8 @@ relabeling, its hypotheses have the form
   \tag{3}
 \end{align}
 The \(m\) summands with numerators \(a_1,\ldots,a_m\) tend to zero, while
-every other positive summand is at most \(1/(s-m)\).  This gives the printed
-count
+every other positive summand is at most \(1/(s-m)\).  These printed estimates
+imply the upper-limit bound
 \begin{align}
   \limsup f_{N,m,s}(x)
     &\le \frac{N-m}{s-m}
@@ -69,9 +71,9 @@ condition: choose \(j\) with
 \end{align}
 and says that the argument is similar.  The paper does not print the finite
 first-positive construction or the simultaneous limsup calculation.  Thus
-(3)--(4) are the printed single-singularity calculation, whereas the passage
-from an arbitrary collection of singular denominators to one global count is
-an omitted detail.
+(3) and the estimates leading to (4) are the printed single-singularity
+calculation, whereas the passage from an arbitrary collection of singular
+denominators to one global count is an omitted detail.
 
 \section{The completed simultaneous count}
 

--- a/docs/paper-gaps/yamagami93_simultaneous_singularity_boundary.tex
+++ b/docs/paper-gaps/yamagami93_simultaneous_singularity_boundary.tex
@@ -1,0 +1,146 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{./command.tex}
+
+\title{Yamagami's Simultaneous-Singularity Boundary Count}
+\author{}
+\date{2026-08-24}
+
+\begin{document}
+\maketitle
+\gapnote{clarification}{resolved}
+
+\section{The cyclic function and its boundary}
+
+For the case denoted by \(l=1\), Yamagami studies the cyclic function
+\cite[pp.~524--525]{Yamagami1993Cyclic}
+\begin{align}
+  f_{N,m,s}(x)
+    &=\sum_{q\in\mathbb Z/N\mathbb Z}
+      \frac{x_q}
+      {(s-m)x_q+x_{q+1}+\cdots+x_{q+m}}.
+  \tag{1}
+\end{align}
+Here the indices are cyclic and the interior argument assumes \(x_q>0\).
+Suppose that a positive family tends coordinatewise to a nonzero boundary
+vector \(a\ge0\).  The singular-boundary question is how to control (1) when
+one or more limiting denominators vanish.
+
+A zero limiting denominator at an index \(i\) gives
+\begin{align}
+  a_i=a_{i+1}=\cdots=a_{i+m}=0,
+  \tag{2}
+\end{align}
+because \(s-m>0\) and every coordinate is nonnegative.  Since \(a\neq0\), a
+positive coordinate is eventually encountered after this forward zero
+window.
+
+\section{What is printed in the source}
+
+The paper first treats a single indeterminate summand.  After a cyclic
+relabeling, its hypotheses have the form
+\begin{align}
+  a_N=a_1=\cdots=a_m=0,
+  \qquad a_{m+1}>0,\qquad a_{N-1}>0.
+  \tag{3}
+\end{align}
+The \(m\) summands with numerators \(a_1,\ldots,a_m\) tend to zero, while
+every other positive summand is at most \(1/(s-m)\).  This gives the printed
+count
+\begin{align}
+  \limsup f_{N,m,s}(x)
+    &\le \frac{N-m}{s-m}
+     \le \frac Ns.
+  \tag{4}
+\end{align}
+
+For several indeterminate summands, Yamagami records the cyclic zero-string
+condition: choose \(j\) with
+\begin{align}
+  a_j>0,
+  \qquad
+  a_{j-m-1}=a_{j-m}=\cdots=a_{j-1}=0,
+  \tag{5}
+\end{align}
+and says that the argument is similar.  The paper does not print the finite
+first-positive construction or the simultaneous limsup calculation.  Thus
+(3)--(4) are the printed single-singularity calculation, whereas the passage
+from an arbitrary collection of singular denominators to one global count is
+an omitted detail.
+
+\section{The completed simultaneous count}
+
+Starting from (2), traverse the cyclic coordinates after \(i+m\) and take the
+first positive value.  Finiteness of the cyclic index set and \(a\neq0\) give
+such a first value \(a_j>0\).  Minimality shows that all coordinates from the
+end of (2) through \(j-1\) are zero, and in particular gives (5).
+\footnote{The finite first-positive step is formalized by
+\leanid{Yamagami.exists\_hasSingularRun\_of\_zero\_window}; its application
+to a zero denominator is
+\leanid{Yamagami.exists\_hasSingularRun\_of\_forwardDenominator\_eq\_zero}
+in \doclink{QICLean/Analysis/YamagamiBoundary}.}
+
+Let
+\begin{align}
+  V&=\{j-1,j-2,\ldots,j-m\}.\notag
+\end{align}
+The condition \(m<N\) makes these \(m\) cyclic indices distinct.  For
+\(q=j-k\in V\), the limiting numerator is zero, while the forward denominator
+contains the fixed positive coordinate \(a_j\).  Hence the corresponding
+summand tends to zero.  Every summand outside \(V\) remains nonnegative and is
+bounded above by \(1/(s-m)\) along the positive approximants.  A single
+partition of the finite sum therefore gives
+\begin{align}
+  \limsup f_{N,m,s}(x)
+    &\le |(\mathbb Z/N\mathbb Z)\setminus V|\frac1{s-m}
+     =\frac{N-m}{s-m}.
+  \tag{6}
+\end{align}
+If \(N\le s\), elementary cross-multiplication gives the second inequality in
+(4).
+\footnote{The reusable finite limsup estimate is
+\leanid{Yamagami.limsup\_sum\_le\_card\_mul\_of\_tendsto\_zero\_on}.
+The boundary-condition form of (6) and its comparison with \(N/s\) are
+\leanid{Yamagami.limsup\_functional\_le\_sub\_ratio\_of\_singularDenominator}
+and
+\leanid{Yamagami.limsup\_functional\_le\_card\_ratio\_of\_singularDenominator}
+in \doclink{QICLean/Analysis/YamagamiBoundary}.}
+
+This is one global count.  It neither assigns singular denominators to
+maximal zero blocks nor adds estimates from several blocks.  Consequently it
+applies unchanged when any number of limiting denominators vanish.
+
+\section{Scope of the resolution}
+
+The formal development also proves a conditional passage to the direct
+nonnegative value of (1), where real division makes \(0/0=0\).  It assumes the
+corresponding inequality for every strictly positive vector and approaches a
+nonnegative vector through the uniform perturbation
+\(x_q+1/(r+1)\).
+\footnote{Formal declarations:
+\leanid{Yamagami.functional\_le\_of\_strictlyPositive} and
+\leanid{Yamagami.functional\_le\_card\_ratio\_of\_strictlyPositive} in
+\doclink{QICLean/Analysis/YamagamiBoundary}.}
+This conditional theorem does not supply the strictly positive interior
+inequality.  It also does not replace Yamagami's separate regular-boundary
+reduction.  The interior uniqueness input, tracked separately as
+\ghissue{448}, and the regular-boundary induction remain prerequisites of the
+full cyclic inequality.
+
+\section{Verdict}
+
+The omitted simultaneous-singularity calculation is a resolved
+clarification.  The formal lemma proves precisely the global counting and
+limsup step suggested by (5), without attributing that unprinted calculation
+to Yamagami.  This resolution alone is not a proof of the full cyclic
+inequality.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -678,6 +678,16 @@ so that the cited formal statements are available from the main project import.
   endpoint `m = d - 1`, `s = d` is false with a strict inequality and is
   recorded in the paper-gap note; this theorem does not prove the cyclic
   inequality ✓
+- `Yamagami.limsup_functional_le_card_ratio_of_singularDenominator`
+  formalizes the omitted simultaneous-singularity boundary count: one
+  least-next-positive zero string supplies all `m` vanishing summands, without
+  a maximal-block decomposition ✓
+- `Yamagami.functional_le_card_ratio_of_strictlyPositive` transfers an
+  already proved strictly positive inequality to Lean's direct nonnegative
+  `0 / 0 = 0` value. This theorem is conditional; the positive-interior input
+  remains tracked by issue #448, and the regular-boundary induction is still
+  required. See
+  `docs/paper-gaps/yamagami93_simultaneous_singularity_boundary.tex` ✓
 - Positivity in the middle range `2 ≤ n ≤ d - 3` remains open; its exact
   scope and cyclic reciprocal inequality are recorded in
   `docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`. The factor


### PR DESCRIPTION
## Summary

- formalize the cyclic first-positive construction following a vanishing forward denominator, without a maximal-zero-block decomposition
- prove Yamagami's simultaneous-singularity limsup count against the shared `Yamagami.forwardDenominator` and `Yamagami.functional` API
- provide the conditional passage from an already proved strictly positive bound to Lean's direct nonnegative `0 / 0 = 0` value
- synchronize the Chapter 4 Blueprint, Wolf coverage table, and a source-facing paper-gap note that distinguishes the printed one-singularity estimates from the completed upper-limit argument

## Scope

This PR establishes only the singular-boundary counting step and the conditional totalized passage. It does not assert the full cyclic reciprocal inequality. The positive-interior uniqueness theorem remains tracked by #448, and Yamagami's regular-boundary induction remains to be formalized.

## Verification

- `lake env lean QICLean/Analysis/YamagamiBoundary.lean`
- `lake build QICLean.Analysis.YamagamiBoundary`
- `lake build QICLean.Analysis`
- `lake exe lint_style --github`
- oversized and numbered-module policy checks
- Blueprint synchronization and reverse-coverage checks (2403/2403)
- ChkTeX, pinned `texra-blueprint` web rendering, paper-gap reference check, and the three-page gap-note PDF build/visual inspection
- kernel axiom audit of the first-positive, singular-denominator limsup, and conditional totalized theorems (`propext`, `Classical.choice`, and `Quot.sound` only)
- independent exact-head review, including a concrete nonvacuity instance

Refs #449