### PR TITLE
fix(docs): use resolved SIC gap status

### DIFF
--- a/docs/paper-gaps/wolf_sic_povm_linear_independence.tex
+++ b/docs/paper-gaps/wolf_sic_povm_linear_independence.tex
@@ -13,7 +13,7 @@
 
 \begin{document}
 \maketitle
-\gapnote{local-correction}{formalized}
+\gapnote{local-correction}{resolved}
 
 \section{Source passage}
 


### PR DESCRIPTION
Fix the paper-gap verdict marker merged by #488. The policy accepts `resolved`, not `formalized`.

Validation: `texra-blueprint paper-gaps check`; `git diff --check`.