### PR TITLE
docs(wolf): split open operator-convexity scope

### DIFF
--- a/blueprint/src/chapter/ch06_operator_convexity_schwarz_and_jensen.tex
+++ b/blueprint/src/chapter/ch06_operator_convexity_schwarz_and_jensen.tex
@@ -599,7 +599,7 @@ matrix-order tools used independently of the Fundamental Theorem.
     \cite[Corollary~5.2(3)]{Wolf2012Quantum}.  The printed common hypothesis
     $T(\Id)\le\Id$ is insufficient: in dimension one, for $0<c<1$, the
     positive subunital map $T(x)=cx$ and $A=1$ would give
-    $0=T(\log A)\le\log(T(A))=\log c$.  The formal theorem instead assumes
+    $0=T(\log A)\le\log(T(A))=\log c$.  The corrected theorem instead assumes
     $T(\Id)=\Id$; see \cite{gap:wolf_ch5_operator_jensen_lieb}.
 \end{theorem}
 
@@ -623,22 +623,20 @@ matrix-order tools used independently of the Fundamental Theorem.
     Direct application of Theorem~\ref{thm:posMap_log_concave_jensen}.
 \end{proof}
 
-\subsection{Boundary of the source package}
+\subsection{Special functions and the general inequalities}
 
-The preceding declarations prove the real-power instances and the corrected
-unital logarithm instance.  The former pass-through declarations which rewrote
-the real-power inequalities into the exact exponent-parameterization of
-Corollary~5.2(1)--(2) are not live declarations.  Nor do the results above
-package the full block of results in Wolf's Section~5.4: the integral
-characterization of operator-convex
-functions, L\"owner's operator-monotonicity theorem, the two general projection
-inequalities, Jensen's inequality for an arbitrary operator-convex function,
-the entropic operator inequality, the general positive-map monotonicity theorem,
-and the finite-family Jensen corollary remain outside the proved declarations
-listed here.  Thus the special-function slice is proved, while the complete
-source package remains partial by packaging and scope.  The false common
-subunital hypothesis in the printed logarithm clause and the exact formal
-boundary are recorded in \cite{gap:wolf_ch5_operator_jensen_lieb}.
+The power and logarithm inequalities above are special cases of the
+function-theoretic results in Wolf's Section~5.4.  For an operator-convex
+function $f$ with $f(0)\le 0$ and a positive map $T$ satisfying
+$T(\Id)\le\Id$, Wolf's Theorems~5.10--5.11 give
+$f(T(A))\le T(f(A))$; Theorem~5.12 removes the condition $f(0)\le0$ when
+$T$ is unital.  For an operator-monotone function $f$ with
+$f(0)\ge 0$, Theorem~5.13 gives the reverse inequality
+$T(f(A))\le f(T(A))$.  These assertions concern arbitrary functions in the
+respective classes, whereas Corollary~5.2 specializes them to powers and the
+logarithm.  The distinction is recorded in
+\cite{gap:wolf_ch5_operator_convexity_scope}; the correction to the logarithmic
+clause is recorded separately in \cite{gap:wolf_ch5_operator_jensen_lieb}.
 
 \section{Source boundary for Wolf's unitary comparison}
 

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -365,6 +365,16 @@
   note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_ch5_operator_jensen_lieb.pdf}},
 }
 
