### PR TITLE
refactor(algebra): promote shared matrix identities

### DIFF
--- a/QICLean/Algebra.lean
+++ b/QICLean/Algebra.lean
@@ -41,6 +41,7 @@ import QICLean.Algebra.MatrixFamilyAction
 import QICLean.Algebra.MatrixFamilySupport
 import QICLean.Algebra.MatrixGramConjugation
 import QICLean.Algebra.MatrixGramUnitary
+import QICLean.Algebra.MatrixIsometryEntries
 import QICLean.Algebra.MatrixIsometryKronecker
 import QICLean.Algebra.MatrixKernelRigidity
 import QICLean.Algebra.MatrixKroneckerEmbed

--- a/QICLean/Algebra/MatrixAux.lean
+++ b/QICLean/Algebra/MatrixAux.lean
@@ -42,6 +42,10 @@ Extracted from various files for reusability.
   semidefinite cone for the trace pairing
 - `Matrix.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero`: faithfulness of a
   positive-definite weighted trace on the positive semidefinite cone
+- `Matrix.PosDef.trace_mul_pos_of_posSemidef_of_ne_zero`: strict positivity of
+  the positive-definite trace pairing
+- `Matrix.PosSemidef.trace_mul_pos_of_ne_zero_of_posDef`: the opposite product
+  orientation of the strict trace-pairing identity
 - `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero`: a positive sum of squares
   vanishes only if every summand vanishes
 - `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`: the conjugate-transpose
@@ -701,6 +705,23 @@ theorem posSemidef_eq_zero_of_posDef_trace_mul_eq_zero
   have : M * Sᴴ = 0 * Sᴴ := by
     simpa [zero_mul] using hMS_zero
   exact IsUnit.mul_right_cancel hSstar_unit this
+
+/-- A positive-definite matrix has strictly positive trace pairing with every
+nonzero positive-semidefinite matrix. -/
+theorem PosDef.trace_mul_pos_of_posSemidef_of_ne_zero
+    {A B : Matrix n n ℂ} (hA : A.PosDef) (hB : B.PosSemidef) (hB_ne : B ≠ 0) :
+    0 < trace (A * B) := by
+  refine lt_of_le_of_ne (hA.posSemidef.trace_mul_nonneg hB) ?_
+  simpa only [ne_eq, eq_comm] using fun hzero ↦
+    hB_ne (posSemidef_eq_zero_of_posDef_trace_mul_eq_zero hB hA hzero)
+
+/-- A nonzero positive-semidefinite matrix has strictly positive trace pairing
+with every positive-definite matrix. -/
+theorem PosSemidef.trace_mul_pos_of_ne_zero_of_posDef
+    {A B : Matrix n n ℂ} (hB : B.PosSemidef) (hB_ne : B ≠ 0) (hA : A.PosDef) :
+    0 < trace (B * A) := by
+  rw [trace_mul_comm]
+  exact hA.trace_mul_pos_of_posSemidef_of_ne_zero hB hB_ne
 
 end PosSemidefTrace
 

--- a/QICLean/Algebra/MatrixIsometryEntries.lean
+++ b/QICLean/Algebra/MatrixIsometryEntries.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import Mathlib.Data.Complex.Basic
+import Mathlib.LinearAlgebra.Matrix.ConjTranspose
+
+/-!
+# Entrywise identities for rectangular matrix isometries
+
+This module records the two scalar-product orientations of column
+orthonormality obtained from the matrix equation `Vᴴ * V = 1`.
+
+## Main results
+
+* `Matrix.sum_star_mul_eq_ite_of_conjTranspose_mul_eq_one`
+* `Matrix.sum_mul_star_eq_ite_of_conjTranspose_mul_eq_one`
+-/
+
+open scoped Matrix BigOperators
+
+namespace Matrix
+
+variable {m n : Type*} [Fintype m] [DecidableEq n]
+
+/-- The entries of `Vᴴ * V = 1` express orthonormality of the columns of `V`. -/
+theorem sum_star_mul_eq_ite_of_conjTranspose_mul_eq_one
+    (V : Matrix m n ℂ) (hV : Vᴴ * V = 1) (i j : n) :
+    (∑ k, star (V k i) * V k j) = if i = j then 1 else 0 := by
+  simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply] using
+    congrFun (congrFun hV i) j
+
+/-- Column orthonormality with the scalar factors written in the opposite order. -/
+theorem sum_mul_star_eq_ite_of_conjTranspose_mul_eq_one
+    (V : Matrix m n ℂ) (hV : Vᴴ * V = 1) (i j : n) :
+    (∑ k, V k i * star (V k j)) = if i = j then 1 else 0 := by
+  simpa only [mul_comm, eq_comm] using
+    sum_star_mul_eq_ite_of_conjTranspose_mul_eq_one V hV j i
+
+end Matrix

