### PR TITLE
refactor(kraus): make transferMap definitionally mapLM

### DIFF
--- a/QICLean/Kraus/CPPrimitive.lean
+++ b/QICLean/Kraus/CPPrimitive.lean
@@ -101,7 +101,7 @@ it is defined as the Kraus map `E_A(X) = ∑ᵢ Aᵢ X Aᵢ†`. -/
 theorem transferMap_isCPMap
     (A : MPSTensor d D) :
     IsCPMap (transferMap (d := d) (D := D) A) :=
-  ⟨d, A, fun X => by simp [transferMap_apply]⟩
+  isCPMap_mapLM A
 
 /-! ### Iterated transfer map
 

--- a/QICLean/Kraus/Transfer.lean
+++ b/QICLean/Kraus/Transfer.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import QICLean.Channel.Schwarz.Basic
 import QICLean.Kraus.Word
 import QICLean.Kraus.Tactic.Attr
 
@@ -25,17 +26,17 @@ namespace Kraus
 variable {d D : ℕ}
 
 /-- The transfer operator associated to a finite Kraus family `A`:
-$$E_A(X) = \sum_i A_i X A_i^{\dagger}.$$ -/
-noncomputable def transferMap (A : MPSTensor d D) :
-    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
-  ∑ i : Fin d,
-    (LinearMap.mulLeft ℂ (A i)).comp (LinearMap.mulRight ℂ (A i)ᴴ)
+$$E_A(X) = \sum_i A_i X A_i^{\dagger}.$$
 
-@[simp, kraus_transfer]
+This is the finite-index specialization of `Kraus.mapLM`. -/
+noncomputable abbrev transferMap (A : MPSTensor d D) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+  mapLM A
+
+@[kraus_transfer]
 lemma transferMap_apply (A : MPSTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) :
     transferMap (d := d) (D := D) A X = ∑ i : Fin d, A i * X * (A i)ᴴ := by
-  classical
-  simp [transferMap, Matrix.mul_assoc]
+  rw [mapLM_apply, map_apply]
 
 /-- Gauge covariance of the transfer map. -/
 lemma transferMap_gauge_conj (A : MPSTensor d D) (X : GL (Fin D) ℂ)
@@ -47,7 +48,7 @@ lemma transferMap_gauge_conj (A : MPSTensor d D) (X : GL (Fin D) ℂ)
               ((X⁻¹ : Matrix _ _ ℂ) * Y * ((X⁻¹ : Matrix _ _ ℂ)ᴴ))
           * (X : Matrix _ _ ℂ)ᴴ := by
   classical
-  simp [transferMap_apply, Finset.mul_sum, Finset.sum_mul, Matrix.mul_assoc]
+  simp [Finset.mul_sum, Finset.sum_mul, Matrix.mul_assoc]
 
 /-- Positivity of the transfer map: it maps PSD matrices to PSD matrices.
 

--- a/QICLean/Kraus/TransferChannel.lean
+++ b/QICLean/Kraus/TransferChannel.lean
@@ -45,23 +45,18 @@ local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
 /-- The finite Kraus map agrees with the transfer map of the same matrix family. -/
 theorem mapLM_eq_transferMap (K : Fin d → Mat) :
-    mapLM K = transferMap (d := d) (D := D) K := by
-  apply LinearMap.ext
-  intro X
-  simp [mapLM_apply, map_apply, transferMap_apply]
+    mapLM K = transferMap (d := d) (D := D) K := rfl
 
 /-- Transfer-map irreducibility expressed for the equal finite Kraus map. -/
 theorem isIrreducibleMap_mapLM_of_transferMap (K : Fin d → Mat)
     (hIrr : IsIrreducibleMap (transferMap (d := d) (D := D) K)) :
-    IsIrreducibleMap (mapLM K) := by
-  simpa only [mapLM_eq_transferMap] using hIrr
+    IsIrreducibleMap (mapLM K) := hIrr
 
 /-- An irreducible finite matrix family has an irreducible transfer map. -/
 theorem isIrreducibleMap_transferMap_of_isIrreducibleFamily
     (K : Fin d → Mat) (hIrr : IsIrreducibleFamily K) :
