### PR TITLE
feat(semigroup): package generator representation freedom

### DIFF
--- a/QICLean/Channel/KrausUnitaryFreedom.lean
+++ b/QICLean/Channel/KrausUnitaryFreedom.lean
@@ -20,6 +20,9 @@ iff statements matching Wolf Theorem 2.1(4) (ensemble equivalence, Eq. (2.10)).
   zeros, they are related by an isometric mixing matrix.
 * `kraus_unitary_freedom_iff` — same-size Kraus families define the same map if
   and only if they are related by a unitary mixing matrix.
+* `kraus_unitary_freedom_iff_of_zeroPad` — arbitrary finite Kraus families
+  define the same map if and only if their zero paddings to the larger
+  cardinality are related by a unitary mixing matrix.
 
 ## References
 
@@ -31,6 +34,37 @@ open scoped Matrix
 open Matrix Finset BigOperators
 
 variable {d d' : ℕ}
+
+namespace Kraus
+
+/-- Pad a finite Kraus family with zero operators to a prescribed length.
+
+For `m ≤ n`, the first `m` operators are retained and the remaining `n - m`
+operators are zero. This is the zero padding in Wolf Theorem 2.1(4) and
+Proposition 7.4(2). -/
+def zeroPad {m n : ℕ} (A : Fin m → Matrix (Fin d') (Fin d) ℂ) :
+    Fin n → Matrix (Fin d') (Fin d) ℂ := fun i =>
+  if h : (i : ℕ) < m then A ⟨i, h⟩ else 0
+
+@[simp]
+theorem zeroPad_castLE {m n : ℕ} (h : m ≤ n)
+    (A : Fin m → Matrix (Fin d') (Fin d) ℂ) (i : Fin m) :
+    zeroPad (n := n) A (Fin.castLE h i) = A i := by
+  simp [zeroPad]
+
+/-- Zero padding a Kraus family leaves its completely positive map unchanged. -/
+theorem sum_zeroPad {m n : ℕ} (h : m ≤ n)
+    (A : Fin m → Matrix (Fin d') (Fin d) ℂ)
+    (X : Matrix (Fin d) (Fin d) ℂ) :
+    ∑ i : Fin n, zeroPad A i * X * (zeroPad A i)ᴴ =
+      ∑ j : Fin m, A j * X * (A j)ᴴ := by
+  rw [Fin.sum_castLE_extend_zero (fun j => A j * X * (A j)ᴴ) h]
+  apply Finset.sum_congr rfl
+  intro i _
+  simp only [zeroPad]
+  split_ifs <;> simp
+
+end Kraus
 
 /-- **Wolf Theorem 2.1(4) (isometric form)**: two finite Kraus families define the
 same completely positive map if and only if, after padding the smaller family
@@ -66,3 +100,33 @@ theorem kraus_unitary_freedom_iff
   rw [kraus_isometry_freedom_iff B A le_rfl]
   refine ⟨fun ⟨V, hV, hBA⟩ => ⟨⟨V, Matrix.mem_unitaryGroup_iff'.2 hV⟩, hBA⟩,
           fun ⟨U, hBA⟩ => ⟨(U : Matrix ι ι ℂ), Matrix.mem_unitaryGroup_iff'.mp U.prop, hBA⟩⟩
+
+/-- **Wolf Theorem 2.1(4) (zero-padded unitary form)**: two finite Kraus
+families define the same completely positive map if and only if, after padding
+both families with zeros to the larger cardinality, the primed family is a
+unitary linear combination of the unprimed family. -/
+theorem kraus_unitary_freedom_iff_of_zeroPad
+    {r r' : ℕ}
+    (L' : Fin r' → Matrix (Fin d') (Fin d) ℂ)
+    (L : Fin r → Matrix (Fin d') (Fin d) ℂ) :
+    (∀ X : Matrix (Fin d) (Fin d) ℂ,
+      ∑ i, L' i * X * (L' i)ᴴ = ∑ j, L j * X * (L j)ᴴ) ↔
+      ∃ U : Matrix.unitaryGroup (Fin (max r r')) ℂ,
+        ∀ i, Kraus.zeroPad L' i =
+          ∑ j, (U : Matrix (Fin (max r r')) (Fin (max r r')) ℂ) i j •
+            Kraus.zeroPad L j := by
+  constructor
+  · intro h
+    apply (kraus_unitary_freedom_iff
+      (Kraus.zeroPad (n := max r r') L')
+      (Kraus.zeroPad (n := max r r') L)).mp
+    intro X
+    rw [Kraus.sum_zeroPad (le_max_right r r') L' X,
+      Kraus.sum_zeroPad (le_max_left r r') L X, h X]
+  · intro h
+    have hpad := (kraus_unitary_freedom_iff
+      (Kraus.zeroPad (n := max r r') L')
+      (Kraus.zeroPad (n := max r r') L)).mpr h
+    intro X
+    rw [← Kraus.sum_zeroPad (le_max_right r r') L' X,
+      ← Kraus.sum_zeroPad (le_max_left r r') L X, hpad X]

--- a/QICLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
+++ b/QICLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
@@ -15,6 +15,7 @@ This file proves the GKSL theorem characterizing generators of CPTP semigroups.
 ## Main results
 
 * `generator_shift_invariance` — **Proposition 7.4** (Kraus shift freedom).
+* `exists_traceless_kraus_shift` — **Proposition 7.4(1)** (traceless choice).
 * `IsGKSLGenerator` — definition.
 * `gksl_iff_lindbladForm` — **Theorem 7.1**: GKSL ↔ Lindblad form.
 -/
@@ -84,7 +85,7 @@ theorem generator_shift_invariance
   rw [hX]
   simpa [neg_smul] using hgoal
 
-/-- **Wolf Proposition 7.4 (item 2 — existence of traceless Kraus operators)**:
+/-- **Wolf Proposition 7.4(1), existence of traceless Kraus operators**:
 Given any Kraus representation `{Lⱼ}`, there exist shifts `cⱼ` such that
 `L'ⱼ = Lⱼ + cⱼ 𝟙` is traceless. -/
 theorem exists_traceless_kraus_shift

--- a/QICLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
+++ b/QICLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
@@ -5,16 +5,27 @@ Authors: TNLean contributors
 -/
 import QICLean.Channel.Semigroup.LindbladForm.Basic
 import QICLean.Channel.ChoiJamiolkowski
+import QICLean.Channel.KrausUnitaryFreedom
 
 /-!
-# Lindblad Form — Uniqueness of traceless GKSL decompositions
+# Freedom between traceless generator representations
 
-This file formalizes the uniqueness direction of Wolf Proposition 7.4 (item 2):
-if two Lindblad / generator decompositions define the same generator and both
-use traceless Kraus operators, then
+This file formalizes Wolf Proposition 7.4(2) for arbitrary generator
+decompositions. If two pairs `(φ, κ)` and `(φ', κ')` define the same generator
+and both completely positive parts are displayed by traceless Kraus families,
+then
 
 * the dissipative CP parts coincide, and
-* the drift matrices agree up to an imaginary scalar multiple of the identity.
+* the drift matrices agree up to an imaginary scalar multiple of the identity,
+  with the two zero-padded Kraus families related by a unitary matrix.
+
+The earlier results for trace-preserving `LindbladForm` structures are retained
+as consequences of the source-level generator-decomposition statements.
+
+## Main result
+
+* `generatorDecomp_traceless_representation_freedom` — Wolf Proposition 7.4(2),
+  with the source signs, zero padding, and unitary orientation.
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal MatrixOrder TNOperatorSpace
@@ -36,9 +47,11 @@ def LindbladForm.HasTracelessKraus (F : LindbladForm D) : Prop :=
 `choiMatrix(φ) *ᵥ ω = 0` when all Kraus operators are traceless. -/
 private theorem choi_phi_mulVec_omega_eq_zero
     [NeZero D]
-    (F : LindbladForm D) (htr : F.HasTracelessKraus) :
-    ChoiJamiolkowski.choiMatrix F.toGeneratorDecomp.φ *ᵥ Matrix.omegaVec D = 0 := by
-  set G := F.toGeneratorDecomp
+    (G : GeneratorDecomp D)
+    {r : ℕ} (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (hK : ∀ ρ, G.φ ρ = ∑ i, K i * ρ * (K i)ᴴ)
+    (htr : ∀ i, trace (K i) = 0) :
+    ChoiJamiolkowski.choiMatrix G.φ *ᵥ Matrix.omegaVec D = 0 := by
   set α : ℂ := ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * star ((1 : ℂ) / ((D : ℝ).sqrt : ℂ))
   set c : ℂ := (1 : ℂ) / ((D : ℝ).sqrt : ℂ)
   funext ⟨i₁, i₂⟩
@@ -56,22 +69,23 @@ private theorem choi_phi_mulVec_omega_eq_zero
   -- Rewrite bipartiteSlice using ChoiJamiolkowski.omegaSlice_eq_single
   simp_rw [ChoiJamiolkowski.omegaSlice_eq_single]
   -- Unfold G.φ (Kraus sum)
-  change ∑ j₂ : Fin D, (∑ k : Fin F.r, F.L k * Matrix.single i₂ j₂ α * (F.L k)ᴴ) i₁ j₂ *
+  simp_rw [hK]
+  change ∑ j₂ : Fin D, (∑ k : Fin r, K k * Matrix.single i₂ j₂ α * (K k)ᴴ) i₁ j₂ *
     (1 / ↑(Real.sqrt ↑D)) = 0
   simp_rw [Matrix.sum_apply, Finset.sum_mul]
   rw [Finset.sum_comm]
   -- For each k: show the sum is zero
   refine Finset.sum_eq_zero fun k _ => ?_
-  -- Compute (L_k * single i₂ j α * L_kᴴ) i₁ j
+  -- Compute (K_k * single i₂ j α * K_kᴴ) i₁ j
   have hentry : ∀ j : Fin D,
-      (F.L k * Matrix.single i₂ j α * (F.L k)ᴴ) i₁ j =
-        F.L k i₁ i₂ * α * star (F.L k j j) := by
+      (K k * Matrix.single i₂ j α * (K k)ᴴ) i₁ j =
+        K k i₁ i₂ * α * star (K k j j) := by
     intro j
     rw [Matrix.mul_assoc]
     simp only [Matrix.mul_apply, Matrix.conjTranspose_apply]
-    -- Inner sum: ∑_x single i₂ j α a x * star(F.L k j x) = δ_{a,i₂} · α · star(F.L k j j)
-    have hinner : ∀ a : Fin D, ∑ x, Matrix.single i₂ j α a x * star (F.L k j x) =
-        if a = i₂ then α * star (F.L k j j) else 0 := by
+    -- Inner sum: ∑_x single i₂ j α a x * star(K k j x) = δ_{a,i₂} · α · star(K k j j)
+    have hinner : ∀ a : Fin D, ∑ x, Matrix.single i₂ j α a x * star (K k j x) =
+        if a = i₂ then α * star (K k j j) else 0 := by
       intro a
       by_cases ha : a = i₂
       · rw [ite_eq_left ha, ha, Finset.sum_eq_single j]
@@ -90,10 +104,10 @@ private theorem choi_phi_mulVec_omega_eq_zero
     · exact absurd (Finset.mem_univ _)
   simp_rw [hentry]
   -- Factor out common terms and collapse to trace
-  conv_lhs => arg 2; ext j; rw [show F.L k i₁ i₂ * α * star (F.L k j j) * c =
-      α * c * F.L k i₁ i₂ * star (F.L k j j) from by ring]
+  conv_lhs => arg 2; ext j; rw [show K k i₁ i₂ * α * star (K k j j) * c =
+      α * c * K k i₁ i₂ * star (K k j j) from by ring]
   rw [← Finset.mul_sum]
-  rw [show ∑ j : Fin D, star (F.L k j j) = star (trace (F.L k)) from by
+  rw [show ∑ j : Fin D, star (K k j j) = star (trace (K k)) from by
     simp [Matrix.trace, star_sum]]
   rw [htr k, star_zero, mul_zero]
 
@@ -101,12 +115,15 @@ private theorem choi_phi_mulVec_omega_eq_zero
 CP part equals the full Choi matrix. -/
 private theorem projectedChoiMatrix_eq_choiMatrix_of_traceless
     [NeZero D]
-    (F : LindbladForm D) (htr : F.HasTracelessKraus) :
-    ChoiJamiolkowski.projectedChoiMatrix F.toGeneratorDecomp.φ =
-      ChoiJamiolkowski.choiMatrix F.toGeneratorDecomp.φ := by
-  set τ := ChoiJamiolkowski.choiMatrix F.toGeneratorDecomp.φ
+    (G : GeneratorDecomp D)
+    {r : ℕ} (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (hK : ∀ ρ, G.φ ρ = ∑ i, K i * ρ * (K i)ᴴ)
+    (htr : ∀ i, trace (K i) = 0) :
+    ChoiJamiolkowski.projectedChoiMatrix G.φ =
+      ChoiJamiolkowski.choiMatrix G.φ := by
+  set τ := ChoiJamiolkowski.choiMatrix G.φ
   set Ω := Matrix.omegaProj D
-  have hmv := choi_phi_mulVec_omega_eq_zero F htr
+  have hmv := choi_phi_mulVec_omega_eq_zero G K hK htr
   have hτΩ : τ * Ω = 0 := by
     change τ * Matrix.vecMulVec (Matrix.omegaVec D) (star (Matrix.omegaVec D)) = 0
     rw [Matrix.star_omegaVec, Matrix.mul_vecMulVec, hmv, Matrix.zero_vecMulVec]
@@ -114,8 +131,7 @@ private theorem projectedChoiMatrix_eq_choiMatrix_of_traceless
     change Matrix.vecMulVec (Matrix.omegaVec D) (star (Matrix.omegaVec D)) * τ = 0
     rw [Matrix.star_omegaVec, Matrix.vecMulVec_mul]
     have hτ_herm : τ.IsHermitian :=
-      (ChoiJamiolkowski.choiMatrix_of_kraus_posSemidef F.L
-        F.toGeneratorDecomp.φ (fun _ => rfl)).1
+      (ChoiJamiolkowski.choiMatrix_of_kraus_posSemidef K G.φ hK).1
     have : Matrix.omegaVec D ᵥ* τ = 0 := by
       calc Matrix.omegaVec D ᵥ* τ
           = Matrix.omegaVec D ᵥ* τᴴ := by rw [hτ_herm.eq]
@@ -130,24 +146,23 @@ private theorem projectedChoiMatrix_eq_choiMatrix_of_traceless
 
 /-! ### Main uniqueness theorems -/
 
-/--
-If two Lindblad forms induce the same generator and both Kraus families are
-traceless, then their CP parts agree.
-
-This is the Choi-projection uniqueness step in Wolf Proposition 7.4 (item 2). -/
-theorem generatorDecomp_traceless_unique_phi
-    (F F' : LindbladForm D)
-    (hL : F.toLinearMap = F'.toLinearMap)
-    (htr : F.HasTracelessKraus)
-    (htr' : F'.HasTracelessKraus) :
-    F.toGeneratorDecomp.φ = F'.toGeneratorDecomp.φ := by
+/-- If two generator decompositions induce the same generator and their chosen
+Kraus representations are traceless, then their completely positive parts
+agree. This is the Choi-projection step in Wolf Proposition 7.4(2). -/
+theorem generatorDecomp_traceless_unique_phi_of_kraus
+    (G G' : GeneratorDecomp D)
+    {r r' : ℕ}
+    (L : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (L' : Fin r' → Matrix (Fin D) (Fin D) ℂ)
+    (hK : ∀ ρ, G.φ ρ = ∑ i, L i * ρ * (L i)ᴴ)
+    (hK' : ∀ ρ, G'.φ ρ = ∑ i, L' i * ρ * (L' i)ᴴ)
+    (hG : G.toLinearMap = G'.toLinearMap)
+    (htr : ∀ i, trace (L i) = 0)
+    (htr' : ∀ i, trace (L' i) = 0) :
+    G.φ = G'.φ := by
   by_cases hD : D = 0
   · subst hD; exact Subsingleton.elim _ _
   · have : NeZero D := ⟨hD⟩
-    set G := F.toGeneratorDecomp
-    set G' := F'.toGeneratorDecomp
-    have hGL : G.toLinearMap = G'.toLinearMap := by
-      rw [← F.toLinearMap_eq_generatorDecomp, ← F'.toLinearMap_eq_generatorDecomp]; exact hL
     have hproj : ChoiJamiolkowski.projectedChoiMatrix G.φ =
         ChoiJamiolkowski.projectedChoiMatrix G'.φ := by
       have h1 : ChoiJamiolkowski.projectedChoiMatrix G.toLinearMap =
@@ -166,38 +181,54 @@ theorem generatorDecomp_traceless_unique_phi
           ChoiJamiolkowski.projectedChoiMatrix_mulLeft_eq_zero,
           ChoiJamiolkowski.projectedChoiMatrix_mulRight_eq_zero,
           sub_zero, sub_zero]
-      rw [← h1, ← h2, hGL]
-    have hc1 := projectedChoiMatrix_eq_choiMatrix_of_traceless F htr
-    have hc2 := projectedChoiMatrix_eq_choiMatrix_of_traceless F' htr'
+      rw [← h1, ← h2, hG]
+    have hc1 := projectedChoiMatrix_eq_choiMatrix_of_traceless G L hK htr
+    have hc2 := projectedChoiMatrix_eq_choiMatrix_of_traceless G' L' hK' htr'
     exact ChoiJamiolkowski.eq_of_choiMatrix_eq (by rw [← hc1, ← hc2, hproj])
 
-/--
-If two Lindblad forms induce the same generator and both Kraus families are
-traceless, then `κ' = κ + iλ·𝟙` for some `λ : ℝ`.
-
-This is the Hamiltonian uniqueness modulo global energy shift in Wolf Proposition 7.4
-(item 2). -/
-theorem generatorDecomp_traceless_unique_kappa_modPhase
+/-- If two Lindblad forms induce the same generator and both Kraus families are
+traceless, then their completely positive parts agree. -/
+theorem generatorDecomp_traceless_unique_phi
     (F F' : LindbladForm D)
     (hL : F.toLinearMap = F'.toLinearMap)
     (htr : F.HasTracelessKraus)
     (htr' : F'.HasTracelessKraus) :
+    F.toGeneratorDecomp.φ = F'.toGeneratorDecomp.φ := by
+  apply generatorDecomp_traceless_unique_phi_of_kraus (L := F.L) (L' := F'.L)
+  · intro ρ
+    rfl
+  · intro ρ
+    rfl
+  · rw [← F.toLinearMap_eq_generatorDecomp,
+      ← F'.toLinearMap_eq_generatorDecomp, hL]
+  · exact htr
+  · exact htr'
+
+/-- If two generator decompositions induce the same generator and their chosen
+Kraus representations are traceless, then `κ' = κ + iλ·𝟙` for some
+`λ : ℝ`. This is the drift-uniqueness step in Wolf Proposition 7.4(2). -/
+theorem generatorDecomp_traceless_unique_kappa_modPhase_of_kraus
+    (G G' : GeneratorDecomp D)
+    {r r' : ℕ}
+    (L : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (L' : Fin r' → Matrix (Fin D) (Fin D) ℂ)
+    (hK : ∀ ρ, G.φ ρ = ∑ i, L i * ρ * (L i)ᴴ)
+    (hK' : ∀ ρ, G'.φ ρ = ∑ i, L' i * ρ * (L' i)ᴴ)
+    (hG : G.toLinearMap = G'.toLinearMap)
+    (htr : ∀ i, trace (L i) = 0)
+    (htr' : ∀ i, trace (L' i) = 0) :
     ∃ l : ℝ,
-      F'.toGeneratorDecomp.κ =
-        F.toGeneratorDecomp.κ + (Complex.I * (l : ℂ)) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+      G'.κ = G.κ + (Complex.I * (l : ℂ)) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
   by_cases hD : D = 0
   · subst hD; exact ⟨0, Subsingleton.elim _ _⟩
   · have : NeZero D := ⟨hD⟩
-    set G := F.toGeneratorDecomp
-    set G' := F'.toGeneratorDecomp
-    have hφ := generatorDecomp_traceless_unique_phi F F' hL htr htr'
-    have hGL : G.toLinearMap = G'.toLinearMap := by
-      rw [← F.toLinearMap_eq_generatorDecomp, ← F'.toLinearMap_eq_generatorDecomp]; exact hL
+    have hφ := generatorDecomp_traceless_unique_phi_of_kraus
+      G G' L L' hK hK' hG htr htr'
     set Δ := G'.κ - G.κ
     -- Key: Δρ + ρΔ† = 0 for all ρ
     have hΔρ : ∀ ρ : Matrix (Fin D) (Fin D) ℂ, Δ * ρ + ρ * Δᴴ = 0 := by
       intro ρ
-      have h : G.toLinearMap ρ = G'.toLinearMap ρ := congrFun (congrArg _ hGL) ρ
+      have h : G.toLinearMap ρ = G'.toLinearMap ρ := congrFun (congrArg _ hG) ρ
       simp only [GeneratorDecomp.toLinearMap_apply] at h
       rw [hφ] at h
       suffices hsuff : Δ * ρ + ρ * Δᴴ =
@@ -253,6 +284,65 @@ theorem generatorDecomp_traceless_unique_kappa_modPhase
     refine ⟨d.im, ?_⟩
     have hGΔ : G'.κ = G.κ + Δ := by simp [Δ]
     rw [hGΔ, hΔ_eq, hd_val, Complex.I_mul_im, Complex.ofReal_re]
+
+/-- If two Lindblad forms induce the same generator and both Kraus families are
+traceless, then `κ' = κ + iλ·𝟙` for some `λ : ℝ`. -/
+theorem generatorDecomp_traceless_unique_kappa_modPhase
+    (F F' : LindbladForm D)
+    (hL : F.toLinearMap = F'.toLinearMap)
+    (htr : F.HasTracelessKraus)
+    (htr' : F'.HasTracelessKraus) :
+    ∃ l : ℝ,
+      F'.toGeneratorDecomp.κ =
+        F.toGeneratorDecomp.κ + (Complex.I * (l : ℂ)) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+  apply generatorDecomp_traceless_unique_kappa_modPhase_of_kraus
+    (L := F.L) (L' := F'.L)
+  · intro ρ
+    rfl
+  · intro ρ
+    rfl
+  · rw [← F.toLinearMap_eq_generatorDecomp,
+      ← F'.toLinearMap_eq_generatorDecomp, hL]
+  · exact htr
+  · exact htr'
+
+/-- **Wolf Proposition 7.4(2), freedom in representation of generators.**
+
+Suppose two pairs `(φ, κ)` and `(φ', κ')` define the same generator and
+the displayed families `L` and `L'` are traceless Kraus representations of
+`φ` and `φ'`. Then `φ = φ'`, `κ = κ' + iλ·𝟙` for some real `λ`, and,
+after the smaller Kraus family is padded with zeros, there is a unitary matrix
+with `L'ᵢ = ∑ⱼ Uᵢⱼ Lⱼ`.
+
+The signs, primed-to-unprimed unitary orientation, and zero padding follow
+`Notes/WolfNoteTexSource/ch07_semigroup_structure.tex`, lines 223–236. -/
+theorem generatorDecomp_traceless_representation_freedom
+    (G G' : GeneratorDecomp D)
+    {r r' : ℕ}
+    (L : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (L' : Fin r' → Matrix (Fin D) (Fin D) ℂ)
+    (hK : ∀ ρ, G.φ ρ = ∑ i, L i * ρ * (L i)ᴴ)
+    (hK' : ∀ ρ, G'.φ ρ = ∑ i, L' i * ρ * (L' i)ᴴ)
+    (hG : G.toLinearMap = G'.toLinearMap)
+    (htr : ∀ i, trace (L i) = 0)
+    (htr' : ∀ i, trace (L' i) = 0) :
+    G.φ = G'.φ ∧
+      (∃ l : ℝ,
+        G.κ = G'.κ + (Complex.I * (l : ℂ)) • (1 : Matrix (Fin D) (Fin D) ℂ)) ∧
+      ∃ U : Matrix.unitaryGroup (Fin (max r r')) ℂ,
+        ∀ i, Kraus.zeroPad L' i =
+          ∑ j, (U : Matrix (Fin (max r r')) (Fin (max r r')) ℂ) i j •
+            Kraus.zeroPad L j := by
+  have hφ := generatorDecomp_traceless_unique_phi_of_kraus
+    G G' L L' hK hK' hG htr htr'
+  have hκ := generatorDecomp_traceless_unique_kappa_modPhase_of_kraus
+    G' G L' L hK' hK hG.symm htr' htr
+  have hmap : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ∑ i, L' i * X * (L' i)ᴴ = ∑ j, L j * X * (L j)ᴴ := by
+    intro X
+    rw [← hK' X, ← hK X, hφ]
+  have hU := (kraus_unitary_freedom_iff_of_zeroPad L' L).mp hmap
+  exact ⟨hφ, hκ, hU⟩
 
 /-- Combined uniqueness statement for traceless Lindblad decompositions. -/
 theorem generatorDecomp_traceless_unique

--- a/blueprint/src/chapter/ch02_channels_rectangular_kraus_maps.tex
+++ b/blueprint/src/chapter/ch02_channels_rectangular_kraus_maps.tex
@@ -501,7 +501,11 @@ the input factor is written $\tr_B$.
     \label{thm:kraus_rect_freedom}
     \lean{kraus_isometry_freedom_iff,
         kraus_unitary_freedom_iff,
+        kraus_unitary_freedom_iff_of_zeroPad,
         kraus_rectangular_freedom,
+        Kraus.zeroPad,
+        Kraus.zeroPad_castLE,
+        Kraus.sum_zeroPad,
         kraus_same_map_of_isometry_combination,
         kraus_dual_eq_of_map_eq,
         kraus_conjTranspose_mul_eq_of_map_eq}

--- a/blueprint/src/chapter/ch11_semigroup_dynamics_and_gksl.tex
+++ b/blueprint/src/chapter/ch11_semigroup_dynamics_and_gksl.tex
@@ -719,27 +719,36 @@ which shows that such generators have the standard Lindblad form.
 \begin{theorem}[Traceless Kraus operators exist]
     \label{thm:exists_traceless_kraus_shift}
     \lean{exists_traceless_kraus_shift}\leanok
-    Assume $d > 0$. Given any Kraus operators $\{K_j\}$, there exist
-    $c_j \in \C$ such that $K_j' = K_j+c_j\Id$ is traceless.
-    This is part of \cite[Proposition~7.4]{Wolf2012Quantum}.
+    Assume $d > 0$. Given any Kraus operators $\{L_i\}$, there exist
+    $c_i \in \C$ such that $L_i' = L_i+c_i\Id$ is traceless.
+    This is the final assertion of \cite[Proposition~7.4(1)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Set $c_j = -\tr(K_j)/d$.
+    Set $c_i = -\tr(L_i)/d$.
 \end{proof}
 
 \begin{theorem}[Shift invariance of generators]
     \label{thm:generator_shift_invariance}
     \lean{generator_shift_invariance}\leanok
-    If $K_j' = K_j+c_j\Id$ and $\kappa'$ is adjusted per
-    \cite[Equation~(7.19)]{Wolf2012Quantum},
-    then $(\phi',\kappa')$ and $(\phi,\kappa)$ define the same generator.
+    Suppose $\phi(\rho)=\sum_iL_i\rho L_i^\dagger$. If
+    \begin{align}
+        L_i'&=L_i+c_i\Id, \label{eq:semigroup_kraus_shift}\\
+        \kappa'&=\kappa+\sum_i\overline{c_i}L_i+i\lambda\Id
+            +\frac12\sum_i|c_i|^2\Id,
+            \label{eq:semigroup_drift_shift}
+    \end{align}
+    where $\phi'(\rho)=\sum_iL_i'\rho(L_i')^\dagger$, then
+    $(\phi',\kappa')$ and $(\phi,\kappa)$ define the same generator.
+    This is \cite[Proposition~7.4(1), Equations~(7.18)--(7.19)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Direct algebraic expansion.
+    Direct expansion of~(\ref{eq:semigroup_kraus_shift}) and
+    (\ref{eq:semigroup_drift_shift}) cancels the linear, quadratic, and
+    purely imaginary scalar terms.
 \end{proof}
 
 \subsection{Uniqueness of the traceless Lindblad form}
@@ -791,21 +800,43 @@ which shows that such generators have the standard Lindblad form.
     and skew-Hermiticity forces $c=i\lambda$ for some $\lambda\in\R$.
 \end{proof}
 
-\begin{theorem}[Combined uniqueness of the traceless Lindblad form]
+\begin{theorem}[Freedom between traceless representations]
     \label{thm:generatorDecomp_traceless_unique}
-    \lean{generatorDecomp_traceless_unique}\leanok
-    \uses{thm:generatorDecomp_traceless_unique_phi,
-        thm:generatorDecomp_traceless_unique_kappa}
-    If two Lindblad forms $F,F'$ induce the same generator and
-    both have traceless Kraus operators, then $\phi=\phi'$ and
-    $\kappa'=\kappa+i\lambda\,\Id$ for some $\lambda\in\R$.
+    \lean{generatorDecomp_traceless_representation_freedom,
+        generatorDecomp_traceless_unique_phi_of_kraus,
+        generatorDecomp_traceless_unique_kappa_modPhase_of_kraus,
+        generatorDecomp_traceless_unique}\leanok
+    \uses{def:generator_decomp, thm:kraus_rect_freedom}
+    Suppose $(\phi,\kappa)$ and $(\phi',\kappa')$ represent the same
+    generator, and let $\{L_i\}_{i=0}^{r-1}$ and
+    $\{L_i'\}_{i=0}^{r'-1}$ be traceless Kraus representations of
+    $\phi$ and $\phi'$, respectively. Then
+    \begin{align}
+        \phi&=\phi', \notag\\
+        \kappa&=\kappa'+i\lambda\Id \label{eq:semigroup_drift_unique}
+    \end{align}
+    for some $\lambda\in\R$. Put $N=\max\{r,r'\}$ and pad the smaller
+    family with zero operators to obtain
+    $\{\widetilde L_j\}_{j=0}^{N-1}$ and
+    $\{\widetilde L_i'\}_{i=0}^{N-1}$. There is a unitary
+    $U\in M_N(\C)$ such that
+    \begin{align}
+        \widetilde L_i'=\sum_{j=0}^{N-1}U_{ij}\widetilde L_j
+        \label{eq:semigroup_kraus_unitary}
+    \end{align}
+    for every $i$. This is \cite[Proposition~7.4(2)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:generatorDecomp_traceless_unique_phi,
-        thm:generatorDecomp_traceless_unique_kappa}
-    Combine Theorems~\ref{thm:generatorDecomp_traceless_unique_phi}
-    and~\ref{thm:generatorDecomp_traceless_unique_kappa}.
+    \uses{thm:kraus_rect_freedom}
+    Tracelessness makes the Choi matrices of the CP parts vanish on the
+    maximally entangled vector. Projecting the Choi matrix of the common
+    generator onto its orthogonal complement therefore gives $\phi=\phi'$.
+    The remaining generator equality and matrix units show that
+    $\kappa-\kappa'$ is a purely imaginary scalar matrix, proving
+    (\ref{eq:semigroup_drift_unique}). Theorem~\ref{thm:kraus_rect_freedom}
+    applied to the zero-padded Kraus families gives
+    (\ref{eq:semigroup_kraus_unitary}).
 \end{proof}
 
 \subsection{Trace-annihilation and trace preservation}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -2061,12 +2061,9 @@ for every submultiplicative norm from the Duhamel identity, while
 Here Wolf's “any norm” refers to the operator norm induced by the chosen norm on
 the state space, as defined immediately before Proposition 7.1.
 
-The complete named-environment audit therefore classifies exactly four Chapter
+The complete named-environment audit therefore classifies exactly three Chapter
 7 source environments as partial rather than exact:
 
-- Proposition 7.4, “Freedom in representation of generators”: the shift,
-  tracelessness, uniqueness, and Kraus-freedom ingredients are formalized, but
-  not assembled under one source-facing proposition (partial-packaging).
 - Theorem 7.1, “Generators for semigroups of quantum channels”: the GKSL and
   Lindblad forms are proved, but the public Kossakowski package does not retain
   the exact fixed basis of the traceless subspace used in Equation (7.23)
@@ -2078,9 +2075,18 @@ The complete named-environment audit therefore classifies exactly four Chapter
   yield non-reducibility, but the source's faithful stationary state and global
   relaxation conclusion are not packaged (partial-packaging).
 
-Propositions 7.2 and 7.3 are exact completions. The `\leanok` markers in the
-semigroup Blueprint certify individual Lean declarations; they must not be read
-as exact-coverage markers for a larger containing Wolf environment.
+Proposition 7.4 is an exact completion. The shift formula and traceless choice
+are `generator_shift_invariance` and `exists_traceless_kraus_shift`.
+`generatorDecomp_traceless_representation_freedom` packages the second clause
+for arbitrary generator decompositions: it returns equality of the CP parts,
+the source-oriented equation $\kappa=\kappa'+i\lambda\Id$, and a unitary
+relation $L_i'=\sum_jU_{ij}L_j$ after both families are padded with zeros to
+the larger cardinality.
+
+Propositions 7.1--7.4 and Corollary 7.1 are exact completions. The `\leanok`
+markers in the semigroup Blueprint certify individual Lean declarations; they
+must not be read as exact-coverage markers for a larger containing Wolf
+environment.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds reusable zero padding for finite Kraus families and the arbitrary-cardinality unitary freedom form of Wolf Theorem 2.1(4).
- Packages Wolf Proposition 7.4(2) for arbitrary generator decompositions with chosen traceless Kraus representations.
- Preserves the source equations `φ = φ′`, `κ = κ′ + iλ𝟙`, and `L′ᵢ = ∑ⱼ Uᵢⱼ Lⱼ`, with both families padded to `max r r′` and with the primed-to-unprimed unitary orientation.
- Uses the existing projected-Choi uniqueness argument, scalar-drift theorem, and Kraus unitary-freedom theorem; no independent proof route is introduced.
- Synchronizes the Chapter 2 and Chapter 11 Blueprint entries and records Proposition 7.4 as an exact Chapter 7 completion.

## Verification

- `lake build QICLean.Channel.Semigroup.LindbladForm.GKSLTheorem QICLean.Channel.Semigroup.LindbladForm.Uniqueness -q --log-level=info`
- `lake build -q --log-level=info`
- `lake exe lint_style --github`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- changed-declaration Blueprint coverage check
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `chktex` on both changed Blueprint chapters
- `texra-blueprint paper-gaps check`
- `leanblueprint pdf`
- `texra-blueprint web`
- browser render test: 30 pages, 31,215 typeset nodes
- changed-Lean-file blocker scan and `git diff --check`

Closes #481