### PR TITLE
Formalize Weyl monotonicity and Wolf's corrected unitary comparison

### DIFF
--- a/QICLean/Analysis.lean
+++ b/QICLean/Analysis.lean
@@ -98,4 +98,5 @@ import QICLean.Analysis.UnitarySchurTriangularization
 import QICLean.Analysis.UpperTriangularBound
 import QICLean.Analysis.WeightedCesaroMean
 import QICLean.Analysis.WeightedPositiveKernel
+import QICLean.Analysis.WeylMonotonicity
 import QICLean.Analysis.YamagamiBoundary

--- a/QICLean/Analysis/WeylMonotonicity.lean
+++ b/QICLean/Analysis/WeylMonotonicity.lean
@@ -1,0 +1,207 @@
+/-
+Copyright (c) 2026 Sirui Lu and QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import Mathlib.Analysis.InnerProductSpace.Positive
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.Matrix.Spectrum
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+import Mathlib.Order.Interval.Finset.Fin
+
+/-!
+# Weyl monotonicity for finite Hermitian matrices
+
+For Hermitian matrices in the Loewner order, the decreasingly ordered
+eigenvalues are ordered term by term.  This is the consequence of Weyl's
+monotonicity theorem used immediately before Wolf's Proposition 5.3:
+
+`A ≤ B → λⱼ↓(A) ≤ λⱼ↓(B)`.
+
+The proof uses the finite-dimensional variational argument.  The span of the
+first `j + 1` eigenvectors of `A` and the span of the last `d - j`
+eigenvectors of `B` have dimensions summing to `d + 1`, hence contain a common
+nonzero vector.  The two ordered spectral expansions bound its quadratic form
+from below and above, while positivity of `B - A` compares the two forms.
+
+## Main results
+
+* `LinearMap.IsSymmetric.eigenvalues_le_of_sub_isPositive` compares the ordered
+  eigenvalues of symmetric endomorphisms when their difference is positive.
+* `Matrix.IsHermitian.eigenvalues₀_mono` is Weyl monotonicity for the canonical
+  `Fin (Fintype.card n)` indexing.
+* `Matrix.IsHermitian.eigenvalues_mono` gives the corresponding statement for
+  Mathlib's matrix-indexed eigenvalue family.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 5,
+  Equation (5.56)][Wolf2012QChannels]
+* [R. Bhatia, *Matrix Analysis*][bhatia1997]
+-/
+
+open scoped ComplexOrder InnerProductSpace MatrixOrder
+
+private theorem symmetric_quadraticForm_eq_sum_eigenvalues_mul_norm_sq
+    {n : ℕ} {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+    [FiniteDimensional ℂ E] {T : E →ₗ[ℂ] E} (hT : T.IsSymmetric)
+    (hn : Module.finrank ℂ E = n) (x : E) :
+    (inner ℂ (T x) x).re =
+      ∑ j : Fin n, hT.eigenvalues hn j *
+        ‖(hT.eigenvectorBasis hn).repr x j‖ ^ 2 := by
+  let b := hT.eigenvectorBasis hn
+  rw [← b.sum_inner_mul_inner (T x) x, Complex.re_sum]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [hT x (b j), hT.apply_eigenvectorBasis]
+  rw [inner_smul_right]
+  rw [← inner_conj_symm]
+  rw [← b.repr_apply_apply]
+  rw [mul_assoc, ← Complex.normSq_eq_conj_mul_self, Complex.normSq_eq_norm_sq]
+  change ((↑(hT.eigenvalues hn j) : ℂ) * (↑(‖b.repr x j‖ ^ 2) : ℂ)).re =
+    hT.eigenvalues hn j * ‖b.repr x j‖ ^ 2
+  rw [Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im]
+  change hT.eigenvalues hn j * ‖b.repr x j‖ ^ 2 - 0 * 0 =
+    hT.eigenvalues hn j * ‖b.repr x j‖ ^ 2
+  ring
+
+private theorem exists_nonzero_mem_span_Iic_inter_span_Ici
+    {n : ℕ} {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+    [FiniteDimensional ℂ E] (b c : Module.Basis (Fin n) ℂ E)
+    (hn : Module.finrank ℂ E = n) (i : Fin n) :
+    ∃ x : E, x ≠ 0 ∧
+      x ∈ Submodule.span ℂ (b '' Set.Iic i) ∧
+      x ∈ Submodule.span ℂ (c '' Set.Ici i) := by
+  let P := Submodule.span ℂ (b '' Set.Iic i)
+  let Q := Submodule.span ℂ (c '' Set.Ici i)
+  have hliP : LinearIndependent ℂ (fun j : Set.Iic i ↦ b j.1) :=
+    b.linearIndependent.comp (fun j : Set.Iic i ↦ j.1) Subtype.val_injective
+  have hrangeP : Set.range (fun j : Set.Iic i ↦ b j.1) = b '' Set.Iic i := by
+    ext x
+    constructor
+    · rintro ⟨j, rfl⟩
+      exact ⟨j.1, j.2, rfl⟩
+    · rintro ⟨j, hj, rfl⟩
+      exact ⟨⟨j, hj⟩, rfl⟩
+  have hdimP : Module.finrank ℂ P = i.1 + 1 := by
+    change Module.finrank ℂ (Submodule.span ℂ (b '' Set.Iic i)) = i.1 + 1
+    rw [← hrangeP, finrank_span_eq_card hliP]
+    simp
+  have hliQ : LinearIndependent ℂ (fun j : Set.Ici i ↦ c j.1) :=
+    c.linearIndependent.comp (fun j : Set.Ici i ↦ j.1) Subtype.val_injective
+  have hrangeQ : Set.range (fun j : Set.Ici i ↦ c j.1) = c '' Set.Ici i := by
+    ext x
+    constructor
+    · rintro ⟨j, rfl⟩
+      exact ⟨j.1, j.2, rfl⟩
+    · rintro ⟨j, hj, rfl⟩
+      exact ⟨⟨j, hj⟩, rfl⟩
+  have hdimQ : Module.finrank ℂ Q = n - i.1 := by
+    change Module.finrank ℂ (Submodule.span ℂ (c '' Set.Ici i)) = n - i.1
+    rw [← hrangeQ, finrank_span_eq_card hliQ]
+    simp
+  have hnotdisjoint : ¬ Disjoint P Q := by
+    intro hdisjoint
+    have hdim := Submodule.finrank_add_finrank_le_of_disjoint hdisjoint
+    rw [hdimP, hdimQ, hn] at hdim
+    omega
+  have hinf : ⊥ < P ⊓ Q := by
+    rw [bot_lt_iff_ne_bot]
+    intro heq
+    apply hnotdisjoint
+    rw [disjoint_iff]
+    exact heq
+  obtain ⟨x, hx⟩ := Submodule.nonzero_mem_of_bot_lt hinf
+  refine ⟨x, ?_, x.2.1, x.2.2⟩
+  intro hzero
+  apply hx
+  exact Subtype.ext hzero
+
+namespace LinearMap.IsSymmetric
+
+/-- **Weyl monotonicity for symmetric endomorphisms.** If `T - S` is positive,
+then every decreasingly ordered eigenvalue of `S` is at most the eigenvalue of
+`T` with the same index. -/
+theorem eigenvalues_le_of_sub_isPositive
+    {n : ℕ} {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+    [FiniteDimensional ℂ E] {S T : E →ₗ[ℂ] E}
+    (hS : S.IsSymmetric) (hT : T.IsSymmetric)
+    (hn : Module.finrank ℂ E = n) (hST : (T - S).IsPositive)
+    (i : Fin n) : hS.eigenvalues hn i ≤ hT.eigenvalues hn i := by
+  let bS := hS.eigenvectorBasis hn
+  let bT := hT.eigenvectorBasis hn
+  obtain ⟨x, hx, hxS, hxT⟩ :=
+    exists_nonzero_mem_span_Iic_inter_span_Ici bS.toBasis bT.toBasis hn i
+  have hsuppS : ↑(bS.toBasis.repr x).support ⊆ Set.Iic i :=
+    bS.toBasis.repr_support_subset_of_mem_span (Set.Iic i) hxS
+  have hsuppT : ↑(bT.toBasis.repr x).support ⊆ Set.Ici i :=
+    bT.toBasis.repr_support_subset_of_mem_span (Set.Ici i) hxT
+  have hzeroS (j : Fin n) (hj : ¬ j ≤ i) : bS.repr x j = 0 := by
+    by_contra hne
+    have hjmem : j ∈ (bS.toBasis.repr x).support := by
+      rw [Finsupp.mem_support_iff, bS.coe_toBasis_repr_apply]
+      exact hne
+    exact hj (hsuppS hjmem)
+  have hzeroT (j : Fin n) (hj : ¬ i ≤ j) : bT.repr x j = 0 := by
+    by_contra hne
+    have hjmem : j ∈ (bT.toBasis.repr x).support := by
+      rw [Finsupp.mem_support_iff, bT.coe_toBasis_repr_apply]
+      exact hne
+    exact hj (hsuppT hjmem)
+  have hnormS : ∑ j : Fin n, ‖bS.repr x j‖ ^ 2 = ‖x‖ ^ 2 := by
+    simpa [bS.repr_apply_apply] using bS.sum_sq_norm_inner_right x
+  have hnormT : ∑ j : Fin n, ‖bT.repr x j‖ ^ 2 = ‖x‖ ^ 2 := by
+    simpa [bT.repr_apply_apply] using bT.sum_sq_norm_inner_right x
+  have hSlower : hS.eigenvalues hn i * ‖x‖ ^ 2 ≤ (inner ℂ (S x) x).re := by
+    rw [symmetric_quadraticForm_eq_sum_eigenvalues_mul_norm_sq hS hn,
+      ← hnormS, Finset.mul_sum]
+    apply Finset.sum_le_sum
+    intro j _
+    by_cases hj : j ≤ i
+    · exact mul_le_mul_of_nonneg_right (hS.eigenvalues_antitone hn hj) (sq_nonneg _)
+    · rw [hzeroS j hj, norm_zero, zero_pow (by omega), mul_zero, mul_zero]
+  have hTupper : (inner ℂ (T x) x).re ≤ hT.eigenvalues hn i * ‖x‖ ^ 2 := by
+    rw [symmetric_quadraticForm_eq_sum_eigenvalues_mul_norm_sq hT hn,
+      ← hnormT, Finset.mul_sum]
+    apply Finset.sum_le_sum
+    intro j _
+    by_cases hj : i ≤ j
+    · exact mul_le_mul_of_nonneg_right (hT.eigenvalues_antitone hn hj) (sq_nonneg _)
+    · rw [hzeroT j hj, norm_zero, zero_pow (by omega), mul_zero, mul_zero]
+  have hmiddle : (inner ℂ (S x) x).re ≤ (inner ℂ (T x) x).re := by
+    have hnonneg := hST.re_inner_nonneg_left x
+    simpa [sub_apply, inner_sub_left] using hnonneg
+  have hnormpos : 0 < ‖x‖ ^ 2 := sq_pos_of_pos (norm_pos_iff.mpr hx)
+  nlinarith [hSlower.trans (hmiddle.trans hTupper)]
+
+end LinearMap.IsSymmetric
+
+namespace Matrix.IsHermitian
+
+/-- **Weyl monotonicity for Hermitian matrices.** Loewner order compares the
+decreasingly ordered eigenvalues term by term, using the canonical
+`Fin (Fintype.card n)` indexing.  This is the cross-matrix spectral input used
+in Wolf, Chapter 5, Equation (5.56). -/
+theorem eigenvalues₀_mono
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.IsHermitian) (hB : B.IsHermitian)
+    (hAB : A ≤ B) (i : Fin (Fintype.card n)) :
+    hA.eigenvalues₀ i ≤ hB.eigenvalues₀ i := by
+  have hpos :
+      (Matrix.toEuclideanLin B - Matrix.toEuclideanLin A).IsPositive := by
+    have hsub : (B - A).PosSemidef := Matrix.le_iff.mp hAB
+    simpa using (Matrix.isPositive_toEuclideanLin_iff.mpr hsub)
+  exact LinearMap.IsSymmetric.eigenvalues_le_of_sub_isPositive
+    (Matrix.isSymmetric_toEuclideanLin_iff.mpr hA)
+    (Matrix.isSymmetric_toEuclideanLin_iff.mpr hB)
+    finrank_euclideanSpace hpos i
+
+/-- Matrix-indexed form of `Matrix.IsHermitian.eigenvalues₀_mono`. -/
+theorem eigenvalues_mono
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.IsHermitian) (hB : B.IsHermitian)
+    (hAB : A ≤ B) (i : n) : hA.eigenvalues i ≤ hB.eigenvalues i := by
+  exact hA.eigenvalues₀_mono hB hAB
+    ((Fintype.equivOfCardEq (Fintype.card_fin (Fintype.card n))).symm i)
+
+end Matrix.IsHermitian

--- a/QICLean/Channel/Schwarz.lean
+++ b/QICLean/Channel/Schwarz.lean
@@ -52,6 +52,7 @@ import QICLean.Channel.Schwarz.TwoPositive
 import QICLean.Channel.Schwarz.TwoVariable
 import QICLean.Channel.Schwarz.TwoVariableEquality
 import QICLean.Channel.Schwarz.TwoVariableUnconditional
+import QICLean.Channel.Schwarz.UnitaryComparison
 import QICLean.Channel.Schwarz.WeylRelativeEntropyIntegral
 import QICLean.Channel.Schwarz.WeylSupportPetzRecovery
 import QICLean.Channel.Schwarz.WeylSupportRelativeEntropyEquality

--- a/QICLean/Channel/Schwarz/UnitaryComparison.lean
+++ b/QICLean/Channel/Schwarz/UnitaryComparison.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 Sirui Lu and QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import QICLean.Analysis.WeylMonotonicity
+
+/-!
+# Unitary comparison for monotone scalar functions
+
+This file proves the corrected form of the unitary comparison following Weyl's
+monotonicity theorem in Wolf, Chapter 5.  If Hermitian matrices satisfy
+`A ≤ B`, their decreasingly ordered eigenvalues satisfy
+`λⱼ↓(A) ≤ λⱼ↓(B)`.  Aligning the corresponding ordered eigenbases therefore
+gives one unitary `U` such that
+
+`f(A) ≤ U * f(B) * U†`
+
+for every scalar function `f` that is nondecreasing on an interval containing
+both spectra.  The same `U` works for all such intervals and functions.
+
+The order hypothesis is indispensable: it is present in Wolf's immediately
+preceding statement of Weyl monotonicity, but absent from the original printed
+statement of the proposition containing Equation (5.57).
+
+## Main result
+
+* `Matrix.IsHermitian.exists_unitary_cfc_le_cfc_of_le` is the corrected form of
+  Wolf's unitary comparison, Equation (5.57).
+
+## Reference
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 5,
+  Equations (5.56)--(5.57)][Wolf2012QChannels]
+-/
+
+open scoped ComplexOrder MatrixOrder
+
+namespace Matrix.IsHermitian
+
+/-- **Wolf's unitary comparison for monotone scalar functions (corrected).**
+Let `A` and `B` be Hermitian matrices with `A ≤ B`.  There is a unitary `U`,
+depending only on their decreasingly ordered eigenbases, such that
+`f(A) ≤ U * f(B) * U†` whenever `f` is nondecreasing on an interval containing
+both spectra.
+
+No continuity assumption on `f` is needed: the spectrum of a finite matrix is
+finite, so every function on it is continuous. -/
+theorem exists_unitary_cfc_le_cfc_of_le
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.IsHermitian) (hB : B.IsHermitian)
+    (hAB : A ≤ B) :
+    ∃ U : Matrix.unitaryGroup n ℂ,
+      ∀ (I : Set ℝ) (f : ℝ → ℝ), I.OrdConnected →
+        spectrum ℝ A ⊆ I → spectrum ℝ B ⊆ I → MonotoneOn f I →
+        cfc f A ≤ (U : Matrix n n ℂ) * cfc f B * star (U : Matrix n n ℂ) := by
+  let UA : Matrix.unitaryGroup n ℂ := hA.eigenvectorUnitary
+  let UB : Matrix.unitaryGroup n ℂ := hB.eigenvectorUnitary
+  refine ⟨UA * star UB, ?_⟩
+  intro I f _hI hspecA hspecB hf
+  let DA : Matrix n n ℂ :=
+    Matrix.diagonal (fun i => (f (hA.eigenvalues i) : ℂ))
+  let DB : Matrix n n ℂ :=
+    Matrix.diagonal (fun i => (f (hB.eigenvalues i) : ℂ))
+  have hf_eigenvalues (i : n) : f (hA.eigenvalues i) ≤ f (hB.eigenvalues i) :=
+    hf (hspecA (hA.eigenvalues_mem_spectrum_real i))
+      (hspecB (hB.eigenvalues_mem_spectrum_real i))
+      (hA.eigenvalues_mono hB hAB i)
+  have hDBDA : (DB - DA).PosSemidef := by
+    rw [show DB - DA = Matrix.diagonal
+      (fun i => ((f (hB.eigenvalues i) - f (hA.eigenvalues i) : ℝ) : ℂ)) from by
+        ext i j
+        by_cases hij : i = j
+        · subst j
+          simp [DA, DB]
+        · simp [DA, DB, hij]]
+    rw [Matrix.posSemidef_diagonal_iff]
+    intro i
+    simpa using sub_nonneg.mpr (hf_eigenvalues i)
+  have hconj :
+      ((UA : Matrix n n ℂ) * (DB - DA) * star (UA : Matrix n n ℂ)).PosSemidef := by
+    simpa only [star_eq_conjTranspose] using
+      hDBDA.mul_mul_conjTranspose_same (UA : Matrix n n ℂ)
+  have haligned :
+      (UA : Matrix n n ℂ) * DA * star (UA : Matrix n n ℂ) ≤
+        (UA : Matrix n n ℂ) * DB * star (UA : Matrix n n ℂ) := by
+    rw [Matrix.le_iff]
+    simpa only [mul_sub, sub_mul] using hconj
+  have hAcfc :
+      cfc f A = (UA : Matrix n n ℂ) * DA * star (UA : Matrix n n ℂ) := by
+    rw [hA.cfc_eq]
+    rfl
+  have hBcfc :
+      cfc f B = (UB : Matrix n n ℂ) * DB * star (UB : Matrix n n ℂ) := by
+    rw [hB.cfc_eq]
+    rfl
+  rw [hAcfc, hBcfc]
+  apply haligned.trans_eq
+  rw [Submonoid.coe_mul, Unitary.coe_star, star_mul, star_star]
+  change (UA : Matrix n n ℂ) * DB * star (UA : Matrix n n ℂ) =
+    (((UA : Matrix n n ℂ) * star (UB : Matrix n n ℂ)) *
+      ((UB : Matrix n n ℂ) * DB * star (UB : Matrix n n ℂ))) *
+      ((UB : Matrix n n ℂ) * star (UA : Matrix n n ℂ))
+  have hUB : star (UB : Matrix n n ℂ) * (UB : Matrix n n ℂ) = 1 :=
+    Unitary.coe_star_mul_self UB
+  calc
+    (UA : Matrix n n ℂ) * DB * star (UA : Matrix n n ℂ) =
+        (UA : Matrix n n ℂ) *
+          (star (UB : Matrix n n ℂ) * (UB : Matrix n n ℂ)) * DB *
+          (star (UB : Matrix n n ℂ) * (UB : Matrix n n ℂ)) *
+          star (UA : Matrix n n ℂ) := by rw [hUB]; simp
+    _ = (((UA : Matrix n n ℂ) * star (UB : Matrix n n ℂ)) *
+          ((UB : Matrix n n ℂ) * DB * star (UB : Matrix n n ℂ))) *
+          ((UB : Matrix n n ℂ) * star (UA : Matrix n n ℂ)) := by
+      noncomm_ring
+
+end Matrix.IsHermitian

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order.tex
@@ -322,6 +322,96 @@ Section~\ref{sec:app_schwarz_trace_order}.
     (\ref{eq:schwarz_order_interval}) back into spectral bounds.
 \end{proof}
 
