### PR TITLE
feat(semigroup): complete extension and perturbation scope

### DIFF
--- a/QICLean/Channel/Semigroup/Basic.lean
+++ b/QICLean/Channel/Semigroup/Basic.lean
@@ -21,6 +21,7 @@ finite-dimensional space is of the form `T_t = exp(tL)` for some generator `L`
   `T(t+s) = T(t) ∘ T(s)` and `T(0) = id`.
 * `IsContinuousDynSemigroup` — adds norm-continuity in `t`.
 * `expSemigroupCLM L t` — the canonical semigroup `t ↦ exp(t • L)` (CLM version).
+* `complexExpSemigroupCLM L z` — its complex-parameter extension `z ↦ exp(z • L)`.
 
 ## Main results
 
@@ -30,6 +31,8 @@ finite-dimensional space is of the form `T_t = exp(tL)` for some generator `L`
 * `hasDerivAt_expSemigroupCLM` — `d/dt exp(t•L) = exp(t•L) * L`.
 * `continuousDynSemigroup_eq_exp` — **Proposition 7.1**: every norm-continuous
   semigroup on `M_D(ℂ)` equals `exp(tL)` for some generator `L`.
+* `continuousDynSemigroup_exists_real_complex_extension` — **Proposition 7.1**:
+  the exponential representation extends to real and complex parameter groups.
 
 ## References
 
@@ -132,7 +135,43 @@ def expSemigroupCLM
     (L : MatrixCLM (Fin D)) (t : ℝ) : MatrixCLM (Fin D) :=
   NormedSpace.exp (((t : ℂ) • L))
 
+/-- The complex-parameter exponential extension of a dynamical semigroup generator,
+as in Wolf Proposition 7.1. -/
+def complexExpSemigroupCLM
+    (L : MatrixCLM (Fin D)) (z : ℂ) : MatrixCLM (Fin D) :=
+  NormedSpace.exp (z • L)
+
 /-! ### Semigroup law for exp -/
+
+theorem complexExpSemigroupCLM_add
+    (L : MatrixCLM (Fin D)) (z w : ℂ) :
+    complexExpSemigroupCLM L (z + w) =
+      complexExpSemigroupCLM L z * complexExpSemigroupCLM L w := by
+  rw [complexExpSemigroupCLM, complexExpSemigroupCLM, complexExpSemigroupCLM]
+  have hsum : (z + w) • L = z • L + w • L := add_smul z w L
+  rw [hsum]
+  exact NormedSpace.exp_add_of_commute
+    (((Commute.refl L).smul_left z).smul_right w)
+
+theorem complexExpSemigroupCLM_zero
+    (L : MatrixCLM (Fin D)) :
+    complexExpSemigroupCLM L 0 = 1 := by
+  rw [complexExpSemigroupCLM, zero_smul ℂ L, NormedSpace.exp_zero]
+
+theorem complexExpSemigroupCLM_neg_mul
+    (L : MatrixCLM (Fin D)) (z : ℂ) :
+    complexExpSemigroupCLM L (-z) * complexExpSemigroupCLM L z = 1 := by
+  rw [← complexExpSemigroupCLM_add, neg_add_cancel, complexExpSemigroupCLM_zero]
+
+theorem complexExpSemigroupCLM_mul_neg
+    (L : MatrixCLM (Fin D)) (z : ℂ) :
+    complexExpSemigroupCLM L z * complexExpSemigroupCLM L (-z) = 1 := by
+  rw [← complexExpSemigroupCLM_add, add_neg_cancel, complexExpSemigroupCLM_zero]
+
+theorem complexExpSemigroupCLM_ofReal
+    (L : MatrixCLM (Fin D)) (t : ℝ) :
+    complexExpSemigroupCLM L (t : ℂ) = expSemigroupCLM L t := by
+  rfl
 
 theorem expSemigroupCLM_add
     (L : MatrixCLM (Fin D))
@@ -151,6 +190,16 @@ theorem expSemigroupCLM_zero
   have hz : (0 : ℂ) • L = (0 : MatrixCLM (Fin D)) := by
     exact zero_smul ℂ L
   simp [expSemigroupCLM, hz]
