### PR TITLE
Formalize Yamagami's regular-boundary recurrence

### DIFF
--- a/QICLean/Analysis.lean
+++ b/QICLean/Analysis.lean
@@ -101,3 +101,4 @@ import QICLean.Analysis.WeightedPositiveKernel
 import QICLean.Analysis.WeylMonotonicity
 import QICLean.Analysis.YamagamiBoundary
 import QICLean.Analysis.YamagamiCyclicMatrix
+import QICLean.Analysis.YamagamiRegularBoundary

--- a/QICLean/Analysis/YamagamiRegularBoundary.lean
+++ b/QICLean/Analysis/YamagamiRegularBoundary.lean
@@ -1,0 +1,268 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Analysis.CyclicReciprocal
+import Mathlib.Tactic.NormNum
+import Lean.Elab.Tactic.Omega
+
+/-!
+# Yamagami's regular-boundary recurrence
+
+This file formalizes the dimension-reduction step on p. 525 of
+S. Yamagami, *Cyclic inequalities*, Proc. Amer. Math. Soc. 118 (1993),
+521--527.  For the stride-one functional, delete a zero final coordinate.
+The remaining cyclic order is represented by the map
+
+`ZMod (N - 1) → ZMod N,  i ↦ i.val`.
+
+The reduced forward window skips the deleted coordinate.  Before that
+coordinate is reached, the original denominator has one additional
+nonnegative term; after it is reached, the two windows agree because the
+skipped term is zero.  Consequently the comparison is non-strict.  The
+statement uses Lean's total division, so it remains valid when the reduced
+vector has a singular denominator.
+-/
+
+open scoped BigOperators
+
+namespace Yamagami
+
+/-- Delete the final coordinate from a cyclic vector while preserving the
+linear order `0, ..., N - 2` used in Yamagami's p. 525 reduction. -/
+def deleteLastCoordinate (N : ℕ) (x : ZMod N → ℝ) : ZMod (N - 1) → ℝ :=
+  fun i ↦ x (i.val : ZMod N)
+
+/-- Embed a step in the reduced forward window into the original window.
+After the path crosses the deleted final coordinate, its step is increased
+by one. -/
+private def reducedStepEmbedding (N m : ℕ) (i : ZMod (N - 1))
+    (hm : 1 ≤ m) (q : Fin (m - 1)) : Fin m :=
+  if i.val + q.val + 1 < N - 1 then
+    ⟨q.val, by omega⟩
+  else
+    ⟨q.val + 1, by omega⟩
+
+private theorem reducedStepEmbedding_injective
+    (N m : ℕ) (hm : 1 ≤ m) (i : ZMod (N - 1)) :
+    Function.Injective (reducedStepEmbedding N m i hm) := by
+  intro q r hqr
+  apply Fin.ext
+  have hval := congrArg Fin.val hqr
+  by_cases hq : i.val + q.val + 1 < N - 1 <;>
+    by_cases hr : i.val + r.val + 1 < N - 1 <;>
+      simp [reducedStepEmbedding, hq, hr] at hval <;> omega
+
+private theorem deleteLastCoordinate_forwardStep
+    (N m : ℕ) [NeZero N] (hN : 3 ≤ N) (hm : 1 ≤ m)
+    (hmN : m ≤ N - 2) (x : ZMod N → ℝ) (i : ZMod (N - 1))
+    (q : Fin (m - 1)) :
+    deleteLastCoordinate N x
+        (i + ((q.val + 1 : ℕ) : ZMod (N - 1))) =
+      x ((i.val : ZMod N) +
+        (((reducedStepEmbedding N m i hm q).val + 1 : ℕ) : ZMod N)) := by
+  let _ : NeZero (N - 1) := ⟨by omega⟩
+  unfold deleteLastCoordinate
+  congr 1
+  apply ZMod.val_injective N
+  have hreducedVal :
+      (i + ((q.val + 1 : ℕ) : ZMod (N - 1))).val < N - 1 :=
+    ZMod.val_lt _
+  rw [ZMod.val_natCast_of_lt (by omega :
+    (i + ((q.val + 1 : ℕ) : ZMod (N - 1))).val < N)]
+  have hqReduced : q.val + 1 < N - 1 := by omega
+  have hqReducedVal :
+      (((q.val + 1 : ℕ) : ZMod (N - 1))).val = q.val + 1 :=
+    ZMod.val_natCast_of_lt hqReduced
+  by_cases hcross : i.val + q.val + 1 < N - 1
+  · have hleft :
+        i.val + (((q.val + 1 : ℕ) : ZMod (N - 1))).val < N - 1 := by
+      omega
+    rw [ZMod.val_add_of_lt hleft]
+    rw [hqReducedVal]
+    simp only [reducedStepEmbedding, hcross, ite_true, Fin.val_mk]
+    have hiN : i.val < N := by
+      have hi := ZMod.val_lt i
+      omega
+    have hstepN : q.val + 1 < N := by omega
+    have hright :
+        ((i.val : ZMod N).val +
+          (((q.val + 1 : ℕ) : ZMod N)).val < N) := by
+      rw [ZMod.val_natCast_of_lt hiN, ZMod.val_natCast_of_lt hstepN]
+      omega
+    rw [ZMod.val_add_of_lt hright, ZMod.val_natCast_of_lt hiN,
+      ZMod.val_natCast_of_lt hstepN]
+  · have hleft :
+        N - 1 ≤ i.val + (((q.val + 1 : ℕ) : ZMod (N - 1))).val := by
+      omega
+    rw [ZMod.val_add_of_le hleft, hqReducedVal]
+    simp only [reducedStepEmbedding, hcross, ite_false, Fin.val_mk]
+    have hiN : i.val < N := by
+      have hi := ZMod.val_lt i
+      omega
+    have hstepN : q.val + 1 + 1 < N := by omega
+    have hright :
+        N ≤ (i.val : ZMod N).val +
+          (((q.val + 1 + 1 : ℕ) : ZMod N)).val := by
+      rw [ZMod.val_natCast_of_lt hiN, ZMod.val_natCast_of_lt hstepN]
+      omega
+    rw [ZMod.val_add_of_le hright, ZMod.val_natCast_of_lt hiN,
+      ZMod.val_natCast_of_lt hstepN]
+    omega
+
+private theorem reduced_forward_sum_le
+    (N m : ℕ) [NeZero N] (hN : 3 ≤ N) (hm : 1 ≤ m)
+    (hmN : m ≤ N - 2) (x : ZMod N → ℝ) (hx : ∀ j, 0 ≤ x j)
+    (i : ZMod (N - 1)) :
+    (∑ q : Fin (m - 1),
+        deleteLastCoordinate N x
+          (i + ((q.val + 1 : ℕ) : ZMod (N - 1)))) ≤
+      ∑ k : Fin m,
+        x ((i.val : ZMod N) + ((k.val + 1 : ℕ) : ZMod N)) := by
+  let e : Fin (m - 1) → Fin m := reducedStepEmbedding N m i hm
+  have he : Function.Injective e := reducedStepEmbedding_injective N m hm i
+  calc
+    (∑ q : Fin (m - 1),
+        deleteLastCoordinate N x
+          (i + ((q.val + 1 : ℕ) : ZMod (N - 1)))) =
+        ∑ q : Fin (m - 1),
+          x ((i.val : ZMod N) + ((e q).val + 1 : ℕ)) := by
+      apply Finset.sum_congr rfl
+      intro q _
+      exact deleteLastCoordinate_forwardStep N m hN hm hmN x i q
+    _ = ∑ k ∈ Finset.univ.image e,
+        x ((i.val : ZMod N) + ((k.val + 1 : ℕ) : ZMod N)) := by
+      symm
+      rw [Finset.sum_image he.injOn]
+    _ ≤ ∑ k : Fin m,
+        x ((i.val : ZMod N) + ((k.val + 1 : ℕ) : ZMod N)) := by
+      exact Finset.sum_le_sum_of_subset_of_nonneg (Finset.subset_univ _)
+        (fun k _ _ ↦ hx _)
+
+private theorem sum_erase_lastCoordinate
+    (N : ℕ) [NeZero N] [NeZero (N - 1)] (hN : 2 ≤ N)
+    (f : ZMod N → ℝ) :
+    (∑ j ∈ (Finset.univ : Finset (ZMod N)).erase
+        ((N - 1 : ℕ) : ZMod N), f j) =
+      ∑ i : ZMod (N - 1), f (i.val : ZMod N) := by
+  symm
+  apply Finset.sum_bij (fun i _ ↦ (i.val : ZMod N))
+  · intro i _
+    simp only [Finset.mem_erase, Finset.mem_univ, and_true]
+    intro heq
+    have hval := congrArg ZMod.val heq
+    rw [ZMod.val_natCast_of_lt (by
+      have hi := ZMod.val_lt i
+      omega : i.val < N)] at hval
+    rw [ZMod.val_natCast_of_lt (by omega : N - 1 < N)] at hval
+    have hi := ZMod.val_lt i
+    omega
+  · intro a _ b _ hab
+    apply ZMod.val_injective (N - 1)
+    have hval := congrArg ZMod.val hab
+    rw [ZMod.val_natCast_of_lt (by
+      have ha := ZMod.val_lt a
+      omega : a.val < N)] at hval
+    rw [ZMod.val_natCast_of_lt (by
+      have hb := ZMod.val_lt b
+      omega : b.val < N)] at hval
+    exact hval
+  · intro b hb
+    have hbne : b ≠ ((N - 1 : ℕ) : ZMod N) := (Finset.mem_erase.mp hb).1
+    have hbvalne : b.val ≠ N - 1 := by
+      intro hval
+      apply hbne
+      apply ZMod.val_injective N
+      rw [ZMod.val_natCast_of_lt (by omega : N - 1 < N)]
+      exact hval
+    have hbsmall : b.val < N - 1 := by
+      have hbval := ZMod.val_lt b
+      omega
+    refine ⟨(b.val : ZMod (N - 1)), Finset.mem_univ _, ?_⟩
+    rw [ZMod.val_natCast_of_lt hbsmall, ZMod.natCast_zmod_val]
+  · intro i _
+    rfl
+
+private theorem retained_summand_le_reduced
+    (N m : ℕ) [NeZero N] [NeZero (N - 1)] (hN : 3 ≤ N)
+    (hm : 1 ≤ m) (hmN : m ≤ N - 2) (s : ℝ) (hs : (N : ℝ) ≤ s)
+    (x : ZMod N → ℝ) (hx : ∀ j, 0 ≤ x j) (i : ZMod (N - 1)) :
+    x (i.val : ZMod N) /
+        forwardDenominator N m s x (i.val : ZMod N) ≤
+      deleteLastCoordinate N x i /
+        forwardDenominator (N - 1) (m - 1) (s - 1)
+          (deleteLastCoordinate N x) i := by
+  have hcoeff :
+      (s - 1) - ((m - 1 : ℕ) : ℝ) = s - (m : ℝ) := by
+    rw [Nat.cast_sub hm]
+    norm_num
+  have hsum := reduced_forward_sum_le N m hN hm hmN x hx i
+  have hdenominator :
+      forwardDenominator (N - 1) (m - 1) (s - 1)
+          (deleteLastCoordinate N x) i ≤
+        forwardDenominator N m s x (i.val : ZMod N) := by
+    unfold forwardDenominator
+    rw [hcoeff]
+    change
+      (s - (m : ℝ)) * x (i.val : ZMod N) +
+          ∑ q : Fin (m - 1), deleteLastCoordinate N x
+            (i + ((q.val + 1 : ℕ) : ZMod (N - 1))) ≤
+        (s - (m : ℝ)) * x (i.val : ZMod N) +
+          ∑ k : Fin m,
+            x ((i.val : ZMod N) + ((k.val + 1 : ℕ) : ZMod N))
+    exact add_le_add_right hsum _
+  change
+    x (i.val : ZMod N) / forwardDenominator N m s x (i.val : ZMod N) ≤
+      x (i.val : ZMod N) /
+        forwardDenominator (N - 1) (m - 1) (s - 1)
+          (deleteLastCoordinate N x) i
+  by_cases hxi : x (i.val : ZMod N) = 0
+  · have hxiCast : x (ZMod.cast i : ZMod N) = 0 := by
+      rw [ZMod.cast_eq_val]
+      exact hxi
+    simp [hxiCast]
+  · have hxipos : 0 < x (i.val : ZMod N) :=
+      lt_of_le_of_ne (hx _) (Ne.symm hxi)
+    have hmNlt : m < N := by omega
+    have hms : (m : ℝ) < s := by
+      have hmNR : (m : ℝ) < (N : ℝ) := by exact_mod_cast hmNlt
+      exact hmNR.trans_le hs
+    have hsumNonneg :
+        0 ≤ ∑ q : Fin (m - 1), deleteLastCoordinate N x
+          (i + ((q.val + 1 : ℕ) : ZMod (N - 1))) :=
+      Finset.sum_nonneg fun q _ ↦ hx _
+    have hdenominatorPos :
+        0 < forwardDenominator (N - 1) (m - 1) (s - 1)
+          (deleteLastCoordinate N x) i := by
+      unfold forwardDenominator
+      rw [hcoeff]
+      exact add_pos_of_pos_of_nonneg
+        (mul_pos (sub_pos.mpr hms) hxipos) hsumNonneg
+    exact div_le_div_of_nonneg_left (hx _) hdenominatorPos hdenominator
+
+/-- Yamagami's p. 525 regular-boundary recurrence, with the zero placed in
+the final coordinate.  The hypotheses are the exact stride-one source range
+used before the `m = 1` base case.  No regularity condition is needed after
+adopting Lean's totalized convention `0 / 0 = 0`; in particular, the reduced
+vector is allowed to be singular. -/
+theorem functional_le_deleteLastCoordinate
+    (N m : ℕ) [NeZero N] (hN : 3 ≤ N) (hm : 2 ≤ m)
+    (hmN : m ≤ N - 2) (s : ℝ) (hs : (N : ℝ) ≤ s)
+    (x : ZMod N → ℝ) (hx : ∀ i, 0 ≤ x i)
+    (hlast : x ((N - 1 : ℕ) : ZMod N) = 0) :
+    functional N m s x ≤
+      @functional (N - 1) (m - 1) ⟨by omega⟩
+        (s - 1) (deleteLastCoordinate N x) := by
+  let _ : NeZero (N - 1) := ⟨by omega⟩
+  unfold functional
+  rw [← Finset.sum_erase_add (Finset.univ : Finset (ZMod N))
+    (fun i ↦ x i / forwardDenominator N m s x i)
+    (Finset.mem_univ ((N - 1 : ℕ) : ZMod N))]
+  rw [hlast, zero_div, add_zero]
+  rw [sum_erase_lastCoordinate N (by omega)
+    (fun i ↦ x i / forwardDenominator N m s x i)]
+  exact Finset.sum_le_sum fun i _ ↦
+    retained_summand_le_reduced N m hN (by omega) hmN s hs x hx i
+
+end Yamagami