+\subsection{Weyl monotonicity and unitary comparison}
+
+\begin{theorem}[Weyl monotonicity in the Loewner order]
+    \label{thm:weyl_monotonicity_loewner}
+    \lean{LinearMap.IsSymmetric.eigenvalues_le_of_sub_isPositive,
+        Matrix.IsHermitian.eigenvalues₀_mono,
+        Matrix.IsHermitian.eigenvalues_mono}
+    \leanok
+    Let $A,B\in\MN{d}$ be Hermitian. If $A\leq B$, then their decreasingly
+    ordered eigenvalues satisfy
+    \begin{align}
+        \lambda_j^\downarrow(A)
+         & \leq \lambda_j^\downarrow(B)
+        \qquad (0\leq j<d).
+        \label{eq:schwarz_weyl_monotonicity}
+    \end{align}
+    This is the consequence of \cite[Equation~(5.56)]{Wolf2012Quantum}
+    used immediately before Proposition~5.3.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Let $S$ and $T$ be the symmetric endomorphisms associated with $A$ and
+    $B$. Fix $j$, let $P$ be the span of the first $j+1$ eigenvectors of
+    $S$, and let $Q$ be the span of the last $d-j$ eigenvectors of $T$.
+    Since $\dim P+\dim Q=d+1$, there is a nonzero vector
+    $x\in P\cap Q$. The two ordered spectral expansions and positivity of
+    $T-S$ give
+    \begin{align}
+        \lambda_j^\downarrow(A)\lVert x\rVert^2
+         & \leq \operatorname{Re}\langle Sx,x\rangle
+          \leq \operatorname{Re}\langle Tx,x\rangle
+          \leq \lambda_j^\downarrow(B)\lVert x\rVert^2.
+        \notag
+    \end{align}
+    Division by $\lVert x\rVert^2>0$ proves
+    (\ref{eq:schwarz_weyl_monotonicity}).
+\end{proof}
+
+\begin{theorem}[Unitary comparison for non-decreasing functions]
+    \label{thm:wolf_unitary_comparison}
+    \lean{Matrix.IsHermitian.exists_unitary_cfc_le_cfc_of_le}
+    \leanok
+    Let $A,B\in\MN{d}$ be Hermitian. The corrected form of
+    \cite[Proposition~5.3 and Equation~(5.57)]{Wolf2012Quantum} is, with
+    $\mathcal U(d)$ denoting the unitary matrices,
+    \begin{align}
+        A\leq B\quad\Longrightarrow\quad
+        \exists U\in\mathcal U(d)\quad
+        &\forall I\subseteq\R\ \forall f:\R\to\R, \notag\\
+        &\Bigl(I\text{ is an interval}\Bigr)\ \land
+          \Bigl(\spec(A)\cup\spec(B)\subseteq I\Bigr) \notag\\
+        &\land\ \Bigl(f\text{ is non-decreasing on }I\Bigr) \notag\\
+        &\Longrightarrow f(A)\leq U f(B)U^\dagger.
+        \label{eq:schwarz_unitary_comparison}
+    \end{align}
+    In particular, the unitary is chosen before the interval and the function;
+    it depends only on $A$ and $B$. No continuity hypothesis on $f$ is
+    required, since both spectra are finite.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:weyl_monotonicity_loewner}
+    Choose unitary eigenvector matrices $V_A,V_B$ in decreasing eigenvalue
+    order and set $U=V_AV_B^\dagger$. By
+    (\ref{eq:schwarz_weyl_monotonicity}) and monotonicity of $f$,
+    \begin{align}
+        f\bigl(\lambda_j^\downarrow(A)\bigr)
+         &\leq f\bigl(\lambda_j^\downarrow(B)\bigr)
+        \qquad (0\leq j<d).
+        \notag
+    \end{align}
+    Hence the corresponding diagonal matrices are ordered. Conjugating this
+    inequality by $V_A$ and using $U=V_AV_B^\dagger$ gives
+    (\ref{eq:schwarz_unitary_comparison}). The cross-matrix eigenvalue
+    comparison used here is Theorem~\ref{thm:weyl_monotonicity_loewner}, proved
+    by the preceding variational argument; it is not assumed separately.
+\end{proof}
+
+\begin{remark}[Necessity of the order hypothesis]
+    \label{rem:wolf_unitary_comparison_counterexample}
+    Wolf's printed proposition omits $A\leq B$ and is false in that form. In
+    dimension $d=1$, take $A=[1]$, $B=[0]$, $I=[0,1]$, and $f(x)=x$.
+    Every unitary is a scalar phase, so $Uf(B)U^\dagger=0$, whereas
+    (\ref{eq:schwarz_unitary_comparison}) without its order hypothesis would
+    assert $1\leq0$. The correction is recorded in
+    \cite{gap:wolf_ch5_unitary_comparison_missing_order}.
+\end{remark}
+
 \section{Positive Schwarz maps outside complete positivity}
 
 The following example shows that the Schwarz inequality does not force complete