--- a/QICLean/Algebra/OrthogonalProjection.lean
+++ b/QICLean/Algebra/OrthogonalProjection.lean
@@ -6,6 +6,7 @@ import Mathlib.Analysis.Complex.Basic
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.LinearAlgebra.Matrix.PosDef
 import QICLean.Algebra.MatrixAux
+import QICLean.Algebra.MatrixIsometryEntries
 
 /-!
 # Orthogonal projections in finite matrix algebras
@@ -122,7 +123,8 @@ theorem IsOrthogonalProjection.exists_range_isometry
   let V : Matrix (Fin D) (Fin n) ℂ := fun i j ↦ Umat i (eS.symm j).1
   refine ⟨n, V, ?_, ?_⟩
   · ext j k
-    have hentry := congrFun (congrFun hU'U (eS.symm j).1) (eS.symm k).1
+    have hentry := Matrix.sum_star_mul_eq_ite_of_conjTranspose_mul_eq_one
+      Umat hU'U (eS.symm j).1 (eS.symm k).1
     have heq : (eS.symm j).1 = (eS.symm k).1 ↔ j = k := by
       constructor
       · intro h
@@ -136,11 +138,7 @@ theorem IsOrthogonalProjection.exists_range_isometry
         if (eS.symm j).1 = (eS.symm k).1 then 1 else 0 at hentry
     change (∑ i : Fin D, starRingEnd ℂ (Umat i ↑(eS.symm j)) *
       Umat i ↑(eS.symm k)) = if j = k then 1 else 0
-    by_cases hjk : j = k
-    · subst k
-      simpa using hentry
-    · have hval : (eS.symm j).1 ≠ (eS.symm k).1 := fun h ↦ hjk (heq.mp h)
-      simpa [hjk, hval] using hentry
+    simpa only [heq] using hentry
   · have hPdecomp : P = Umat * Matrix.diagonal f * Umatᴴ := by
       calc
         P = (Umat * Umatᴴ) * P * (Umat * Umatᴴ) := by rw [hUU]; simp

--- a/QICLean/Channel/FixedPoint/ExtremeDensityStates.lean
+++ b/QICLean/Channel/FixedPoint/ExtremeDensityStates.lean
@@ -5,6 +5,7 @@ Authors: QICLean contributors
 -/
 import Mathlib.Analysis.Convex.Combination
 import Mathlib.Analysis.Convex.Extreme
+import QICLean.Algebra.MatrixIsometryEntries
 import QICLean.Algebra.TracePurity
 import QICLean.Analysis.TraceNormContractionCoefficient
 import QICLean.Channel.FixedPoint.DirectSumExtension
@@ -103,9 +104,9 @@ theorem IsRankOneOrthogonalProjection.exists_isUnitVector_pureStateProj
   subst n
   let psi : Fin D → ℂ := fun i ↦ V i 0
   refine ⟨psi, ?_, ?_⟩
-  · have hentry := congrFun (congrFun hVstarV (0 : Fin 1)) (0 : Fin 1)
-    change (∑ p : Fin D, star (V p 0) * V p 0) = 1
-    simpa [Matrix.mul_apply, Matrix.conjTranspose_apply] using hentry
+  · change (∑ p : Fin D, star (V p 0) * V p 0) = 1
+    simpa using Matrix.sum_star_mul_eq_ite_of_conjTranspose_mul_eq_one
+      V hVstarV (0 : Fin 1) (0 : Fin 1)
   · calc
       pureStateProj psi = V * Vᴴ := by
         ext i j

--- a/QICLean/Channel/Irreducible/CollatzWielandt.lean
+++ b/QICLean/Channel/Irreducible/CollatzWielandt.lean
@@ -192,19 +192,6 @@ theorem upperCollatzWielandtValue_eq_top_of_not_nonempty
   have hset : upperCollatzWielandtSet T X = ∅ := Set.not_nonempty_iff_eq_empty.mp h
   simp [upperCollatzWielandtValue, hset]
 
-/-- A positive-definite weight has strictly positive trace pairing with every
-nonzero positive semidefinite matrix. -/
-private theorem trace_mul_pos_of_posDef_posSemidef_ne_zero
-    {X₀ Y : Mat} (hX₀ : X₀.PosDef) (hY : Y.PosSemidef) (hY_ne : Y ≠ 0) :
-    0 < Matrix.trace (X₀ * Y) := by
-  have hnonneg : 0 ≤ Matrix.trace (X₀ * Y) :=
-    hX₀.posSemidef.trace_mul_nonneg hY
-  have hne : Matrix.trace (X₀ * Y) ≠ 0 := by
-    intro hzero
-    exact hY_ne
-      (Matrix.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero hY hX₀ hzero)
-  exact lt_of_le_of_ne hnonneg (by simpa only [ne_eq, eq_comm] using hne)
-
 /-- A real number `a` is lower Collatz--Wielandt feasible at `X` for `T` when
 `X` is a density matrix and `T X - a X` is positive semidefinite.
 
@@ -723,7 +710,7 @@ theorem exists_posDef_traceAdjointMap_eigenvector_at_perron [NeZero D]
       (Matrix.traceAdjointMap T) hT.traceAdjointMap
       (hIrr.traceAdjointMap hT) hTstar_ne
   have htrace_pos : 0 < Matrix.trace (X₀ * X) :=
-    trace_mul_pos_of_posDef_posSemidef_ne_zero hX₀ hX.posSemidef hX_ne
+    hX₀.trace_mul_pos_of_posSemidef_of_ne_zero hX.posSemidef hX_ne
   have htrace_ne : Matrix.trace (X₀ * X) ≠ 0 := ne_of_gt htrace_pos
   have hpair := Matrix.trace_traceAdjointMap_mul T X₀ X
   rw [hX₀_eig, hX_eig] at hpair
@@ -753,7 +740,7 @@ theorem positive_eigenvalue_eq_perron_of_irreducible_positive [NeZero D]
     exists_posDef_traceAdjointMap_eigenvector_at_perron
       T hT hIrr hr hX hX_eig
   have htrace_pos : 0 < Matrix.trace (X₀ * Y) :=
-    trace_mul_pos_of_posDef_posSemidef_ne_zero hX₀ hY hY_ne
+    hX₀.trace_mul_pos_of_posSemidef_of_ne_zero hY hY_ne
   have htrace_ne : Matrix.trace (X₀ * Y) ≠ 0 := ne_of_gt htrace_pos
   have hpair := Matrix.trace_traceAdjointMap_mul T X₀ Y
   rw [hX₀_eig, hY_eig] at hpair
@@ -782,7 +769,7 @@ theorem perron_le_upperCollatzWielandtFeasible [NeZero D]
     rw [hYzero, Matrix.trace_zero] at htrace
     norm_num at htrace
   have htrace_pos : 0 < Matrix.trace (X₀ * Y) :=
-    trace_mul_pos_of_posDef_posSemidef_ne_zero hX₀ hYa.1.1 hY_ne
+    hX₀.trace_mul_pos_of_posSemidef_of_ne_zero hYa.1.1 hY_ne
   have hpair := Matrix.trace_traceAdjointMap_mul T X₀ Y
   have htrace_map :
       Matrix.trace (X₀ * T Y) = (r : ℂ) * Matrix.trace (X₀ * Y) := by

--- a/QICLean/Channel/Irreducible/Growth/OrthogonalTrace.lean
+++ b/QICLean/Channel/Irreducible/Growth/OrthogonalTrace.lean
@@ -41,21 +41,6 @@ variable {D : ℕ}
 
 section OrthogonalTrace
 
-private theorem trace_mul_pos_of_posDef_posSemidef_ne_zero
-    {A B : Matrix (Fin D) (Fin D) ℂ}
-    (hA : A.PosDef) (hB : B.PosSemidef) (hB_ne : B ≠ 0) :
-    0 < Matrix.trace (B * A) := by
-  have hnonneg : 0 ≤ Matrix.trace (B * A) :=
-    Matrix.PosSemidef.trace_mul_nonneg hB hA.posSemidef
-  have hne : Matrix.trace (B * A) ≠ 0 := by
-    intro hzero
-    have hzero' : Matrix.trace (A * B) = 0 :=
-      (Matrix.trace_mul_comm A B).trans hzero
-    exact hB_ne
-      (Kraus.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero
-        (hM := hB) (hρ := hA) hzero')
-  exact lt_of_le_of_ne hnonneg (by simpa only [ne_eq, eq_comm] using hne)
-
 /-- **Wolf Theorem 6.2, item 4**: if `E` is an irreducible completely positive map and
 `A`, `B` are nonzero PSD matrices with `trace (B * A) = 0`, then some iterate
 `E^t(A)` with `1 ≤ t ≤ D - 1` has strictly positive trace overlap with `B`.
@@ -76,7 +61,7 @@ theorem orthogonal_trace_pos_of_irreducible_cp
   have h_growth : ((T ^ n) A).PosDef := by
     simpa only using (growth_posDef_of_irreducible_cp E hCP hIrr A hA hA_ne)
   have htrace_growth : 0 < Matrix.trace (B * ((T ^ n) A)) :=
-    trace_mul_pos_of_posDef_posSemidef_ne_zero h_growth hB hB_ne
+    hB.trace_mul_pos_of_ne_zero_of_posDef hB_ne h_growth
   have h_expand :
       (T ^ n) A = ∑ k ∈ Finset.range (n + 1), n.choose k • ((E ^ k) A) := by
     simpa only [nsmul_eq_mul] using idPlusE_pow_apply_eq_sum (E := E) (n := n) A

--- a/QICLean/Channel/KrausFreedom.lean
+++ b/QICLean/Channel/KrausFreedom.lean
@@ -8,6 +8,7 @@ import QICLean.Channel.KrausRepresentation
 import QICLean.Channel.Stinespring
 import QICLean.Algebra.FinSum
 import QICLean.Algebra.MatrixGramUnitary
+import QICLean.Algebra.MatrixIsometryEntries
 import QICLean.Algebra.MatrixTracePairing
 
 /-!
@@ -237,9 +238,8 @@ theorem kraus_rectangular_freedom'
     rw [show ∑ x : ι₁, star (V' (e₁ x) (e₂ j)) * V' (e₁ x) (e₂ k) =
         ∑ β, star (V' β (e₂ j)) * V' β (e₂ k) from
       e₁.sum_comp (fun β => star (V' β (e₂ j)) * V' β (e₂ k))]
-    have h_entry := congr_fun (congr_fun hV'_iso (e₂ j)) (e₂ k)
-    change (∑ β, star (V' β (e₂ j)) * V' β (e₂ k)) =
-      if e₂ j = e₂ k then 1 else 0 at h_entry
+    have h_entry := Matrix.sum_star_mul_eq_ite_of_conjTranspose_mul_eq_one
+      V' hV'_iso (e₂ j) (e₂ k)
     simpa only [e₂.injective.eq_iff] using h_entry
   · -- B α = ∑ j, V(α,j) • A j
     intro α

--- a/QICLean/Channel/KrausRectangular.lean
+++ b/QICLean/Channel/KrausRectangular.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import QICLean.Channel.ChoiRectangular
 import QICLean.Channel.KrausRank
 import QICLean.Channel.KrausRepresentation
+import QICLean.Algebra.MatrixIsometryEntries
 
 /-!
 # Rectangular Kraus representation theorem
@@ -138,10 +139,10 @@ theorem exists_kraus_orthogonal_of_isKrausCP [NeZero d]
             Matrix (Fin d' × Fin d) (Fin d' × Fin d) ℂ) = 1 := by
       simpa [Matrix.star_eq_conjTranspose] using
         Matrix.UnitaryGroup.star_mul_self hτ.eigenvectorUnitary
-    have h := congrFun (congrFun hu m.1) n.1
-    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply] at h
-    rw [h]
-    simp [Subtype.ext_iff, eq_comm]
+    simpa only [Subtype.ext_iff, eq_comm] using
+      Matrix.sum_star_mul_eq_ite_of_conjTranspose_mul_eq_one
+        (hτ.eigenvectorUnitary :
+          Matrix (Fin d' × Fin d) (Fin d' × Fin d) ℂ) hu m.1 n.1
   -- The Hilbert–Schmidt Gram matrix of the reconstructed family.
   have hgram : ∀ m n : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0},
       ((Ks m)ᴴ * Ks n).trace =

--- a/QICLean/Channel/PartialTrace.lean
+++ b/QICLean/Channel/PartialTrace.lean
@@ -7,6 +7,7 @@ import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.LinearAlgebra.Matrix.Trace
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Data.Complex.Basic
+import QICLean.Algebra.MatrixIsometryEntries
 
 /-!
 # Partial trace on bipartite matrices
@@ -166,10 +167,8 @@ theorem partialTraceRight_kronecker_conj_of_right_isometry
   classical
   ext i j
   have horth (x y : β) :
-      (∑ k : δ, B k x * star (B k y)) = if x = y then 1 else 0 := by
-    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
-      Matrix.one_apply, mul_comm, eq_comm] using
-      congrFun (congrFun hB y) x
+      (∑ k : δ, B k x * star (B k y)) = if x = y then 1 else 0 :=
+    sum_mul_star_eq_ite_of_conjTranspose_mul_eq_one B hB x y
   simp only [partialTraceRight_apply, Matrix.mul_apply,
     Matrix.conjTranspose_apply, kroneckerMap_apply, Fintype.sum_prod_type, star_mul]
   simp_rw [Finset.mul_sum, Finset.sum_mul]
@@ -336,10 +335,8 @@ theorem partialTraceLeft_kronecker_conj_of_left_isometry
   classical
   ext i j
   have horth (x y : α) :
-      (∑ k : γ, A k x * star (A k y)) = if x = y then 1 else 0 := by
-    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
-      Matrix.one_apply, mul_comm, eq_comm] using
-      congrFun (congrFun hA y) x
+      (∑ k : γ, A k x * star (A k y)) = if x = y then 1 else 0 :=
+    sum_mul_star_eq_ite_of_conjTranspose_mul_eq_one A hA x y
   simp only [partialTraceLeft_apply, Matrix.mul_apply,
     Matrix.conjTranspose_apply, kroneckerMap_apply, Fintype.sum_prod_type, star_mul]
   simp_rw [Finset.mul_sum, Finset.sum_mul]


### PR DESCRIPTION
## Summary

- expose both scalar orientations of rectangular column-orthonormality from `Vᴴ * V = 1`
- expose strict positivity of the trace pairing between a positive-definite matrix and a nonzero positive-semidefinite matrix, in both product orientations
- replace repeated entrywise expansions and two private strict-positivity proofs with the shared declarations

## Scope and downstream relationship

These are source-independent finite-matrix identities. This pull request does not change a paper theorem, introduce a paper-specific proof path, or alter blueprint completion status.

The declarations provide the QICLean-owned APIs requested by LionSR/TNLean#7101 and LionSR/TNLean#7096. Those leaves are children of LionSR/TNLean#7338, the final-closure tracker under LionSR/TNLean#232. TNLean must keep its current QICLean pin until this change is merged and available at an upstream revision.

## Verification

- `lake build QICLean.Algebra.MatrixIsometryEntries QICLean.Algebra.MatrixAux QICLean.Algebra.OrthogonalProjection QICLean.Channel.PartialTrace QICLean.Channel.KrausFreedom QICLean.Channel.KrausRectangular QICLean.Channel.FixedPoint.ExtremeDensityStates QICLean.Channel.Irreducible.Growth.OrthogonalTrace QICLean.Channel.Irreducible.CollatzWielandt QICLean.Algebra`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --changed-files ...`
- proof-integrity scan over the changed Lean files
- `git diff --check`

Closes #510.
Advances LionSR/TNLean#7101.
Advances LionSR/TNLean#7096.
Advances LionSR/TNLean#7338.