+@techreport{gap:wolf_ch5_operator_convexity_scope,
+  author      = {The {QICLean} contributors},
+  title       = {Scope of {Wolf} Chapter 5 Operator Convexity and Monotonicity Results},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_ch5\_operator\_convexity\_scope},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_ch5_operator_convexity_scope.pdf}},
+}
+
 @techreport{gap:wolf_ch01_operator_system_extension_matrix_scope,
   author      = {The {QICLean} contributors},
   title       = {Wolf's Operator-System Extension: Matrix-Algebra Realization},

--- a/docs/paper-gaps/wolf_ch5_operator_convexity_scope.tex
+++ b/docs/paper-gaps/wolf_ch5_operator_convexity_scope.tex
@@ -1,0 +1,135 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Scope of Wolf Chapter~5 Operator Convexity and Monotonicity Results}
+\author{}
+\date{2026-08-24}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{The source assertions}
+
+Wolf's Section~5.4 passes from functional calculus to general results about
+operator-convex and operator-monotone functions.  For operators on a
+finite-dimensional Hilbert space, $A\le B$ denotes the Loewner order.  A linear
+map $T$ is positive when it preserves this order and subunital when
+$T(\mathbf 1)\le\mathbf 1$.
+
+The section first characterizes the two classes of functions.  Theorem~5.8
+states that $f:[0,\infty)\to\mathbb R$ is operator convex if and only if
+\begin{align}
+  f(x)=a+bx+cx^2+\int_0^\infty \frac{y x^2}{y+x}\,d\mu(y),
+  \tag{Wolf (5.18)}
+\end{align}
+where $a,b\in\mathbb R$, $c\ge0$, and $\mu$ is a finite positive measure.
+L\"owner's theorem, Theorem~5.9, characterizes continuous operator-monotone
+functions on $(0,\infty)$ by their Pick-function continuation and by the
+integral representation
+\begin{align}
+  f(x)=a+bx+\int_{-\infty}^0\frac{1+xy}{y-x}\,d\mu(y),
+  \tag{Wolf (5.19)}
+\end{align}
+with $a\in\mathbb R$, $b\ge0$, and $\mu$ a finite positive measure.
+
+Wolf's Theorem~5.10 starts from the projection inequality
+\begin{align}
+  f(PAP)\le P f(A)P
+  \tag{Wolf (5.22)}
+\end{align}
+for every dimension, Hermitian projection $P$, and Hermitian $A$ whose spectrum
+is contained in an interval containing zero.  It deduces $f(0)\le0$, operator
+convexity of $f$, and Jensen's inequality
+\begin{align}
+  f(T(A))\le T(f(A))
+  \tag{Wolf (5.23)}
+\end{align}
+for every positive subunital map $T$.  Theorem~5.11 proves the converse
+projection inequality for an operator-convex function:
+\begin{align}
+  f(PAP)\le P f(A)P+P^\perp f(0)P^\perp,
+  \tag{Wolf (5.25)}
+\end{align}
+and, when $f(0)\le0$, obtains the corresponding Jensen inequality
+\begin{align}
+  f(T(A))\le T(f(A)).
+  \tag{Wolf (5.26)}
+\end{align}
+Theorem~5.12 removes the condition $f(0)\le0$ when $T$ is unital.  Its
+entropic corollary is the operator inequality
+\begin{align}
+  T(\rho)\log T(\rho)\le T(\rho\log\rho).
+  \tag{Wolf (5.33)}
+\end{align}
+For an operator-monotone function on $[0,a]$ with $f(0)\ge0$, Theorem~5.13
+gives the reverse Jensen inequality
+\begin{align}
+  T(f(A))\le f(T(A)).
+  \tag{Wolf (5.34)}
+\end{align}
+Finally, the corollary following Corollary~5.2 extends both inequalities to a
+finite collection of positive maps $\{T_i\}_{i=1}^n$ satisfying
+$\sum_i T_i(\mathbf 1)\le\mathbf 1$: the operator-monotone case gives
+\begin{align}
+  \sum_{i=1}^n T_i(f(A_i))
+  \le f\!\left(\sum_{i=1}^n T_i(A_i)\right),
+  \tag{Wolf (5.37)}
+\end{align}
+and the operator-convex case gives the reverse inequality.
+
+These are the assertions and terminology of the source itself.
+\cite[Section~5.4, Theorems~5.8--5.13, and the corollaries following
+Theorem~5.12 and Corollary~5.2]{Wolf2012Quantum}
+
+\section{The special-function restriction}
+
+The formal development proves Jensen inequalities for the particular functions
+$x\mapsto x^p$ and $x\mapsto\log x$.  For a positive subunital map $T$ and a
+positive semidefinite operator $A$, they give
+\begin{align}
+  T(A^p)&\le (T(A))^p, &&0\le p\le1,\tag{power concavity}\\[0.3em]
+  (T(A))^p&\le T(A^p), &&1\le p\le2.\tag{power convexity}
+\end{align}
+For a positive \emph{unital} map and $A>0$, they also give
+\begin{align}
+  T(\log A)\le\log(T(A)).
+  \tag{logarithm concavity}
+\end{align}
+The unital hypothesis in the last line corrects the false common subunital
+hypothesis in the original Corollary~5.2.\footnote{The counterexample and
+corrected statement are recorded in
+\doclink{docs/paper-gaps/wolf_ch5_operator_jensen_lieb}.}
+
+These inequalities are proved through the integral representations of the
+specific power functions and a limit at $p=0$.\footnote{Formal declarations:
+\leanid{posMap_rpow_concave_jensen},
+\leanid{posMap_rpow_convex_jensen}, and
+\leanid{posMap_log_concave_jensen} in
+\doclink{QICLean/Analysis/LiebConcavity}.}
+They are instances of the source's general Jensen inequalities, but instances
+for these three functions do not imply the characterization of all
+operator-convex functions, L\"owner's theorem, the projection equivalences,
+the arbitrary-function forms of Jensen's inequality, or the finite-family
+corollary.
+
+\clearpage
+\section{Verdict}
+
+The proved power and logarithm inequalities form a proper special-function
+restriction of Wolf's Section~5.4 results.  The source's general
+operator-convexity and operator-monotonicity assertions listed above remain an
+open scope gap; no conclusion for an arbitrary function $f$ follows from the
+three special cases alone.  The gap is resolved only when the general source
+assertions themselves, or source-faithful theorems that imply them, are proved.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch5_operator_convexity_scope.tex
+++ b/docs/paper-gaps/wolf_ch5_operator_convexity_scope.tex
@@ -105,7 +105,7 @@ For a positive \emph{unital} map and $A>0$, they also give
 The unital hypothesis in the last line corrects the false common subunital
 hypothesis in the original Corollary~5.2.\footnote{The counterexample and
 corrected statement are recorded in
-\doclink{docs/paper-gaps/wolf_ch5_operator_jensen_lieb}.}
+\path{docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex}.}
 
 These inequalities are proved through the integral representations of the
 specific power functions and a limit at $p=0$.\footnote{Formal declarations:

--- a/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
+++ b/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
@@ -7,7 +7,7 @@
 
 \input{command}
 
-\title{Wolf Chapter~5 Operator Jensen and Lieb Concavity Boundary}
+\title{Wolf Chapter~5 Special-Function Jensen and Lieb Concavity}
 \author{}
 \date{2026-08-24}
 
@@ -17,26 +17,22 @@
 
 \section{Scope}
 
-This note records three distinct parts of the Chapter~5
-operator-convexity boundary.  First, the special-function Jensen declarations
-are proved.\footnote{%
+This note records two resolved parts of Wolf's Chapter~5.  First, the
+special-function Jensen inequalities are proved.\footnote{%
     The declarations are
     \leanid{posMap_rpow_concave_jensen}, \leanid{posMap_rpow_convex_jensen},
     \leanid{posMap_log_concave_jensen}, and \leanid{lieb_concavity_posDef} in
     \doclink{QICLean/Analysis/LiebConcavity}; all four are proved theorems and
     none is an axiom.}
-Second, the common subunital hypothesis printed in Wolf Corollary~5.2 is false
-for its logarithmic clause and must be replaced there by unitality.  Third, the
+The common subunital hypothesis printed in Wolf Corollary~5.2 is false for its
+logarithmic clause and must be replaced there by unitality.  Second, the
 finite-dimensional Ando--Lieb theorem is proved in the full exponent range
-described in Section~\ref{sec:lieb}.  This note does not identify the proved
-special-function declarations with the full general function-theoretic package
-in Wolf's Section~5.4.  The positive-map Jensen declarations
-underlie \cite[Corollary~5.2]{Wolf2012Quantum} (the second corollary of Wolf's
-\S5.4) and rest on the operator-convexity and
-operator-monotonicity-versus-positive-maps results
-\cite[Theorems~5.10--5.13]{Wolf2012Quantum}; the Lieb declaration is the
-Ando--Lieb trace functional \cite[Theorem~5.15]{Wolf2012Quantum}.  (Wolf's Theorem~5.1 is
-Douglas' theorem and is unrelated to this development.)
+described in Section~\ref{sec:lieb}.  The positive-map Jensen inequalities
+specialize \cite[Corollary~5.2]{Wolf2012Quantum}; the Lieb theorem is the
+Ando--Lieb trace functional \cite[Theorem~5.15]{Wolf2012Quantum}.  The distinct
+scope question for Wolf's general operator-convexity and operator-monotonicity
+results is recorded in
+\path{docs/paper-gaps/wolf_ch5_operator_convexity_scope.tex}.
 
 The notation is fixed throughout.  Operators act on a finite-dimensional Hilbert
 space, identified with $D\times D$ complex matrices.  The order $A\le B$ is the
@@ -74,7 +70,7 @@ $[1,2]$).  The logarithmic case proved in the development assumes $T$ unital.
 The weaker common subunital hypothesis printed by Wolf is insufficient, as the
 scalar counterexample below shows.
 
-\subsection{The proved special-function route and the general-package boundary}
+\subsection{The proved special-function route}
 
 Mathlib~4.31 supplies the integral
 representation\footnote{%
@@ -208,17 +204,10 @@ The integral representation of the power integrand, previously named as the
 obstruction, is present.  The printed subunital logarithm clause remains false;
 its resolution is the source-facing unital correction above.
 
-These special-function theorems do not package Wolf's full Section~5.4 block.
-No source-level declaration has been identified for the general operator-convex
-integral criterion (Theorem~5.8), L\"owner's theorem (Theorem~5.9), the two
-general projection-inequality implications (Theorems~5.10--5.11), Jensen's
-inequality for an arbitrary operator-convex function and a unital positive map
-(Theorem~5.12), the entropic corollary, the general positive-map
-operator-monotonicity theorem (Theorem~5.13), or the finite-family Jensen
-corollary following Corollary~5.2.  The exact source package is therefore still
-partial by scope and packaging; in particular, the former pass-through wrappers
-for Corollary~5.2(1)--(2) are no longer live declarations.  The special
-real-power and corrected logarithm slice itself remains axiom-free.
+The verdict of this note is limited to these special functions: the real-power
+inequalities are proved, and the false logarithmic clause is repaired by the
+unital hypothesis.  The separate question of arbitrary operator-convex and
+operator-monotone functions does not affect this resolved source correction.
 
 \section{The Lieb concavity theorem (boundary exponent)}\label{sec:lieb}
 
@@ -339,8 +328,8 @@ The relevant formal-library inputs now available are
 \leanid{CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁},
 \leanid{CFC.concaveOn_rpow}, \leanid{CFC.convexOn_rpow}, and
 \leanid{CFC.concaveOn_log}.  Thus the scalar functional-calculus inputs are
-available, and all four positive-map Jensen and Lieb declarations of this
-boundary are now proved theorems.
+available, and the three positive-map Jensen inequalities and the Lieb theorem
+treated in this note are proved.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- replace the visible formalization-status inventory added by #459 with the mathematical distinction between Wolf's special-function corollary and the general operator-convexity/monotonicity inequalities
- keep the false subunital logarithm clause in its resolved `false-source` note while moving the still-open Section 5.4 scope to a separate live `scope-restriction` note
- state Wolf's source route with its own terminology and equations: (5.18), (5.19), (5.22)–(5.23), (5.25)–(5.26), (5.33)–(5.34), and (5.37)
- register the new note in the Blueprint bibliography and remove the remaining visible “formal theorem” wording

## Review provenance

This is the corrective follow-up for the two valid post-merge review threads on #459. It does not close #28: the general Section 5.4 source package remains open and machine-readable.

Primary source: `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, especially the operator-convexity and monotonicity block at local lines 414–810.

## Verification

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — 2403/2403 entries synchronized
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base a29f0e4879dc8e1dcc419620e37bd2b6e77a1b33 --ci`
- `texra-blueprint paper-gaps check` — 47 referenced slugs resolve
- `texra-blueprint bbl`
- `texra-blueprint --root . paper-gaps build`
- direct PDF builds and visual inspection of both affected notes
- `git diff --check`
- independent exact-head source/style review: clean at `d65ef06b76efd06ddde5f3490813f21eb2599da7`; stable patch `c005ab51529846f0c8e64acb19ae3071d2f3391d`