--- a/docs/paper-gaps/wolf_ch5_unitary_comparison_missing_order.tex
+++ b/docs/paper-gaps/wolf_ch5_unitary_comparison_missing_order.tex
@@ -13,7 +13,7 @@
 
 \begin{document}
 \maketitle
-\gapnote{false-source}{open}
+\gapnote{false-source}{resolved}
 
 \section{The assertion}
 
@@ -58,17 +58,20 @@ immediately'' does not supply the hypothesis needed by the proposition.
 
 \section{The corrected statement and source proof}
 
-The source argument proves the following corrected proposition.
-
-Let $A,B\in M_d(\C)$ be Hermitian and assume $A\le B$.  Then there is a
-unitary $U\in M_d(\C)$ such that, for every non-decreasing
-$f:I\to\mathbb R$ on an interval $I$ containing the spectra of both $A$ and
-$B$,
+The source argument proves the following corrected proposition, with the
+existential unitary quantified before the interval and the function:
 \begin{align}
-  f(A)\le U f(B)U^\dagger.
+  A\le B\quad\Longrightarrow\quad
+  \exists U\in M_d(\C)\ \Bigl[
+  &U^\dagger U=UU^\dagger=\Id\ \land
+    \forall I\subseteq\mathbb R\ \forall f:I\to\mathbb R, \notag\\
+  &\bigl(I\text{ is an interval}\ \land
+    \operatorname{spec}(A)\cup\operatorname{spec}(B)\subseteq I\ \land
+    f\text{ is non-decreasing on }I\bigr) \notag\\
+  &\hspace{7em}\Longrightarrow f(A)\le U f(B)U^\dagger\Bigr].
   \tag{corrected Wolf (5.57)}
 \end{align}