+
+theorem expSemigroupCLM_neg_mul
+    (L : MatrixCLM (Fin D)) (t : ℝ) :
+    expSemigroupCLM L (-t) * expSemigroupCLM L t = 1 := by
+  rw [← expSemigroupCLM_add, neg_add_cancel, expSemigroupCLM_zero]
+
+theorem expSemigroupCLM_mul_neg
+    (L : MatrixCLM (Fin D)) (t : ℝ) :
+    expSemigroupCLM L t * expSemigroupCLM L (-t) = 1 := by
+  rw [← expSemigroupCLM_add, add_neg_cancel, expSemigroupCLM_zero]
 
 /-! ### Continuity of the exponential semigroup -/
 
@@ -594,6 +643,49 @@ theorem continuousDynSemigroup_eq_exp
       have hvt : 0 ≤ v - u := sub_nonneg.mpr hv
       simpa [show u + (v - u) = v by ring] using hS_add u (v - u) hu hvt)
     (by simp [hS_zero])
+
+/-- **Wolf Proposition 7.1, real and complex group extension.** Every
+norm-continuous dynamical semigroup on `M_D(ℂ)` agrees at nonnegative real
+times with an exponential family. The same exponential formula satisfies the
+group law and has two-sided inverses for every real or complex parameter, and
+the complex family restricts to the real family.
+
+Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 7.1;
+`Notes/WolfNoteTexSource/ch07_semigroup_structure.tex`, lines 67--84. -/
+theorem continuousDynSemigroup_exists_real_complex_extension
+    (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hT : IsContinuousDynSemigroup T) :
+    ∃ L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
+      (∀ t : ℝ, 0 ≤ t → T t = expSemigroup L t) ∧
+      (∀ t s : ℝ,
+        expSemigroupCLM (endEquiv L) (t + s) =
+          expSemigroupCLM (endEquiv L) t * expSemigroupCLM (endEquiv L) s) ∧
+      (∀ t : ℝ,
+        expSemigroupCLM (endEquiv L) (-t) * expSemigroupCLM (endEquiv L) t = 1 ∧
+        expSemigroupCLM (endEquiv L) t * expSemigroupCLM (endEquiv L) (-t) = 1) ∧
+      (∀ z w : ℂ,
+        complexExpSemigroupCLM (endEquiv L) (z + w) =
+          complexExpSemigroupCLM (endEquiv L) z *
+            complexExpSemigroupCLM (endEquiv L) w) ∧
+      (∀ z : ℂ,
+        complexExpSemigroupCLM (endEquiv L) (-z) *
+            complexExpSemigroupCLM (endEquiv L) z = 1 ∧
+        complexExpSemigroupCLM (endEquiv L) z *
+            complexExpSemigroupCLM (endEquiv L) (-z) = 1) ∧
+      (∀ t : ℝ,
+        complexExpSemigroupCLM (endEquiv L) (t : ℂ) =
+          expSemigroupCLM (endEquiv L) t) := by
+  obtain ⟨L, hL⟩ := continuousDynSemigroup_eq_exp T hT
+  refine ⟨L, hL, ?_, ?_, ?_, ?_, ?_⟩
+  · exact expSemigroupCLM_add (endEquiv L)
+  · intro t
+    exact ⟨expSemigroupCLM_neg_mul (endEquiv L) t,
+      expSemigroupCLM_mul_neg (endEquiv L) t⟩
+  · exact complexExpSemigroupCLM_add (endEquiv L)
+  · intro z
+    exact ⟨complexExpSemigroupCLM_neg_mul (endEquiv L) z,
+      complexExpSemigroupCLM_mul_neg (endEquiv L) z⟩
+  · exact complexExpSemigroupCLM_ofReal (endEquiv L)
 
 /-- Uniqueness of the generator: if `exp(t•L) = exp(t•L')` for all `t ≥ 0`,
 then `L = L'`. Proof: both CLM semigroups agree on `[0,∞)`, hence their

--- a/QICLean/Channel/Semigroup/Perturbation.lean
+++ b/QICLean/Channel/Semigroup/Perturbation.lean
@@ -22,6 +22,8 @@ import Mathlib.Analysis.Normed.Group.InfiniteSum
 ## Main results
 
 * `duhamel_formula` — **Lemma 7.1** (Duhamel/perturbation integral formula)