--- a/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch04_positive_not_cp_choi_and_decomposable_maps.tex
@@ -370,12 +370,57 @@ normalization; it is not a separate Lean theorem.
     pp.~523--524~\cite{Yamagami1993Cyclic}.
 \end{proof}
 
+\begin{theorem}[Yamagami's regular-boundary recurrence]
+    \label{thm:yamagami_regular_boundary_recurrence}
+    \lean{Yamagami.deleteLastCoordinate,
+        Yamagami.functional_le_deleteLastCoordinate}
+    \leanok
+    \uses{def:yamagami_stride_one_reciprocal}
+    Let $N\ge3$, $2\le m\le N-2$, and $s\ge N$.  Suppose that
+    $x\colon\Z/N\Z\to\R$ is nonnegative and $x_{N-1}=0$, and let
+    $x'\colon\Z/(N-1)\Z\to\R$ be given in the standard cyclic coordinates by
+    $x'_i=x_i$ for $0\le i<N-1$.  Then
+    \begin{align}
+        f_{N,m,s}(x)&\le f_{N-1,m-1,s-1}(x').
+        \label{eq:yamagami_regular_boundary_recurrence}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The coefficient of the distinguished coordinate is unchanged, since
+    $(s-1)-(m-1)=s-m$.  For every retained coordinate, the reduced
+    $(m-1)$-step forward window embeds in the original $m$-step window while
+    preserving cyclic order.  Nonnegativity of $x$ therefore makes the
+    reduced denominator no larger than the original denominator.  If the
+    common numerator is positive, then $s-m>0$ makes the reduced denominator
+    positive, so the original summand is at most the reduced one.  If the
+    numerator is zero, both summands have totalized value zero.  Summing these
+    comparisons and removing the zero summand at $N-1$ proves
+    (\ref{eq:yamagami_regular_boundary_recurrence}).  This is the
+    regular-boundary reduction on p.~525 of
+    \cite{Yamagami1993Cyclic}.
+
+    The comparison cannot in general be made strict.  For
+    $(N,m,s)=(5,2,5)$ and $x=(1,0,0,1,0)$, the original denominators are
+    $(3,1,1,4,1)$, whereas the denominators of the reduced vector
+    $x'=(1,0,0,1)$ are $(3,0,1,4)$.  Both sides of
+    (\ref{eq:yamagami_regular_boundary_recurrence}) equal $7/12$.  Thus a
+    regular original boundary point can become singular after deletion, and
+    the totalized comparison must be non-strict.  It is nevertheless
+    sufficient for induction, because an upper bound for the reduced
+    functional is preserved under equality.
+\end{proof}
+
 Theorem~\ref{thm:yamagami_forward_fourier_hessian} supplies the concrete
 Fourier--Hessian and functional-identification prerequisites for the
-uniqueness argument in Yamagami's Lemma~3.  It does not prove that
-$\mathbf 1$ is a local maximum, carry out the regular-boundary reduction on
-p.~525, or establish the global cyclic reciprocal inequality.  These steps,
-and hence the middle-range positivity theorem, are not yet formalized.
+uniqueness argument in Yamagami's Lemma~3, and
+Theorem~\ref{thm:yamagami_regular_boundary_recurrence} supplies the
+dimension reduction on p.~525.  These results do not prove that $\mathbf 1$
+is a local maximum or assemble the interior, singular-boundary, and
+regular-boundary estimates into a compact global maximum.  The full cyclic
+reciprocal inequality and the resulting middle-range Choi positivity theorem
+are not yet formalized.
 
 \begin{lemma}[The first positive coordinate after a singular window]
     \label{lem:yamagami_singular_zero_run}
@@ -473,12 +518,14 @@ and hence the middle-range positivity theorem, are not yet formalized.
     summand converges to its direct boundary value.  The omitted singular
     summands of the positive approximants are nonnegative, while their
     totalized boundary values are zero.  Passing to the limit gives the
-    claim.  This lemma is conditional: it supplies neither the positive
-    interior inequality nor Yamagami's regular-boundary induction.  In
-    particular, Theorem~\ref{thm:yamagami_lemma_three_uniqueness} supplies
-    only the uniqueness assertion for positive local maxima; it establishes
-    neither the existence of the unit maximum nor the global cyclic
-    inequality.  The full cyclic inequality is not asserted here.
+    claim.  This lemma is conditional: it does not supply the positive
+    interior inequality.  Theorem~\ref{thm:yamagami_regular_boundary_recurrence}
+    supplies the regular-boundary dimension reduction, but neither theorem
+    assembles a compact global maximum.  In particular,
+    Theorem~\ref{thm:yamagami_lemma_three_uniqueness} supplies only the
+    uniqueness assertion for positive local maxima; it establishes neither
+    the existence of the unit maximum nor the global cyclic inequality.  The
+    full cyclic inequality is not asserted here.
 \end{proof}
 
 \begin{definition}[Choi-type map]

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -198,13 +198,16 @@ $sS^{-1}\log((Sa)/s)$ in $\ker H$.  This is the uniqueness assertion of
 Yamagami's Lemma~3 on p.~522, not a proof that the unit vector is itself a
 local maximum.
 
-These results are still not the cyclic reciprocal inequality.  The cyclic
-Fourier--Hessian specialization and the functional identity are now proved,
-but no current declaration proves that the unit vector is a local maximum,
-carries out Yamagami's regular-boundary reduction on p.~525, or concludes the
-global strictly positive inequality.  The direct theorem for Lean's literal
+These results are still not the cyclic reciprocal inequality.  The declaration
+\leanid{Yamagami.functional\_le\_deleteLastCoordinate} now proves Yamagami's
+regular-boundary recurrence on p.~525 in the range $N\ge3$,
+$2\le m\le N-2$, and $s\ge N$, allowing the reduced vector to have singular
+denominators under Lean's totalized convention.  No current declaration proves
+that the unit vector is a local maximum or assembles the boundary reductions
+into a compact global maximum.  The direct theorem for Lean's literal
 \(0/0=0\) functional remains conditional on that global interior input.  Thus
-the regular-boundary and global steps, and hence issue~\#19, remain open.
+the full cyclic reciprocal inequality and the middle-range Choi positivity
+theorem remain open.
 
 Two verifiable computations locate the obstruction to elementary summand
 bounds in the remaining range.  First, the estimate is tight in two distinct

--- a/docs/paper-gaps/yamagami93_lemma6_endpoint.tex
+++ b/docs/paper-gaps/yamagami93_lemma6_endpoint.tex
@@ -78,10 +78,12 @@ The cyclic matrix package in
 \doclink{QICLean/Analysis/YamagamiCyclicMatrix} now also proves invertibility,
 the positive-semidefinite Hessian with kernel $\mathbb R\mathbf1$, and the
 bridge from the generic Nowosad functional to the concrete cyclic
-\leanid{Yamagami.functional}.  What remains includes the proof that the unit
-vector is a local maximum, the separate regular-boundary induction, and the
-global cyclic inequality.  Thus this resolved endpoint remains only a
-prerequisite for the still-open issue~\#19.
+\leanid{Yamagami.functional}.  The declaration
+\leanid{Yamagami.functional\_le\_deleteLastCoordinate} now also proves the
+regular-boundary recurrence on p.~525.  What remains includes the proof that
+the unit vector is a local maximum, the compact global maximization argument,
+and the full cyclic inequality.  Thus this resolved endpoint remains only a
+prerequisite for the still-open positivity theorem.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/yamagami93_simultaneous_singularity_boundary.tex
+++ b/docs/paper-gaps/yamagami93_simultaneous_singularity_boundary.tex
@@ -129,16 +129,19 @@ nonnegative vector through the uniform perturbation
 \leanid{Yamagami.functional\_le\_card\_ratio\_of\_strictlyPositive} in
 \doclink{QICLean/Analysis/YamagamiBoundary}.}
 This conditional theorem does not supply the strictly positive interior
-inequality.  It also does not replace Yamagami's separate regular-boundary
-reduction.  The finite-coordinate Nowosad theorem and the uniqueness assertion
+inequality.  Yamagami's separate regular-boundary recurrence on p.~525 is now
+formalized as
+\leanid{Yamagami.functional\_le\_deleteLastCoordinate}.  The finite-coordinate
+Nowosad theorem and the uniqueness assertion
 of Yamagami's Lemma~3 are now formalized in
 \leanid{Nowosad.finiteCoordinate\_theorem\_one\_eight} and
 \leanid{Yamagami.lemma\_three\_localMax\_isScalar}.  The cyclic matrix package
 in \doclink{QICLean/Analysis/YamagamiCyclicMatrix} now verifies the Fourier
 Hessian hypotheses and identifies the generic Nowosad functional with the
 concrete cyclic \leanid{Yamagami.functional}.  It does not prove that the unit
-vector is a local maximum or supply the regular-boundary induction.  Those
-steps remain prerequisites of the full cyclic inequality and of issue~\#19.
+vector is a local maximum or assemble the available boundary reductions into
+a compact global maximum.  Those remaining steps are prerequisites of the
+full cyclic inequality.
 
 \section{Verdict}
 

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -724,6 +724,12 @@ so that the cited formal statements are available from the main project import.
   cyclic matrix is nonnegative and invertible, its negative-Hessian
   representative is positive semidefinite with kernel `ℝ · 1`, and the
   concrete functional is exactly `λ_{S⁻¹}(Sx)` ✓
+- `Yamagami.deleteLastCoordinate` and
+  `Yamagami.functional_le_deleteLastCoordinate` formalize the p. 525
+  regular-boundary recurrence. In the exact range `N ≥ 3`,
+  `2 ≤ m ≤ N - 2`, and `s ≥ N`, deleting a zero final coordinate gives
+  `f_{N,m,s}(x) ≤ f_{N-1,m-1,s-1}(x')`, including when the reduced vector has
+  a singular denominator under Lean's totalized division ✓
 - `Nowosad.inducedHilbertNorm_sq` and
   `Nowosad.exists_inducedHilbertNorm_bound` identify the norm induced by the
   faithful coordinate-sum functional with the finite `L²` norm and prove that
@@ -767,11 +773,10 @@ so that the cited formal statements are available from the main project import.
   a maximal-block decomposition ✓
 - `Yamagami.functional_le_card_ratio_of_strictlyPositive` transfers an
   already proved strictly positive inequality to Lean's direct nonnegative
-  `0 / 0 = 0` value. This theorem is conditional; the positive-interior input
-  and the regular-boundary induction are still required. The finite Nowosad
-  theorem and the cyclic Fourier--Hessian package supply the abstract
-  uniqueness and concrete matrix prerequisites, but they supply neither a
-  proof that the unit vector is a local maximum nor the global inequality. See
+  `0 / 0 = 0` value. This theorem is conditional. The regular-boundary
+  recurrence is now formalized, but the finite Nowosad theorem and the cyclic
+  Fourier--Hessian package supply neither a proof that the unit vector is a
+  local maximum nor the compact global maximization argument. See
   `docs/paper-gaps/yamagami93_simultaneous_singularity_boundary.tex` ✓
 - Positivity in the middle range `2 ≤ n ≤ d - 3` remains open; its exact
   scope and cyclic reciprocal inequality are recorded in


### PR DESCRIPTION
## Statement

This pull request formalizes the regular-boundary recurrence on p. 525 of Yamagami's *Cyclic inequalities*. Let $N \ge 3$, $2 \le m \le N-2$, and $s \ge N$. For a nonnegative vector $x : \mathbb Z/N\mathbb Z \to \mathbb R$ with $x_{N-1}=0$, let $x' : \mathbb Z/(N-1)\mathbb Z \to \mathbb R$ be obtained by deleting the final coordinate. The main theorem proves

$$
f_{N,m,s}(x) \le f_{N-1,m-1,s-1}(x').
$$

The theorem uses Lean's totalized division, so the reduced vector may have a zero denominator. This is essential for the induction and for the non-strict form of the recurrence. For example, with

$$
(N,m,s)=(5,2,5), \qquad x=(1,0,0,1,0),
$$

the original denominators are $(3,1,1,4,1)$, so the original boundary point is regular. After deletion, $x'=(1,0,0,1)$ has denominators $(3,0,1,4)$, and is singular at coordinate $1$. Nevertheless,

$$
f_{5,2,5}(x)=f_{4,1,4}(x')=\frac{7}{12}.
$$

Thus equality can occur when deletion changes a regular boundary point into a singular reduced point.

## Integration

- Adds the placeholder-free recurrence module and the generated `QICLean.Analysis` import.
- Records the p. 525 recurrence in Chapter 4 immediately after the Fourier--Hessian prerequisite.
- Corrects only the stale regular-boundary status in the existing Yamagami and Choi scope notes and in Wolf numbering coverage.

This is a prerequisite only. Compact global maximization, the full cyclic reciprocal inequality, the resulting Choi positivity theorem, and issue #19 all remain open.

## Verification

- Targeted builds of `QICLean.Analysis.YamagamiRegularBoundary` and `QICLean.Analysis` pass.
- Generated imports, Lean file policies, size and naming policies, and style checks pass.
- Blueprint synchronization and reverse coverage, reader-facing prose, ChkTeX, paper-gap references, and the three affected gap-note PDF builds pass.
- Diff and proof-hazard scans pass.
- A concrete $N=5,m=2,s=5$ theorem instantiation compiles.
- `#print axioms Yamagami.functional_le_deleteLastCoordinate` reports only `propext`, `Classical.choice`, and `Quot.sound`.

Refs #19
