### PR TITLE
Formalize Yamagami's Fourier–Hessian prerequisite

### DIFF
--- a/QICLean/Analysis.lean
+++ b/QICLean/Analysis.lean
@@ -100,3 +100,4 @@ import QICLean.Analysis.WeightedCesaroMean
 import QICLean.Analysis.WeightedPositiveKernel
 import QICLean.Analysis.WeylMonotonicity
 import QICLean.Analysis.YamagamiBoundary
+import QICLean.Analysis.YamagamiCyclicMatrix

--- a/QICLean/Analysis/YamagamiCyclicMatrix.lean
+++ b/QICLean/Analysis/YamagamiCyclicMatrix.lean
@@ -1,0 +1,670 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import Mathlib.Analysis.Fourier.ZMod
+import Mathlib.LinearAlgebra.Matrix.Circulant
+import QICLean.Analysis.CyclicReciprocal
+import QICLean.Analysis.FiniteCoordinateNowosad.Yamagami
+
+/-!
+# Yamagami's forward cyclic matrix
+
+This file constructs the stride-one cyclic matrix used on pp. 522--524 of
+S. Yamagami, *Cyclic inequalities*, Proc. Amer. Math. Soc. 118 (1993),
+521--527.  Its Fourier symbol is the one already defined in
+`QICLean.Analysis.CyclicReciprocal`.  The corrected strict-disk estimate in
+that file yields invertibility and the positive-semidefinite Hessian package
+required by Yamagami's Lemma 3.
+
+The only finite Fourier facts developed locally are the translation formula
+for the discrete Fourier transform and its finite Parseval identity.  Mathlib
+provides DFT inversion on `ZMod`, but currently provides neither of these two
+forms directly.
+-/
+
+open scoped BigOperators Matrix ZMod
+open AddChar Nowosad
+
+namespace Yamagami
+
+variable (N m : ℕ) [NeZero N]
+
+/-- The matrix whose action is Yamagami's forward cyclic denominator:
+`(Sx) i = (s - m) x i + ∑_{k=1}^m x (i+k)`.
+
+The displayed entry formula is invariant under simultaneous cyclic
+translation of its row and column indices, so this is a circulant matrix. -/
+noncomputable def forwardMatrix (s : ℝ) : Matrix (ZMod N) (ZMod N) ℝ :=
+  fun i j ↦
+    (s - (m : ℝ)) * (if j = i then 1 else 0)
+      + ∑ k : Fin m,
+          if j = i + ((k.1 + 1 : ℕ) : ZMod N) then 1 else 0
+
+omit [NeZero N] in
+@[simp]
+theorem forwardMatrix_apply (s : ℝ) (i j : ZMod N) :
+    forwardMatrix N m s i j =
+      (s - (m : ℝ)) * (if j = i then 1 else 0)
+        + ∑ k : Fin m,
+            if j = i + ((k.1 + 1 : ℕ) : ZMod N) then 1 else 0 :=
+  rfl
+
+/-- Matrix multiplication by the forward cyclic matrix is exactly the
+previously defined forward denominator. -/
+theorem forwardMatrix_mulVec (s : ℝ) (x : ZMod N → ℝ) :
+    forwardMatrix N m s *ᵥ x = forwardDenominator N m s x := by
+  classical
+  funext i
+  unfold forwardMatrix forwardDenominator Matrix.mulVec dotProduct
+  simp_rw [add_mul]
+  rw [Finset.sum_add_distrib]
+  have hdiagonal :
+      (∑ j : ZMod N,
+        ((s - (m : ℝ)) * (if j = i then 1 else 0)) * x j) =
+        (s - (m : ℝ)) * x i := by
+    simp
+  rw [hdiagonal]
+  congr 1
+  simp_rw [Finset.sum_mul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro k _
+  simp
+
+omit [NeZero N] in
+/-- Simultaneous cyclic translation leaves every matrix entry unchanged. -/
+theorem forwardMatrix_add_add (s : ℝ) (a i j : ZMod N) :
+    forwardMatrix N m s (i + a) (j + a) = forwardMatrix N m s i j := by
+  classical
+  have hdiag : j + a = i + a ↔ j = i := by
+    constructor
+    · exact add_right_cancel
+    · exact congrArg (fun z ↦ z + a)
+  have hshift (q : ZMod N) : j + a = i + a + q ↔ j = i + q := by
+    rw [show i + a + q = (i + q) + a by abel]
+    constructor
+    · exact add_right_cancel
+    · exact congrArg (fun z ↦ z + a)
+  simp only [forwardMatrix_apply, hdiag, hshift]
+
+omit [NeZero N] in
+/-- The entry formula is a `Matrix.circulant` in Mathlib's convention. -/
+theorem forwardMatrix_eq_circulant (s : ℝ) :
+    forwardMatrix N m s =
+      Matrix.circulant (fun q : ZMod N ↦ forwardMatrix N m s q 0) := by
+  ext i j
+  simp only [Matrix.circulant_apply]
+  simpa using forwardMatrix_add_add N m s j (i - j) 0
+
+omit [NeZero N] in
+/-- The matrix entries are nonnegative as soon as the diagonal coefficient
+`s - m` is nonnegative. -/
+theorem forwardMatrix_nonnegative (s : ℝ) (hms : (m : ℝ) ≤ s) :
+    ∀ i j, 0 ≤ forwardMatrix N m s i j := by
+  classical
+  intro i j
+  rw [forwardMatrix_apply]
+  apply add_nonneg
+  · exact mul_nonneg (sub_nonneg.mpr hms) (by split_ifs <;> norm_num)
+  · apply Finset.sum_nonneg
+    intro k _
+    split_ifs <;> norm_num
+
+omit [NeZero N] in
+/-- The source range implies entrywise nonnegativity.  Only its upper bound
+on `m` and lower bound on `s` are needed for this conclusion. -/
+theorem forwardMatrix_nonnegative_of_sourceRange
+    (hm₂ : m ≤ N - 2) (s : ℝ) (hs : (N : ℝ) ≤ s) :
+    ∀ i j, 0 ≤ forwardMatrix N m s i j := by
+  apply forwardMatrix_nonnegative N m s
+  exact le_trans (by exact_mod_cast (by omega : m ≤ N)) hs
+
+/-- Every row of the forward cyclic matrix has sum `s`. -/
+theorem forwardMatrix_mulVec_one (s : ℝ) :
+    forwardMatrix N m s *ᵥ (1 : ZMod N → ℝ) =
+      s • (1 : ZMod N → ℝ) := by
+  rw [forwardMatrix_mulVec]
+  funext i
+  have hone : (1 : ZMod N → ℝ) = fun _ ↦ 1 := rfl
+  rw [hone, forwardDenominator_one]
+  simp
+
+private theorem sum_ite_eq_add_right (q i : ZMod N) :
+    ∑ j : ZMod N, (if i = j + q then (1 : ℝ) else 0) = 1 := by
+  calc
+    (∑ j : ZMod N, (if i = j + q then (1 : ℝ) else 0)) =
+        ∑ j : ZMod N, (if i = j then (1 : ℝ) else 0) := by
+      refine Fintype.sum_equiv (Equiv.addRight q) _ _ fun j ↦ ?_
+      by_cases h : i = j + q <;> simp [h]
+    _ = 1 := by simp
+
+/-- Every column of the forward cyclic matrix has sum `s`. -/
+theorem forwardMatrix_transpose_mulVec_one (s : ℝ) :
+    (forwardMatrix N m s).transpose *ᵥ (1 : ZMod N → ℝ) =
+      s • (1 : ZMod N → ℝ) := by
+  classical
+  funext i
+  simp only [Matrix.mulVec, dotProduct, Matrix.transpose_apply,
+    Pi.one_apply, Pi.smul_apply, smul_eq_mul, mul_one]
+  simp_rw [forwardMatrix_apply]
+  rw [Finset.sum_add_distrib]
+  rw [show (∑ j : ZMod N,
+      (s - (m : ℝ)) * (if i = j then 1 else 0)) =
+      s - (m : ℝ) by simp]
+  rw [Finset.sum_comm]
+  have hshift (k : Fin m) :
+      ∑ j : ZMod N,
+        (if i = j + ((k.1 + 1 : ℕ) : ZMod N) then (1 : ℝ) else 0) = 1 :=
+    sum_ite_eq_add_right N ((k.1 + 1 : ℕ) : ZMod N) i
+  simp_rw [hshift]
+  simp
+
+/-- The real eigenvalue of Yamagami's Hessian on the character indexed by
+`j`. -/
+noncomputable def hessianSymbol (s : ℝ) (j : ZMod N) : ℝ :=
+  2 * (s * (symbol N m s j).re - Complex.normSq (symbol N m s j))
+
+@[simp]
+theorem symbol_zero (s : ℝ) : symbol N m s 0 = (s : ℂ) := by
+  simp [symbol]
+
+@[simp]
+theorem hessianSymbol_zero (s : ℝ) : hessianSymbol N m s 0 = 0 := by
+  simp [hessianSymbol]
+
+/-- The corrected strict-disk estimate is precisely strict positivity of
+the Hessian symbol away from the constant character. -/
+theorem hessianSymbol_pos
+    (hN : 3 ≤ N) (hm₁ : 1 ≤ m) (hm₂ : m ≤ N - 2)
+    (s : ℝ) (hs : (N : ℝ) ≤ s) {j : ZMod N} (hj : j ≠ 0) :
+    0 < hessianSymbol N m s j := by
+  have hNpos : (0 : ℝ) < N := by exact_mod_cast (by omega : 0 < N)
+  have hspos : 0 < s := lt_of_lt_of_le hNpos hs
+  have hdisk := norm_symbol_sub_half_lt_half N m hN hm₁ hm₂ s hs hj
+  have hsquare :
+      ‖symbol N m s j - ((s / 2 : ℝ) : ℂ)‖ ^ 2 < (s / 2) ^ 2 :=
+    (sq_lt_sq₀ (norm_nonneg _) (by positivity)).mpr hdisk
+  have hweight :
+      Complex.normSq (symbol N m s j) < s * (symbol N m s j).re := by
+    rw [Complex.sq_norm, Complex.normSq_apply] at hsquare
+    simp only [Complex.sub_re, Complex.sub_im, Complex.ofReal_re,
+      Complex.ofReal_im, sub_zero] at hsquare
+    rw [Complex.normSq_apply]
+    nlinarith
+  unfold hessianSymbol
+  linarith
+
+/-- Every Fourier Hessian multiplier is nonnegative in the exact corrected
+Wolf range. -/
+theorem hessianSymbol_nonneg
+    (hN : 3 ≤ N) (hm₁ : 1 ≤ m) (hm₂ : m ≤ N - 2)
+    (s : ℝ) (hs : (N : ℝ) ≤ s) (j : ZMod N) :
+    0 ≤ hessianSymbol N m s j := by
+  by_cases hj : j = 0
+  · subst j
+    simp
+  · exact (hessianSymbol_pos N m hN hm₁ hm₂ s hs hj).le
+
+/-- No cyclic-matrix Fourier multiplier vanishes in the corrected Wolf
+range. -/
+theorem symbol_ne_zero
+    (hN : 3 ≤ N) (hm₁ : 1 ≤ m) (hm₂ : m ≤ N - 2)
+    (s : ℝ) (hs : (N : ℝ) ≤ s) (j : ZMod N) :
+    symbol N m s j ≠ 0 := by
+  by_cases hj : j = 0
+  · subst j
+    rw [symbol_zero]
+    exact_mod_cast (ne_of_gt (lt_of_lt_of_le
+      (by exact_mod_cast (by omega : 0 < N)) hs))
+  · intro hzero
+    have hpos := hessianSymbol_pos N m hN hm₁ hm₂ s hs hj
+    simp [hessianSymbol, hzero] at hpos
+
+private theorem map_forwardMatrix_mulVec (s : ℝ) (x : ZMod N → ℂ) :
+    (forwardMatrix N m s).map Complex.ofRealHom *ᵥ x =
+      fun i ↦
+        ((s - (m : ℝ) : ℝ) : ℂ) * x i +
+          ∑ k : Fin m, x (i + ((k.1 + 1 : ℕ) : ZMod N)) := by
+  classical
+  funext i
+  simp only [Matrix.mulVec, dotProduct, Matrix.map_apply, forwardMatrix_apply,
+    map_add, map_mul, map_sub, map_natCast, map_sum, apply_ite, map_one, map_zero]
+  simp_rw [add_mul]
+  rw [Finset.sum_add_distrib]
+  congr 1
+  · simp
+  · simp_rw [Finset.sum_mul]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro k _
+    simp
+
+/-- The DFT diagonalizes a cyclic translation. -/
+private theorem dft_comp_add_right (x : ZMod N → ℂ) (q j : ZMod N) :
+    ZMod.dft (fun i ↦ x (i + q)) j =
+      ZMod.stdAddChar (j * q) * ZMod.dft x j := by
+  simp only [ZMod.dft_apply, smul_eq_mul]
+  calc
+    (∑ i : ZMod N,
+        ZMod.stdAddChar (-(i * j)) * x (i + q)) =
+        ∑ i : ZMod N,
+          ZMod.stdAddChar (-((i - q) * j)) * x i := by
+      refine Fintype.sum_equiv (Equiv.addRight q) _ _ fun i ↦ ?_
+      simp only [Equiv.coe_addRight, add_sub_cancel_right]
+    _ = ∑ i : ZMod N,
+        ZMod.stdAddChar (j * q) *
+          (ZMod.stdAddChar (-(i * j)) * x i) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [show -((i - q) * j) = j * q + -(i * j) by ring,
+        map_add_eq_mul]
+      ring
+    _ = ZMod.stdAddChar (j * q) *
+        ∑ i : ZMod N, ZMod.stdAddChar (-(i * j)) * x i := by
+      rw [Finset.mul_sum]
+
+private theorem star_stdAddChar (t : ZMod N) :
+    star (ZMod.stdAddChar t) = ZMod.stdAddChar (-t) := by
+  change (starRingEnd ℂ) (ZMod.stdAddChar t) = ZMod.stdAddChar (-t)
+  rw [← inv_apply_eq_conj, map_neg_eq_inv]
+
+private theorem dft_adjoint (x y : ZMod N → ℂ) :
+    star (ZMod.dft x) ⬝ᵥ y =
+      star x ⬝ᵥ (fun i ↦ ZMod.dft y (-i)) := by
+  rw [dotProduct, dotProduct]
+  simp_rw [Pi.star_apply, ZMod.dft_apply, star_sum, smul_eq_mul,
+    StarMul.star_mul, star_stdAddChar, Finset.sum_mul]
+  rw [Finset.sum_comm]
+  simp only [Finset.mul_sum]
+  congr 1 with i
+  congr 1 with j
+  simp only [neg_neg, mul_neg, neg_neg]
+  rw [mul_comm i j]
+  ring
+
+/-- Parseval's identity for the unnormalized finite Fourier transform. -/
+private theorem dft_parseval (x y : ZMod N → ℂ) :
+    star (ZMod.dft x) ⬝ᵥ ZMod.dft y =
+      (N : ℂ) * (star x ⬝ᵥ y) := by
+  rw [dft_adjoint, ZMod.dft_dft]
+  simp only [neg_neg, smul_eq_mul]
+  rw [dotProduct, dotProduct, Finset.mul_sum]
+  congr 1 with i
+  ring
+
+private theorem invDFT_eq_zero_mode
+    (x : ZMod N → ℂ) (hx : ∀ j : ZMod N, j ≠ 0 → ZMod.dft x j = 0)
+    (i : ZMod N) :
+    x i = (N : ℂ)⁻¹ * ZMod.dft x 0 := by
+  have hsum :
+      (∑ j : ZMod N, ZMod.stdAddChar (j * i) • ZMod.dft x j) =
+        ZMod.dft x 0 := by
+    classical
+    rw [Finset.sum_eq_single 0]
+    · simp
+    · intro j _ hj
+      rw [hx j hj]
+      simp
+    · simp
+  calc
+    x i = ZMod.dft.symm (ZMod.dft x) i := by
+      exact (congrFun (ZMod.dft.symm_apply_apply x) i).symm
+    _ = (N : ℂ)⁻¹ •
+        ∑ j : ZMod N, ZMod.stdAddChar (j * i) • ZMod.dft x j :=
+      ZMod.invDFT_apply (ZMod.dft x) i
+    _ = (N : ℂ)⁻¹ * ZMod.dft x 0 := by rw [hsum]; rfl
+
+private theorem eq_const_of_dft_eq_zero_of_ne
+    (x : ZMod N → ℂ) (hx : ∀ j : ZMod N, j ≠ 0 → ZMod.dft x j = 0) :
+    x = fun _ ↦ x 0 := by
+  funext i
+  rw [invDFT_eq_zero_mode N x hx i, invDFT_eq_zero_mode N x hx 0]
+
+/-- The DFT diagonalizes the forward cyclic matrix, with eigenvalue exactly
+`Yamagami.symbol`.  This is the stride-one form of Yamagami's Lemma 4. -/
+theorem dft_map_forwardMatrix_mulVec (s : ℝ) (x : ZMod N → ℂ)
+    (j : ZMod N) :
+    ZMod.dft ((forwardMatrix N m s).map Complex.ofRealHom *ᵥ x) j =
+      symbol N m s j * ZMod.dft x j := by
+  rw [map_forwardMatrix_mulVec]
+  have haction :
+      (fun i ↦
+        ((s - (m : ℝ) : ℝ) : ℂ) * x i +
+          ∑ k : Fin m, x (i + ((k.1 + 1 : ℕ) : ZMod N))) =
+        ((s - (m : ℝ) : ℝ) : ℂ) • x +
+          ∑ k : Fin m,
+            (fun i ↦ x (i + ((k.1 + 1 : ℕ) : ZMod N))) := by
+    funext i
+    simp [smul_eq_mul]
+  rw [haction, map_add, map_smul, map_sum]
+  simp only [Pi.add_apply, Pi.smul_apply, Finset.sum_apply, smul_eq_mul]
+  simp_rw [dft_comp_add_right]
+  unfold symbol
+  rw [← Finset.sum_mul]
+  ring
+
+/-- Reversing the character index conjugates the real cyclic symbol. -/
+theorem symbol_neg (s : ℝ) (j : ZMod N) :
+    symbol N m s (-j) = star (symbol N m s j) := by
+  simp only [symbol, neg_mul]
+  rw [star_add, star_sum]
+  congr 1
+  · simp
+  · apply Finset.sum_congr rfl
+    intro k _
+    rw [map_neg_eq_inv, inv_apply_eq_conj]
+    rfl
+
+private theorem sum_ite_mul_eq_sub_right
+    (x : ZMod N → ℂ) (q i : ZMod N) :
+    ∑ j : ZMod N, (if i = j + q then (1 : ℂ) else 0) * x j =
+      x (i - q) := by
+  calc
+    (∑ j : ZMod N, (if i = j + q then (1 : ℂ) else 0) * x j) =
+        ∑ j : ZMod N, (if i = j then (1 : ℂ) else 0) * x (j - q) := by
+      refine Fintype.sum_equiv (Equiv.addRight q) _ _ fun j ↦ ?_
+      simp only [Equiv.coe_addRight, add_sub_cancel_right]
+      by_cases h : i = j + q <;> simp [h]
+    _ = x (i - q) := by simp
+
+private theorem map_transpose_forwardMatrix_mulVec
+    (s : ℝ) (x : ZMod N → ℂ) :
+    (forwardMatrix N m s).transpose.map Complex.ofRealHom *ᵥ x =
+      fun i ↦
+        ((s - (m : ℝ) : ℝ) : ℂ) * x i +
+          ∑ k : Fin m, x (i - ((k.1 + 1 : ℕ) : ZMod N)) := by
+  classical
+  funext i
+  simp only [Matrix.mulVec, dotProduct, Matrix.map_apply,
+    Matrix.transpose_apply, forwardMatrix_apply, map_add, map_mul, map_sub,
+    map_natCast, map_sum, apply_ite, map_one, map_zero]
+  simp_rw [add_mul]
+  rw [Finset.sum_add_distrib]
+  congr 1
+  · simp
+  · simp_rw [Finset.sum_mul]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro k _
+    exact sum_ite_mul_eq_sub_right N x
+      ((k.1 + 1 : ℕ) : ZMod N) i
+
+/-- The transpose cyclic matrix has the conjugate Fourier multiplier. -/
+theorem dft_map_transpose_forwardMatrix_mulVec
+    (s : ℝ) (x : ZMod N → ℂ) (j : ZMod N) :
+    ZMod.dft
+        ((forwardMatrix N m s).transpose.map Complex.ofRealHom *ᵥ x) j =
+      symbol N m s (-j) * ZMod.dft x j := by
+  rw [map_transpose_forwardMatrix_mulVec]
+  have haction :
+      (fun i ↦
+        ((s - (m : ℝ) : ℝ) : ℂ) * x i +
+          ∑ k : Fin m, x (i - ((k.1 + 1 : ℕ) : ZMod N))) =
+        ((s - (m : ℝ) : ℝ) : ℂ) • x +
+          ∑ k : Fin m,
+            (fun i ↦ x (i + (-((k.1 + 1 : ℕ) : ZMod N)))) := by
+    funext i
+    simp [smul_eq_mul, sub_eq_add_neg]
+  rw [haction, map_add, map_smul, map_sum]
+  simp only [Pi.add_apply, Pi.smul_apply, Finset.sum_apply, smul_eq_mul]
+  simp_rw [dft_comp_add_right]
+  unfold symbol
+  rw [← Finset.sum_mul]
+  simp only [mul_neg, neg_mul]
+  ring
+
+private theorem hessianSymbol_coe (s : ℝ) (j : ZMod N) :
+    (hessianSymbol N m s j : ℂ) =
+      (s : ℂ) * (symbol N m s j + star (symbol N m s j)) -
+        2 * (star (symbol N m s j) * symbol N m s j) := by
+  rw [Complex.star_def, Complex.add_conj,
+    ← Complex.normSq_eq_conj_mul_self]
+  unfold hessianSymbol
+  push_cast
+  ring
+
+private theorem map_hessianMatrix (S : Matrix (ZMod N) (ZMod N) ℝ)
+    (s : ℝ) :
+    (hessianMatrix S s).map Complex.ofRealHom =
+      (s : ℂ) • (S.map Complex.ofRealHom + S.transpose.map Complex.ofRealHom) -
+        (2 : ℕ) •
+          (S.transpose.map Complex.ofRealHom * S.map Complex.ofRealHom) := by
+  classical
+  ext i j
+  unfold hessianMatrix
+  simp only [Matrix.map_apply, Matrix.sub_apply, Matrix.smul_apply,
+    Matrix.add_apply, Matrix.transpose_apply]
+  simp only [two_nsmul]
+  simp only [map_sub, map_add, smul_eq_mul, Matrix.mul_apply, map_mul,
+    map_sum, Matrix.map_apply, Matrix.transpose_apply]
+  have hof (r : ℝ) : Complex.ofRealHom r = (r : ℂ) := rfl
+  simp only [hof]
+
+/-- The DFT diagonalizes Yamagami's Hessian.  Its multiplier is
+`q_j = 2 (s Re(λ_j) - |λ_j|²)`. -/
+theorem dft_map_hessianMatrix_mulVec (s : ℝ) (x : ZMod N → ℂ)
+    (j : ZMod N) :
+    ZMod.dft
+        ((hessianMatrix (forwardMatrix N m s) s).map Complex.ofRealHom *ᵥ x) j =
+      (hessianSymbol N m s j : ℂ) * ZMod.dft x j := by
+  rw [map_hessianMatrix]
+  rw [two_nsmul]
+  rw [Matrix.sub_mulVec, Matrix.smul_mulVec, Matrix.add_mulVec,
+    Matrix.add_mulVec, ← Matrix.mulVec_mulVec]
+  rw [map_sub, map_smul, map_add, map_add]
+  simp only [Pi.sub_apply, Pi.smul_apply, Pi.add_apply, smul_eq_mul]
+  rw [dft_map_forwardMatrix_mulVec, dft_map_transpose_forwardMatrix_mulVec,
+    dft_map_transpose_forwardMatrix_mulVec,
+    dft_map_forwardMatrix_mulVec, symbol_neg]
+  rw [hessianSymbol_coe]
+  ring
+
+private theorem ofReal_dotProduct_hessianMatrix_mulVec
+    (s : ℝ) (x : ZMod N → ℝ) :
+    Complex.ofRealHom
+        (x ⬝ᵥ hessianMatrix (forwardMatrix N m s) s *ᵥ x) =
+      star (Complex.ofRealHom ∘ x) ⬝ᵥ
+        ((hessianMatrix (forwardMatrix N m s) s).map Complex.ofRealHom *ᵥ
+          (Complex.ofRealHom ∘ x)) := by
+  rw [RingHom.map_dotProduct]
+  apply congrArg₂ dotProduct
+  · funext i
+    simp
+  · funext i
+    simpa only [Function.comp_apply] using
+      RingHom.map_mulVec Complex.ofRealHom
+        (hessianMatrix (forwardMatrix N m s) s) x i
+
+private theorem dft_hessian_quadratic_identity
+    (s : ℝ) (x : ZMod N → ℝ) :
+    (N : ℂ) * Complex.ofRealHom
+        (x ⬝ᵥ hessianMatrix (forwardMatrix N m s) s *ᵥ x) =
+      ∑ j : ZMod N,
+        (hessianSymbol N m s j : ℂ) *
+          Complex.normSq (ZMod.dft (Complex.ofRealHom ∘ x) j) := by
+  calc
+    (N : ℂ) * Complex.ofRealHom
+        (x ⬝ᵥ hessianMatrix (forwardMatrix N m s) s *ᵥ x) =
+        (N : ℂ) *
+          (star (Complex.ofRealHom ∘ x) ⬝ᵥ
+            ((hessianMatrix (forwardMatrix N m s) s).map
+                Complex.ofRealHom *ᵥ (Complex.ofRealHom ∘ x))) := by
+      rw [ofReal_dotProduct_hessianMatrix_mulVec]
+    _ = star (ZMod.dft (Complex.ofRealHom ∘ x)) ⬝ᵥ
+        ZMod.dft
+          ((hessianMatrix (forwardMatrix N m s) s).map
+              Complex.ofRealHom *ᵥ (Complex.ofRealHom ∘ x)) := by
+      exact (dft_parseval N (Complex.ofRealHom ∘ x)
+        ((hessianMatrix (forwardMatrix N m s) s).map
+          Complex.ofRealHom *ᵥ (Complex.ofRealHom ∘ x))).symm
+    _ = ∑ j : ZMod N,
+        (hessianSymbol N m s j : ℂ) *
+          Complex.normSq (ZMod.dft (Complex.ofRealHom ∘ x) j) := by
+      rw [dotProduct]
+      apply Finset.sum_congr rfl
+      intro j _
+      simp only [Pi.star_apply]
+      rw [dft_map_hessianMatrix_mulVec]
+      rw [Complex.star_def, Complex.normSq_eq_conj_mul_self]
+      ring
+
+private theorem hessian_quadratic_identity
+    (s : ℝ) (x : ZMod N → ℝ) :
+    (N : ℝ) *
+        (x ⬝ᵥ hessianMatrix (forwardMatrix N m s) s *ᵥ x) =
+      ∑ j : ZMod N,
+        hessianSymbol N m s j *
+          Complex.normSq (ZMod.dft (Complex.ofRealHom ∘ x) j) := by
+  apply Complex.ofReal_injective
+  push_cast
+  exact dft_hessian_quadratic_identity N m s x
+
+private theorem hessianMatrix_isHermitian
+    (S : Matrix (ZMod N) (ZMod N) ℝ) (s : ℝ) :
+    (hessianMatrix S s).IsHermitian := by
+  rw [Matrix.isHermitian_iff_isSymm]
+  unfold hessianMatrix
+  exact ((Matrix.isSymm_add_transpose_self S).smul s).sub
+    ((Matrix.isSymm_transpose_mul_self S).smul (2 : ℕ))
+
+/-- Yamagami's negative-Hessian representative is positive semidefinite in
+the exact corrected Wolf range. -/
+theorem hessianMatrix_forwardMatrix_posSemidef
+    (hN : 3 ≤ N) (hm₁ : 1 ≤ m) (hm₂ : m ≤ N - 2)
+    (s : ℝ) (hs : (N : ℝ) ≤ s) :
+    (hessianMatrix (forwardMatrix N m s) s).PosSemidef := by
+  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg
+    (hessianMatrix_isHermitian N (forwardMatrix N m s) s) ?_
+  intro x
+  have hsum :
+      0 ≤ ∑ j : ZMod N,
+        hessianSymbol N m s j *
+          Complex.normSq (ZMod.dft (Complex.ofRealHom ∘ x) j) := by
+    apply Finset.sum_nonneg
+    intro j _
+    exact mul_nonneg
+      (hessianSymbol_nonneg N m hN hm₁ hm₂ s hs j)
+      (Complex.normSq_nonneg _)
+  have hproduct :
+      0 ≤ (N : ℝ) *
+        (x ⬝ᵥ hessianMatrix (forwardMatrix N m s) s *ᵥ x) := by
+    rw [hessian_quadratic_identity N m s x]
+    exact hsum
+  have hNpos : (0 : ℝ) < N := by
+    exact_mod_cast (by omega : 0 < N)
+  have hquadratic :
+      0 ≤ x ⬝ᵥ hessianMatrix (forwardMatrix N m s) s *ᵥ x := by
+    nlinarith
+  simpa using hquadratic
+
+/-- In the corrected Wolf range, the kernel of Yamagami's Hessian is
+exactly the line spanned by the constant vector. -/
+theorem hessianMatrix_forwardMatrix_mulVec_eq_zero_iff_isScalarVector
+    (hN : 3 ≤ N) (hm₁ : 1 ≤ m) (hm₂ : m ≤ N - 2)
+    (s : ℝ) (hs : (N : ℝ) ≤ s) (x : ZMod N → ℝ) :
+    hessianMatrix (forwardMatrix N m s) s *ᵥ x = 0 ↔
+      IsScalarVector x := by
+  constructor
+  · intro hx
+    let xℂ : ZMod N → ℂ := Complex.ofRealHom ∘ x
+    have hxℂ :
+        (hessianMatrix (forwardMatrix N m s) s).map Complex.ofRealHom *ᵥ
+            xℂ = 0 := by
+      funext i
+      dsimp [xℂ]
+      calc
+        ((hessianMatrix (forwardMatrix N m s) s).map Complex.ofRealHom *ᵥ
+            (Complex.ofRealHom ∘ x)) i =
+            Complex.ofRealHom
+              ((hessianMatrix (forwardMatrix N m s) s *ᵥ x) i) := by
+          simpa only [Function.comp_apply] using
+            (RingHom.map_mulVec Complex.ofRealHom
+              (hessianMatrix (forwardMatrix N m s) s) x i).symm
+        _ = 0 := by rw [hx]; rfl
+    have hfreq : ∀ j : ZMod N, j ≠ 0 → ZMod.dft xℂ j = 0 := by
+      intro j hj
+      have hd := dft_map_hessianMatrix_mulVec N m s xℂ j
+      rw [hxℂ, map_zero, Pi.zero_apply] at hd
+      apply (mul_eq_zero.mp hd.symm).resolve_left
+      exact_mod_cast
+        (ne_of_gt (hessianSymbol_pos N m hN hm₁ hm₂ s hs hj))
+    have hconst := eq_const_of_dft_eq_zero_of_ne N xℂ hfreq
+    refine ⟨x 0, ?_⟩
+    funext i
+    simp only [Pi.smul_apply, Pi.one_apply, smul_eq_mul, mul_one]
+    apply Complex.ofReal_injective
+    have hi := congrFun hconst i
+    simpa [xℂ] using hi
+  · rintro ⟨c, rfl⟩
+    rw [Matrix.mulVec_smul,
+      hessianMatrix_mulVec_one_eq_zero (forwardMatrix N m s) s
+        (forwardMatrix_mulVec_one N m s)
+        (forwardMatrix_transpose_mulVec_one N m s)]
+    exact smul_zero c
+
+/-- Yamagami's cyclic matrix is invertible throughout the exact corrected
+Wolf range `N ≥ 3`, `1 ≤ m ≤ N - 2`, and `N ≤ s`. -/
+theorem forwardMatrix_isUnit_det
+    (hN : 3 ≤ N) (hm₁ : 1 ≤ m) (hm₂ : m ≤ N - 2)
+    (s : ℝ) (hs : (N : ℝ) ≤ s) :
+    IsUnit (forwardMatrix N m s).det := by
+  rw [← Matrix.isUnit_iff_isUnit_det, ← Matrix.mulVec_injective_iff_isUnit]
+  intro x y hxy
+  apply sub_eq_zero.mp
+  let z : ZMod N → ℝ := x - y
+  have hz : forwardMatrix N m s *ᵥ z = 0 := by
+    dsimp [z]
+    rw [Matrix.mulVec_sub, hxy, sub_self]
+  let zℂ : ZMod N → ℂ := Complex.ofRealHom ∘ z
+  have hzℂ :
+      (forwardMatrix N m s).map Complex.ofRealHom *ᵥ zℂ = 0 := by
+    funext i
+    dsimp [zℂ]
+    calc
+      ((forwardMatrix N m s).map Complex.ofRealHom *ᵥ
+          (Complex.ofRealHom ∘ z)) i =
+          Complex.ofRealHom ((forwardMatrix N m s *ᵥ z) i) := by
+        simpa only [Function.comp_apply] using
+          (RingHom.map_mulVec Complex.ofRealHom (forwardMatrix N m s) z i).symm
+      _ = 0 := by rw [hz]; rfl
+  have hfreq : ∀ j : ZMod N, ZMod.dft zℂ j = 0 := by
+    intro j
+    have hdiag := dft_map_forwardMatrix_mulVec N m s zℂ j
+    rw [hzℂ, map_zero, Pi.zero_apply] at hdiag
+    exact (mul_eq_zero.mp hdiag.symm).resolve_left
+      (symbol_ne_zero N m hN hm₁ hm₂ s hs j)
+  have hzℂ_zero : zℂ = 0 := by
+    apply (ZMod.dft (N := N) (E := ℂ)).injective
+    funext j
+    simpa using hfreq j
+  have hz_zero : z = 0 := by
+    funext i
+    have hi := congrFun hzℂ_zero i
+    change (z i : ℂ) = 0 at hi
+    exact Complex.ofReal_injective (by simpa using hi)
+  exact hz_zero
+
+/-- Yamagami's reciprocal functional is the composed Nowosad functional
+`L_{S⁻¹}(Sx)` for the forward cyclic matrix `S`.  The identity is valid
+with Lean's total division and therefore needs no positivity hypothesis on
+`x`. -/
+theorem functional_eq_lambdaT_inverseOperator_mulVec
+    (s : ℝ) (hS : IsUnit (forwardMatrix N m s).det) (x : ZMod N → ℝ) :
+    functional N m s x =
+      lambdaT (inverseOperator (forwardMatrix N m s))
+        (forwardMatrix N m s *ᵥ x) := by
+  unfold functional lambdaT
+  rw [inverseOperator_apply, Matrix.mulVec_mulVec,
+    Matrix.nonsing_inv_mul _ hS, Matrix.one_mulVec]
+  rw [← forwardMatrix_mulVec N m s x]
+  unfold coordinateSum
+  apply Finset.sum_congr rfl
+  intro i _
+  simp only [Pi.inv_apply, Pi.mul_apply, div_eq_mul_inv]
+  ring
+
+
+
+end Yamagami

--- a/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
@@ -375,8 +375,7 @@ Fourier--Hessian and functional-identification prerequisites for the
 uniqueness argument in Yamagami's Lemma~3.  It does not prove that
 $\mathbf 1$ is a local maximum, carry out the regular-boundary reduction on
 p.~525, or establish the global cyclic reciprocal inequality.  These steps,
-and hence the middle-range positivity problem tracked by issue~\#19, remain
-open.
+and hence the middle-range positivity theorem, are not yet formalized.
 
 \begin{lemma}[The first positive coordinate after a singular window]
     \label{lem:yamagami_singular_zero_run}

--- a/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
@@ -229,7 +229,7 @@ normalization; it is not a separate Lean theorem.
     so is this tangent, contradicting $\ker H=\R\mathbf 1$.
 
     This proves only the uniqueness assertion of Yamagami's Lemma~3 on
-    p.~523.  It does not prove that $\mathbf 1$ is itself a local maximum, and
+    p.~522.  It does not prove that $\mathbf 1$ is itself a local maximum, and
     it does not prove the cyclic reciprocal inequality.
 \end{proof}
 
@@ -285,9 +285,98 @@ normalization; it is not a separate Lean theorem.
     $s-d$ gives the result for $s\ge d$.
 \end{proof}
 
-This spectral lemma is only one dependency of Yamagami's variational proof.
-It does not establish the cyclic reciprocal inequality or positivity in the
-middle range.
+\begin{theorem}[Yamagami's cyclic Fourier--Hessian prerequisite]
+    \label{thm:yamagami_forward_fourier_hessian}
+    \lean{Yamagami.forwardMatrix,
+        Yamagami.forwardMatrix_apply,
+        Yamagami.forwardMatrix_mulVec,
+        Yamagami.forwardMatrix_add_add,
+        Yamagami.forwardMatrix_eq_circulant,
+        Yamagami.forwardMatrix_nonnegative,
+        Yamagami.forwardMatrix_nonnegative_of_sourceRange,
+        Yamagami.forwardMatrix_mulVec_one,
+        Yamagami.forwardMatrix_transpose_mulVec_one,
+        Yamagami.hessianSymbol,
+        Yamagami.symbol_zero,
+        Yamagami.hessianSymbol_zero,
+        Yamagami.hessianSymbol_pos,
+        Yamagami.hessianSymbol_nonneg,
+        Yamagami.symbol_ne_zero,
+        Yamagami.dft_map_forwardMatrix_mulVec,
+        Yamagami.symbol_neg,
+        Yamagami.dft_map_transpose_forwardMatrix_mulVec,
+        Yamagami.dft_map_hessianMatrix_mulVec,
+        Yamagami.hessianMatrix_forwardMatrix_posSemidef,
+        Yamagami.hessianMatrix_forwardMatrix_mulVec_eq_zero_iff_isScalarVector,
+        Yamagami.forwardMatrix_isUnit_det,
+        Yamagami.functional_eq_lambdaT_inverseOperator_mulVec}
+    \leanok
+    \uses{def:yamagami_stride_one_reciprocal,
+        def:yamagami_nowosad_change_of_variables}
+    On $\Z/d\Z$, let
+    \begin{align}
+        S_{i,j}
+         &=(s-m)\mathbf 1_{j=i}
+           +\sum_{k=1}^{m}\mathbf 1_{j=i+k},
+        &
+        H&=s(S+S^{\mathsf T})-2S^{\mathsf T}S.
+        \label{eq:yamagami_forward_matrix}
+    \end{align}
+    In the range $d\ge3$, $1\le m\le d-2$, and $s\ge d$, the matrix $S$
+    has nonnegative entries, is circulant and invertible, and satisfies
+    \begin{align}
+        S\mathbf 1&=S^{\mathsf T}\mathbf 1=s\mathbf 1,
+        &H&\succeq0,
+        &\ker H&=\R\mathbf 1.
+        \label{eq:yamagami_hessian_package}
+    \end{align}
+    More explicitly, for the unnormalized discrete Fourier transform,
+    \begin{align}
+        \widehat{Sx}_j
+         &=\lambda_j(s)\widehat{x}_j,
+        &
+        \widehat{Hx}_j
+         &=q_j\widehat{x}_j,
+        &
+        q_j
+         &=2\bigl(s\operatorname{Re}\lambda_j(s)
+                   -|\lambda_j(s)|^2\bigr).
+        \label{eq:yamagami_fourier_hessian}
+    \end{align}
+    Here $q_0=0$ and $q_j>0$ for $j\ne0$.  Finally, $Sx$ is the forward
+    denominator and
+    \begin{align}
+        f_{d,m,s}(x)&=\lambda_{S^{-1}}(Sx).
+        \label{eq:yamagami_functional_bridge}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:yamagami_stride_one_open_disk}
+    Formula~(\ref{eq:yamagami_forward_matrix}) gives nonnegativity and both
+    row-sum identities directly.  Translation is diagonal in the standard
+    character basis; expanding $H$ therefore gives
+    (\ref{eq:yamagami_fourier_hessian}).  The corrected open-disk inequality
+    makes $q_j$ strictly positive off the constant character and also makes
+    every Fourier multiplier of $S$ nonzero.  Thus $S$ is invertible.
+    Parseval's identity proves $H\succeq0$ and identifies its kernel with the
+    constant vectors.  Matrix inversion then reduces
+    $\lambda_{S^{-1}}(Sx)$ term by term to $\sum_i x_i/(Sx)_i$.
+
+    The negative-Hessian matrix $H$ is the one in Yamagami's Lemmas~2--3 on
+    p.~522; the cyclic diagonalization and disk criterion are Lemma~4 and
+    Corollary~5 on p.~523, followed by Lemma~6 on
+    pp.~523--524~\cite{Yamagami1993Cyclic}.
+\end{proof}
+
+Theorem~\ref{thm:yamagami_forward_fourier_hessian} supplies the concrete
+Fourier--Hessian and functional-identification prerequisites for the
+uniqueness argument in Yamagami's Lemma~3.  It does not prove that
+$\mathbf 1$ is a local maximum, carry out the regular-boundary reduction on
+p.~525, or establish the global cyclic reciprocal inequality.  These steps,
+and hence the middle-range positivity problem tracked by issue~\#19, remain
+open.
 
 \begin{lemma}[The first positive coordinate after a singular window]
     \label{lem:yamagami_singular_zero_run}

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -127,6 +127,27 @@ printed endpoint and its stride-one correction are recorded separately in
 \cite{gap:yamagami_lemma6_endpoint}; this scope note continues to track only
 the unfinished Choi-type positivity proof.
 
+The cyclic matrix and Hessian prerequisite built from this disk estimate is
+now formalized in
+\doclink{QICLean/Analysis/YamagamiCyclicMatrix}.  In the exact range
+$d\ge3$, $1\le m\le d-2$, and $s\ge d$, the matrix
+\begin{align}
+  S&=(s-m)I+C+\cdots+C^m,
+  &H&=s(S+S^{\mathsf T})-2S^{\mathsf T}S
+\end{align}
+has nonnegative entries, row and column sum $s$, is invertible, and satisfies
+$H\succeq0$ with $\ker H=\mathbb R\mathbf1$.  The proof diagonalizes $S$
+and $H$ by the finite Fourier transform and uses
+\leanid{Yamagami.hessianSymbol\_pos} off the constant character.  The theorem
+\leanid{Yamagami.functional\_eq\_lambdaT\_inverseOperator\_mulVec} also proves
+the previously missing identity
+\begin{align}
+  f_{d,m,s}(x)&=\lambda_{S^{-1}}(Sx).
+\end{align}
+These are the algebraic ingredients in Yamagami's Lemmas~2--4 and
+Corollary~5 on pp.~522--523, using the corrected Lemma~6 range on
+pp.~523--524~\cite{Yamagami1993Cyclic}.
+
 The accompanying definitions retain Yamagami's forward window and provide the
 explicit index-negation bridge to the backward Choi window.  The
 simultaneous-singularity part of the projective-boundary analysis is now
@@ -174,19 +195,16 @@ positive local maximum is scalar.  More precisely,
 \leanid{Yamagami.pulledBackTangent\_mem\_hessianKernel\_and\_not\_isScalarVector}
 shows that a non-scalar maximum would give the non-scalar tangent
 $sS^{-1}\log((Sa)/s)$ in $\ker H$.  This is the uniqueness assertion of
-Yamagami's Lemma~3 on p.~523, not a proof that the unit vector is itself a
+Yamagami's Lemma~3 on p.~522, not a proof that the unit vector is itself a
 local maximum.
 
-These results are still not the cyclic reciprocal inequality.  The
-strictly-positive global inequality, including the cyclic specialization of
-the Hessian hypotheses and the required existence or attainment argument,
-and the separate regular-boundary induction remain open.  In particular, no
-current declaration identifies the generic composition
-$x\mapsto\lambda_{S^{-1}}(Sx)$ used by the Nowosad layer with the concrete
-stride-one \leanid{Yamagami.functional}.  The direct theorem for Lean's
-literal \(0/0=0\) functional is correspondingly conditional on an already
-proved strictly positive inequality; it supplies none of these remaining
-steps.
+These results are still not the cyclic reciprocal inequality.  The cyclic
+Fourier--Hessian specialization and the functional identity are now proved,
+but no current declaration proves that the unit vector is a local maximum,
+carries out Yamagami's regular-boundary reduction on p.~525, or concludes the
+global strictly positive inequality.  The direct theorem for Lean's literal
+\(0/0=0\) functional remains conditional on that global interior input.  Thus
+the regular-boundary and global steps, and hence issue~\#19, remain open.
 
 Two verifiable computations locate the obstruction to elementary summand
 bounds in the remaining range.  First, the estimate is tight in two distinct

--- a/docs/paper-gaps/yamagami93_lemma6_endpoint.tex
+++ b/docs/paper-gaps/yamagami93_lemma6_endpoint.tex
@@ -74,9 +74,14 @@ range.}  This correction concerns only Lemma~6's open-disk condition.  It
 does not by itself prove Yamagami's cyclic reciprocal inequality.  The finite
 Nowosad theorem and the uniqueness assertion of Yamagami's Lemma~3 are now
 formalized, and the simultaneous-singularity boundary count is also complete.