-The quantifier order is unchanged: the same $U$ works for every such $f$.
+Thus the same $U$ works for every admissible interval and function.
 
 Indeed, choose eigenvector unitaries $V_A,V_B$ in decreasing eigenvalue order,
 so that
@@ -96,33 +99,41 @@ With $U=V_A V_B^\dagger$, functional calculus in these eigenbases yields
 The entrywise diagonal inequality, transported by the unitary congruence
 $X\mapsto V_A X V_A^\dagger$, is the corrected conclusion.
 
-\section{Formalization boundary}
+\section{Formalization}
 
-The current matrix API already provides decreasingly ordered Hermitian
-eigenvalues and unitary covariance of the continuous functional calculus.
-The latter is recorded as \leanid{Matrix.cfc_conj_unitary} in
-\doclink{QICLean/Analysis/CfcConjugation}.  What is not yet exposed by the
-current dependency surface is the cross-matrix Weyl step
+The cross-matrix Weyl step is now proved as
+\leanid{LinearMap.IsSymmetric.eigenvalues\_le\_of\_sub\_isPositive}, with
+matrix forms \leanid{Matrix.IsHermitian.eigenvalues₀\_mono}
+and \leanid{Matrix.IsHermitian.eigenvalues\_mono}.
+The proof is a finite-dimensional variational argument: the span of the first
+$j+1$ eigenvectors of $A$ and the span of the last $d-j$ eigenvectors of $B$
+have dimensions summing to $d+1$, so they contain a common nonzero vector.
+The ordered spectral expansions and positivity of $B-A$ then give
 \begin{align}
