### PR TITLE
refactor(kraus): retire transfer compatibility wrappers

### DIFF
--- a/QICLean/Kraus/CPPrimitive.lean
+++ b/QICLean/Kraus/CPPrimitive.lean
@@ -3,7 +3,8 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Kraus.TransferChannel
+import QICLean.Channel.KrausMap
+import QICLean.Kraus.Transfer
 import QICLean.Kraus.Injectivity
 import QICLean.Algebra.MatrixAux
 import QICLean.Channel.Irreducible.Basic
@@ -105,12 +106,10 @@ theorem transferMap_isCPMap
 
 /-! ### Iterated transfer map
 
-The iterated transfer map identity is `transferMap_pow_apply'` in
-`QICLean.Kraus.TransferChannel`. It follows from the finite Kraus map word expansion
-`Kraus.mapLM_pow_apply`.
+The iterated finite Kraus map identity is `Kraus.mapLM_pow_apply` in
+`QICLean.Kraus.MapIterate`.
 
-The channel property of a normalized transfer map (completely positive and
-trace-preserving) is `Kraus.isChannel_transferMap` in
-`QICLean.Kraus.TransferChannel`. -/
+The channel property of a trace-preserving finite Kraus map is
+`Kraus.isChannel_mapLM` in `QICLean.Channel.KrausMap`. -/
 
 end Kraus

--- a/QICLean/Kraus/TransferChannel.lean
+++ b/QICLean/Kraus/TransferChannel.lean
@@ -3,29 +3,19 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Channel.Irreducible.Basic
 import QICLean.Channel.KrausMap
 import QICLean.Kraus.MapIterate
-import QICLean.Kraus.InvariantProjection
 import QICLean.Kraus.Transfer
 
 /-!
-# Channel compatibility for finite-Kraus-family transfer maps
+# Trace identities for finite-Kraus-family transfer maps
 
 For a family $K$, the transfer map is the finite Kraus action
-$X\mapsto\sum_i K_iXK_i^\dagger$. This file states its channel and trace-pairing
-properties in transfer-map notation.
+$X\mapsto\sum_i K_iXK_i^\dagger$. This file states trace-preservation, iterate,
+and trace-pairing identities in transfer-map notation.
 
 ## Main declarations
 
-* `Kraus.mapLM_eq_transferMap`: the generic Kraus map and the transfer map agree.
-* `Kraus.isIrreducibleMap_mapLM_of_transferMap`: transfer-map irreducibility in Kraus-map
-  notation.
-* `Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily`: irreducibility of a finite
-  matrix family gives irreducibility of its transfer map.
-* `Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap`: the converse implication.
-* `Kraus.isChannel_transferMap`: the transfer map of a trace-preserving Kraus family is
-  a channel.
 * `Kraus.trace_transferMap`: trace preservation in transfer-map notation.
 * `Kraus.transferMap_pow_apply'`: iterates of a transfer map are sums over Kraus words.
 * `Kraus.trace_mul_transferMap_adjoint`: the generic Kraus trace-adjoint identity in