-What remains includes the bridge from the generic Nowosad functional to the
-concrete cyclic \leanid{Yamagami.functional}, the proof that the unit vector is
-a local maximum, and the separate regular-boundary induction.
+The cyclic matrix package in
+\doclink{QICLean/Analysis/YamagamiCyclicMatrix} now also proves invertibility,
+the positive-semidefinite Hessian with kernel $\mathbb R\mathbf1$, and the
+bridge from the generic Nowosad functional to the concrete cyclic
+\leanid{Yamagami.functional}.  What remains includes the proof that the unit
+vector is a local maximum, the separate regular-boundary induction, and the
+global cyclic inequality.  Thus this resolved endpoint remains only a
+prerequisite for the still-open issue~\#19.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/yamagami93_simultaneous_singularity_boundary.tex
+++ b/docs/paper-gaps/yamagami93_simultaneous_singularity_boundary.tex
@@ -133,11 +133,12 @@ inequality.  It also does not replace Yamagami's separate regular-boundary
 reduction.  The finite-coordinate Nowosad theorem and the uniqueness assertion
 of Yamagami's Lemma~3 are now formalized in
 \leanid{Nowosad.finiteCoordinate\_theorem\_one\_eight} and
-\leanid{Yamagami.lemma\_three\_localMax\_isScalar}.  They do not identify the
-generic Nowosad functional with the concrete cyclic
-\leanid{Yamagami.functional}, prove that the unit vector is a local maximum,
-or supply the regular-boundary induction.  These remain prerequisites of the
-full cyclic inequality.
+\leanid{Yamagami.lemma\_three\_localMax\_isScalar}.  The cyclic matrix package
+in \doclink{QICLean/Analysis/YamagamiCyclicMatrix} now verifies the Fourier
+Hessian hypotheses and identifies the generic Nowosad functional with the
+concrete cyclic \leanid{Yamagami.functional}.  It does not prove that the unit
+vector is a local maximum or supply the regular-boundary induction.  Those
+steps remain prerequisites of the full cyclic inequality and of issue~\#19.
 
 \section{Verdict}
 

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -714,6 +714,16 @@ so that the cited formal statements are available from the main project import.
   endpoint `m = d - 1`, `s = d` is false with a strict inequality and is
   recorded in the paper-gap note; this theorem does not prove the cyclic
   inequality ✓