-  A\le B
-  \Longrightarrow
-  \lambda_j^\downarrow(A)\le\lambda_j^\downarrow(B)
-  \quad\text{for every }j.
+  \lambda_j^\downarrow(A)\lVert x\rVert^2
+  \le \operatorname{Re}\langle Ax,x\rangle
+  \le \operatorname{Re}\langle Bx,x\rangle
+  \le \lambda_j^\downarrow(B)\lVert x\rVert^2.
 \end{align}
-The available antitonicity theorem for the ordered list only compares indices
-within one fixed Hermitian matrix; it does not compare two matrices in the
-Loewner order.  Consequently no replacement proof of the corrected proposition
-is asserted here.  Formalizing Weyl monotonicity by its own finite-dimensional
-spectral route remains the exact open dependency.
+Thus the cross-matrix comparison is proved rather than supplied as a pointwise
+hypothesis.
+
+The corrected proposition is formalized as
+\leanid{Matrix.IsHermitian.exists\_unitary\_cfc\_le\_cfc\_of\_le}.
+It chooses the unitary from the two decreasingly ordered eigenbases and then
+uses the proved Weyl comparison for every interval and every non-decreasing
+function. The declarations are in
+\doclink{QICLean/Analysis/WeylMonotonicity} and
+\doclink{QICLean/Channel/Schwarz/UnitaryComparison}.
 
 \section{Conclusion}
 