-    IsIrreducibleMap (transferMap (d := d) (D := D) K) := by
-  rw [← mapLM_eq_transferMap]
-  exact isIrreducibleMap_mapLM_of_isIrreducibleFamily K hIrr
+    IsIrreducibleMap (transferMap (d := d) (D := D) K) :=
+  isIrreducibleMap_mapLM_of_isIrreducibleFamily K hIrr
 
 /-- Irreducibility of the transfer map implies irreducibility of its finite
 matrix family. -/
@@ -74,25 +69,22 @@ theorem isIrreducibleFamily_of_isIrreducibleMap_transferMap
 
 /-- The transfer map of a trace-preserving finite Kraus family is a quantum channel. -/
 theorem isChannel_transferMap (K : Fin d → Mat) (h_tp : IsTP K) :
-    IsChannel (transferMap (d := d) (D := D) K) := by
-  rw [← mapLM_eq_transferMap]
-  exact isChannel_mapLM K h_tp
+    IsChannel (transferMap (d := d) (D := D) K) :=
+  isChannel_mapLM K h_tp
 
 /-- The standard transfer map preserves trace for a trace-preserving Kraus family. -/
 lemma trace_transferMap (A : MPSTensor d D) (Z : Matrix (Fin D) (Fin D) ℂ)
     (hA : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
-    Matrix.trace (transferMap (d := d) (D := D) A Z) = Matrix.trace Z := by
-  rw [← mapLM_eq_transferMap]
-  exact isTracePreservingMap_mapLM_of_isTP A hA Z
+    Matrix.trace (transferMap (d := d) (D := D) A Z) = Matrix.trace Z :=
+  isTracePreservingMap_mapLM_of_isTP A hA Z
 
 /-- Iterating the transfer map gives the sum over word evaluations. -/
 theorem transferMap_pow_apply' (A : MPSTensor d D) (N : ℕ) :
     ∀ X : Matrix (Fin D) (Fin D) ℂ,
       ((transferMap (d := d) (D := D) A) ^ N) X =
         ∑ σ : Fin N → Fin d,
-          evalWord A (List.ofFn σ) * X * (evalWord A (List.ofFn σ))ᴴ := by
-  rw [← mapLM_eq_transferMap]
-  exact mapLM_pow_apply A N
+          evalWord A (List.ofFn σ) * X * (evalWord A (List.ofFn σ))ᴴ :=
+  mapLM_pow_apply A N
 
 /-- The adjoint trace-pairing identity in transfer-map notation.
 
@@ -104,9 +96,7 @@ lemma trace_mul_transferMap_adjoint
     (hE_eq : E = transferMap (d := n) (D := D) K)
     (ρ X : Matrix (Fin D) (Fin D) ℂ) :
     Matrix.trace (ρ * E X) =
-      Matrix.trace (transferMap (d := n) (D := D) (fun i => (K i)ᴴ) ρ * X) := by
-  simpa only [mapLM_eq_transferMap] using
-    trace_mul_mapLM_adjoint (K := K)
-      (hE_eq := by rw [hE_eq, mapLM_eq_transferMap]) ρ X
+      Matrix.trace (transferMap (d := n) (D := D) (fun i => (K i)ᴴ) ρ * X) :=
+  trace_mul_mapLM_adjoint (K := K) hE_eq ρ X
 
 end Kraus

--- a/QICLean/Spectral/GaugeConstruction.lean
+++ b/QICLean/Spectral/GaugeConstruction.lean
@@ -120,10 +120,8 @@ theorem gauged_intertwining_core
       (∀ i : Fin d,
         gaugeTensor SA A i * gaugeEigenvector SA SB X =
           μ • gaugeEigenvector SA SB X * gaugeTensor SB B i) := by
-  have hρA_fix' : Kraus.mapLM A ρA = ρA := by
-    simpa only [Kraus.mapLM_eq_transferMap] using hρA_fix
-  have hρB_fix' : Kraus.mapLM B ρB = ρB := by
-    simpa only [Kraus.mapLM_eq_transferMap] using hρB_fix
+  have hρA_fix' : Kraus.mapLM A ρA = ρA := hρA_fix
+  have hρB_fix' : Kraus.mapLM B ρB = ρB := hρB_fix
   have hFX' : Kraus.mixedMapLM A B X = μ • X := by
     simpa only [mixedTransferMap₂] using hFX
   simpa only [gaugeTensor, gaugeEigenvector, Kraus.IsUnital] using
@@ -138,11 +136,9 @@ theorem self_mul_conjTranspose_fixed_of_intertwining
     (hB_unital : ∑ i : Fin d, B i * (B i)ᴴ = 1)
     (hInter : ∀ i : Fin d, A i * X = μ • X * B i)
     (hμ : ‖μ‖ = 1) :
-    transferMap A (X * Xᴴ) = X * Xᴴ := by
-  have hfixed :=
-    Kraus.mapLM_self_mul_conjTranspose_fixed_of_intertwining
-      A B X μ hB_unital hInter hμ
-  simpa only [Kraus.mapLM_eq_transferMap] using hfixed
+    transferMap A (X * Xᴴ) = X * Xᴴ :=
+  Kraus.mapLM_self_mul_conjTranspose_fixed_of_intertwining
+    A B X μ hB_unital hInter hμ
 
 /-- Transport a fixed point of the gauged transfer map back to the original tensor. -/
 theorem ungauge_transfer_fixedPoint
@@ -151,10 +147,8 @@ theorem ungauge_transfer_fixedPoint
     (hσ : transferMap (gaugeTensor S A) σ = σ) :
     transferMap A (S * σ * Sᴴ) = S * σ * Sᴴ := by
   have hσ' : Kraus.mapLM (Kraus.gaugeFamily S A) σ = σ := by
-    simpa only [Kraus.mapLM_eq_transferMap, gaugeTensor] using hσ
-  have hfixed :=
-    Kraus.mapLM_congruence_fixedPoint_of_gauge_fixedPoint A S σ hS hσ'
-  simpa only [Kraus.mapLM_eq_transferMap] using hfixed
+    simpa only [gaugeTensor] using hσ
+  exact Kraus.mapLM_congruence_fixedPoint_of_gauge_fixedPoint A S σ hS hσ'
 
 /-- Cancel an invertible gauge from a scalar identity `S * σ * Sᴴ = c • (S * Sᴴ)`. -/
 theorem ungauge_scalar_of_conjugated_scalar

--- a/QICLean/Spectral/MixedTransfer.lean
+++ b/QICLean/Spectral/MixedTransfer.lean
@@ -73,7 +73,7 @@ lemma mixedTransferMap_apply (A B : MPSTensor d D) (X : Matrix (Fin D) (Fin D) â
 /-- The mixed transfer operator with `A = B` is the standard transfer map. -/
 theorem mixedTransferMap_self (A : MPSTensor d D) :
     mixedTransferMap A A = transferMap (d := d) (D := D) A := by
-  rw [mixedTransferMap, Kraus.mixedMapLM_self, Kraus.mapLM_eq_transferMap]
+  rw [mixedTransferMap, Kraus.mixedMapLM_self]
 
 end MixedTransfer
 


### PR DESCRIPTION
First coordinated step toward wrapper-free MPS/channel theorem reuse.

- makes `Kraus.mapLM` the sole implementation owner
- turns `Kraus.transferMap` into a reducible noncomputable alias
- keeps `mapLM_eq_transferMap` temporarily as a non-deprecated compatibility theorem while TNLean consumers migrate
- keeps one canonical global apply simp theorem (`mapLM_apply`) while preserving `transferMap_apply` in the `kraus_transfer` simp set
- removes internal QIC translation rewrites and uses definitional equality directly

No MPS-to-channel coercion or global property instance is introduced. This PR is intentionally independent of the already-open TNLean migration PR LionSR/TNLean#7170. After both merge, a follow-up TNLean PR will pin this QIC revision, remove its 40 `mapLM_eq_transferMap` rewrites, and eliminate pass-through wrappers.

Validation:
- full QICLean build: 9,324 jobs
- focused rebuilt dependency chain after review corrections
- clean diagnostics and `git diff --check`
- no proof-integrity bypasses in changed declarations
- independent API/style review: execution 979ef0531dc7