### PR TITLE
docs(wolf): close SIC coverage after migration

### DIFF
--- a/docs/paper-gaps/wolf_sic_povm_linear_independence.tex
+++ b/docs/paper-gaps/wolf_sic_povm_linear_independence.tex
@@ -13,7 +13,7 @@
 
 \begin{document}
 \maketitle
-\gapnote{local-correction}{open}
+\gapnote{local-correction}{formalized}
 
 \section{Source passage}
 
@@ -58,24 +58,25 @@ unit purity.
 
 \section{Formalization status}
 
-The current repository contains supporting trace--purity inequalities and the
-specialized \texttt{SICPOVM} API, including linear independence for an already
-bundled $d^2$-element SIC family. It does not yet contain a source-level theorem
-for Equation~\eqref{eq:wolf-sic-bound}, its equality characterization, or the
-corrected general linear-independence consequence. In particular, the
-specialized SIC theorem cannot replace the general proposition because its
-structure already assumes the equiangular rank-one family.
-
-The intended combined nondegeneracy condition for the missing general
-linear-independence theorem is $d>1$ or $n=1$, while the equality theorem itself
-should not be artificially restricted.
+The source-level package is formalized in
+\texttt{QICLean.Algebra.SICPOVMBound}. The theorem
+\texttt{Matrix.sicPOVM\_offDiag\_overlap\_sq\_bound} proves
+Equation~\eqref{eq:wolf-sic-bound}, and
+\texttt{Matrix.sicPOVM\_offDiag\_overlap\_sq\_eq\_iff} proves its
+full equality characterization. The corrected linear-independence conclusion
+is split into
+\texttt{Matrix.sicPOVM\_linearIndependent\_of\_overlap\_bound\_eq}
+for $d\ge2$ and
+\texttt{Matrix.singleton\_linearIndependent\_of\_trace\_sq\_eq\_one}
+for the singleton branch. The specialized \texttt{SICPOVM} API then supplies
+the $n=d^2$ operator-basis and channel consequences.
 
 \section{Verdict}
 
-\textbf{Verdict: source correction identified; formalization open.}
-Wolf's overlap bound and equality characterization remain to be formalized.
-Only the final linear-independence consequence requires the qualification
-$d>1$, with the singleton case treated separately.
+\textbf{Verdict: source correction formalized.}
+Wolf's overlap bound and equality characterization are formalized without an
+artificial dimension restriction. The final linear-independence consequence
+is stated with $d>1$, with the singleton case treated separately.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -26,13 +26,13 @@ Kraus-span characterization of primitive channels is formalized here.
 
 The August 25, 2026 audit covers all 153 literal lemma, proposition, theorem,
 and corollary environments in the transcribed Wolf chapters. Definitions and
-examples are outside this named-result count. The dispositions are: 71 exact,
-14 corrected or otherwise dispositioned, 11
-partial-packaging, 13 partial-scope, 2 obstructed, and 42 open. Only 13 of the
-14 corrected/dispositioned entries have an implemented corrected theorem; the
+examples are outside this named-result count. After the SIC--POVM migration,
+the dispositions are: 71 exact, 15 corrected or otherwise dispositioned, 10
+partial-packaging, 13 partial-scope, 2 obstructed, and 42 open. Fourteen of the
+15 corrected/dispositioned entries have an implemented corrected theorem; the
 remaining entry is a documented disposition rather than a replacement
-declaration. Thus 68 environments remain audit-unresolved
-(11 partial-packaging + 13 partial-scope + 2 obstructed + 42 open), and 69 do
+declaration. Thus 67 environments remain audit-unresolved
+(10 partial-packaging + 13 partial-scope + 2 obstructed + 42 open), and 68 do
 not have an implemented exact or corrected theorem.
 
 Here "partial-packaging" means that substantial clauses or equation-level
@@ -257,22 +257,28 @@ so that the cited formal statements are available from the main project import.
   - `Instrument` — quantum-instrument structure + `total_isChannel`,
     `sum_probability`, `posteriorState` interface ✓
 
-* **Proposition 2.7 (SIC POVMs) — PARTIAL-PACKAGING**:
-  - The general package beginning with Equation (2.30), including the equality
-    characterization and the corrected linear-independence conclusion, is not
-    formalized as a source-level theorem.
+* **Proposition 2.7 (SIC POVMs) — CORRECTED / SOURCE-DISPOSITIONED**:
+  - `Matrix.sicPOVM_offDiag_overlap_sq_bound` — Wolf Equation (2.30) for PSD
+    Hilbert--Schmidt-normalized families ✓
+  - `Matrix.sicPOVM_offDiag_overlap_sq_eq_iff` — equality iff each matrix is a
+    rank-one orthogonal projection, the family sums to `(n/d) • 1`, and all
+    off-diagonal overlaps are constant ✓
+  - `Matrix.sicPOVM_linearIndependent_of_overlap_bound_eq` — Wolf's
+    coefficient proof with the necessary correction `2 ≤ d` ✓
+  - `Matrix.singleton_linearIndependent_of_trace_sq_eq_one` — the corrected
+    singleton branch ✓
   - `SICPOVM` — the specialized SIC structure of unscaled rank-one projectors,
     with `∑ᵢ Pᵢ = d𝟙` and off-diagonal overlap `1/(d+1)` ✓
   - `SICPOVM.toPOVM` — the effects `Pᵢ/d` form a POVM ✓
-  - `SICPOVM.linearIndependent_projector` — within this specialized SIC API,
-    the `d²` projectors form an operator basis ✓
+  - `SICPOVM.linearIndependent_projector` — the `d²` projectors form an
+    operator basis ✓
   - `SICPOVM.diagonal_representation` — Wolf Equation (2.33) ✓
   - `SICPOVM.krausMap_eq` / `SICPOVM.isChannel_krausMap` — the Kraus
     operators `Pᵢ/√d` define the channel in Wolf Equation (2.34) ✓
 
-  These specialized declarations do not supply the missing general Equation
-  (2.30), its equality case, or the corrected proposition-level
-  linear-independence package.
+  The source's unqualified linear-independence conclusion fails for `d = 1`
+  and `n > 1`; the formalization records this correction and proves all valid
+  branches.
 
 #### Section 2.1 Representation corollaries (Propositions 2.2–2.4)
 


### PR DESCRIPTION
## Summary

- mark Wolf Proposition 2.7 as corrected/source-dispositioned now that #487 is merged
- record the four source-level SIC bound, equality, and corrected linear-independence declarations
- update the 153-environment coverage totals
- mark the one-dimensional SIC paper-gap correction as formalized

## Validation

- paper-gap `latexmk`
- `git diff --check`

Follow-up to #487 and #322.