-Wolf's Proposition~5.3 is false as printed because it omits $A\le B$.  Adding
-that hypothesis makes the proposition an immediate consequence of the
-preceding Equation~(5.56), exactly as the source says: order the two spectra,
-apply the scalar monotonicity of $f$, and align the two eigenbases by one
-unitary.  The source correction is definitive; the formal Weyl-monotonicity
-dependency remains open.
+Wolf's Proposition~5.3 is false as printed because it omits $A\le B$. Adding
+that hypothesis makes the proposition a consequence of the preceding
+Equation~(5.56): order the two spectra, apply the scalar monotonicity of $f$,
+and align the two eigenbases by one unitary. Both the cross-matrix Weyl
+comparison and the corrected unitary comparison are now formalized without an
+assumed pointwise eigenvalue comparison.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -497,8 +497,9 @@ $f(A)\le Uf(B)U^\dagger$.  This unitary depends only on the two ordered
 eigenbases, so it works simultaneously for every admissible $f$, as required
 by the quantifier order of the printed proposition. In the formal proof, the
 cross-matrix eigenvalue comparison is established by the intersection of the
-first $j+1$ eigenspaces of $A$ with the last $d-j$ eigenspaces of $B$; it is
-not assumed as a pointwise comparison.
+span of the first $j+1$ ordered eigenvectors of $A$ with the span of the last
+$d-j$ ordered eigenvectors of $B$; it is not assumed as a pointwise
+comparison.
 
 \paragraph{Classification.}
 This is a genuine source error: the printed theorem is false, while its

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -462,19 +462,29 @@ the second global extremum is read as an infimum.
 \paragraph{Formalization trigger.}
 The correction and the exact source proof route are documented in
 \path{docs/paper-gaps/wolf_ch5_unitary_comparison_missing_order.tex}.  The