+* `perturbation_bound_of_duhamel` — **Corollary 7.1** for an arbitrary
+  submultiplicative norm
 * `perturbation_bound` — **Corollary 7.1** (perturbation of generators)
 * `dysonTerm_continuous` — continuity of each Dyson iterate in the time parameter
 * `norm_dysonRemainder_le` — factorial norm bound on the Dyson partial-sum remainder
@@ -152,6 +154,52 @@ theorem duhamel_formula
         expSemigroupCLM L (t - 0) * expSemigroupCLM L' 0
   simp [sub_self, sub_zero, expSemigroupCLM_zero]
 
+/-! ## Corollary 7.1 for an arbitrary submultiplicative norm -/
+
+/-- The norm estimate in Wolf Corollary 7.1 uses only the Duhamel identity,
+the triangle inequality for the Bochner integral, and submultiplicativity.
+Consequently it holds for every norm making the ambient algebra a normed
+ring. In Wolf's setting this is the operator norm induced by any chosen norm
+on the finite-dimensional state space (source lines 47--50 and 133--140).
+
+Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 7.1;
+`Notes/WolfNoteTexSource/ch07_semigroup_structure.tex`, lines 133--140. -/
+theorem perturbation_bound_of_duhamel
+    {A : Type*} [NormedRing A] [NormedSpace ℝ A] [CompleteSpace A]
+    (T T' : ℝ → A) (Δ : A) (t M M' : ℝ) (ht : 0 ≤ t)
+    (hduhamel : T' t - T t =
+      ∫ s in Set.Icc 0 t, T (t - s) * Δ * T' s)
+    (hT : ∀ s ∈ Set.Icc 0 t, ‖T s‖ ≤ M)
+    (hT' : ∀ s ∈ Set.Icc 0 t, ‖T' s‖ ≤ M') :
+    ‖T' t - T t‖ ≤ t * ‖Δ‖ * M * M' := by
+  rw [hduhamel]
+  have hmeas : volume (Set.Icc (0 : ℝ) t) < ⊤ := by
+    rw [Real.volume_Icc]
+    exact ENNReal.ofReal_lt_top
+  have hpointwise : ∀ s ∈ Set.Icc 0 t,
+      ‖T (t - s) * Δ * T' s‖ ≤ M * ‖Δ‖ * M' := by
+    intro s hs
+    refine (norm_mul₃_le : ‖T (t - s) * Δ * T' s‖ ≤
+      ‖T (t - s)‖ * ‖Δ‖ * ‖T' s‖).trans ?_
+    have hts : t - s ∈ Set.Icc (0 : ℝ) t :=
+      ⟨sub_nonneg.mpr hs.2, sub_le_self t hs.1⟩
+    have hM : 0 ≤ M :=
+      (norm_nonneg (T 0)).trans (hT 0 (Set.left_mem_Icc.mpr ht))
+    exact mul_le_mul
+      (mul_le_mul_of_nonneg_right (hT (t - s) hts) (norm_nonneg Δ))
+      (hT' s hs) (norm_nonneg (T' s)) (mul_nonneg hM (norm_nonneg Δ))
+  have hInt := MeasureTheory.norm_setIntegral_le_of_norm_le_const hmeas hpointwise
+  have hvol : volume.real (Set.Icc (0 : ℝ) t) = t := by
+    rw [Measure.real_def, Real.volume_Icc,
+      ENNReal.toReal_ofReal (sub_nonneg.mpr ht)]
+    ring
+  calc
+    ‖∫ s in Set.Icc 0 t, T (t - s) * Δ * T' s‖
+        ≤ M * ‖Δ‖ * M' * t := by
+          rw [hvol] at hInt
+          exact hInt
+    _ = t * ‖Δ‖ * M * M' := by ring
+
 /-! ## Auxiliary estimate for biSup bounds -/
 
 private lemma norm_expSemigroup_le_biSup (L : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ t)
@@ -188,33 +236,14 @@ theorem perturbation_bound
       t * ‖L' - L‖ *
         (⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖) *
         (⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L' s‖) := by
-  rw [duhamel_formula L L' t ht]
-  set Δ := L' - L
-  set M := ⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖
-  set M' := ⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L' s‖
-  have hmeas : volume (Set.Icc (0 : ℝ) t) < ⊤ := by
-    rw [Real.volume_Icc]; exact ENNReal.ofReal_lt_top
-  have hpointwise : ∀ s ∈ Set.Icc 0 t,
-      ‖expSemigroupCLM L (t - s) * Δ * expSemigroupCLM L' s‖ ≤ M * ‖Δ‖ * M' := by
-    intro s hs
-    calc ‖expSemigroupCLM L (t - s) * Δ * expSemigroupCLM L' s‖
-        ≤ ‖expSemigroupCLM L (t - s) * Δ‖ * ‖expSemigroupCLM L' s‖ := norm_mul_le _ _
-      _ ≤ ‖expSemigroupCLM L (t - s)‖ * ‖Δ‖ * ‖expSemigroupCLM L' s‖ :=
-          mul_le_mul_of_nonneg_right (norm_mul_le _ _) (norm_nonneg _)
-      _ ≤ M * ‖Δ‖ * M' := by
-          apply mul_le_mul (mul_le_mul_of_nonneg_right ?_ (norm_nonneg _)) ?_
-            (norm_nonneg _) (mul_nonneg ?_ (norm_nonneg _))
-          · exact norm_expSemigroup_le_biSup L ht
-              ⟨sub_nonneg.mpr hs.2, sub_le_self t hs.1⟩
-          · exact norm_expSemigroup_le_biSup L' ht hs
-          · exact le_trans (norm_nonneg _)
-              (norm_expSemigroup_le_biSup L ht (Set.left_mem_Icc.mpr ht))
-  calc ‖∫ s in Set.Icc 0 t, expSemigroupCLM L (t - s) * Δ * expSemigroupCLM L' s‖
-      ≤ M * ‖Δ‖ * M' * (volume (Set.Icc (0 : ℝ) t)).toReal :=
-        norm_setIntegral_le_of_norm_le_const hmeas hpointwise
-    _ = t * ‖Δ‖ * M * M' := by
-        rw [Real.volume_Icc, ENNReal.toReal_ofReal (by linarith : (0 : ℝ) ≤ t - 0)]
-        ring
+  exact perturbation_bound_of_duhamel
+    (T := expSemigroupCLM L) (T' := expSemigroupCLM L') (Δ := L' - L)
+    (t := t)
+    (M := ⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖)
+    (M' := ⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L' s‖)
+    ht (duhamel_formula L L' t ht)
+    (fun s hs => norm_expSemigroup_le_biSup L ht hs)
+    (fun s hs => norm_expSemigroup_le_biSup L' ht hs)
 
 /-- Simplified perturbation bound for quantum channels (where ‖T_s‖ ≤ 1):
 `‖T'_t - T_t‖ ≤ t · ‖Δ‖`. -/

--- a/blueprint/src/chapter/ch11_semigroup_dynamics_and_gksl.tex
+++ b/blueprint/src/chapter/ch11_semigroup_dynamics_and_gksl.tex
@@ -173,13 +173,26 @@
     Theorem~\ref{thm:expSemigroup_zero_ch12}.
 \end{proof}
 
-\begin{theorem}[Every continuous semigroup is exponential]
+\begin{theorem}[Continuous semigroups and exponential group extensions]
     \label{thm:continuousDynSemigroup_eq_exp_ch12}
-    \lean{continuousDynSemigroup_eq_exp}\leanok
+    \lean{continuousDynSemigroup_eq_exp,
+        continuousDynSemigroup_exists_real_complex_extension,
+        complexExpSemigroupCLM, expSemigroupCLM_add,
+        expSemigroupCLM_neg_mul, expSemigroupCLM_mul_neg,
+        complexExpSemigroupCLM_add, complexExpSemigroupCLM_neg_mul,
+        complexExpSemigroupCLM_mul_neg,
+        complexExpSemigroupCLM_ofReal}\leanok
     \uses{def:continuous_dyn_semigroup_ch12, def:exp_semigroup_ch12}
     Every norm-continuous dynamical semigroup $T$ on $\MN{D}$ is
     of the form $T_t = e^{tL}$ for some generator
     $L \in \End_{\C}(\MN{D})$ and every $t \ge 0$.
+    Moreover, the same formula $T_z=e^{zL}$ for $z\in\C$ gives a complex
+    parameter group, whose restriction to $\R$ gives the real parameter group:
+    \begin{align}
+        T_{z+w}&=T_zT_w,
+        &T_{-z}T_z=T_zT_{-z}&=\Id.
+        \label{eq:semigroup_real_complex_extension}
+    \end{align}
     This is \cite[Proposition~7.1]{Wolf2012Quantum}.
 \end{theorem}
 
@@ -192,6 +205,11 @@
     $T_t = M_\varepsilon^{-1}(M_{t+\varepsilon} - M_t)$
     is differentiable for $t \ge 0$.
     ODE uniqueness then gives $T_t = e^{tL}$ for all $t \ge 0$.
+    Since scalar multiples of $L$ commute, the exponential addition formula
+    gives the complex group law in
+    (\ref{eq:semigroup_real_complex_extension}); substituting $-z$
+    gives the two-sided inverses. Restricting the complex parameter to
+    $\R\subset\C$ gives the real group extension.
 \end{proof}
 
 %% ---------------------------------------------------------
@@ -221,9 +239,10 @@
 \end{proof}
 
 \begin{theorem}[Perturbation bound]\label{thm:perturbation_bound_ch12}
-    \lean{perturbation_bound}\leanok
+    \lean{perturbation_bound_of_duhamel, perturbation_bound}\leanok
     \uses{thm:duhamel_formula_ch12}
-    For $t \ge 0$,
+    For $t \ge 0$ and every operator norm induced by a norm on the
+    finite-dimensional state space,
     \begin{align}
         \bigl\|e^{tL'} - e^{tL}\bigr\|
         &\le t\,\|\Delta\|

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -2051,15 +2051,19 @@ tensor-network layer; it is indexed in `TNLean.Wielandt.WolfChapter6TNIndex`.
 
 ## Wolf Lecture Notes — Chapter 7: Continuous one-parameter semigroups
 
-The complete named-environment audit classifies exactly six Chapter 7
-source environments as partial rather than exact:
+Proposition 7.1 is exact: `continuousDynSemigroup_exists_real_complex_extension`
+states the nonnegative-time exponential representation together with the
+real and complex exponential group laws, two-sided inverses, and agreement of
+the complex family with the real family. Corollary 7.1 is also exact. The
+abstract theorem `perturbation_bound_of_duhamel` proves the displayed estimate
+for every submultiplicative norm from the Duhamel identity, while
+`perturbation_bound` supplies the finite-dimensional matrix specialization.
+Here Wolf's “any norm” refers to the operator norm induced by the chosen norm on
+the state space, as defined immediately before Proposition 7.1.
 
-- Proposition 7.1, “From continuous semigroups to differentiable groups”: the
-  real nonnegative-time exponential representation is proved, but the claimed
-  real/complex parameter group extension is not packaged (partial-scope).
-- Corollary 7.1, “Perturbation of generators”: the displayed estimate is proved
-  for the project's fixed operator norm, not for an arbitrary submultiplicative
-  norm as printed (partial-scope).
+The complete named-environment audit therefore classifies exactly four Chapter
+7 source environments as partial rather than exact:
+
 - Proposition 7.4, “Freedom in representation of generators”: the shift,
   tracelessness, uniqueness, and Kraus-freedom ingredients are formalized, but
   not assembled under one source-facing proposition (partial-packaging).


### PR DESCRIPTION
## Summary

- define the complex-parameter family `T_z = exp(zL)` and prove its additive law, two-sided inverses, and restriction to the real family
- assemble the real and complex group-extension conclusion of Wolf Proposition 7.1 from the existing exponential representation
- prove the Corollary 7.1 perturbation estimate in an arbitrary complete normed ring and specialize it to the induced operator norm already used for matrix endomorphisms
- synchronize the Blueprint and the Wolf numbering audit

## Source fidelity

The statements follow `Notes/WolfNoteTexSource/ch07_semigroup_structure.tex`, lines 47--50, 67--84, and 133--140. In particular, the notation remains `T_z = e^{zL}`. The phrase “any norm” is read in the context established on lines 47--50: the operator norm induced by a chosen norm on the finite-dimensional state space. The abstract proof records precisely the required submultiplicativity.

## Verification

- `lake build QICLean -q --log-level=info`
- `lake build lint_style`
- `lake exe lint_style --github`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `texra-blueprint paper-gaps check`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch11_semigroup_dynamics_and_gksl.tex`
- `leanblueprint pdf`
- proof-integrity scan over the changed Lean files
- `git diff --check`

Closes #480.