@@ -42,35 +32,6 @@ namespace Kraus
 variable {d : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
-
-/-- The finite Kraus map agrees with the transfer map of the same matrix family. -/
-theorem mapLM_eq_transferMap (K : Fin d → Mat) :
-    mapLM K = transferMap (d := d) (D := D) K := rfl
-
-/-- Transfer-map irreducibility expressed for the equal finite Kraus map. -/
-theorem isIrreducibleMap_mapLM_of_transferMap (K : Fin d → Mat)
-    (hIrr : IsIrreducibleMap (transferMap (d := d) (D := D) K)) :
-    IsIrreducibleMap (mapLM K) := hIrr
-
-/-- An irreducible finite matrix family has an irreducible transfer map. -/
-theorem isIrreducibleMap_transferMap_of_isIrreducibleFamily
-    (K : Fin d → Mat) (hIrr : IsIrreducibleFamily K) :
-    IsIrreducibleMap (transferMap (d := d) (D := D) K) :=
-  isIrreducibleMap_mapLM_of_isIrreducibleFamily K hIrr
-
-/-- Irreducibility of the transfer map implies irreducibility of its finite
-matrix family. -/
-theorem isIrreducibleFamily_of_isIrreducibleMap_transferMap
-    (K : Fin d → Mat)
-    (hIrr : IsIrreducibleMap (transferMap (d := d) (D := D) K)) :
-    IsIrreducibleFamily K :=
-  isIrreducibleFamily_of_isIrreducibleMap_mapLM K
-    (isIrreducibleMap_mapLM_of_transferMap K hIrr)
-
-/-- The transfer map of a trace-preserving finite Kraus family is a quantum channel. -/
-theorem isChannel_transferMap (K : Fin d → Mat) (h_tp : IsTP K) :
-    IsChannel (transferMap (d := d) (D := D) K) :=
-  isChannel_mapLM K h_tp
 
 /-- The standard transfer map preserves trace for a trace-preserving Kraus family. -/
 lemma trace_transferMap (A : MPSTensor d D) (Z : Matrix (Fin D) (Fin D) ℂ)

--- a/QICLean/QPF/Assembly.lean
+++ b/QICLean/QPF/Assembly.lean
@@ -72,7 +72,7 @@ theorem exists_posSemidef_fixedPoint
     (hD : 0 < D) :
     ∃ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.PosSemidef ∧ ρ ≠ 0 ∧
       transferMap (d := d) (D := D) A ρ = ρ :=
-  (isChannel_transferMap A hNorm).exists_posSemidef_fixedPoint
+  (isChannel_mapLM A hNorm).exists_posSemidef_fixedPoint
     (E := transferMap A) hD
 
 end Existence

--- a/QICLean/QPF/Primitive.lean
+++ b/QICLean/QPF/Primitive.lean
@@ -75,6 +75,6 @@ theorem quantum_perron_frobenius_irreducible [DecidableEq (Fin D)]
     ∃ ρ : Matrix (Fin D) (Fin D) ℂ,
       HasUniqueFixedPoint (transferMap (d := d) (D := D) A) ρ := by
   exact IsChannel.exists_hasUniqueFixedPoint_of_irreducible
-    (isChannel_transferMap A (by unfold IsTP; convert hNorm)) hIrr hD
+    (isChannel_mapLM A (by unfold IsTP; convert hNorm)) hIrr hD
 
 end Kraus

--- a/blueprint/src/chapter/ch02_channels_transfer_map_foundations.tex
+++ b/blueprint/src/chapter/ch02_channels_transfer_map_foundations.tex
@@ -131,7 +131,8 @@ across the chapter boundary.
     \lean{Kraus.transferMap}
     \leanok
     The \emph{transfer map} associated to a finite matrix family~$A$ is the
-    linear map $\E_A : \MN{D} \to \MN{D}$ defined by
+    finite Kraus map of that family; the notation $\E_A$ abbreviates the
+    linear map $\MN{D} \to \MN{D}$ defined by
     \begin{align}
         \E_A(X)
         &= \sum_{i=0}^{d-1} A^i X (A^i)^\dagger.
@@ -208,9 +209,9 @@ across the chapter boundary.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{thm:trace_mul_kraus_map_adjoint,
-        thm:kraus_map_eq_transfer_map}
-    Identify the two Kraus maps with the corresponding transfer maps.
+    \uses{thm:trace_mul_kraus_map_adjoint}
+    Apply the Kraus-map trace identity directly, since transfer-map notation
+    abbreviates the finite Kraus maps of the two matrix families.
 \end{proof}
 
 \begin{lemma}[Left-canonical transfer maps preserve trace]
@@ -238,7 +239,7 @@ across the chapter boundary.
 \end{proof}
 
 \begin{theorem}[Transfer map is a channel]\label{thm:transfer_channel}
-    \lean{Kraus.isChannel_transferMap}
+    \lean{Kraus.isChannel_mapLM}
     \leanok
     \uses{def:transfer_map, def:channel}
     If $\sum_i(A^i)^\dagger A^i=\Id$, then the transfer map

--- a/blueprint/src/chapter/ch05_schwarz_ft_core.tex
+++ b/blueprint/src/chapter/ch05_schwarz_ft_core.tex
@@ -3,8 +3,8 @@
 A linear map is completely positive (Definition~\ref{def:cp_map}) if and only
 if it has a Kraus form. The Kadison--Schwarz inequality and the
 multiplicative-domain characterisation are proved first for Kraus maps.
-The transfer map defined in (\ref{eq:mps_transfer_map}) is a Kraus map
-(Theorem~\ref{thm:transfer_cp}), so these results apply directly to transfer
+The transfer map defined in (\ref{eq:mps_transfer_map}) is the finite
+Kraus map of the same matrix family, so these results apply directly to transfer
 maps.
 
 \begin{definition}[Kraus map]\label{def:kraus_map}
@@ -22,47 +22,6 @@ maps.
     (Definition~\ref{def:cp_map}) if and only if it can be written in this
     form, as in (\ref{eq:channel_kraus_representation}).
 \end{definition}
-
-\begin{theorem}[Kraus-map form of the transfer map]
-    \label{thm:kraus_map_eq_transfer_map}
-    \lean{Kraus.mapLM_eq_transferMap}
-    \leanok
-    \uses{def:kraus_map, def:transfer_map}
-    For a finite matrix family $A$, write $\mathcal K_A$ for its Kraus map.
-    Then
-    \begin{align}
-        \mathcal K_A
-         & =\E_A.
-        \notag
-    \end{align}
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    For every $X\in\MN{D}$,
-    \begin{align}
-        \mathcal K_A(X)
-         & =\sum_i A^iX(A^i)^\dagger
-          =\E_A(X).
-        \notag
-    \end{align}
-\end{proof}
-
-\begin{theorem}[Irreducibility in Kraus-map notation]
-    \label{thm:kraus_map_irreducible_of_transfer_map}
-    \lean{Kraus.isIrreducibleMap_mapLM_of_transferMap}
-    \leanok
-    \uses{def:kraus_map, def:transfer_map, def:irreducible_cp}
-    If the transfer map $\E_A$ of a finite matrix family is irreducible, then
-    its Kraus map $\mathcal K_A$ is irreducible.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:kraus_map_eq_transfer_map}
-    The two maps are equal by
-    Theorem~\ref{thm:kraus_map_eq_transfer_map}.
-\end{proof}
 
 \begin{definition}[Adjoint Kraus map]\label{def:kraus_adjoint_map}
     \lean{KadisonSchwarz.krausAdjointMap}

