### PR TITLE
refactor: own generic Kraus and matrix rigidity APIs

### DIFF
--- a/QICLean/Algebra.lean
+++ b/QICLean/Algebra.lean
@@ -39,6 +39,7 @@ import QICLean.Algebra.MatrixCongruence
 import QICLean.Algebra.MatrixCyclicTracePower
 import QICLean.Algebra.MatrixFamilyAction
 import QICLean.Algebra.MatrixFamilySupport
+import QICLean.Algebra.MatrixGramConjugation
 import QICLean.Algebra.MatrixGramUnitary
 import QICLean.Algebra.MatrixIsometryKronecker
 import QICLean.Algebra.MatrixKernelRigidity

--- a/QICLean/Algebra/MatrixGramConjugation.lean
+++ b/QICLean/Algebra/MatrixGramConjugation.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Algebra.MatrixGramUnitary
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+
+/-!
+# Gram conjugation identities for complex matrices
+
+This file collects algebraic identities relating dressed matrix conjugations,
+Gram matrices, relative Gram ratios, and unitary normalization.  The results
+are stated for arbitrary finite complex matrix algebras.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- If conjugation by an invertible gauge carries `B` to the dressing of an
+abstract target `C`, then conjugation by the Gram matrix carries `B` to `C`.
+
+This is a conditional algebraic route to the relative Gram identity in
+arXiv:1606.00608, proof of Proposition 4.13, lines 1909--1919.  The source's
+reflected marked-chain argument does not identify such a target separately
+for each sector. -/
+theorem gram_conj_eq_of_dressed_target
+    {X B C : Matrix n n ℂ} (hX : IsUnit X.det)
+    (hdress : X * B * X⁻¹ = X⁻¹ᴴ * C * Xᴴ) :
+    Xᴴ * X * B * (Xᴴ * X)⁻¹ = C := by
+  have hXH : IsUnit (Xᴴ).det := by
+    rw [Matrix.det_conjTranspose]
+    exact hX.star
+  have h1 : Xᴴ * (X * B * X⁻¹) * X⁻¹ᴴ = Xᴴ * X * B * (Xᴴ * X)⁻¹ := by
+    rw [Matrix.mul_inv_rev, Matrix.conjTranspose_nonsing_inv]
+    simp only [Matrix.mul_assoc]
+  have h2 : Xᴴ * (X⁻¹ᴴ * C * Xᴴ) * X⁻¹ᴴ = C := by
+    rw [Matrix.conjTranspose_nonsing_inv, ← Matrix.mul_assoc, ← Matrix.mul_assoc,
+      Matrix.mul_nonsing_inv _ hXH, Matrix.one_mul, Matrix.mul_assoc,
+      Matrix.mul_nonsing_inv _ hXH, Matrix.mul_one]
+  rw [← h1, hdress, h2]
+
+/-- **From the first displayed diagram to the second** (arXiv:1606.00608,
+proof of Proposition 4.13, lines 1909--1919): if a letter dressed by an
+invertible gauge equals its adjoint dressing,
+$XBX^{-1} = (X^{-1})^\dagger B^\dagger X^\dagger$, then conjugation by the
+Gram matrix $X^\dagger X$ carries the letter to its adjoint. -/
+theorem gram_conj_eq_conjTranspose_of_dressed_adjoint
+    {X B : Matrix n n ℂ} (hX : IsUnit X.det)
+    (hdress : X * B * X⁻¹ = X⁻¹ᴴ * Bᴴ * Xᴴ) :
+    Xᴴ * X * B * (Xᴴ * X)⁻¹ = Bᴴ :=
+  gram_conj_eq_of_dressed_target hX hdress
+
+/-- **The second displayed diagram** (arXiv:1606.00608, proof of Proposition
+4.13, lines 1914--1919): two gauges whose dressings carry the same letter `B`
+to the same target `C` have equal Gram conjugations. -/
+theorem gram_conj_eq_gram_conj_of_common_dressed_target
+    {X Y B C : Matrix n n ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (hdX : X * B * X⁻¹ = X⁻¹ᴴ * C * Xᴴ)
+    (hdY : Y * B * Y⁻¹ = Y⁻¹ᴴ * C * Yᴴ) :
+    Xᴴ * X * B * (Xᴴ * X)⁻¹ = Yᴴ * Y * B * (Yᴴ * Y)⁻¹ := by
+  rw [gram_conj_eq_of_dressed_target hX hdX,
+    gram_conj_eq_of_dressed_target hY hdY]
+
+/-- **The second displayed diagram** (arXiv:1606.00608, proof of Proposition
+4.13, lines 1914--1919): two gauges whose dressings both equal the adjoint
+dressing have equal Gram conjugations,
+$X^\dagger X\,B\,(X^\dagger X)^{-1} = Y^\dagger Y\,B\,(Y^\dagger Y)^{-1}$. -/
+theorem gram_conj_eq_gram_conj_of_dressed_adjoint
+    {X Y B : Matrix n n ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (hdX : X * B * X⁻¹ = X⁻¹ᴴ * Bᴴ * Xᴴ)
+    (hdY : Y * B * Y⁻¹ = Y⁻¹ᴴ * Bᴴ * Yᴴ) :
+    Xᴴ * X * B * (Xᴴ * X)⁻¹ = Yᴴ * Y * B * (Yᴴ * Y)⁻¹ :=
+  gram_conj_eq_gram_conj_of_common_dressed_target hX hY hdX hdY
+
+/-- **The relative commutant in the second displayed diagram**
+(arXiv:1606.00608, proof of Proposition 4.13, lines 1914--1921): if two
+invertible matrices have the same Gram conjugation of a matrix, then the
+ratio of their Gram matrices commutes with that matrix. -/
+theorem commute_gram_ratio_of_gram_conj_eq
+    {X Y B : Matrix n n ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (h : Xᴴ * X * B * (Xᴴ * X)⁻¹ = Yᴴ * Y * B * (Yᴴ * Y)⁻¹) :
+    (Yᴴ * Y)⁻¹ * (Xᴴ * X) * B =
+      B * ((Yᴴ * Y)⁻¹ * (Xᴴ * X)) := by
+  have hGX : IsUnit (Xᴴ * X).det := by
+    rw [Matrix.det_mul, Matrix.det_conjTranspose]
+    exact hX.star.mul hX
+  have hGY : IsUnit (Yᴴ * Y).det := by
+    rw [Matrix.det_mul, Matrix.det_conjTranspose]
+    exact hY.star.mul hY
+  have hGYinv : (Yᴴ * Y)⁻¹ * (Yᴴ * Y) = 1 :=
+    Matrix.nonsing_inv_mul _ hGY
+  calc
+    (Yᴴ * Y)⁻¹ * (Xᴴ * X) * B =
+        (Yᴴ * Y)⁻¹ * (Xᴴ * X) * B * ((Xᴴ * X)⁻¹ * (Xᴴ * X)) := by
+          rw [Matrix.nonsing_inv_mul _ hGX, Matrix.mul_one]
+    _ = (Yᴴ * Y)⁻¹ *
+        (Xᴴ * X * B * (Xᴴ * X)⁻¹) * (Xᴴ * X) := by
+          simp only [Matrix.mul_assoc]
+    _ = (Yᴴ * Y)⁻¹ *
+        (Yᴴ * Y * B * (Yᴴ * Y)⁻¹) * (Xᴴ * X) := by rw [h]
+    _ = ((Yᴴ * Y)⁻¹ * (Yᴴ * Y)) * B *
+        ((Yᴴ * Y)⁻¹ * (Xᴴ * X)) := by noncomm_ring
+    _ = B * ((Yᴴ * Y)⁻¹ * (Xᴴ * X)) := by rw [hGYinv, Matrix.one_mul]
+
+/-- For a self-adjoint matrix, equality with its dressing by the inverse
+conjugate transpose makes the Gram matrix $X^\dagger X$ commute with it.
+
+This is a purely algebraic same-letter specialization.  The vertical-sector
+identity in arXiv:1606.00608, proof of Proposition 4.13, lines 1909--1919,
+instead exchanges the two oriented horizontal bond indices. -/
+theorem commute_gram_of_dressed_adjoint_of_conjTranspose_eq
+    {X B : Matrix n n ℂ} (hX : IsUnit X.det)
+    (hdress : X * B * X⁻¹ = X⁻¹ᴴ * Bᴴ * Xᴴ) (hB : Bᴴ = B) :
+    Xᴴ * X * B = B * (Xᴴ * X) := by
+  have hG : IsUnit (Xᴴ * X).det := by
+    rw [Matrix.det_mul, Matrix.det_conjTranspose]
+    exact hX.star.mul hX
+  have h := gram_conj_eq_conjTranspose_of_dressed_adjoint hX hdress
+  rw [hB] at h
+  calc
+    Xᴴ * X * B = Xᴴ * X * B * ((Xᴴ * X)⁻¹ * (Xᴴ * X)) := by
+      rw [Matrix.nonsing_inv_mul _ hG, Matrix.mul_one]
+    _ = Xᴴ * X * B * (Xᴴ * X)⁻¹ * (Xᴴ * X) := by
+      simp only [Matrix.mul_assoc]
+    _ = B * (Xᴴ * X) := by rw [h]
+
+/-- A relative Gram identity gives the unitary normalization of the relative
+gauge.  This is the two-gauge form of the normalization used in
+arXiv:1606.00608, proof of Proposition 4.13, lines 1904--1908. -/
+theorem smul_mul_nonsing_inv_mem_unitaryGroup_of_gram_eq_smul
+    {X Y : Matrix n n ℂ} (hY : IsUnit Y.det) {ω : ℝ} (hω : 0 < ω)
+    (hgram : Xᴴ * X = (ω : ℂ) • (Yᴴ * Y)) :
+    ((Real.sqrt ω : ℂ))⁻¹ • (X * Y⁻¹) ∈ Matrix.unitaryGroup n ℂ := by
+  apply smul_mem_unitaryGroup_of_conjTranspose_mul_self_eq_smul_one hω
+  have hYH : IsUnit (Yᴴ).det := by
+    rw [Matrix.det_conjTranspose]
+    exact hY.star
+  have hleft : Y⁻¹ᴴ * Yᴴ = 1 := by
+    rw [Matrix.conjTranspose_nonsing_inv]
+    exact Matrix.nonsing_inv_mul _ hYH
+  have hright : Y * Y⁻¹ = 1 := Matrix.mul_nonsing_inv _ hY
+  calc
+    (X * Y⁻¹)ᴴ * (X * Y⁻¹) = Y⁻¹ᴴ * (Xᴴ * X) * Y⁻¹ := by
+      rw [Matrix.conjTranspose_mul]
+      noncomm_ring
+    _ = Y⁻¹ᴴ * ((ω : ℂ) • (Yᴴ * Y)) * Y⁻¹ := by rw [hgram]
+    _ = (ω : ℂ) • ((Y⁻¹ᴴ * Yᴴ) * (Y * Y⁻¹)) := by
+      simp only [Matrix.mul_smul, Matrix.smul_mul]
+      congr 1
+      noncomm_ring
+    _ = (ω : ℂ) • 1 := by rw [hleft, hright, Matrix.one_mul]
+
+end Matrix

--- a/QICLean/Algebra/OrthogonalProjection.lean
+++ b/QICLean/Algebra/OrthogonalProjection.lean
@@ -19,6 +19,7 @@ channels and irreducibility.
 * `IsOrthogonalProjection`
 * `IsOrthogonalProjection.one_sub`
 * `IsOrthogonalProjection.exists_range_isometry`
+* `IsOrthogonalProjection.exists_support_isometry`
 * `IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one`
 * `isOrthogonalProjection_posSemidef`
 * `isOrthogonalProjection_sum_of_pairwise_mul_eq_zero`
@@ -177,6 +178,21 @@ theorem IsOrthogonalProjection.exists_range_isometry
           by_cases hp : p j
           · simp [hp, show f j = 1 from hp]
           · simp [hp, show f j = 0 from (hf01 j).resolve_right hp]
+
+/-- Every orthogonal projection is the range projection of an isometry: there
+are `n` and `V` with `Vᴴ * V = 1`, `V * Vᴴ = P`, and `n = tr P`.
+
+This is the support-isometry factorization used by the sector compressions of
+arXiv:1606.00608, Appendix A; it is stated here without any trace-preservation
+hypothesis on a tensor. -/
+theorem IsOrthogonalProjection.exists_support_isometry {D : ℕ}
+    {P : Matrix (Fin D) (Fin D) ℂ} (hP : IsOrthogonalProjection P) :
+    ∃ (n : ℕ) (V : Matrix (Fin D) (Fin n) ℂ),
+      ((n : ℂ) = Matrix.trace P) ∧ Vᴴ * V = 1 ∧ V * Vᴴ = P := by
+  obtain ⟨n, V, hViso, hVrange⟩ := hP.exists_range_isometry
+  refine ⟨n, V, ?_, hViso, hVrange⟩
+  rw [← hVrange, Matrix.trace_mul_comm, hViso, Matrix.trace_one]
+  simp
 
 /-- A finite sum of pairwise orthogonal projections is an orthogonal
 projection. -/

--- a/QICLean/Algebra/RankOneSandwich.lean
+++ b/QICLean/Algebra/RankOneSandwich.lean
@@ -18,6 +18,80 @@ open Matrix
 
 namespace Matrix
 
+/-- Closing a rank-one insertion between two matrices factorizes the boundary
+contraction into the two single-matrix contractions. -/
+theorem sandwich_mul_rankOne_mul {n : Type*} [Fintype n]
+    (a b : n → ℂ) (A X : Matrix n n ℂ) :
+    a ⬝ᵥ ((A * vecMulVec b a * X) *ᵥ b) =
+      (a ⬝ᵥ (A *ᵥ b)) * (a ⬝ᵥ (X *ᵥ b)) := by
+  simp only [Matrix.mul_vecMulVec, Matrix.vecMulVec_mul,
+    Matrix.vecMulVec_mulVec, dotProduct_smul, Matrix.dotProduct_mulVec]
+  simp [dotProduct, Finset.mul_sum, Finset.sum_mul]
+
+/-- When adjacent factors of a nonempty list admit the rank-one insertion
+`vecMulVec b a`, the boundary contraction of the list product is the product of
+the individual boundary contractions. -/
+theorem sandwich_listProd {n : Type*} [Fintype n] [DecidableEq n]
+    (a b : n → ℂ) (P : Matrix n n ℂ → Prop)
+    (hpair : ∀ A B, P A → P B → A * B = A * vecMulVec b a * B) :
+    ∀ l : List (Matrix n n ℂ), l ≠ [] → (∀ A ∈ l, P A) →
+      a ⬝ᵥ (l.prod *ᵥ b) =
+        (l.map fun A ↦ a ⬝ᵥ (A *ᵥ b)).prod := by
+  intro l hl hP
+  induction l with
+  | nil => exact (hl rfl).elim
+  | cons A l ih =>
+      cases l with
+      | nil => simp
+      | cons B l =>
+          have hA : P A := hP A (by simp)
+          have hB : P B := hP B (by simp)
+          have htail : ∀ X ∈ B :: l, P X := by
+            intro X hX
+            exact hP X (by simp [hX])
+          rw [List.prod_cons, List.prod_cons, ← Matrix.mul_assoc,
+            hpair A B hA hB, Matrix.mul_assoc,
+            sandwich_mul_rankOne_mul]
+          change (a ⬝ᵥ (A *ᵥ b)) * (a ⬝ᵥ ((B :: l).prod *ᵥ b)) = _
+          rw [ih (by simp) htail]
+          simp
+
+/-- The trace of a rank-one insertion between two matrices is the boundary
+contraction of their cyclically rotated product. -/
+theorem trace_mul_rankOne_mul {n : Type*} [Fintype n]
+    (a b : n → ℂ) (A X : Matrix n n ℂ) :
+    Matrix.trace (A * vecMulVec b a * X) = a ⬝ᵥ ((X * A) *ᵥ b) := by
+  rw [Matrix.trace_mul_comm (A * vecMulVec b a) X, ← Matrix.mul_assoc,
+    Matrix.mul_vecMulVec, Matrix.trace_vecMulVec, ← Matrix.mulVec_mulVec]
+  simp [dotProduct, mul_comm]
+
+/-- When adjacent factors of a list of length at least two admit the rank-one
+insertion `vecMulVec b a`, the trace of the list product is the product of the
+individual boundary contractions. -/
+theorem trace_listProd {n : Type*} [Fintype n] [DecidableEq n]
+    (a b : n → ℂ) (P : Matrix n n ℂ → Prop)
+    (hpair : ∀ A B, P A → P B → A * B = A * vecMulVec b a * B)
+    (l : List (Matrix n n ℂ)) (hl : 1 < l.length) (hP : ∀ A ∈ l, P A) :
+    Matrix.trace l.prod = (l.map fun A ↦ a ⬝ᵥ (A *ᵥ b)).prod := by
+  rcases l with _ | ⟨A, l⟩
+  · simp at hl
+  cases l with
+  | nil => simp at hl
+  | cons B l =>
+      have hA : P A := hP A (by simp)
+      have hB : P B := hP B (by simp)
+      have hrot : ∀ X ∈ (B :: l) ++ [A], P X := by
+        intro X hX
+        apply hP X
+        simp only [List.mem_append, List.mem_cons] at hX ⊢
+        tauto
+      rw [List.prod_cons, List.prod_cons, ← Matrix.mul_assoc,
+        hpair A B hA hB, Matrix.mul_assoc, trace_mul_rankOne_mul]
+      have hprod : ((B :: l) ++ [A]).prod = B * l.prod * A := by
+        simp [Matrix.mul_assoc]
+      rw [← hprod, sandwich_listProd a b P hpair _ (by simp) hrot]
+      simp [mul_comm, mul_left_comm]
+
 /-- Rank-one sandwiching is scalar multiplication by the corresponding trace. -/
 theorem vecMulVec_mul_mul_vecMulVec_eq_trace_smul
     {n : Type*} [Fintype n] (ρ Φ : n → ℂ) (P : Matrix n n ℂ) :

--- a/QICLean/Kraus.lean
+++ b/QICLean/Kraus.lean
@@ -19,6 +19,7 @@ import QICLean.Kraus.MixedMap.Gap
 import QICLean.Kraus.MixedMap.GaugeRigidity
 import QICLean.Kraus.MixedMap.SpectralRadius
 import QICLean.Kraus.MultiBlockWord
+import QICLean.Kraus.NormalCommutant
 import QICLean.Kraus.PrimitiveFixedPoint
 import QICLean.Kraus.PrimitiveFixedPoint.Basic
 import QICLean.Kraus.PrimitiveFixedPoint.FromPeripheral

--- a/QICLean/Kraus/Injectivity.lean
+++ b/QICLean/Kraus/Injectivity.lean
@@ -39,6 +39,19 @@ def IsInjective (A : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
 lemma IsInjective.span_eq_top {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : IsInjective A) :
     Submodule.span ℂ (Set.range A) = ⊤ := hA
 
+/-- A finite Kraus family is not injective as soon as some linear functional
+annihilates every one of its matrices while not annihilating some matrix. -/
+theorem not_isInjective_of_linearMap
+    {A : Fin d → Matrix (Fin D) (Fin D) ℂ}
+    (φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ℂ) (hA : ∀ i, φ (A i) = 0)
+    (M : Matrix (Fin D) (Fin D) ℂ) (hM : φ M ≠ 0) :
+    ¬ Kraus.IsInjective A := by
+  intro h
+  have hmem : M ∈ Submodule.span ℂ (Set.range A) := h.span_eq_top ▸ Submodule.mem_top
+  have hle : Submodule.span ℂ (Set.range A) ≤ LinearMap.ker φ :=
+    Submodule.span_le.2 (Set.range_subset_iff.2 fun i => LinearMap.mem_ker.2 (hA i))
+  exact hM (LinearMap.mem_ker.1 (hle hmem))
+
 /-- Multiplication of every physical letter by a nonzero scalar preserves
 injectivity. -/
 theorem IsInjective.smul
@@ -83,6 +96,24 @@ theorem IsNBlkInjective.span_eq_top {A : Fin d → Matrix (Fin D) (Fin D) ℂ} {
     (hA : IsNBlkInjective A N) :
     Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => Kraus.evalWord A (List.ofFn σ)) = ⊤ := by
   simpa only [IsNBlkInjective, Kraus.wordSpan] using hA
+
+/-- A finite Kraus family is not `N`-block injective as soon as some linear
+functional annihilates every length-`N` word while not annihilating some matrix. -/
+theorem not_isNBlkInjective_of_linearMap
+    {A : Fin d → Matrix (Fin D) (Fin D) ℂ} {N : ℕ}
+    (φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ℂ)
+    (hA : ∀ σ : Fin N → Fin d, φ (Kraus.evalWord A (List.ofFn σ)) = 0)
+    (M : Matrix (Fin D) (Fin D) ℂ) (hM : φ M ≠ 0) :
+    ¬ Kraus.IsNBlkInjective A N := by
+  intro h
+  have hmem : M ∈ Submodule.span ℂ
+      (Set.range fun σ : Fin N → Fin d => Kraus.evalWord A (List.ofFn σ)) :=
+    h.span_eq_top ▸ Submodule.mem_top
+  have hle : Submodule.span ℂ
+      (Set.range fun σ : Fin N → Fin d => Kraus.evalWord A (List.ofFn σ)) ≤
+      LinearMap.ker φ :=
+    Submodule.span_le.2 (Set.range_subset_iff.2 fun σ => LinearMap.mem_ker.2 (hA σ))
+  exact hM (LinearMap.mem_ker.1 (hle hmem))
 
 /-- Normality means eventual block injectivity at a positive length:
 there exists `N ≥ 1` such that the tensor is `N`-block-injective.

--- a/QICLean/Kraus/NormalCommutant.lean
+++ b/QICLean/Kraus/NormalCommutant.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Algebra.MatrixGramConjugation
+import QICLean.Algebra.ScalarCommutant
+import QICLean.Kraus.Injectivity
+import Mathlib.LinearAlgebra.Matrix.PosDef
+
+/-!
+# Commutant rigidity for normal finite Kraus families
+
+A normal finite Kraus family spans the full matrix algebra after blocking, so
+a matrix commuting with every family member is scalar.  Applying this to Gram
+matrices yields positive scalar comparison and unitary normalization results.
+
+The theorem docstrings retain source notes for applications to gauge rigidity.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+/-- A matrix commuting with every matrix of a normal finite Kraus family is a
+scalar multiple of the identity. Commutation extends from the matrices to all
+word evaluations, and after blocking these span the full matrix algebra.
+
+This is the commutant triviality behind the step "since $M_\alpha$ is a NT in
+the vertical direction" in the proof of Proposition 4.13 of arXiv:1606.00608,
+line 1921. -/
+theorem IsNormal.eq_smul_one_of_commute
+    {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : Kraus.IsNormal A)
+    {S : Matrix (Fin D) (Fin D) ℂ} (hS : ∀ i, S * A i = A i * S) :
+    ∃ c : ℂ, S = c • 1 := by
+  obtain ⟨N, _hNpos, hN⟩ := hA
+  have hwords : ∀ M ∈ Set.range fun σ : Fin N → Fin d => Kraus.evalWord A (List.ofFn σ),
+      S * M = M * S := by
+    rintro _ ⟨σ, rfl⟩
+    exact Kraus.commutes_evalWord_of_commutes_letters S A hS (List.ofFn σ)
+  obtain ⟨c, hc⟩ := Matrix.isScalar_of_commute_span_eq_top S hN hwords
+  refine ⟨c, ?_⟩
+  rw [hc, Matrix.scalar_apply, Matrix.smul_one_eq_diagonal]
+
+/-- **Relative equation eq3:proof.IV.12.** If two invertible Gram matrices
+induce the same conjugation on every letter of a normal finite Kraus family,
+then one Gram matrix is a positive real multiple of the other:
+$X^\dagger X=\omega Y^\dagger Y$ with $\omega>0$.
+
+This is the conclusion drawn from the second displayed diagram in the proof
+of Proposition 4.13 of arXiv:1606.00608, lines 1914--1921.  It compares the
+sector $k$ directly with the distinguished sector $1$ and does not assume that
+the matrices of the representative family are self-adjoint. -/
+theorem IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq
+    {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : Kraus.IsNormal A)
+    {X Y : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (hgram : ∀ i,
+      Xᴴ * X * A i * (Xᴴ * X)⁻¹ = Yᴴ * Y * A i * (Yᴴ * Y)⁻¹) :
+    ∃ ω : ℝ, 0 < ω ∧ Xᴴ * X = (ω : ℂ) • (Yᴴ * Y) := by
+  have hGY : IsUnit (Yᴴ * Y).det := by
+    rw [Matrix.det_mul, Matrix.det_conjTranspose]
+    exact hY.star.mul hY
+  have hcomm : ∀ i, (Yᴴ * Y)⁻¹ * (Xᴴ * X) * A i =
+      A i * ((Yᴴ * Y)⁻¹ * (Xᴴ * X)) := fun i =>
+    Matrix.commute_gram_ratio_of_gram_conj_eq hX hY (hgram i)
+  obtain ⟨c, hc⟩ := hA.eq_smul_one_of_commute hcomm
+  have hcGram : Xᴴ * X = c • (Yᴴ * Y) := by
+    calc
+      Xᴴ * X = (Yᴴ * Y) * ((Yᴴ * Y)⁻¹ * (Xᴴ * X)) := by
+        rw [← Matrix.mul_assoc, Matrix.mul_nonsing_inv _ hGY, Matrix.one_mul]
+      _ = (Yᴴ * Y) * (c • 1) := by rw [hc]
+      _ = c • (Yᴴ * Y) := by
+        rw [Matrix.mul_smul, Matrix.mul_one]
+  rcases Nat.eq_zero_or_pos D with hD | hD
+  · subst D
+    refine ⟨1, by positivity, ?_⟩
+    ext i
+    exact i.elim0
+  · let i : Fin D := ⟨0, hD⟩
+    have hGXpd : (Xᴴ * X).PosDef :=
+      Matrix.PosDef.conjTranspose_mul_self X
+        (Matrix.mulVec_injective_of_det_ne_zero hX.ne_zero)
+    have hGYpd : (Yᴴ * Y).PosDef :=
+      Matrix.PosDef.conjTranspose_mul_self Y
+        (Matrix.mulVec_injective_of_det_ne_zero hY.ne_zero)
+    have hcEntry : (Xᴴ * X) i i = c * (Yᴴ * Y) i i := by
+      simpa [Matrix.smul_apply] using congr_fun (congr_fun hcGram i) i
+    have hcPos : (0 : ℂ) < c := by
+      apply pos_of_mul_pos_left
+      · rw [← hcEntry]
+        exact hGXpd.diag_pos
+      · exact hGYpd.diag_pos.le
+    obtain ⟨hcRe, hcIm⟩ := Complex.pos_iff.mp hcPos
+    refine ⟨c.re, hcRe, ?_⟩
+    rw [hcGram]
+    congr 1
+    exact (Complex.ext (Complex.ofReal_re c.re)
+      (by rw [Complex.ofReal_im]; exact hcIm)).symm
+
+/-- **Equation eq3 with the distinguished gauge fixed to the identity.**
+If an invertible gauge's Gram conjugation fixes every member of a normal finite
+Kraus family, then its Gram matrix is a positive real multiple of the identity.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, lines 1903--1921. -/
+theorem IsNormal.gram_eq_pos_smul_one_of_gram_conj_eq
+    {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : Kraus.IsNormal A)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det)
+    (hgram : ∀ i, Xᴴ * X * A i * (Xᴴ * X)⁻¹ = A i) :
+    ∃ ω : ℝ, 0 < ω ∧ Xᴴ * X = (ω : ℂ) • 1 := by
+  have hOne : IsUnit (1 : Matrix (Fin D) (Fin D) ℂ).det := by
+    simp
+  obtain ⟨ω, hω, hGram⟩ :=
+    hA.gram_eq_pos_smul_gram_of_gram_conj_eq hX hOne (fun i => by
+      simpa using hgram i)
+  exact ⟨ω, hω, by simpa using hGram⟩
+
+/-- An invertible gauge whose Gram conjugation fixes a normal finite Kraus
+family becomes unitary after division by the square root of its positive Gram
+scalar.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, lines 1903--1921. -/
+theorem IsNormal.exists_unitary_normalization_of_gram_conj_eq
+    {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : Kraus.IsNormal A)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det)
+    (hgram : ∀ i, Xᴴ * X * A i * (Xᴴ * X)⁻¹ = A i) :
+    ∃ ω : ℝ, 0 < ω ∧
+      ((Real.sqrt ω : ℂ))⁻¹ • X ∈ Matrix.unitaryGroup (Fin D) ℂ := by
+  obtain ⟨ω, hω, hGram⟩ :=
+    hA.gram_eq_pos_smul_one_of_gram_conj_eq hX hgram
+  have hOne : IsUnit (1 : Matrix (Fin D) (Fin D) ℂ).det := by
+    simp
+  have hUnit := Matrix.smul_mul_nonsing_inv_mem_unitaryGroup_of_gram_eq_smul
+    (X := X) (Y := (1 : Matrix (Fin D) (Fin D) ℂ)) hOne hω
+    (by simpa using hGram)
+  exact ⟨ω, hω, by simpa using hUnit⟩
+
+/-- **Conditional relative equation eq3 from a common dressed target.** If two
+invertible gauges dress every member of a normal finite Kraus family to the
+same target, then their Gram matrices differ by a positive real scalar. The
+target may depend on the letter.
+
+This is an algebraic consequence of the Figure 8 equality in
+arXiv:1606.00608, proof of Proposition 4.13, lines 1909--1921.  It is not the
+source-facing reflected marked-chain statement. -/
+theorem IsNormal.gram_eq_pos_smul_gram_of_common_dressed_target
+    {A C : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : Kraus.IsNormal A)
+    {X Y : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (hdX : ∀ i, X * A i * X⁻¹ = X⁻¹ᴴ * C i * Xᴴ)
+    (hdY : ∀ i, Y * A i * Y⁻¹ = Y⁻¹ᴴ * C i * Yᴴ) :
+    ∃ ω : ℝ, 0 < ω ∧ Xᴴ * X = (ω : ℂ) • (Yᴴ * Y) :=
+  hA.gram_eq_pos_smul_gram_of_gram_conj_eq hX hY fun i =>
+    Matrix.gram_conj_eq_gram_conj_of_common_dressed_target
+      hX hY (hdX i) (hdY i)
+
+/-- The relative gauge of the preceding theorem becomes unitary after
+division by the square root of its positive Gram scalar.  In the normalization
+$Y=\Id$, this is $\omega^{-1/2}X$ from arXiv:1606.00608, lines 1904--1908. -/
+theorem IsNormal.smul_mul_nonsing_inv_mem_unitaryGroup_of_common_dressed_target
+    {A C : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : Kraus.IsNormal A)
+    {X Y : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (hdX : ∀ i, X * A i * X⁻¹ = X⁻¹ᴴ * C i * Xᴴ)
+    (hdY : ∀ i, Y * A i * Y⁻¹ = Y⁻¹ᴴ * C i * Yᴴ) :
+    ∃ ω : ℝ, 0 < ω ∧
+      ((Real.sqrt ω : ℂ))⁻¹ • (X * Y⁻¹) ∈ Matrix.unitaryGroup (Fin D) ℂ := by
+  obtain ⟨ω, hω, hgram⟩ :=
+    hA.gram_eq_pos_smul_gram_of_common_dressed_target hX hY hdX hdY
+  exact ⟨ω, hω,
+    Matrix.smul_mul_nonsing_inv_mem_unitaryGroup_of_gram_eq_smul hY hω hgram⟩
+
+/-- **Equation eq3:proof.IV.12 in the normalization $X_{\alpha,1} = \Id$.**
+If $X \ne 0$ and the Gram matrix $X^\dagger X$ commutes with every matrix of
+a normal finite Kraus family, then $X^\dagger X = \omega\,\Id$ for a
+necessarily positive constant $\omega$ (arXiv:1606.00608, proof of Proposition
+4.13, lines 1904--1908 and 1921). The source's gauges $X_{\alpha,k}$ are
+invertible; only $X \ne 0$ is needed here, and invertibility of $X$ follows from the
+conclusion. -/
+theorem IsNormal.conjTranspose_mul_self_eq_smul_one_of_commute
+    {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : Kraus.IsNormal A)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX : X ≠ 0)
+    (hcomm : ∀ i, Xᴴ * X * A i = A i * (Xᴴ * X)) :
+    ∃ ω : ℝ, 0 < ω ∧ Xᴴ * X = (ω : ℂ) • 1 := by
+  obtain ⟨c, hc⟩ := hA.eq_smul_one_of_commute hcomm
+  have hW_psd : (Xᴴ * X).PosSemidef := Matrix.posSemidef_conjTranspose_mul_self X
+  have hW_ne : Xᴴ * X ≠ 0 := fun h0 =>
+    hX (Matrix.conjTranspose_mul_self_eq_zero.mp h0)
+  have hc_ne : c ≠ 0 := fun h0 => hW_ne (by rw [hc, h0, zero_smul])
+  have hD : 0 < D := by
+    rcases Nat.eq_zero_or_pos D with h0 | h0
+    · exact absurd (by subst h0; exact Matrix.ext fun i => i.elim0) hX
+    · exact h0
+  have hc_nonneg : (0 : ℂ) ≤ c := by
+    have hd := hW_psd.diag_nonneg (i := (⟨0, hD⟩ : Fin D))
+    have hWii : (Xᴴ * X) (⟨0, hD⟩ : Fin D) (⟨0, hD⟩ : Fin D) = c := by
+      rw [hc]
+      simp [Matrix.smul_apply, Matrix.one_apply_eq]
+    rwa [hWii] at hd
+  obtain ⟨-, hc_im⟩ := Complex.nonneg_iff.mp hc_nonneg
+  have hc_pos : (0 : ℂ) < c := lt_of_le_of_ne hc_nonneg (Ne.symm hc_ne)
+  obtain ⟨hc_re_pos, -⟩ := Complex.pos_iff.mp hc_pos
+  refine ⟨c.re, hc_re_pos, ?_⟩
+  rw [hc]
+  congr 1
+  exact (Complex.ext (Complex.ofReal_re c.re)
+    (by rw [Complex.ofReal_im]; exact hc_im)).symm
+
+/-- **The isometric normalization $U_{\alpha,k} =
+\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$** (arXiv:1606.00608, proof of
+Proposition 4.13, lines 1906--1908): a nonzero $X$ whose Gram matrix commutes
+with every matrix of a normal finite Kraus family becomes unitary after
+division by the square root of the positive constant from eq3:proof.IV.12. -/
+theorem IsNormal.smul_mem_unitaryGroup_of_commute
+    {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : Kraus.IsNormal A)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX : X ≠ 0)
+    (hcomm : ∀ i, Xᴴ * X * A i = A i * (Xᴴ * X)) :
+    ∃ ω : ℝ, 0 < ω ∧
+      ((Real.sqrt ω : ℂ))⁻¹ • X ∈ Matrix.unitaryGroup (Fin D) ℂ := by
+  obtain ⟨ω, hω, hXX⟩ := hA.conjTranspose_mul_self_eq_smul_one_of_commute hX hcomm
+  exact ⟨ω, hω,
+    Matrix.smul_mem_unitaryGroup_of_conjTranspose_mul_self_eq_smul_one hω hXX⟩
+
+end Kraus


### PR DESCRIPTION
## Summary

Moves the remaining low-risk generic matrix/Kraus ownership surface identified in the TNLean boundary audit into QICLean:

- linear-functional criteria for failure of injectivity and block injectivity;
- rank-one sandwich and trace identities for list products;
- support-isometry factorization of orthogonal projections with trace/rank equality;
- generic Gram-conjugation matrix identities;
- commutant rigidity and unitary normalization for normal finite Kraus families.

The normal-family statements use raw finite matrix families rather than reintroducing MPS vocabulary. Public qualified theorem names are preserved so TNLean consumers can migrate without wrappers.

Closes LionSR/TNLean#7216 after the downstream pin/delete PR lands.
Closes LionSR/TNLean#7217 after the downstream pin/delete PR lands.

## Verification

- `lake build` — 9,333 jobs, success
- focused builds for all seven changed/new modules and the `Algebra`/`Kraus` aggregators
- generated import aggregators current (30 files, 592 production modules)
- zero Lean diagnostics in the declaration modules
- `git diff --check`
- no `sorry`, `admit`, or `axiom` introduced

## Architecture

- no `ChannelTensor` coercion;
- no transfer/mixed-transfer compatibility aliases;
- no MPS-facing theorem ecosystem copied into QICLean;
- `Kraus.mapLM` / `Kraus.mixedMapLM` architecture unchanged.
