### PR TITLE
feat(sic): migrate overlap bound from TNLean

### DIFF
--- a/QICLean/Algebra.lean
+++ b/QICLean/Algebra.lean
@@ -52,6 +52,7 @@ import QICLean.Algebra.PosSemidefSupport
 import QICLean.Algebra.PositiveSemidefiniteNormalization
 import QICLean.Algebra.RankOneSandwich
 import QICLean.Algebra.RectangularChoi
+import QICLean.Algebra.SICPOVMBound
 import QICLean.Algebra.ScalarCommutant
 import QICLean.Algebra.ShiftedTracePowerSpectrum
 import QICLean.Algebra.SkolemNoether

--- a/QICLean/Algebra/SICPOVMBound.lean
+++ b/QICLean/Algebra/SICPOVMBound.lean
@@ -1,0 +1,474 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.TracePurity
+
+/-!
+# The SIC--POVM overlap bound
+
+This file proves Wolf's lower bound for the sum of the squared pairwise
+Hilbert--Schmidt overlaps of positive semidefinite matrices of unit purity,
+together with its equality criterion.
+
+## References
+
+* Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs",
+  Equation (2.30); `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 790--823
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace Matrix
+
+variable {d n : ℕ}
+
+private lemma trace_sum_sq_re_eq_diag_add_offDiag
+    (P : Fin n → Matrix (Fin d) (Fin d) ℂ) :
+    ((∑ i, P i) ^ 2).trace.re =
+      (∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+        ((P ij.1 * P ij.2).trace).re) +
+      ∑ i, ((P i) ^ 2).trace.re := by
+  classical
+  rw [pow_two, Finset.sum_mul_sum, Matrix.trace_sum, Complex.re_sum]
+  simp_rw [Matrix.trace_sum, Complex.re_sum]
+  calc
+    (∑ i, ∑ j, (P i * P j).trace.re) =
+        ∑ ij ∈ (Finset.univ : Finset (Fin n)) ×ˢ Finset.univ,
+          (P ij.1 * P ij.2).trace.re := by
+      rw [Finset.sum_product]
+    _ = ∑ ij ∈ (Finset.univ : Finset (Fin n)).diag ∪ Finset.univ.offDiag,
+          (P ij.1 * P ij.2).trace.re := by
+      rw [Finset.diag_union_offDiag]
+    _ = _ := by
+      rw [Finset.sum_union (Finset.disjoint_diag_offDiag _)]
+      simp [pow_two, add_comm]
+
+private lemma sum_trace_re_eq_trace_sum_re
+    (P : Fin n → Matrix (Fin d) (Fin d) ℂ) :
+    (∑ i, (P i).trace.re) = (∑ i, P i).trace.re := by
+  rw [Matrix.trace_sum, Complex.re_sum]
+
+private lemma sum_posSemidef (P : Fin n → Matrix (Fin d) (Fin d) ℂ)
+    (hP : ∀ i, (P i).PosSemidef) :
+    (∑ i, P i).PosSemidef := by
+  classical
+  exact Finset.sum_induction _ Matrix.PosSemidef (fun A B hA hB ↦ hA.add hB)
+    Matrix.PosSemidef.zero (fun i _ ↦ hP i)
+
+private lemma offDiag_card_fin :
+    ((Finset.univ : Finset (Fin n)).offDiag.card : ℝ) =
+      (n : ℝ) * ((n : ℝ) - 1) := by
+  rw [Finset.offDiag_card]
+  simp only [Finset.card_univ, Fintype.card_fin]
+  have hnle : n ≤ n * n := by
+    by_cases hn0 : n = 0
+    · simp [hn0]
+    · exact Nat.le_mul_of_pos_right n (Nat.pos_of_ne_zero hn0)
+  rw [Nat.cast_sub hnle]
+  push_cast
+  ring
+
+private lemma rankOne_of_sum_trace_eq_card
+    (P : Fin n → Matrix (Fin d) (Fin d) ℂ)
+    (hP : ∀ i, (P i).PosSemidef)
+    (hpurity : ∀ i, ((P i) ^ 2).trace = 1)
+    (hsumtrace : ∑ i, (P i).trace.re = n) :
+    ∀ i, IsRankOneOrthogonalProjection (P i) := by
+  have htrace_each : ∀ i, 1 ≤ (P i).trace.re := fun i ↦
+    (hP i).one_le_trace_re_of_trace_sq_eq_one (hpurity i)
+  have hdefsum : ∑ i, ((P i).trace.re - 1) = 0 := by
+    rw [Finset.sum_sub_distrib, hsumtrace]
+    simp
+  have hdefnonneg : ∀ i, 0 ≤ (P i).trace.re - 1 := fun i ↦
+    sub_nonneg.mpr (htrace_each i)
+  intro i
+  have hiFun : (fun i ↦ (P i).trace.re - 1) = 0 :=
+    Fintype.sum_eq_zero_iff_of_nonneg hdefnonneg |>.mp hdefsum
+  have hi := congrFun hiFun i
+  change (P i).trace.re - 1 = 0 at hi
+  apply ((hP i).trace_re_eq_one_iff_isRankOneOrthogonalProjection (hpurity i)).mp
+  linarith
+
+private lemma eq_card_div_smul_one_of_trace_equalities
+    (Q : Matrix (Fin d) (Fin d) ℂ) (hd : 0 < d)
+    (hQ : Q.IsHermitian) (htrace : Q.trace.re = n)
+    (htraceSq : Q.trace.re ^ 2 = (d : ℝ) * (Q ^ 2).trace.re) :
+    Q = ((n : ℝ) / d : ℂ) • 1 := by
+  obtain ⟨r, hr⟩ := hQ.trace_re_sq_eq_card_mul_trace_sq_re_iff.mp htraceSq
+  have hrval : r = (n : ℝ) / d := by
+    rw [hr] at htrace
+    simp at htrace
+    have hdR : (0 : ℝ) < d := by exact_mod_cast hd
+    apply (eq_div_iff hdR.ne').2
+    nlinarith
+  simpa [hrval] using hr
+
+private lemma offDiag_overlap_eq_of_cauchySchwarz_eq
+    (P : Fin n → Matrix (Fin d) (Fin d) ℂ) (hn : 2 ≤ n) (hd : 0 < d)
+    (hcsEq :
+      (∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+          (P ij.1 * P ij.2).trace.re) ^ 2 =
+        (n : ℝ) * ((n : ℝ) - 1) *
+          ∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+            ((P ij.1 * P ij.2).trace.re) ^ 2)
+    (hT_eq :
+      (d : ℝ) *
+          (∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+            (P ij.1 * P ij.2).trace.re) =
+        (n : ℝ) * ((n : ℝ) - d)) :
+    ∀ i j, i ≠ j →
+      (P i * P j).trace.re =
+        ((n : ℝ) - d) / (((n : ℝ) - 1) * d) := by
+  have hnR : (1 : ℝ) < n := by exact_mod_cast hn
+  have hdR : (0 : ℝ) < d := by exact_mod_cast hd
+  have hconst : ∀ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+      ∀ kl ∈ (Finset.univ : Finset (Fin n)).offDiag,
+        (P ij.1 * P ij.2).trace.re = (P kl.1 * P kl.2).trace.re := by
+    apply (Finset.sq_sum_eq_card_mul_sum_sq_iff
+      (s := (Finset.univ : Finset (Fin n)).offDiag)
+      (f := fun ij ↦ (P ij.1 * P ij.2).trace.re)).mp
+    rw [offDiag_card_fin]
+    simpa [mul_assoc] using hcsEq
+  intro i j hij
+  have hijmem : (i, j) ∈ (Finset.univ : Finset (Fin n)).offDiag := by simp [hij]
+  have hsumconst :
+      (∑ kl ∈ (Finset.univ : Finset (Fin n)).offDiag,
+          (P kl.1 * P kl.2).trace.re) =
+        ((Finset.univ : Finset (Fin n)).offDiag.card : ℝ) *
+          (P i * P j).trace.re := by
+    calc
+      (∑ kl ∈ (Finset.univ : Finset (Fin n)).offDiag,
+          (P kl.1 * P kl.2).trace.re) =
+          ∑ _kl ∈ (Finset.univ : Finset (Fin n)).offDiag,
+            (P i * P j).trace.re := by
+        apply Finset.sum_congr rfl
+        intro kl hkl
+        exact hconst kl hkl (i, j) hijmem
+      _ = _ := by simp
+  rw [offDiag_card_fin] at hsumconst
+  apply (eq_div_iff (by positivity : ((n : ℝ) - 1) * d ≠ 0)).2
+  nlinarith
+
+private lemma sicPOVM_bound_eq_of_offDiag_overlap_eq
+    (P : Fin n → Matrix (Fin d) (Fin d) ℂ) (hn : 2 ≤ n) (hd : 0 < d)
+    (hoverlap : ∀ i j, i ≠ j →
+      (P i * P j).trace.re =
+        ((n : ℝ) - d) / (((n : ℝ) - 1) * d)) :
+    (n : ℝ) * ((n : ℝ) - d) ^ 2 / (((n : ℝ) - 1) * (d : ℝ) ^ 2) =
+      ∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+        ((P ij.1 * P ij.2).trace.re) ^ 2 := by
+  have hnR : (1 : ℝ) < n := by exact_mod_cast hn
+  have hdR : (0 : ℝ) < d := by exact_mod_cast hd
+  calc
+    (n : ℝ) * ((n : ℝ) - d) ^ 2 / (((n : ℝ) - 1) * (d : ℝ) ^ 2) =
+        (n : ℝ) * ((n : ℝ) - 1) *
+          (((n : ℝ) - d) / (((n : ℝ) - 1) * d)) ^ 2 := by
+      field_simp
+    _ = ((Finset.univ : Finset (Fin n)).offDiag.card : ℝ) *
+          (((n : ℝ) - d) / (((n : ℝ) - 1) * d)) ^ 2 := by
+      rw [offDiag_card_fin]
+    _ = ∑ _ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+          (((n : ℝ) - d) / (((n : ℝ) - 1) * d)) ^ 2 := by simp
+    _ = _ := by
+      apply Finset.sum_congr rfl
+      intro ij hij
+      rw [hoverlap ij.1 ij.2 (Finset.mem_offDiag.mp hij).2.2]
+
+/-- Wolf's SIC--POVM bound: among positive semidefinite matrices of unit purity,
+the sum of the squared off-diagonal Hilbert--Schmidt overlaps has the stated
+dimension-dependent lower bound.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs",
+Equation (2.30); `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 790--807. -/
+theorem sicPOVM_offDiag_overlap_sq_bound
+    (P : Fin n → Matrix (Fin d) (Fin d) ℂ)
+    (hn : 2 ≤ n) (hd : 0 < d) (hdn : d ≤ n)
+    (hP : ∀ i, (P i).PosSemidef)
+    (hpurity : ∀ i, ((P i) ^ 2).trace = 1) :
+    (n : ℝ) * ((n : ℝ) - d) ^ 2 / (((n : ℝ) - 1) * (d : ℝ) ^ 2) ≤
+      ∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+        ((P ij.1 * P ij.2).trace.re) ^ 2 := by
+  classical
+  let Q : Matrix (Fin d) (Fin d) ℂ := ∑ i, P i
+  let T : ℝ := ∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+    (P ij.1 * P ij.2).trace.re
+  let S : ℝ := ∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+    ((P ij.1 * P ij.2).trace.re) ^ 2
+  have hQpsd : Q.PosSemidef := sum_posSemidef P hP
+  have htrace_each : ∀ i, 1 ≤ (P i).trace.re := fun i ↦
+    (hP i).one_le_trace_re_of_trace_sq_eq_one (hpurity i)
+  have htraceQ : (n : ℝ) ≤ Q.trace.re := by
+    rw [← sum_trace_re_eq_trace_sum_re P]
+    calc
+      (n : ℝ) = ∑ _i : Fin n, (1 : ℝ) := by simp
+      _ ≤ ∑ i, (P i).trace.re := Finset.sum_le_sum fun i _ ↦ htrace_each i
+  have hQsq : (Q ^ 2).trace.re = T + n := by
+    rw [trace_sum_sq_re_eq_diag_add_offDiag]
+    simp only [hpurity, Complex.one_re, Finset.sum_const, Finset.card_univ,
+      Fintype.card_fin, nsmul_eq_mul, mul_one]
+    rfl
+  have htrace_sq := hQpsd.isHermitian.trace_re_sq_le_card_mul_trace_sq_re
+  have hTlower : (n : ℝ) * ((n : ℝ) - d) ≤ (d : ℝ) * T := by
+    rw [hQsq] at htrace_sq
+    have hn0 : (0 : ℝ) ≤ n := by positivity
+    have htrace0 : 0 ≤ Q.trace.re := le_trans hn0 htraceQ
+    nlinarith
+  have hT0 : 0 ≤ T := by
+    apply Finset.sum_nonneg
+    intro ij hij
+    exact (Complex.nonneg_iff.mp
+      ((hP ij.1).trace_mul_nonneg (hP ij.2))).1
+  have hcs : T ^ 2 ≤ (n : ℝ) * ((n : ℝ) - 1) * S := by
+    have h := sq_sum_le_card_mul_sum_sq
+      (s := (Finset.univ : Finset (Fin n)).offDiag)
+      (f := fun ij ↦ (P ij.1 * P ij.2).trace.re)
+    rw [offDiag_card_fin] at h
+    simpa [T, S, mul_assoc] using h
+  have hnum0 : 0 ≤ (n : ℝ) * ((n : ℝ) - d) := by
+    have hdn' : (d : ℝ) ≤ n := by exact_mod_cast hdn
+    positivity
+  have hsquared :
+      ((n : ℝ) * ((n : ℝ) - d)) ^ 2 ≤ ((d : ℝ) * T) ^ 2 := by
+    nlinarith
+  have hpoly :
+      (n : ℝ) * ((n : ℝ) - d) ^ 2 ≤
+        ((n : ℝ) - 1) * (d : ℝ) ^ 2 * S := by
+    have hnpos : (0 : ℝ) < n := by positivity
+    have hd0 : (0 : ℝ) ≤ d := by positivity
+    nlinarith
+  rw [div_le_iff₀]
+  · simpa [mul_assoc, mul_left_comm, mul_comm] using hpoly
+  · have hn' : (1 : ℝ) < n := by exact_mod_cast hn
+    have hd' : (0 : ℝ) < d := by exact_mod_cast hd
+    positivity
+
+/-- Equality in Wolf's SIC--POVM bound holds precisely for rank-one
+projections forming a tight equiangular family.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs",
+Equations (2.30)--(2.32); `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 798--815. -/
+theorem sicPOVM_offDiag_overlap_sq_eq_iff
+    (P : Fin n → Matrix (Fin d) (Fin d) ℂ)
+    (hn : 2 ≤ n) (hd : 0 < d) (hdn : d ≤ n)
+    (hP : ∀ i, (P i).PosSemidef)
+    (hpurity : ∀ i, ((P i) ^ 2).trace = 1) :
+    (n : ℝ) * ((n : ℝ) - d) ^ 2 / (((n : ℝ) - 1) * (d : ℝ) ^ 2) =
+        ∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+          ((P ij.1 * P ij.2).trace.re) ^ 2 ↔
+      (∀ i, IsRankOneOrthogonalProjection (P i)) ∧
+      (∑ i, P i) = ((n : ℝ) / d : ℂ) • 1 ∧
+      ∀ i j, i ≠ j →
+        (P i * P j).trace.re =
+          ((n : ℝ) - d) / (((n : ℝ) - 1) * d) := by
+  classical
+  let Q : Matrix (Fin d) (Fin d) ℂ := ∑ i, P i
+  let T : ℝ := ∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+    (P ij.1 * P ij.2).trace.re
+  let S : ℝ := ∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+    ((P ij.1 * P ij.2).trace.re) ^ 2
+  have hnR : (1 : ℝ) < n := by exact_mod_cast hn
+  have hn0 : (0 : ℝ) < n := lt_trans (by norm_num) hnR
+  have hdR : (0 : ℝ) < d := by exact_mod_cast hd
+  have hdnR : (d : ℝ) ≤ n := by exact_mod_cast hdn
+  have hden : 0 < ((n : ℝ) - 1) * (d : ℝ) ^ 2 := by positivity
+  have hQpsd : Q.PosSemidef := sum_posSemidef P hP
+  have htrace_each : ∀ i, 1 ≤ (P i).trace.re := fun i ↦
+    (hP i).one_le_trace_re_of_trace_sq_eq_one (hpurity i)
+  have htraceQ : (n : ℝ) ≤ Q.trace.re := by
+    rw [← sum_trace_re_eq_trace_sum_re P]
+    calc
+      (n : ℝ) = ∑ _i : Fin n, (1 : ℝ) := by simp
+      _ ≤ ∑ i, (P i).trace.re := Finset.sum_le_sum fun i _ ↦ htrace_each i
+  have hQsq : (Q ^ 2).trace.re = T + n := by
+    rw [trace_sum_sq_re_eq_diag_add_offDiag]
+    simp only [hpurity, Complex.one_re, Finset.sum_const, Finset.card_univ,
+      Fintype.card_fin, nsmul_eq_mul, mul_one]
+    rfl
+  have htrace_sq := hQpsd.isHermitian.trace_re_sq_le_card_mul_trace_sq_re
+  have hTlower : (n : ℝ) * ((n : ℝ) - d) ≤ (d : ℝ) * T := by
+    rw [hQsq] at htrace_sq
+    nlinarith
+  have hT0 : 0 ≤ T := by
+    apply Finset.sum_nonneg
+    intro ij hij
+    exact (Complex.nonneg_iff.mp
+      ((hP ij.1).trace_mul_nonneg (hP ij.2))).1
+  have hcs : T ^ 2 ≤ (n : ℝ) * ((n : ℝ) - 1) * S := by
+    have h := sq_sum_le_card_mul_sum_sq
+      (s := (Finset.univ : Finset (Fin n)).offDiag)
+      (f := fun ij ↦ (P ij.1 * P ij.2).trace.re)
+    rw [offDiag_card_fin] at h
+    simpa [T, S, mul_assoc] using h
+  constructor
+  · intro heq
+    have heqpoly :
+        (n : ℝ) * ((n : ℝ) - d) ^ 2 =
+          ((n : ℝ) - 1) * (d : ℝ) ^ 2 * S := by
+      rw [div_eq_iff hden.ne'] at heq
+      simpa [S, mul_assoc, mul_left_comm, mul_comm] using heq
+    have hsquared :
+        ((n : ℝ) * ((n : ℝ) - d)) ^ 2 ≤ ((d : ℝ) * T) ^ 2 := by
+      have hnum0 : 0 ≤ (n : ℝ) * ((n : ℝ) - d) := by positivity
+      nlinarith
+    have heqpoly' :
+        ((n : ℝ) * ((n : ℝ) - d)) ^ 2 =
+          (d : ℝ) ^ 2 * ((n : ℝ) * ((n : ℝ) - 1) * S) := by
+      nlinarith [heqpoly]
+    have hreverse : ((d : ℝ) * T) ^ 2 ≤
+        ((n : ℝ) * ((n : ℝ) - d)) ^ 2 := by
+      have hscaled := mul_le_mul_of_nonneg_left hcs (sq_nonneg (d : ℝ))
+      rw [← heqpoly'] at hscaled
+      simpa [pow_two, mul_assoc, mul_left_comm, mul_comm] using hscaled
+    have hsquaresEq :
+        ((d : ℝ) * T) ^ 2 = ((n : ℝ) * ((n : ℝ) - d)) ^ 2 :=
+      le_antisymm hreverse hsquared
+    have hcsEq : T ^ 2 = (n : ℝ) * ((n : ℝ) - 1) * S := by
+      nlinarith [heqpoly']
+    have hT_eq : (d : ℝ) * T = (n : ℝ) * ((n : ℝ) - d) := by
+      have hnum0 : 0 ≤ (n : ℝ) * ((n : ℝ) - d) := by positivity
+      nlinarith [hsquaresEq]
+    have htraceQeq : Q.trace.re = n := by
+      rw [hQsq] at htrace_sq
+      nlinarith
+    have htraceSqEq :
+        Q.trace.re ^ 2 = (d : ℝ) * (Q ^ 2).trace.re := by
+      rw [hQsq]
+      nlinarith
+    have hsumtrace : ∑ i, (P i).trace.re = n := by
+      rw [sum_trace_re_eq_trace_sum_re P]
+      exact htraceQeq
+    have hrankOne := rankOne_of_sum_trace_eq_card P hP hpurity hsumtrace
+    have hQscalar := eq_card_div_smul_one_of_trace_equalities
+      Q hd hQpsd.isHermitian htraceQeq htraceSqEq
+    dsimp only [T, S] at hcsEq hT_eq
+    have hoverlap := offDiag_overlap_eq_of_cauchySchwarz_eq P hn hd hcsEq hT_eq
+    exact ⟨hrankOne, hQscalar, hoverlap⟩
+  · rintro ⟨hrankOne, hQscalar, hoverlap⟩
+    exact sicPOVM_bound_eq_of_offDiag_overlap_eq P hn hd hoverlap
+
+/-- Equality families in Wolf's SIC--POVM bound are linearly independent when
+the matrix dimension is at least two.
+
+**Local fix (one-dimensional equality families):** Wolf's concluding
+linear-independence assertion fails for `d = 1` and `n > 1`; see
+`https://sirui-lu.com/QICLean/paper-gaps/wolf_sic_povm_linear_independence.pdf`
+(QICLean paper-gap note). The hypothesis `2 ≤ d`
+is exactly the nondegeneracy condition needed by the coefficient equation.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs";
+`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 807--823. -/
+theorem sicPOVM_linearIndependent_of_overlap_bound_eq
+    (P : Fin n → Matrix (Fin d) (Fin d) ℂ)
+    (hn : 2 ≤ n) (hd : 2 ≤ d) (hdn : d ≤ n)
+    (hP : ∀ i, (P i).PosSemidef)
+    (hpurity : ∀ i, ((P i) ^ 2).trace = 1)
+    (heq :
+      (n : ℝ) * ((n : ℝ) - d) ^ 2 / (((n : ℝ) - 1) * (d : ℝ) ^ 2) =
+        ∑ ij ∈ (Finset.univ : Finset (Fin n)).offDiag,
+          ((P ij.1 * P ij.2).trace.re) ^ 2) :
+    LinearIndependent ℂ P := by
+  classical
+  have hd0 : 0 < d := lt_of_lt_of_le (by omega) hd
+  obtain ⟨hrankOne, hsumP, hoverlap⟩ :=
+    (sicPOVM_offDiag_overlap_sq_eq_iff P hn hd0 hdn hP hpurity).mp heq
+  let a : ℝ := ((n : ℝ) - d) / (((n : ℝ) - 1) * d)
+  have htraceP : ∀ i, (P i).trace = 1 := by
+    intro i
+    have hre := ((hP i).trace_re_eq_one_iff_isRankOneOrthogonalProjection
+      (hpurity i)).mpr (hrankOne i)
+    have him := (Complex.nonneg_iff.mp (hP i).trace_nonneg).2
+    apply Complex.ext
+    · simpa using hre
+    · simpa using him.symm
+  have hoverlapComplex : ∀ i j, i ≠ j → (P i * P j).trace = (a : ℂ) := by
+    intro i j hij
+    have hre := hoverlap i j hij
+    have him := (Complex.nonneg_iff.mp ((hP i).trace_mul_nonneg (hP j))).2
+    apply Complex.ext
+    · change (P i * P j).trace.re = a
+      simpa [a] using hre
+    · simpa using him.symm
+  apply Fintype.linearIndependent_iff.mpr
+  intro c hc j
+  have hsumc : ∑ i, c i = 0 := by
+    have h := congrArg Matrix.trace hc
+    simp only [Matrix.trace_sum, Matrix.trace_smul, htraceP, Matrix.trace_zero,
+      smul_eq_mul, mul_one] at h
+    exact h
+  have hsumErase : ∑ i ∈ (Finset.univ : Finset (Fin n)).erase j, c i = -c j := by
+    have hsplit := Finset.add_sum_erase (Finset.univ : Finset (Fin n)) c
+      (Finset.mem_univ j)
+    rw [hsumc] at hsplit
+    linear_combination hsplit
+  have hpair : ∑ i, c i * (P j * P i).trace = 0 := by
+    have h := congrArg (fun X ↦ Matrix.trace (P j * X)) hc
+    simpa only [Matrix.mul_sum, Matrix.mul_smul, Matrix.trace_sum,
+      Matrix.trace_smul, Matrix.mul_zero, Matrix.trace_zero, smul_eq_mul] using h
+  have hpairSplit :
+      c j * (P j * P j).trace +
+        ∑ i ∈ (Finset.univ : Finset (Fin n)).erase j,
+          c i * (P j * P i).trace = 0 := by
+    rw [Finset.add_sum_erase (Finset.univ : Finset (Fin n))
+      (fun i ↦ c i * (P j * P i).trace) (Finset.mem_univ j)]
+    exact hpair
+  have hcoeff : (1 - (a : ℂ)) * c j = 0 := by
+    rw [show (P j * P j).trace = 1 by simpa [pow_two] using hpurity j] at hpairSplit
+    have hoff :
+        (∑ i ∈ (Finset.univ : Finset (Fin n)).erase j,
+          c i * (P j * P i).trace) = (a : ℂ) * (-c j) := by
+      calc
+        (∑ i ∈ (Finset.univ : Finset (Fin n)).erase j,
+            c i * (P j * P i).trace) =
+            ∑ i ∈ (Finset.univ : Finset (Fin n)).erase j, c i * (a : ℂ) := by
+          apply Finset.sum_congr rfl
+          intro i hi
+          rw [hoverlapComplex j i (Finset.ne_of_mem_erase hi).symm]
+        _ = (a : ℂ) *
+            ∑ i ∈ (Finset.univ : Finset (Fin n)).erase j, c i := by
+          rw [Finset.mul_sum]
+          apply Finset.sum_congr rfl
+          intro i hi
+          ring
+        _ = (a : ℂ) * (-c j) := by rw [hsumErase]
+    rw [hoff] at hpairSplit
+    linear_combination hpairSplit
+  have ha_ne : (1 - (a : ℂ)) ≠ 0 := by
+    intro ha
+    have hnR : (1 : ℝ) < n := by exact_mod_cast hn
+    have hdR : (1 : ℝ) < d := by exact_mod_cast hd
+    have haone : a = 1 := by
+      have := congrArg Complex.re (sub_eq_zero.mp ha)
+      simpa using this.symm
+    dsimp [a] at haone
+    rw [div_eq_one_iff_eq (by positivity : ((n : ℝ) - 1) * d ≠ 0)] at haone
+    nlinarith
+  exact (mul_eq_zero.mp hcoeff).resolve_left ha_ne
+
+/-- A singleton family containing a matrix of unit purity is linearly
+independent.
+
+**Local fix (one-dimensional equality families):** This is the `n = 1` branch
+of the corrected nondegeneracy condition; see
+`https://sirui-lu.com/QICLean/paper-gaps/wolf_sic_povm_linear_independence.pdf`
+(QICLean paper-gap note).
+
+Source context: Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition
+"SIC POVMs"; `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 807--823. -/
+theorem singleton_linearIndependent_of_trace_sq_eq_one
+    (P : Fin 1 → Matrix (Fin d) (Fin d) ℂ)
+    (hpurity : ((P 0) ^ 2).trace = 1) :
+    LinearIndependent ℂ P := by
+  classical
+  apply Fintype.linearIndependent_iff.mpr
+  intro c hc i
+  fin_cases i
+  simp only [Fin.sum_univ_one] at hc
+  by_contra hcoeff
+  have hPzero : P 0 = 0 := (smul_eq_zero.mp hc).resolve_left hcoeff
+  rw [hPzero] at hpurity
+  norm_num at hpurity
+
+end Matrix

--- a/blueprint/src/chapter/ch03_channel_representations.tex
+++ b/blueprint/src/chapter/ch03_channel_representations.tex
@@ -8,7 +8,9 @@ representation material for finite-dimensional quantum channels from
 \cite[Chapter~2]{Wolf2012Quantum}: Kraus representation theorems,
 Stinespring and Naimark dilations, ordered completely positive maps,
 Radon--Nikodym and open-system representations, trace-pairing expansions,
-SVD and Lorentz normal forms, and the channel determinant. These results
+SVD and Lorentz normal forms, and the channel determinant. It also develops
+the finite Cauchy--Schwarz and trace-purity criteria underlying SIC--POVM
+overlap bounds, equality cases, and reconstruction formulas. These results
 are important for the later channel theory, but they are not prerequisites
 for the matrix-product-state Fundamental Theorem.
 
@@ -23,3 +25,4 @@ for the matrix-product-state Fundamental Theorem.
 \input{chapter/ch03_channel_representations_normal_forms_and_determinant}
 \input{chapter/ch03_channel_representations_determinant_choi_bound}
 \input{chapter/ch03_channel_representations_self_dual}
+\input{chapter/ch03_channel_representations_sic_povms}

--- a/blueprint/src/chapter/ch03_channel_representations_sic_povms.tex
+++ b/blueprint/src/chapter/ch03_channel_representations_sic_povms.tex
@@ -1,0 +1,348 @@
+\section{Finite Cauchy--Schwarz equality}
+
+\begin{theorem}[Equality in finite Cauchy--Schwarz]
+    \label{thm:finite_cauchy_schwarz_equality}
+    \lean{Finset.sq_sum_eq_card_mul_sum_sq_iff}
+    \leanok
+    Let $S$ be a finite set and let $(x_i)_{i\in S}$ be real numbers. Then
+    \[
+        \left(\sum_{i\in S}x_i\right)^2
+        =|S|\sum_{i\in S}x_i^2
+    \]
+    if and only if $x_i=x_j$ for every $i,j\in S$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The variance identity gives
+    \[
+        \sum_{i,j\in S}(x_i-x_j)^2
+        =2\left(
+        |S|\sum_{i\in S}x_i^2-
+        \left(\sum_{i\in S}x_i\right)^2
+        \right).
+    \]
+    Since every summand on the left is non-negative, equality in
+    Cauchy--Schwarz holds precisely when every difference $x_i-x_j$ vanishes.
+    This argument also includes the empty and singleton cases.
+\end{proof}
+
+This criterion is the equality condition invoked for the off-diagonal overlaps
+and for the eigenvalues in \cite[Chapter~2, Proposition ``SIC POVMs'',
+    equations~(2.31)--(2.32)]{Wolf2012Quantum}.
+
+\section{Trace-square and purity equality}
+
+\begin{definition}[Rank-one orthogonal projection]
+    \label{def:sic_rank_one_orthogonal_projection}
+    \lean{IsRankOneOrthogonalProjection}
+    \leanok
+
+    A matrix $P\in\MN{D}$ is a rank-one orthogonal projection if
+    $P=P^\dagger$, $P^2=P$, and $\rank P=1$.
+\end{definition}
+
+\begin{theorem}[Hermitian trace-square inequality]
+    \label{thm:sic_hermitian_trace_square}
+    \lean{Matrix.IsHermitian.trace_re_sq_le_card_mul_trace_sq_re}
+    \leanok
+    If $Q\in\MN{D}$ is Hermitian, then
+    \begin{align}
+        \tr(Q)^2\le D\tr(Q^2).
+        \label{eq:sic_hermitian_trace_square}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Let $\lambda_0,\ldots,\lambda_{D-1}$ be the eigenvalues of $Q$.
+    The spectral theorem and finite Cauchy--Schwarz give
+    \begin{align}
+        \tr(Q)^2
+        =\left(\sum_i\lambda_i\right)^2
+        \le D\sum_i\lambda_i^2
+        =D\tr(Q^2).
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Equality in the Hermitian trace-square inequality]
+    \label{thm:sic_hermitian_trace_square_equality}
+    \lean{Matrix.IsHermitian.trace_re_sq_eq_card_mul_trace_sq_re_iff}
+    \leanok
+    A Hermitian matrix $Q\in\MN{D}$ satisfies equality
+    in~(\ref{eq:sic_hermitian_trace_square}) if and only if
+    $Q=r\Id$ for some $r\in\R$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:finite_cauchy_schwarz_equality}
+    Equality holds precisely when all eigenvalues of $Q$ coincide. If their
+    common value is $r$, unitary diagonalization gives
+    $Q=U(r\Id)U^\dagger=r\Id$. The converse follows by direct substitution.
+    When $D=0$, every matrix is the zero matrix, so the same conclusion holds.
+\end{proof}
+
+\begin{theorem}[Trace bound at unit purity]
+    \label{thm:sic_psd_unit_purity_trace}
+    \lean{Matrix.PosSemidef.one_le_trace_re_of_trace_sq_eq_one}
+    \leanok
+    If $P\in\MN{D}$ is positive semidefinite and $\tr(P^2)=1$, then
+    $\tr(P)\ge 1$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Write the non-negative eigenvalues of $P$ as $\lambda_i$. Then
+    \begin{align}
+        1=\sum_i\lambda_i^2
+        \le\left(\sum_i\lambda_i\right)^2
+        =\tr(P)^2.
+    \end{align}
+    Since $\tr(P)=\sum_i\lambda_i\ge0$, the assertion follows.
+\end{proof}
+
+\begin{theorem}[Equality at unit purity]
+    \label{thm:sic_psd_unit_purity_equality}
+    \lean{Matrix.PosSemidef.trace_re_eq_one_iff_isRankOneOrthogonalProjection}
+    \leanok
+    \uses{def:sic_rank_one_orthogonal_projection}
+    Suppose that $P\in\MN{D}$ is positive semidefinite and $\tr(P^2)=1$.
+    Then $\tr(P)=1$ if and only if $P$ is a rank-one orthogonal projection.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $\tr(P)=1$, the non-negative eigenvalues satisfy
+    \begin{align}
+        \sum_i\lambda_i=\sum_i\lambda_i^2=1.
+    \end{align}
+    Each $\lambda_i$ lies in $[0,1]$, and
+    $\sum_i\lambda_i(1-\lambda_i)=0$. Hence every eigenvalue is either zero
+    or one. Thus $P^2=P$, and its rank equals its trace, namely one. Conversely,
+    a rank-one orthogonal projection has one unit eigenvalue and all remaining
+    eigenvalues zero, so its trace is one.
+\end{proof}
+
+\section{The SIC--POVM overlap bound}
+
+\begin{theorem}[SIC--POVM overlap bound]
+    \label{thm:sic_povm_overlap_bound}
+    \lean{Matrix.sicPOVM_offDiag_overlap_sq_bound}
+    \leanok
+    Suppose that $2\le n$, $1\le d\le n$, and that
+    $P_1,\ldots,P_n\in\MN{d}$ are positive semidefinite matrices satisfying
+    $\tr(P_i^2)=1$. Then
+    \begin{align}
+        \sum_{i\ne j}\tr(P_iP_j)^2
+        \ge \frac{n(n-d)^2}{(n-1)d^2}.
+        \label{eq:sic_povm_overlap_bound}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:sic_hermitian_trace_square, thm:sic_psd_unit_purity_trace}
+    Put $Q=\sum_iP_i$ and
+    $T=\sum_{i\ne j}\tr(P_iP_j)$. Positivity gives
+    $\tr(P_iP_j)\ge0$ and $\tr(P_i)\ge1$. Hence
+    \begin{align}
+        n^2
+        \le \tr(Q)^2
+        \le d\tr(Q^2)
+        =d(n+T),
+    \end{align}
+    so $T\ge n(n-d)/d$. Finite Cauchy--Schwarz, applied to the
+    $n(n-1)$ off-diagonal overlaps, gives
+    \begin{align}
+        T^2\le n(n-1)\sum_{i\ne j}\tr(P_iP_j)^2.
+    \end{align}
+    Combining the two estimates proves~(\ref{eq:sic_povm_overlap_bound}).
+\end{proof}
+
+\begin{theorem}[Equality in the SIC--POVM overlap bound]
+    \label{thm:sic_povm_overlap_bound_equality}
+    \lean{Matrix.sicPOVM_offDiag_overlap_sq_eq_iff}
+    \leanok
+    \uses{def:sic_rank_one_orthogonal_projection}
+    Under the hypotheses of Theorem~\ref{thm:sic_povm_overlap_bound}, equality
+    holds in~(\ref{eq:sic_povm_overlap_bound}) if and only if
+    \begin{align}
+         & P_i\text{ is a rank-one orthogonal projection for every }i, \\
+         & \sum_iP_i=\frac nd\Id,                                      \\
+         & \tr(P_iP_j)=\frac{n-d}{(n-1)d}\qquad(i\ne j).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:finite_cauchy_schwarz_equality, thm:sic_hermitian_trace_square_equality, thm:sic_psd_unit_purity_equality}
+    Equality in the final estimate forces equality at every preceding step.
+    Thus $\tr(P_i)=1$ for every $i$, so each $P_i$ is a rank-one orthogonal
+    projection. Equality in the trace-square inequality makes $Q$ scalar; its
+    trace is $n$, whence $Q=(n/d)\Id$. Equality in finite
+    Cauchy--Schwarz makes all off-diagonal overlaps equal, and their sum then
+    fixes their common value as $(n-d)/((n-1)d)$. Conversely, these three
+    conditions give equality by direct substitution.
+\end{proof}
+
+\begin{theorem}[Linear independence of nondegenerate equality families]
+    \label{thm:sic_povm_equality_linear_independent}
+    \lean{Matrix.sicPOVM_linearIndependent_of_overlap_bound_eq}
+    \leanok
+    Suppose, in addition, that $d\ge2$. Any family attaining equality
+    in~(\ref{eq:sic_povm_overlap_bound}) is linearly independent.
+
+    \textbf{Local fix (one-dimensional equality families):} The corresponding
+    assertion printed in \cite[Chapter~2, Proposition ``SIC POVMs'',
+        lines~816--823]{Wolf2012Quantum} is false when $d=1<n$: every $P_i$ then
+    equals $[1]$. This deviation is recorded in the QICLean paper-gap note
+    \cite{gap:wolf_sic_povm_linear_independence}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:sic_povm_overlap_bound_equality}
+    Suppose $\sum_i c_iP_i=0$. Taking the trace gives $\sum_i c_i=0$.
+    Taking the trace after multiplication by $P_j$ gives
+    \begin{align}
+        0
+        =c_j+\frac{n-d}{(n-1)d}\sum_{i\ne j}c_i
+        =\left(1-\frac{n-d}{(n-1)d}\right)c_j.
+    \end{align}
+    For $n\ge2$ this prefactor is nonzero precisely when $d>1$. Hence every
+    $c_j$ vanishes.
+\end{proof}
+
+\begin{theorem}[The singleton case]
+    \label{thm:sic_povm_singleton_linear_independent}
+    \lean{Matrix.singleton_linearIndependent_of_trace_sq_eq_one}
+    \leanok
+    A singleton family whose sole matrix $P$ satisfies $\tr(P^2)=1$ is
+    linearly independent.
+\end{theorem}
+
+\begin{proof}\leanok
+    The unit-purity identity implies $P\ne0$, and a singleton containing a
+    nonzero vector is linearly independent.
+\end{proof}
+
+\section{Symmetric informationally complete measurements}
+
+\begin{definition}[Symmetric informationally complete family]
+    \label{def:sic_povm_family}
+    \lean{SICPOVM}
+    \leanok
+    Let $d\ge1$. A symmetric informationally complete family in dimension $d$
+    consists of $d^2$ rank-one orthogonal projections $P_i\in\MN{d}$ satisfying
+    \begin{align}
+        \sum_iP_i=d\Id,
+        \qquad
+        \tr(P_iP_j)=\frac{1}{d+1}\quad(i\ne j).
+    \end{align}
+\end{definition}
+
+\begin{theorem}[POVM effects and Kraus operators]
+    \label{thm:sic_povm_normalizations}
+    \lean{SICPOVM.toPOVM}
+    \lean{SICPOVM.kraus_isTP}
+    \leanok
+    \uses{def:sic_povm_family}
+    For a symmetric informationally complete family $(P_i)_i$, the operators
+    \begin{align}
+        E_i=\frac1dP_i,
+        \qquad
+        K_i=\frac1{\sqrt d}P_i
+    \end{align}
+    are, respectively, the effects of a POVM and a trace-preserving Kraus
+    family.
+\end{theorem}
+
+\begin{proof}\leanok
+    Positivity of the $E_i$ follows from positivity of the projections, and
+    \begin{align}
+        \sum_iE_i=\frac1d\sum_iP_i=\Id.
+    \end{align}
+    Since the $P_i$ are Hermitian and idempotent,
+    \begin{align}
+        \sum_iK_i^\dagger K_i
+        =\frac1d\sum_iP_i^2
+        =\Id.
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Operator-basis property]
+    \label{thm:sic_povm_operator_basis}
+    \lean{SICPOVM.linearIndependent_projector}
+    \lean{SICPOVM.span_projector_eq_top}
+    \leanok
+    \uses{def:sic_povm_family}
+    The $d^2$ projectors in a symmetric informationally complete family form a
+    basis of $\MN{d}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Suppose that $\sum_i c_iP_i=0$. Taking the trace gives
+    $\sum_i c_i=0$. Pairing with $P_j$ and using the constant overlaps gives
+    \begin{align}
+        0=c_j+\frac1{d+1}\sum_{i\ne j}c_i
+        =\frac d{d+1}c_j.
+    \end{align}
+    Since $d\ge1$, every $c_j$ vanishes. Thus the projectors are linearly
+    independent. Since $\dim\MN{d}=d^2$, they form a basis.
+\end{proof}
+
+\begin{theorem}[Diagonal representation]
+    \label{thm:sic_povm_diagonal_representation}
+    \lean{SICPOVM.diagonal_representation}
+    \leanok
+    \uses{thm:sic_povm_operator_basis}
+    Let $(P_i)_i$ be a symmetric informationally complete family. Every
+    $\rho\in\MN{d}$ satisfies
+    \begin{align}
+        \rho=\frac1d\sum_i
+        \left((d+1)\tr(P_i\rho)-\tr(\rho)\right)P_i.
+        \label{eq:sic_povm_diagonal_representation}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Define
+    \begin{align}
+        F(X)=\sum_i\tr(P_iX)P_i.
+    \end{align}
+    For every $j$, the constant-overlap identity and $\sum_iP_i=d\Id$ give
+    \begin{align}
+        F(P_j)
+         & =P_j+\frac1{d+1}\sum_{i\ne j}P_i \\
+         & =\frac{d}{d+1}(P_j+\Id).
+    \end{align}
+    The operator-basis property therefore yields
+    \begin{align}
+        F(X)=\frac{d}{d+1}\left(X+\tr(X)\Id\right)
+    \end{align}
+    for every $X\in\MN{d}$. Expanding the right-hand side of
+    \eqref{eq:sic_povm_diagonal_representation} and substituting this identity
+    gives $\rho$.
+\end{proof}
+
+\begin{theorem}[SIC Kraus channel]
+    \label{thm:sic_povm_kraus_channel}
+    \lean{SICPOVM.kraus_channel_identity}
+    \lean{SICPOVM.krausMap_eq}
+    \lean{SICPOVM.isChannel_krausMap}
+    \leanok
+    \uses{thm:sic_povm_diagonal_representation, thm:sic_povm_normalizations}
+    For every $\rho\in\MN{d}$,
+    \begin{align}
+        \frac1d\sum_{i=1}^{d^2}P_i\rho P_i
+        =\frac{\Id\tr(\rho)+\rho}{d+1}.
+        \label{eq:sic_povm_kraus_channel}
+    \end{align}
+    Equivalently, the left-hand side is the quantum channel with Kraus
+    operators $K_i=P_i/\sqrt d$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Rank-one sandwiching gives
+    \begin{align}
+        P_i\rho P_i=\tr(\rho P_i)P_i.
+    \end{align}
+    Summing this identity and applying the frame-operator formula in the proof
+    of Theorem~\ref{thm:sic_povm_diagonal_representation} proves
+    \eqref{eq:sic_povm_kraus_channel}. The Kraus normalization in
+    Theorem~\ref{thm:sic_povm_normalizations} proves that this map is a quantum
+    channel.
+\end{proof}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -476,3 +476,13 @@
   year        = {2026},
   note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_theorem6_16_schwarz_orientation.pdf}},
 }
+
+@techreport{gap:wolf_sic_povm_linear_independence,
+  author      = {The {QICLean} contributors},
+  title       = {{SIC}--{POVM} Equality Families: the One-Dimensional Degeneracy},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_sic\_povm\_linear\_independence},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_sic_povm_linear_independence.pdf}},
+}


### PR DESCRIPTION
## Summary

- migrate Wolf's SIC--POVM overlap bound and corrected equality/linear-independence results from TNLean into QICLean
- add the complete SIC Blueprint development to the Channel Representations chapter
- add the associated paper-gap bibliography entry

## Ownership

The module is QIC-generic, imports only `QICLean.Algebra.TracePurity`, and has no tensor-network dependencies. The companion TNLean cleanup is LionSR/TNLean#7167.

This PR is temporarily stacked on #486 because the migration reuses that audit's corrected SIC paper-gap/tracker state. It can be retargeted to `main` after #486 merges.

## Validation

- `lake build`
- direct and targeted Algebra builds
- generated import aggregator checks
- Blueprint sync: 2523/2523 theorem-like entries formalized
- declaration check: all 2500 unique `\\lean{}` references resolve
- Blueprint PDF and web builds
- proof-integrity and style-policy scans
- `git diff --check`

Closes #322.