+- `Yamagami.forwardMatrix`, `Yamagami.dft_map_hessianMatrix_mulVec`,
+  `Yamagami.hessianMatrix_forwardMatrix_posSemidef`,
+  `Yamagami.hessianMatrix_forwardMatrix_mulVec_eq_zero_iff_isScalarVector`,
+  `Yamagami.forwardMatrix_isUnit_det`, and
+  `Yamagami.functional_eq_lambdaT_inverseOperator_mulVec` formalize the
+  stride-one Fourier--Hessian prerequisite from Yamagami's Lemmas 2--4 and
+  Corollary 5. In the exact range `d ≥ 3`, `1 ≤ m ≤ d - 2`, and `s ≥ d`, the
+  cyclic matrix is nonnegative and invertible, its negative-Hessian
+  representative is positive semidefinite with kernel `ℝ · 1`, and the
+  concrete functional is exactly `λ_{S⁻¹}(Sx)` ✓
 - `Nowosad.inducedHilbertNorm_sq` and
   `Nowosad.exists_inducedHilbertNorm_bound` identify the norm induced by the
   faithful coordinate-sum functional with the finite `L²` norm and prove that
@@ -746,11 +756,11 @@ so that the cited formal statements are available from the main project import.
   The Lean proof instead uses `Yamagami.dotProduct_hessianMatrix_mulVec` and
   `Yamagami.minimumQuadraticForm_normalizedNegativeInverse_eq`, the exact
   algebraic second-variation identity needed by Nowosad's argument.