--- a/blueprint/src/chapter/ch09_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
@@ -266,8 +266,8 @@ fixed point whose support carries every fixed point. The first ingredient is
 that Loewner domination transfers the support.
 
 \begin{lemma}[The transfer map of a trace-preserving family is a channel]%
-    \label{lem:isChannel_transferMap}
-    \lean{Kraus.isChannel_transferMap}
+    \label{lem:kraus_map_is_channel}
+    \lean{Kraus.isChannel_mapLM}
     \leanok
     \uses{def:channel, def:tp_kraus}
     Let $K_0,\ldots,K_{d-1}$ be a trace-preserving Kraus family. The map


### PR DESCRIPTION
## Summary
- remove the five definitional `transferMap`/`mapLM` compatibility wrappers after coordinated consumer migration
- keep the three substantive transfer-notation theorems and the `TransferChannel` module
- migrate QIC QPF consumers and tighten CPPrimitive imports
- delete tautological Blueprint blocks and repoint channel entries to `Kraus.isChannel_mapLM`

## Dependency
TNLean canonical-consumer migration is being validated separately. This PR is safe for pinned TNLean revisions and will be merged only after downstream consumers are canonicalized.

## Validation
- full `lake build QICLean`: 9,329 jobs
- affected module and aggregate builds (`QICLean.Kraus`, `QICLean.QPF`)
- generated imports
- Blueprint declaration and 2,621/2,621 synchronization checks
- clean diagnostics, style/policy, proof-integrity, retired-name, and diff scans