-corrected theorem is not yet formalized because the current dependency surface
-does not expose the required cross-matrix Weyl monotonicity theorem.
+cross-matrix Weyl comparison is proved by
+\leanid{LinearMap.IsSymmetric.eigenvalues\_le\_of\_sub\_isPositive}, and the
+corrected proposition is formalized by
+\leanid{Matrix.IsHermitian.exists\_unitary\_cfc\_le\_cfc\_of\_le}.
 
 \paragraph{Original statement and correction.}
 Immediately after stating Weyl monotonicity for Hermitian matrices satisfying
-$A\le B$, Wolf's Proposition~5.3 drops that hypothesis and claims that for
-arbitrary Hermitian $A,B$ there is a unitary $U$ such that
+$A\le B$, Wolf's Proposition~5.3 drops that hypothesis. Its corrected form,
+with the unitary chosen before the interval and the function, is
 \begin{align}
-  f(A)\le U f(B)U^\dagger
+  A\le B\quad\Longrightarrow\quad
+  \exists U\in M_d(\C)\ \Bigl[
+  &U^\dagger U=UU^\dagger=\Id\ \land
+    \forall I\subseteq\mathbb R\ \forall f:I\to\mathbb R, \notag\\
+  &\bigl(I\text{ is an interval}\ \land
+    \operatorname{spec}(A)\cup\operatorname{spec}(B)\subseteq I\ \land
+    f\text{ is non-decreasing on }I\bigr) \notag\\
+  &\hspace{7em}\Longrightarrow f(A)\le U f(B)U^\dagger\Bigr].
+  \tag{corrected Wolf (5.57)}
 \end{align}
-for every non-decreasing scalar function $f$ on an interval containing the two
-spectra.  In dimension one, $A=[1]$, $B=[0]$, and $f(x)=x$ contradict the
-printed claim.  The corrected proposition inserts $A\le B$.
+In dimension one, $A=[1]$, $B=[0]$, $I=[0,1]$, and $f(x)=x$ contradict the
+printed unqualified claim: every unitary is a phase, so its conclusion is
+$1\le0$. The hypothesis $A\le B$ is therefore indispensable.
 
 \paragraph{Source proof route.}
 Under $A\le B$, Equation~(5.56) gives
@@ -485,7 +495,10 @@ unitaries $V_A,V_B$ and setting $U=V_A V_B^\dagger$ then transports the
 entrywise diagonal inequality to
 $f(A)\le Uf(B)U^\dagger$.  This unitary depends only on the two ordered
 eigenbases, so it works simultaneously for every admissible $f$, as required
-by the quantifier order of the printed proposition.
+by the quantifier order of the printed proposition. In the formal proof, the
+cross-matrix eigenvalue comparison is established by the intersection of the
+first $j+1$ eigenspaces of $A$ with the last $d-j$ eigenspaces of $B$; it is
+not assumed as a pointwise comparison.
 
 \paragraph{Classification.}
 This is a genuine source error: the printed theorem is false, while its

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -813,12 +813,13 @@ The surrounding complexity prose at source lines 80–83 is not formalized.
 
 - `LinearMap.IsSymmetric.eigenvalues_le_of_sub_isPositive` proves the
   cross-operator Weyl monotonicity step by a finite-dimensional variational
-  argument. For the `j`th decreasing eigenvalue, the first `j + 1`
-  eigenspaces of the smaller operator and the last `d - j` eigenspaces of the
-  larger operator have dimensions summing to `d + 1`. A common nonzero vector
-  gives the lower and upper quadratic-form bounds, while positivity of the
-  difference gives the middle inequality. Thus no pointwise cross-matrix
-  eigenvalue comparison is assumed ✓
+  argument. For the `j`th decreasing eigenvalue, the span of the first
+  `j + 1` ordered eigenvectors of the smaller operator and the span of the
+  last `d - j` ordered eigenvectors of the larger operator have dimensions
+  summing to `d + 1`. A common nonzero vector gives the lower and upper
+  quadratic-form bounds, while positivity of the difference gives the middle
+  inequality. Thus no pointwise cross-matrix eigenvalue comparison is assumed
+  ✓
 - `Matrix.IsHermitian.eigenvalues₀_mono` and
   `Matrix.IsHermitian.eigenvalues_mono` transport this result to Hermitian
   matrices in the Loewner order:

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -2,7 +2,7 @@
 
 Concordance between formalized declarations and the theorem/proposition
 numbering of M. Wolf, *Quantum Channels & Operations: Guided Tour* (2012),