-- The preceding Lemma 3 declaration proves uniqueness only. It does not prove
-  that the unit vector is a local maximum, specialize the Hessian hypotheses
-  to the full cyclic family, identify the generic `lambdaT` composition with
-  the concrete stride-one `Yamagami.functional`, or establish the cyclic
-  reciprocal inequality.
+- The preceding Lemma 3 declaration proves uniqueness only. The cyclic
+  Fourier--Hessian package above now specializes its algebraic hypotheses and
+  identifies the generic `lambdaT` composition with the concrete stride-one
+  `Yamagami.functional`; it still does not prove that the unit vector is a
+  local maximum or establish the global cyclic reciprocal inequality.
 - `Yamagami.limsup_functional_le_card_ratio_of_singularDenominator`
   formalizes the omitted simultaneous-singularity boundary count: one
   least-next-positive zero string supplies all `m` vanishing summands, without
@@ -759,9 +769,9 @@ so that the cited formal statements are available from the main project import.
   already proved strictly positive inequality to Lean's direct nonnegative
   `0 / 0 = 0` value. This theorem is conditional; the positive-interior input
   and the regular-boundary induction are still required. The finite Nowosad
-  theorem now supplies the abstract local-maximum uniqueness ingredient, but
-  it supplies neither existence of the unit maximum nor the global inequality.
-  See
+  theorem and the cyclic Fourier--Hessian package supply the abstract
+  uniqueness and concrete matrix prerequisites, but they supply neither a
+  proof that the unit vector is a local maximum nor the global inequality. See
   `docs/paper-gaps/yamagami93_simultaneous_singularity_boundary.tex` ✓
 - Positivity in the middle range `2 ≤ n ≤ d - 3` remains open; its exact
   scope and cyclic reciprocal inequality are recorded in


