### PR TITLE
refactor(spectral): retire residual mixed-gap forward

### DIFF
--- a/QICLean/Spectral/TransferOperatorGapRectNormalized.lean
+++ b/QICLean/Spectral/TransferOperatorGapRectNormalized.lean
@@ -10,17 +10,17 @@ import QICLean.Kraus.MixedMap.SpectralRadius
 # Normalized rectangular transfer-operator bounds
 
 This module proves the normalized bound $ρ(F_{AB}) ≤ 1$ for the rectangular mixed
-transfer operator and pointwise decay of its powers when the spectral radius is
-strictly below one. The strict dimension-mismatch and overlap-decay theorems are
-proved separately from the normalized estimate.
+map. Pointwise decay below spectral radius one is provided canonically by
+`Kraus.mixedMapLM_pow_tendsto_zero_of_spectralRadius_lt_one`. The strict
+dimension-mismatch and overlap-decay theorems are proved separately from the
+normalized estimate.
 
 ## Main results
 
 * `spectralRadius_mixedTransfer₂_le_one`: the rectangular mixed transfer
   operator of normalized tensors has spectral radius at most one.
-* `mixedTransferMap₂_pow_tendsto_zero_of_spectralRadius_lt_one`: a rectangular
-  mixed transfer operator with spectral radius below one has pointwise-vanishing
-  powers.
+* `mixedMapLM_pow_tendsto_zero_of_spectralRadius_lt_one`: a rectangular mixed map
+  with spectral radius below one has pointwise-vanishing powers.
 
 ## References
 
@@ -76,23 +76,6 @@ theorem spectralRadius_mixedTransfer₂_le_one
     (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1) :
     mixedTransferSpectralRadius₂ A B ≤ 1 :=
   Kraus.mixedMapSpectralRadius_le_one_of_isTP A B hA_norm hB_norm
-
-/-! ## Power decay -/
-
-/--
-If the rectangular mixed transfer operator has spectral radius strictly below one, then its
-powers converge pointwise to zero.
-
-This is the decay step for the off-diagonal operators in CPSV16, Appendix B,
-equations `EasEkk`--`Ekk` and line 1243.
--/
-theorem mixedTransferMap₂_pow_tendsto_zero_of_spectralRadius_lt_one
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (h : mixedTransferSpectralRadius₂ A B < 1)
-    (X : Matrix (Fin D₁) (Fin D₂) ℂ) :
-    Filter.Tendsto (fun n => ((mixedMapLM A B) ^ n) X)
-      Filter.atTop (nhds 0) :=
-  Kraus.mixedMapLM_pow_tendsto_zero_of_spectralRadius_lt_one A B h X
 
 /-!
 Strict dimension-mismatch consequences are intentionally downstream in


### PR DESCRIPTION
## Summary
- remove the final exact forwarding theorem whose name advertised the retired `mixedTransferMap₂` API
- direct readers to canonical `Kraus.mixedMapLM_pow_tendsto_zero_of_spectralRadius_lt_one`
- leave the substantive normalized spectral-radius bound in place

## Verification
- changed module build
- full `lake build`
- generated imports current
- Blueprint sync (2,621/2,621) and declaration resolution
- module policies and `git diff --check`
- no remaining live `mixedTransferMap` / `mixedTransferMap₂` identifiers