-Chapters 2, 6, and the currently compiled Chapter 8 prerequisites. This table
+Chapters 2–6 and the currently compiled Chapter 8 prerequisites. This table
 used to live as compiled Lean documentation
 modules (`WolfChapter2Index.lean`, `WolfChapter6Index.lean`,
 `WolfChapter6Wrappers.lean`); those modules carried zero declarations of
@@ -804,6 +804,39 @@ so that the cited formal statements are available from the main project import.
   the statement.
 
 The surrounding complexity prose at source lines 80–83 is not formalized.
+
+---
+
+## Wolf Lecture Notes — Chapter 5: Schwarz Inequalities
+
+### Consequence of Equation 5.56 and Proposition 5.3, Equation 5.57 — FORMALIZED WITH THE ORDER-HYPOTHESIS CORRECTION
+
+- `LinearMap.IsSymmetric.eigenvalues_le_of_sub_isPositive` proves the
+  cross-operator Weyl monotonicity step by a finite-dimensional variational
+  argument. For the `j`th decreasing eigenvalue, the first `j + 1`
+  eigenspaces of the smaller operator and the last `d - j` eigenspaces of the
+  larger operator have dimensions summing to `d + 1`. A common nonzero vector
+  gives the lower and upper quadratic-form bounds, while positivity of the
+  difference gives the middle inequality. Thus no pointwise cross-matrix
+  eigenvalue comparison is assumed ✓
+- `Matrix.IsHermitian.eigenvalues₀_mono` and
+  `Matrix.IsHermitian.eigenvalues_mono` transport this result to Hermitian
+  matrices in the Loewner order:
+  `A ≤ B` implies `λⱼ↓(A) ≤ λⱼ↓(B)` for every decreasing-eigenvalue index.
+  This is the consequence of Equation 5.56 used immediately before
+  Proposition 5.3 ✓
+- `Matrix.IsHermitian.exists_unitary_cfc_le_cfc_of_le` formalizes the corrected
+  Proposition 5.3. For Hermitian `A ≤ B`, it first chooses one unitary from
+  their decreasingly ordered eigenbases; that same unitary then works for
+  every interval containing both spectra and every scalar function
+  non-decreasing on that interval. Hence the quantifier order is
+  `∃ U, ∀ I, ∀ f`, and the conclusion is the corrected Equation 5.57,
+  `f(A) ≤ U f(B) U†` ✓
+- The hypothesis `A ≤ B` is indispensable. The printed unqualified
+  proposition is false already for `d = 1`: take `A = [1]`, `B = [0]`,
+  `I = [0,1]`, and `f(x) = x`. Every one-dimensional unitary is a phase, so
+  the claimed conclusion becomes `1 ≤ 0`. The resolved false-source note is
+  `docs/paper-gaps/wolf_ch5_unitary_comparison_missing_order.tex`.
 
 ---
 


### PR DESCRIPTION
## Summary

This pull request supplies the Chapter 5 order-theoretic step needed for Wolf's unitary comparison.

- It proves cross-matrix Weyl monotonicity for symmetric linear maps and Hermitian matrices from positivity of the difference. The proof is genuinely variational: for the `j`th ordered eigenvalue, the span of the first `j + 1` ordered eigenvectors of the smaller operator meets the span of the last `d - j` ordered eigenvectors of the larger operator in a nonzero vector. The resulting quadratic-form inequalities yield the comparison; no pointwise cross-matrix eigenvalue inequality is assumed.
- It formalizes the corrected form of Wolf's Proposition 5.3 and Equation (5.57). For Hermitian matrices `A ≤ B`, there exists one unitary `U`, chosen before all subsequent data, such that for every interval `I` containing both spectra and every scalar function `f` that is non-decreasing on `I`,
  `f(A) ≤ U f(B) U†`.
  Thus the essential quantifier order is `∃ U, ∀ I, ∀ f`.
- It records why the missing hypothesis `A ≤ B` is indispensable. In dimension one, `A = [1]`, `B = [0]`, `I = [0,1]`, and `f(x) = x` reduce the printed unqualified conclusion to `1 ≤ 0`, since every one-dimensional unitary is a phase.
- It synchronizes the Chapter 5 Blueprint, the focused paper-gap note, the aggregate Wolf errata, and the Wolf numbering coverage. The operator-convexity scope from #462 is unchanged.

## Verification

- `lake build QICLean.Analysis.WeylMonotonicity QICLean.Channel.Schwarz.UnitaryComparison`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `lake exe lint_style`
- Blueprint/Lean synchronization: 2437 of 2437 theorem-like entries
- Changed-declaration reverse coverage: no omissions
- Reader-facing prose and paper-gap reference checks
- `git diff --check` and operator-convexity scope checks
- Kernel `#print axioms` audit for all four public declarations: only `propext`, `Classical.choice`, and `Quot.sound`

Refs #27