### PR DESCRIPTION
## Summary

This pull request formalizes the cyclic Fourier–Hessian prerequisite in Yamagami's variational route.

- For the exact range `N ≥ 3`, `1 ≤ m ≤ N - 2`, and `s ≥ N`, it constructs the stride-one matrix
  `S = (s - m)I + C + ⋯ + C^m`.
- The finite DFT diagonalizes `S`, `Sᵀ`, and
  `H = s(S + Sᵀ) - 2SᵀS`. The corrected open-disk estimate gives a zero Hessian multiplier only at the constant character and a strictly positive multiplier at every nonconstant character.
- It proves that `S` has nonnegative entries, row and column sum `s`, and is invertible, while `H` is positive semidefinite with kernel exactly `ℝ · 1`.
- It proves the concrete-to-Nowosad functional identity
  `f_{N,m,s}(x) = λ_{S⁻¹}(Sx)`.
- Chapter 4 and the existing Yamagami/Wolf scope notes record this as the algebraic prerequisite from Yamagami's Lemmas 2–4 and Corollary 5 on pp. 522–523, using the corrected Lemma 6 range on pp. 523–524.

## Scope

Refs #19.

This pull request does not prove that the unit vector is a local maximum. It does not formalize the regular-boundary reduction on p. 525, the global cyclic reciprocal inequality, or the resulting middle-range Choi positivity theorem. Issue #19 therefore remains open.

## Verification

The reviewed exact head passed:

- scoped Lean builds for `QICLean.Analysis.YamagamiCyclicMatrix` and `QICLean.Analysis`;
- generated-import and reader-facing prose checks;
- Blueprint synchronization, reverse declaration coverage, ChkTeX, and paper-gap reference checks;
- scoped whitespace and token-hazard checks;
- kernel `#print axioms` checks for the Fourier multiplier, Hessian diagonalization, positive-semidefinite Hessian, exact kernel, invertibility, and functional bridge.

Every headline theorem uses only `propext`, `Classical.choice`, and `Quot.sound`.
