### PR TITLE
feat(semigroup): add basis-level Kossakowski form

### DIFF
--- a/QICLean/Channel/Semigroup/KossakowskiForm.lean
+++ b/QICLean/Channel/Semigroup/KossakowskiForm.lean
@@ -7,20 +7,23 @@ import QICLean.Algebra.MatrixOperatorSpace
 import QICLean.Channel.Semigroup.LindbladForm
 
 /-!
-# Kossakowski Matrix Form — Wolf Theorem 7.1, Form (ii)
+# Kossakowski Matrix Form — Wolf Theorem 7.1, Equation (7.23)
 
 This file defines the Kossakowski matrix form of a quantum dynamical semigroup
 generator (Wolf Equation 7.23) and proves its equivalence with the Lindblad form.
 
 ## Main definitions
 
-* `KossakowskiForm` — the Kossakowski matrix form:
-  `L(ρ) = i[ρ,H] + ½ Σ_{k,l} C_{kl} ([F_k, ρ F_l†] + [F_k ρ, F_l†])`
-  where `C ≥ 0` is the Kossakowski matrix.
+* `TracelessBasisKossakowskiForm` — Wolf's Kossakowski data in a fixed basis
+  of the traceless matrices, with a positive semidefinite Kossakowski matrix.
+* `KossakowskiForm` — the algebraic variant for an arbitrary finite family:
+  `L(ρ) = i[ρ,H] + ½ Σ_{k,l} C_{lk} ([F_k, ρ F_l†] + [F_k ρ, F_l†])`.
 
 ## Main results
 
-* `kossakowski_iff_lindblad` — **Theorem 7.1 (ii ↔ i)**: Kossakowski ↔ Lindblad form.
+* `gksl_iff_tracelessBasisKossakowskiForm` — Wolf's Theorem 7.1,
+  Equation (7.23), at the source-facing basis-level boundary.
+* `kossakowski_iff_lindblad` — algebraic Kossakowski ↔ Lindblad conversion.
 
 ## References
 
@@ -36,10 +39,49 @@ variable {D : ℕ}
 
 section KossakowskiForms
 
-/-! ## Wolf Theorem 7.1, Form (ii): Kossakowski matrix form (Equation 7.23) -/
+/-! ## Wolf Theorem 7.1: Kossakowski matrix form (Equation 7.23) -/
+
+/-- The complex linear subspace of traceless matrices in `M_D(ℂ)`.
+
+This is the space spanned by `F₁, …, F_{D²-1}` in Wolf, Theorem 7.1,
+Equation (7.23). -/
+def tracelessMatrixSubspace (D : ℕ) :
+    Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+  LinearMap.ker (Matrix.traceLinearMap (Fin D) ℂ ℂ)
+
+/-- The space of traceless `D × D` matrices has dimension `D² - 1`, as used
+in Wolf, Theorem 7.1, Equation (7.23). -/
+theorem finrank_tracelessMatrixSubspace :
+    Module.finrank ℂ (tracelessMatrixSubspace D) = D ^ 2 - 1 := by
+  by_cases hD : D = 0
+  · subst D
+    simpa using
+      (Module.finrank_eq_zero_of_subsingleton ℂ (tracelessMatrixSubspace 0))
+  · let _ : NeZero D := ⟨hD⟩
+    let τ := Matrix.traceLinearMap (Fin D) ℂ ℂ
+    have hfin_mat : Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) = D * D := by
+      simp [Module.finrank_matrix, Fintype.card_fin]
+    have hD_ne : (D : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr hD
+    have htrI : τ (1 : Matrix (Fin D) (Fin D) ℂ) = (D : ℂ) := by
+      change Matrix.trace (1 : Matrix (Fin D) (Fin D) ℂ) = _
+      simp [Matrix.trace_one, Fintype.card_fin]
+    have h_rn := τ.finrank_range_add_finrank_ker
+    rw [hfin_mat] at h_rn
+    have h_range : Module.finrank ℂ (LinearMap.range τ) = 1 := by
+      have hrange_top : LinearMap.range τ = ⊤ := by
+        rw [LinearMap.range_eq_top]
+        intro c
+        refine ⟨(c / (D : ℂ)) • (1 : Matrix (Fin D) (Fin D) ℂ), ?_⟩
+        rw [map_smul, htrI, smul_eq_mul, div_mul_cancel₀ c hD_ne]
+      rw [hrange_top, finrank_top]
+      exact Module.finrank_self ℂ
+    rw [h_range] at h_rn
+    change Module.finrank ℂ (LinearMap.ker τ) = D ^ 2 - 1
+    simp only [Nat.pow_two]
+    omega
 
 /-- The **Kossakowski form** of a generator (Wolf Equation 7.23):
-`L(ρ) = i[ρ,H] + ½ Σ_{k,l} C_{kl} ([F_k, ρ F_l†] + [F_k ρ, F_l†])`
+`L(ρ) = i[ρ,H] + ½ Σ_{k,l} C_{lk} ([F_k, ρ F_l†] + [F_k ρ, F_l†])`
 where `C ≥ 0` is the Kossakowski matrix and `F` is the chosen family of
 matrices. In the paper this family is a basis of traceless matrices; the
 current structure states only the data used in the algebraic conversion to
@@ -57,6 +99,32 @@ structure KossakowskiForm (D : ℕ) where
   H_hermitian : H.IsHermitian
   /-- PSD of C. -/
   C_posSemidef : C.PosSemidef
+
+/-- The source-facing Kossakowski data of Wolf, Theorem 7.1, Equation (7.23).
+The family `F₁, …, F_{D²-1}` is a basis of the traceless matrices, and
+`C` is the positive semidefinite Kossakowski matrix in that fixed basis. -/
+structure TracelessBasisKossakowskiForm (D : ℕ) where
+  /-- The Hamiltonian `H`. -/
+  H : Matrix (Fin D) (Fin D) ℂ
+  /-- The fixed basis `F₁, …, F_{D²-1}` of the traceless matrices. -/
+  F : Module.Basis (Fin (D ^ 2 - 1)) ℂ (tracelessMatrixSubspace D)
+  /-- The Kossakowski matrix `C` in the basis `F`. -/
+  C : Matrix (Fin (D ^ 2 - 1)) (Fin (D ^ 2 - 1)) ℂ
+  /-- The Hamiltonian is Hermitian. -/
+  H_hermitian : H.IsHermitian
+  /-- The Kossakowski matrix is positive semidefinite. -/
+  C_posSemidef : C.PosSemidef
+
+/-- Forgetting that `F` is a basis of traceless matrices gives the algebraic
+Kossakowski form with the same `H`, `F`, and `C`. -/
+def TracelessBasisKossakowskiForm.toKossakowskiForm
+    (K : TracelessBasisKossakowskiForm D) : KossakowskiForm D where
+  n := D ^ 2 - 1
+  H := K.H
+  F := fun k ↦ K.F k
+  C := K.C
+  H_hermitian := K.H_hermitian
+  C_posSemidef := K.C_posSemidef
 
 /-- A single summand in the dissipative part of a Kossakowski form. -/
 private def kossakowskiTerm (K : KossakowskiForm D) (k l : Fin K.n)
@@ -116,6 +184,12 @@ def KossakowskiForm.toLinearMap (K : KossakowskiForm D) :
     congr 1
     congr 1 <;> ring_nf
 
+/-- The linear map in Wolf's basis-level Kossakowski form (Equation (7.23)). -/
+def TracelessBasisKossakowskiForm.toLinearMap
+    (K : TracelessBasisKossakowskiForm D) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+  K.toKossakowskiForm.toLinearMap
+
 /-! ### Auxiliary lemmas for Kossakowski ↔ Lindblad conversion -/
 
 /-- The dissipator equals ½ of the Kossakowski commutator sum
@@ -135,11 +209,11 @@ private lemma dissipator_eq_half_kossakowski
 
 /-- Bilinear sum identity: `Σⱼ (Σₖ B_{jk}•Fₖ) * M * (Σₖ B_{jk}•Fₖ)†`
 equals `Σₖₗ (B†B)_{lk} • (Fₖ * M * Fₗ†)`. Used in Kossakowski ↔ Lindblad. -/
-private lemma kraus_sum_eq_double_sum {n : ℕ}
-    (B : Matrix (Fin n) (Fin n) ℂ)
+private lemma kraus_sum_eq_double_sum {r n : ℕ}
+    (B : Matrix (Fin r) (Fin n) ℂ)
     (F : Fin n → Matrix (Fin D) (Fin D) ℂ)
     (M : Matrix (Fin D) (Fin D) ℂ) :
-    ∑ j : Fin n, (∑ k, B j k • F k) * M * (∑ k, B j k • F k)ᴴ =
+    ∑ j : Fin r, (∑ k, B j k • F k) * M * (∑ k, B j k • F k)ᴴ =
     ∑ k : Fin n, ∑ l : Fin n, (Bᴴ * B) l k • (F k * M * (F l)ᴴ) := by
   simp_rw [conjTranspose_sum, Matrix.conjTranspose_smul, Complex.star_def]
   simp_rw [Finset.sum_mul, Finset.mul_sum, smul_mul_assoc, mul_smul_comm, smul_smul,
@@ -152,10 +226,10 @@ private lemma kraus_sum_eq_double_sum {n : ℕ}
   simp [conjTranspose_apply, mul_apply, mul_comm]
 
 /-- Adjoint variant: `Σⱼ Lⱼ†Lⱼ = Σₗ Σₖ (B†B)_{lk} • (Fₗ†Fₖ)`. -/
-private lemma adj_kraus_sum_eq_double_sum {n : ℕ}
-    (B : Matrix (Fin n) (Fin n) ℂ)
+private lemma adj_kraus_sum_eq_double_sum {r n : ℕ}
+    (B : Matrix (Fin r) (Fin n) ℂ)
     (F : Fin n → Matrix (Fin D) (Fin D) ℂ) :
-    ∑ j : Fin n, (∑ k, B j k • F k)ᴴ * (∑ k, B j k • F k) =
+    ∑ j : Fin r, (∑ k, B j k • F k)ᴴ * (∑ k, B j k • F k) =
     ∑ l : Fin n, ∑ k : Fin n, (Bᴴ * B) l k • ((F l)ᴴ * F k) := by
   simp_rw [conjTranspose_sum, Matrix.conjTranspose_smul, Complex.star_def]
   simp_rw [Finset.sum_mul, Finset.mul_sum, smul_mul_assoc, mul_smul_comm, smul_smul]
@@ -164,6 +238,42 @@ private lemma adj_kraus_sum_eq_double_sum {n : ℕ}
   rw [Finset.sum_comm]
   apply Finset.sum_congr rfl; intro k _
   rw [← Finset.sum_smul]; congr 1
+
+/-- A factorization `C = BᴴB` converts a Kossakowski form into the
+corresponding Lindblad family `Lⱼ = ∑ₖ Bⱼₖ Fₖ`. -/
+private theorem KossakowskiForm.toLinearMap_eq_lindblad_of_factor
+    {r : ℕ} (K : KossakowskiForm D)
+    (B : Matrix (Fin r) (Fin K.n) ℂ)
+    (hB : K.C = Bᴴ * B) :
+    K.toLinearMap =
+      (LindbladForm.mk r K.H (fun j ↦ ∑ k, B j k • K.F k) K.H_hermitian).toLinearMap := by
+  ext1 ρ
+  simp only [KossakowskiForm.toLinearMap, LindbladForm.toLinearMap,
+    kossakowskiDissipator, kossakowskiTerm, LinearMap.coe_mk, AddHom.coe_mk]
+  congr 1
+  simp_rw [dissipator_eq_half_kossakowski]
+  rw [← Finset.smul_sum]
+  congr 1
+  have hLML : ∀ N : Matrix (Fin D) (Fin D) ℂ,
+      ∑ j : Fin r, (∑ k, B j k • K.F k) * N * (∑ k, B j k • K.F k)ᴴ =
+      ∑ k, ∑ l, K.C l k • (K.F k * N * (K.F l)ᴴ) :=
+    fun N ↦ by
+      rw [kraus_sum_eq_double_sum]
+      simp_rw [hB]
+  have hLtL : ∑ j : Fin r, (∑ k, B j k • K.F k)ᴴ * (∑ k, B j k • K.F k) =
+      ∑ k, ∑ l, K.C l k • ((K.F l)ᴴ * K.F k) := by
+    rw [adj_kraus_sum_eq_double_sum, Finset.sum_comm]
+    simp_rw [hB]
+  symm
+  simp_rw [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+  simp_rw [hLML]
+  rw [← Finset.sum_mul]
+  simp_rw [mul_assoc ρ]
+  rw [← Finset.mul_sum]
+  rw [hLtL]
+  simp_rw [Finset.sum_mul, Finset.mul_sum, smul_mul_assoc, mul_smul_comm]
+  simp_rw [← Finset.sum_sub_distrib, ← Finset.sum_add_distrib,
+    ← smul_sub, ← smul_add]
 
 /-- The Kossakowski form is equivalent to the Lindblad form:
 diagonalizing `C = M†M` converts between the two.
@@ -187,45 +297,7 @@ theorem kossakowski_iff_lindblad
     -- Define Lindblad operators: `Lⱼ = Σₖ B_{jk} • Fₖ`
     refine ⟨⟨KF.n, KF.H, fun j => ∑ k, B j k • KF.F k, KF.H_hermitian⟩, ?_⟩
     rw [hKF]
-    -- Show the linear maps agree pointwise.
-    ext1 ρ
-    simp only [KossakowskiForm.toLinearMap, LindbladForm.toLinearMap,
-      kossakowskiDissipator, kossakowskiTerm, LinearMap.coe_mk, AddHom.coe_mk]
-    -- Hamiltonian parts are identical
-    congr 1
-    -- Dissipative parts: rewrite Lindblad using half-Kossakowski form
-    simp_rw [dissipator_eq_half_kossakowski]
-    rw [← Finset.smul_sum]
-    congr 1
-    -- Use the bilinear sum identities with C = B†B
-    have hLML : ∀ N : Matrix (Fin D) (Fin D) ℂ,
-        ∑ j : Fin KF.n, (∑ k, B j k • KF.F k) * N * (∑ k, B j k • KF.F k)ᴴ =
-        ∑ k, ∑ l, KF.C l k • (KF.F k * N * (KF.F l)ᴴ) :=
-      fun N => by rw [kraus_sum_eq_double_sum]; simp_rw [hB]
-    have hLtL : ∑ j : Fin KF.n, (∑ k, B j k • KF.F k)ᴴ * (∑ k, B j k • KF.F k) =
-        ∑ k, ∑ l, KF.C l k • ((KF.F l)ᴴ * KF.F k) := by
-      rw [adj_kraus_sum_eq_double_sum, Finset.sum_comm]; simp_rw [hB]
-    -- Convert Lindblad form (RHS) → Kossakowski form (LHS)
-    symm
-    -- Distribute the single sum over +/-
-    simp_rw [Finset.sum_add_distrib, Finset.sum_sub_distrib]
-    -- Convert all L_j * N * L_j† terms to double sums
-    simp_rw [hLML]
-    -- Factor L†L*ρ: Σ_j (L†L)*ρ = (Σ_j L†L)*ρ
-    rw [← Finset.sum_mul]
-    -- Fix associativity: ρ*L†*L → ρ*(L†*L)
-    simp_rw [mul_assoc ρ]
-    -- Factor ρ*L†L: Σ_j ρ*(L†L) = ρ*(Σ_j L†L)
-    rw [← Finset.mul_sum]
-    -- Apply L†L factorization
-    rw [hLtL]
-    -- Distribute (Σ C•(F†F))*ρ and ρ*(Σ C•(F†F)) into double sums
-    simp_rw [Finset.sum_mul, Finset.mul_sum,
-      smul_mul_assoc, mul_smul_comm]
-    -- Recombine separate double sums into one
-    simp_rw [← Finset.sum_sub_distrib,
-      ← Finset.sum_add_distrib,
-      ← smul_sub, ← smul_add]
+    exact KF.toLinearMap_eq_lindblad_of_factor B hB
   · -- Backward: Lindblad → Kossakowski (set C = 𝟙, F_k = L_k)
     rintro ⟨F, hF⟩
     refine ⟨⟨F.r, F.H, F.L, 1, F.H_hermitian,
@@ -248,6 +320,68 @@ theorem kossakowski_iff_lindblad
     intro k _
     symm
     simp [kossakowskiTerm, Matrix.one_apply, Finset.sum_add_distrib]
+
+/-- A linear map has Wolf's basis-level Kossakowski form (Theorem 7.1,
+Equation (7.23)) if and only if it has Lindblad form (Equations (7.21)--(7.22)).
+
+The reverse implication follows Wolf's proof: choose traceless Lindblad
+operators, expand `Lⱼ = ∑ₖ Mⱼₖ Fₖ` in a basis of the traceless matrices,
+and take the Kossakowski matrix `C = MᴴM`. -/
+theorem tracelessBasisKossakowski_iff_lindbladForm
+    (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    (∃ K : TracelessBasisKossakowskiForm D, L = K.toLinearMap) ↔
+    (∃ F : LindbladForm D, L = F.toLinearMap) := by
+  constructor
+  · rintro ⟨K, hK⟩
+    exact (kossakowski_iff_lindblad L).mp ⟨K.toKossakowskiForm, hK⟩
+  · rintro ⟨G, hG⟩
+    obtain ⟨G', hG', htr⟩ := G.exists_traceless
+    let b : Module.Basis (Fin (D ^ 2 - 1)) ℂ (tracelessMatrixSubspace D) :=
+      Module.finBasisOfFinrankEq ℂ (tracelessMatrixSubspace D)
+        finrank_tracelessMatrixSubspace
+    let v : Fin G'.r → tracelessMatrixSubspace D := fun j ↦
+      ⟨G'.L j, by
+        change trace (G'.L j) = 0
+        exact htr j⟩
+    let M : Matrix (Fin G'.r) (Fin (D ^ 2 - 1)) ℂ :=
+      fun j k ↦ b.repr (v j) k
+    have h_expand : ∀ j : Fin G'.r,
+        G'.L j = ∑ k, M j k • (b k : Matrix (Fin D) (Fin D) ℂ) := by
+      intro j
+      have h := congrArg (tracelessMatrixSubspace D).subtype
+        (b.sum_repr (v j)).symm
+      simpa only [M, v, map_sum, map_smul, Submodule.subtype_apply] using h
+    let K : TracelessBasisKossakowskiForm D :=
+      ⟨G'.H, b, Mᴴ * M, G'.H_hermitian,
+        Matrix.posSemidef_conjTranspose_mul_self M⟩
+    refine ⟨K, ?_⟩
+    let F : LindbladForm D :=
+      ⟨G'.r, G'.H, fun j ↦ ∑ k, M j k • (b k : Matrix (Fin D) (Fin D) ℂ),
+        G'.H_hermitian⟩
+    have hF : F.toLinearMap = G'.toLinearMap := by
+      ext1 ρ
+      simp only [F, LindbladForm.toLinearMap, LinearMap.coe_mk, AddHom.coe_mk]
+      congr 1
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [← h_expand j]
+    have hfactor : K.toLinearMap = F.toLinearMap := by
+      exact K.toKossakowskiForm.toLinearMap_eq_lindblad_of_factor M rfl
+    calc
+      L = G.toLinearMap := hG
+      _ = G'.toLinearMap := hG'.symm
+      _ = F.toLinearMap := hF.symm
+      _ = K.toLinearMap := hfactor.symm
+
+/-- **Wolf Theorem 7.1, Equation (7.23).** A linear map generates a semigroup
+of quantum channels if and only if it has a
+Kossakowski representation in a fixed basis of the traceless matrices with a
+positive semidefinite Kossakowski matrix. -/
+theorem gksl_iff_tracelessBasisKossakowskiForm
+    (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    IsGKSLGenerator L ↔
+      ∃ K : TracelessBasisKossakowskiForm D, L = K.toLinearMap := by
+  rw [gksl_iff_lindbladForm, tracelessBasisKossakowski_iff_lindbladForm]
 
 end KossakowskiForms
 

--- a/QICLean/Channel/Semigroup/LindbladForm/Basic.lean
+++ b/QICLean/Channel/Semigroup/LindbladForm/Basic.lean
@@ -15,6 +15,7 @@ and proves basic properties.
 
 * `LindbladForm` — the standard GKSL/Lindblad form
   `L(ρ) = i[ρ, H] + Σⱼ (Lⱼ ρ Lⱼ† - ½{Lⱼ†Lⱼ, ρ})`.
+* `LindbladForm.HasTracelessKraus` — every Lindblad operator has trace zero.
 
 ## Main results
 
@@ -47,6 +48,14 @@ structure LindbladForm (D : ℕ) where
   L : Fin r → Matrix (Fin D) (Fin D) ℂ
   /-- The Hamiltonian is Hermitian. -/
   H_hermitian : H.IsHermitian
+
+/-- A Lindblad form has **traceless Lindblad operators** when
+`trace (Lⱼ) = 0` for every operator in the family.
+
+This is the normalization used in Wolf, Proposition 7.4 and Theorem 7.1,
+Equation (7.23). -/
+def LindbladForm.HasTracelessKraus (F : LindbladForm D) : Prop :=
+  ∀ j : Fin F.r, trace (F.L j) = 0
 
 /-- The dissipative part of a Lindblad form for a single operator:
 `Lⱼ ρ Lⱼ† - ½ Lⱼ†Lⱼ ρ - ½ ρ Lⱼ†Lⱼ`. -/

--- a/QICLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
+++ b/QICLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
@@ -16,6 +16,7 @@ This file proves the GKSL theorem characterizing generators of CPTP semigroups.
 
 * `generator_shift_invariance` — **Proposition 7.4** (Kraus shift freedom).
 * `exists_traceless_kraus_shift` — **Proposition 7.4(1)** (traceless choice).
+* `LindbladForm.exists_traceless` — an equivalent traceless Lindblad form exists.
 * `IsGKSLGenerator` — definition.
 * `gksl_iff_lindbladForm` — **Theorem 7.1**: GKSL ↔ Lindblad form.
 -/
@@ -99,6 +100,135 @@ theorem exists_traceless_kraus_shift
   have hD : (D : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne D)
   rw [div_mul_cancel₀ _ hD]
   abel
+
+/-- Shifting the Lindblad operators as in Wolf, Proposition 7.4,
+Equations (7.18)--(7.19), gives an equivalent Lindblad form with traceless
+operators. If the original operators lie in a linear subspace containing the
+identity, then the shifted operators remain in that subspace. -/
+theorem LindbladForm.exists_traceless_in_submodule
+    (G : LindbladForm D)
+    (V : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (hone : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ V)
+    (hmem : ∀ j : Fin G.r, G.L j ∈ V)
+    [NeZero D] :
+    ∃ G' : LindbladForm D,
+      G'.toLinearMap = G.toLinearMap ∧
+      G'.HasTracelessKraus ∧
+      ∀ j : Fin G'.r, G'.L j ∈ V := by
+  obtain ⟨c, hc⟩ := exists_traceless_kraus_shift G.L
+  set L' : Fin G.r → Matrix (Fin D) (Fin D) ℂ :=
+    fun j ↦ G.L j + c j • (1 : Matrix (Fin D) (Fin D) ℂ) with hL'_def
+  set Δ : Matrix (Fin D) (Fin D) ℂ := ∑ j : Fin G.r,
+    (starRingEnd ℂ (c j) • G.L j - c j • (G.L j)ᴴ) with hΔ_def
+  set H' : Matrix (Fin D) (Fin D) ℂ :=
+    G.H - (Complex.I / 2) • Δ with hH'_def
+  have hH'_herm : H'.IsHermitian := by
+    rw [hH'_def]
+    apply Matrix.IsHermitian.sub G.H_hermitian
+    rw [Matrix.IsHermitian, conjTranspose_smul]
+    have hstar_I2 : star (Complex.I / 2 : ℂ) = -(Complex.I / 2) := by
+      simp [Complex.conj_I]
+      ring
+    rw [hstar_I2, hΔ_def, conjTranspose_sum]
+    simp_rw [conjTranspose_sub, conjTranspose_smul, conjTranspose_conjTranspose,
+      RCLike.star_def, Complex.conj_conj]
+    rw [neg_smul, ← smul_neg]
+    congr 1
+    rw [show -(∑ x, (c x • (G.L x)ᴴ - starRingEnd ℂ (c x) • G.L x)) =
+      ∑ x, (starRingEnd ℂ (c x) • G.L x - c x • (G.L x)ᴴ) from by
+        rw [← Finset.sum_neg_distrib]
+        apply Finset.sum_congr rfl
+        intro j _
+        simp only [neg_sub]]
+  refine ⟨⟨G.r, H', L', hH'_herm⟩, ?_, ?_, ?_⟩
+  · rw [LindbladForm.toLinearMap_eq_generatorDecomp,
+      LindbladForm.toLinearMap_eq_generatorDecomp]
+    set κ_old : Matrix (Fin D) (Fin D) ℂ := G.toGeneratorDecomp.κ
+    have hshift := generator_shift_invariance G.L κ_old c 0
+    simp only [Complex.ofReal_zero, mul_zero, zero_smul, add_zero] at hshift
+    set κ_shift : Matrix (Fin D) (Fin D) ℂ :=
+      κ_old + ∑ i, starRingEnd ℂ (c i) • G.L i +
+      (1 / 2 : ℂ) • ∑ i, (starRingEnd ℂ (c i) * c i) •
+        (1 : Matrix (Fin D) (Fin D) ℂ)
+    have hκ_new :
+        Complex.I • H' + (1 / 2 : ℂ) • ∑ j : Fin G.r, (L' j)ᴴ * L' j =
+          κ_shift := by
+      have h_iH' : Complex.I • H' =
+          Complex.I • G.H + (1 / 2 : ℂ) • Δ := by
+        rw [hH'_def, smul_sub, smul_smul]
+        have : Complex.I * (Complex.I / 2) = -(1 / 2 : ℂ) := by
+          field_simp
+          rw [Complex.I_sq]
+        rw [this, neg_smul, sub_neg_eq_add]
+      have h_adj : (1 / 2 : ℂ) • ∑ j : Fin G.r, (L' j)ᴴ * L' j =
+          (1 / 2 : ℂ) • ∑ j, (G.L j)ᴴ * G.L j +
+          (1 / 2 : ℂ) • ∑ j, starRingEnd ℂ (c j) • G.L j +
+          (1 / 2 : ℂ) • ∑ j, c j • (G.L j)ᴴ +
+          (1 / 2 : ℂ) • ∑ j, (starRingEnd ℂ (c j) * c j) •
+            (1 : Matrix (Fin D) (Fin D) ℂ) := by
+        rw [hL'_def]
+        simp_rw [conjTranspose_add, conjTranspose_smul, conjTranspose_one,
+          Matrix.add_mul, Matrix.mul_add, smul_mul_assoc, mul_smul_comm,
+          Matrix.one_mul, Matrix.mul_one, Finset.sum_add_distrib, smul_smul,
+          smul_add, Finset.smul_sum]
+        simp only [Complex.star_def]
+        abel
+      rw [h_iH', h_adj, hΔ_def, Finset.smul_sum]
+      simp_rw [smul_sub]
+      simp_rw [Finset.sum_sub_distrib]
+      have hcancel :
+          (∑ x, (1 / 2 : ℂ) • starRingEnd ℂ (c x) • G.L x -
+           ∑ x, (1 / 2 : ℂ) • c x • (G.L x)ᴴ) +
+          ((1 / 2 : ℂ) • ∑ j, starRingEnd ℂ (c j) • G.L j +
+           (1 / 2 : ℂ) • ∑ j, c j • (G.L j)ᴴ) =
+          ∑ i, starRingEnd ℂ (c i) • G.L i := by
+        rw [← Finset.smul_sum, ← Finset.smul_sum]
+        module
+      have : κ_shift = κ_old +
+          ∑ i, starRingEnd ℂ (c i) • G.L i +
+          (1 / 2 : ℂ) • ∑ i, (starRingEnd ℂ (c i) * c i) •
+            (1 : Matrix (Fin D) (Fin D) ℂ) := rfl
+      rw [this]
+      clear this
+      have hκ_old_eq : κ_old = Complex.I • G.H +
+          (1 / 2 : ℂ) • ∑ j, (G.L j)ᴴ * G.L j := rfl
+      rw [hκ_old_eq]
+      set A := Complex.I • G.H
+      set B := ∑ x, (1 / 2 : ℂ) • starRingEnd ℂ (c x) • G.L x -
+        ∑ x, (1 / 2 : ℂ) • c x • (G.L x)ᴴ
+      set C := (1 / 2 : ℂ) • ∑ j, (G.L j)ᴴ * G.L j
+      set D_half := (1 / 2 : ℂ) • ∑ j, starRingEnd ℂ (c j) • G.L j
+      set E := (1 / 2 : ℂ) • ∑ j, c j • (G.L j)ᴴ
+      set F := (1 / 2 : ℂ) • ∑ j, (starRingEnd ℂ (c j) * c j) •
+        (1 : Matrix (Fin D) (Fin D) ℂ)
+      set S := ∑ i, starRingEnd ℂ (c i) • G.L i
+      calc A + B + (C + D_half + E + F)
+          = A + C + (B + (D_half + E)) + F := by abel
+        _ = A + C + S + F := by rw [hcancel]
+    ext1 ρ
+    simp only [GeneratorDecomp.toLinearMap_apply, LindbladForm.toGeneratorDecomp]
+    rw [show Complex.I • H' + (1 / 2 : ℂ) • ∑ x, (L' x)ᴴ * L' x = κ_shift from hκ_new]
+    change (∑ x, L' x * ρ * (L' x)ᴴ) - κ_shift * ρ - ρ * κ_shiftᴴ =
+      (∑ j, G.L j * ρ * (G.L j)ᴴ) - κ_old * ρ - ρ * κ_oldᴴ
+    exact hshift ρ
+  · intro j
+    exact hc j
+  · intro j
+    rw [hL'_def]
+    exact V.add_mem (hmem j) (V.smul_mem (c j) hone)
+
+/-- Every Lindblad form has an equivalent form whose Lindblad operators are
+traceless (Wolf, Proposition 7.4(1)). -/
+theorem LindbladForm.exists_traceless (G : LindbladForm D) :
+    ∃ G' : LindbladForm D,
+      G'.toLinearMap = G.toLinearMap ∧ G'.HasTracelessKraus := by
+  by_cases hD : D = 0
+  · subst D
+    exact ⟨G, rfl, fun _ ↦ by simp [Matrix.trace]⟩
+  · let _ : NeZero D := ⟨hD⟩
+    obtain ⟨G', hG', htr, -⟩ :=
+      G.exists_traceless_in_submodule ⊤ (by simp) (fun _ ↦ by simp)
+    exact ⟨G', hG', htr⟩
 
 /-! ## Theorem 7.1: GKSL/Lindblad theorem (Wolf Theorem 7.1) -/
 

--- a/QICLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
+++ b/QICLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
@@ -37,10 +37,6 @@ variable {D : ℕ}
 
 section LindbladForms
 
-/-- Predicate: all Kraus operators in a Lindblad form are traceless. -/
-def LindbladForm.HasTracelessKraus (F : LindbladForm D) : Prop :=
-  ∀ j : Fin F.r, trace (F.L j) = 0
-
 /-! ### Private auxiliary lemmas for the uniqueness proofs -/
 
 /-- Key tracelessness auxiliary lemma:

--- a/QICLean/Channel/Semigroup/RelaxationConditions.lean
+++ b/QICLean/Channel/Semigroup/RelaxationConditions.lean
@@ -703,139 +703,31 @@ private theorem exists_traceless_blockUT_lindblad_form
           (LinearMap.mulRight ℂ P))) ⊓
          (LinearMap.ker (Matrix.traceLinearMap (Fin D) ℂ ℂ)) :
           Submodule ℂ Mat)) := by
-  -- D > 0 from nontrivial projection
   by_cases hD : D = 0
-  · subst hD; exact absurd (Subsingleton.elim P 0) hP.2.1
-  have : NeZero D := ⟨hD⟩
-  -- Get traceless shifts: c_j = -trace(L_j)/D
-  obtain ⟨c, hc⟩ := exists_traceless_kraus_shift G.L
-  -- Shifted operators L'_j = G.L j + c_j · I
-  set L' : Fin G.r → Mat := fun j => G.L j + c j • (1 : Mat) with hL'_def
-  -- Shifted Hamiltonian: H' = G.H - (I/2)·(Σ c'ⱼ Lⱼ - Σ cⱼ Lⱼ†)
-  set Δ : Mat := ∑ j : Fin G.r,
-    (starRingEnd ℂ (c j) • G.L j - c j • (G.L j)ᴴ) with hΔ_def
-  set H' : Mat := G.H - (Complex.I / 2) • Δ with hH'_def
-  -- H' is Hermitian
-  have hH'_herm : H'.IsHermitian := by
-    rw [hH'_def]
-    apply Matrix.IsHermitian.sub G.H_hermitian
-    rw [Matrix.IsHermitian, conjTranspose_smul]
-    have hstar_I2 : star (Complex.I / 2 : ℂ) = -(Complex.I / 2) := by
-      simp [Complex.conj_I]; ring
-    rw [hstar_I2, hΔ_def, conjTranspose_sum]
-    simp_rw [conjTranspose_sub, conjTranspose_smul, conjTranspose_conjTranspose,
-      RCLike.star_def, Complex.conj_conj]
-    rw [neg_smul, ← smul_neg]
-    congr 1
-    rw [show -(∑ x, (c x • (G.L x)ᴴ - starRingEnd ℂ (c x) • G.L x)) =
-      ∑ x, (starRingEnd ℂ (c x) • G.L x - c x • (G.L x)ᴴ) from by
-        rw [← Finset.sum_neg_distrib]; apply Finset.sum_congr rfl; intro j _
-        simp only [neg_sub]]
-  -- Construct the new LindbladForm
-  refine ⟨⟨G.r, H', L', hH'_herm⟩, ?_, ?_⟩
-  · -- Show toLinearMap agrees: use generator_shift_invariance
-    rw [hL_eq]
-    -- Both forms have the same generator via generator_shift_invariance.
-    rw [LindbladForm.toLinearMap_eq_generatorDecomp,
-        LindbladForm.toLinearMap_eq_generatorDecomp]
-    set κ_old : Mat := G.toGeneratorDecomp.κ
-    -- generator_shift_invariance with mu = 0
-    have hshift := generator_shift_invariance G.L κ_old c 0
-    simp only [Complex.ofReal_zero, mul_zero, zero_smul, add_zero] at hshift
-    -- Key: the new form's κ = shifted κ
-    set κ_shift : Mat := κ_old + ∑ i, starRingEnd ℂ (c i) • G.L i +
-      (1/2 : ℂ) • ∑ i, (starRingEnd ℂ (c i) * c i) • (1 : Mat)
-    -- The new form's κ
-    have hκ_new : (Complex.I • H' + (1/2 : ℂ) • ∑ j : Fin G.r, (L' j)ᴴ * L' j) =
-        κ_shift := by
-      -- Step 1: iH' = iG.H + (1/2)Δ
-      have h_iH' : Complex.I • H' =
-          Complex.I • G.H + (1/2 : ℂ) • Δ := by
-        rw [hH'_def, smul_sub, smul_smul]
-        have : Complex.I * (Complex.I / 2) = -(1/2 : ℂ) := by
-          field_simp; rw [Complex.I_sq]
-        rw [this, neg_smul, sub_neg_eq_add]
-      -- Step 2: ½Σ L'†L' = ½Σ G.L†G.L + ½Σ c' G.L + ½Σ c G.L† + ½Σ|c|² I
-      have h_adj : (1/2 : ℂ) • ∑ j : Fin G.r, (L' j)ᴴ * L' j =
-          (1/2 : ℂ) • ∑ j, (G.L j)ᴴ * G.L j +
-          (1/2 : ℂ) • ∑ j, starRingEnd ℂ (c j) • G.L j +
-          (1/2 : ℂ) • ∑ j, c j • (G.L j)ᴴ +
-          (1/2 : ℂ) • ∑ j, (starRingEnd ℂ (c j) * c j) • (1 : Mat) := by
-        rw [hL'_def]
-        simp_rw [conjTranspose_add, conjTranspose_smul, conjTranspose_one,
-          Matrix.add_mul, Matrix.mul_add, smul_mul_assoc, mul_smul_comm,
-          Matrix.one_mul, Matrix.mul_one, Finset.sum_add_distrib, smul_smul,
-          smul_add, Finset.smul_sum]
-        simp only [Complex.star_def]
-        abel
-      -- Step 3: Combine h_iH' and h_adj
-      rw [h_iH', h_adj, hΔ_def, Finset.smul_sum]
-      simp_rw [smul_sub]
-      simp_rw [Finset.sum_sub_distrib]
-      -- The key cancellation: ½Σc'L - ½ΣcL† + ½Σc'L + ½ΣcL† = Σc'L
-      have hcancel :
-          (∑ x, (1 / 2 : ℂ) • starRingEnd ℂ (c x) • G.L x -
-           ∑ x, (1 / 2 : ℂ) • c x • (G.L x)ᴴ) +
-          ((1 / 2 : ℂ) • ∑ j, starRingEnd ℂ (c j) • G.L j +
-           (1 / 2 : ℂ) • ∑ j, c j • (G.L j)ᴴ) =
-          ∑ i, starRingEnd ℂ (c i) • G.L i := by
-        rw [← Finset.smul_sum, ← Finset.smul_sum]
-        -- ½Σc'L - ½ΣcL† + ½Σc'L + ½ΣcL† = Σc'L
-        module
-      -- Now assemble
-      have : κ_shift = κ_old +
-          ∑ i, starRingEnd ℂ (c i) • G.L i +
-          (1 / 2 : ℂ) • ∑ i, (starRingEnd ℂ (c i) * c i) • (1 : Mat) := rfl
-      rw [this]; clear this
-      -- Group the sums on the LHS
-      -- LHS = iG.H + (½Σc'L - ½ΣcL†) + ½ΣG.L†G.L + ½Σc'L + ½ΣcL† + ½Σ|c|²I
-      -- = iG.H + ½ΣG.L†G.L + (½Σc'L - ½ΣcL† + ½Σc'L + ½ΣcL†) + ½Σ|c|²I
-      -- = iG.H + ½ΣG.L†G.L + Σc'L + ½Σ|c|²I
-      -- = κ_old + Σc'L + ½Σ|c|²I
-      have hκ_old_eq : κ_old = Complex.I • G.H +
-          (1 / 2 : ℂ) • ∑ j, (G.L j)ᴴ * G.L j := rfl
-      rw [hκ_old_eq]
-      -- Use hcancel to rewrite
-      -- LHS: iG.H + (½Σc'L - ½ΣcL†) + (½ΣG.L†G.L + ½Σc'L + ½ΣcL† + ½Σ|c|²I)
-      -- Group (½Σc'L - ½ΣcL†) + (½Σc'L + ½ΣcL†) = Σc'L using hcancel
-      -- Then LHS = iG.H + ½ΣG.L†G.L + Σc'L + ½Σ|c|²I = RHS
-      -- Set abbreviations for readability
-      set A := Complex.I • G.H
-      set B := ∑ x, (1 / 2 : ℂ) • starRingEnd ℂ (c x) • G.L x -
-               ∑ x, (1 / 2 : ℂ) • c x • (G.L x)ᴴ
-      set C := (1 / 2 : ℂ) • ∑ j, (G.L j)ᴴ * G.L j
-      set D_half := (1 / 2 : ℂ) • ∑ j, starRingEnd ℂ (c j) • G.L j
-      set E := (1 / 2 : ℂ) • ∑ j, c j • (G.L j)ᴴ
-      set F := (1 / 2 : ℂ) • ∑ j, (starRingEnd ℂ (c j) * c j) • (1 : Mat)
-      set S := ∑ i, starRingEnd ℂ (c i) • G.L i
-      -- hcancel : B + (D_half + E) = S
-      -- Goal: A + B + (C + D_half + E + F) = A + C + S + F
-      -- = A + C + (B + (D_half + E)) + F (by hcancel)
-      calc A + B + (C + D_half + E + F)
-          = A + C + (B + (D_half + E)) + F := by abel
-        _ = A + C + S + F := by rw [hcancel]
-    ext1 ρ
-    simp only [GeneratorDecomp.toLinearMap_apply, LindbladForm.toGeneratorDecomp]
-    -- Rewrite the new form's κ as κ_shift
-    rw [show (Complex.I • H' + (1 / 2 : ℂ) • ∑ x, (L' x)ᴴ * L' x) = κ_shift from hκ_new]
-    -- Unfold κ_old
-    change (∑ x, L' x * ρ * (L' x)ᴴ) - κ_shift * ρ - ρ * κ_shiftᴴ =
-      (∑ j, G.L j * ρ * (G.L j)ᴴ) - κ_old * ρ - ρ * κ_oldᴴ
-    exact hshift ρ
-  · -- Show each L'_j is in the traceless block-UT subspace
+  · subst D
+    exact absurd (Subsingleton.elim P 0) hP.2.1
+  let _ : NeZero D := ⟨hD⟩
+  let V : Submodule ℂ Mat :=
+    LinearMap.ker ((LinearMap.mulLeft ℂ (1 - P)).comp
+      (LinearMap.mulRight ℂ P))
+  have hone : (1 : Mat) ∈ V := by
+    change (1 - P) * ((1 : Mat) * P) = 0
+    rw [Matrix.one_mul]
+    exact IsIdempotentElem.one_sub_mul_self hP.1.2
+  have hmem : ∀ j : Fin G.r, G.L j ∈ V := by
     intro j
-    simp only [Submodule.mem_inf, LinearMap.mem_ker, LinearMap.comp_apply]
-    constructor
-    · -- Block-UT: (1-P) * L'_j * P = 0
-      simp only [LinearMap.mulLeft_apply, LinearMap.mulRight_apply]
-      rw [hL'_def]
-      simp only [Matrix.mul_add, Matrix.add_mul, smul_mul_assoc, mul_smul_comm]
-      rw [Matrix.one_mul, IsIdempotentElem.one_sub_mul_self hP.1.2, smul_zero, add_zero]
-      rw [← Matrix.mul_assoc]
-      exact hBlock j
-    · -- Traceless
-      simp only [Matrix.traceLinearMap_apply]
-      exact hc j
+    change (1 - P) * (G.L j * P) = 0
+    rw [← Matrix.mul_assoc]
+    exact hBlock j
+  obtain ⟨G', hmap, htrace, hV⟩ :=
+    G.exists_traceless_in_submodule V hone hmem
+  refine ⟨G', hmap.trans hL_eq.symm, ?_⟩
+  intro j
+  rw [Submodule.mem_inf]
+  constructor
+  · simpa [V] using hV j
+  · rw [LinearMap.mem_ker, Matrix.traceLinearMap_apply]
+    exact htrace j
 
 /-- Condition (3): Kossakowski rank `> D * D` forbids block-upper-triangular
 Lindblad decompositions (Wolf Corollary 7.2(3)).

--- a/blueprint/src/chapter/ch11_semigroup_dynamics_and_gksl.tex
+++ b/blueprint/src/chapter/ch11_semigroup_dynamics_and_gksl.tex
@@ -718,9 +718,13 @@ which shows that such generators have the standard Lindblad form.
 
 \begin{theorem}[Traceless Kraus operators exist]
     \label{thm:exists_traceless_kraus_shift}
-    \lean{exists_traceless_kraus_shift}\leanok
+    \lean{exists_traceless_kraus_shift,
+        LindbladForm.exists_traceless_in_submodule,
+        LindbladForm.exists_traceless}\leanok
     Assume $d > 0$. Given any Kraus operators $\{L_i\}$, there exist
     $c_i \in \C$ such that $L_i' = L_i+c_i\Id$ is traceless.
+    Hence every Lindblad form has an equivalent one with traceless Lindblad
+    operators; shifting preserves any linear subspace that contains $\Id$.
     This is the final assertion of \cite[Proposition~7.4(1)]{Wolf2012Quantum}.
 \end{theorem}
 
@@ -961,13 +965,13 @@ which shows that such generators have the standard Lindblad form.
 \begin{proof}\leanok
     \uses{thm:generatorDecomp_of_gksl, thm:gksl_iff_ccp_ta,
         thm:lindbladForm_eq_generatorDecomp, thm:lindbladForm_isCCP,
-        thm:lindbladForm_isTraceAnnihilating,
-        thm:exists_traceless_kraus_shift}
+        thm:lindbladForm_isTraceAnnihilating}
     Forward: apply Theorem~\ref{thm:generatorDecomp_of_gksl} to write
     $L(\rho)=\phi(\rho)-\kappa\rho-\rho\kappa^\dagger$ with trace
-    constraint. Then choose traceless Kraus operators by
-    Theorem~\ref{thm:exists_traceless_kraus_shift} and rewrite $\kappa$ as
-    $iH+\frac{1}{2}\phi^*(\Id)$;
+    constraint. Choose Kraus operators $\{L_j\}$ for $\phi$, set
+    $H=\frac{i}{2}(\kappa^\dagger-\kappa)$, and use
+    $\sum_jL_j^\dagger L_j=\kappa+\kappa^\dagger$ to obtain
+    $\kappa=iH+\frac{1}{2}\sum_jL_j^\dagger L_j$.
     Theorem~\ref{thm:lindbladForm_eq_generatorDecomp} gives the Lindblad
     formula (\ref{eq:semigroup_gksl_lindblad}).
     Reverse: Theorems~\ref{thm:lindbladForm_isCCP}
@@ -977,28 +981,34 @@ which shows that such generators have the standard Lindblad form.
 
 \subsection{Kossakowski matrix form}
 
-\begin{definition}[Kossakowski form]\label{def:kossakowski_form}
-    \lean{KossakowskiForm}\leanok
-    A \emph{Kossakowski form} consists of $H=H^\dagger$, a finite family
-    of matrices $\{F_k\}_{k=0}^{n-1}$, and a positive semidefinite matrix
-    $C \in \MN{n}$, defining
+\begin{definition}[Kossakowski form in a traceless basis]\label{def:kossakowski_form}
+    \lean{tracelessMatrixSubspace, finrank_tracelessMatrixSubspace,
+        TracelessBasisKossakowskiForm,
+        TracelessBasisKossakowskiForm.toKossakowskiForm,
+        TracelessBasisKossakowskiForm.toLinearMap,
+        KossakowskiForm, KossakowskiForm.toLinearMap}\leanok
+    A \emph{Kossakowski form} consists of $H=H^\dagger$, a fixed basis
+    $F_1,\ldots,F_{d^2-1}$ of the traceless matrices in
+    $\MN{d}$, and a positive semidefinite matrix
+    $C\in\MN{d^2-1}$, defining
     \begin{align}
         L(\rho)
         &= i[\rho,H]
-        + \tfrac{1}{2}\sum_{k,l}C_{lk}
+        + \tfrac{1}{2}\sum_{k,l=1}^{d^2-1}C_{lk}
         ([F_k,\rho F_l^\dagger]+[F_k\rho,F_l^\dagger]).
         \label{eq:semigroup_kossakowski_form}
     \end{align}
-    In Wolf's formula one takes $\{F_k\}$ to be a basis of traceless matrices;
-    here we keep only the algebraic data needed for the conversion to
-    Lindblad form.
+    This is \cite[Theorem~7.1, Equation~(7.23)]{Wolf2012Quantum}.
+    Allowing an arbitrary finite family $\{F_k\}$ gives the corresponding
+    algebraic form used in the factorization argument.
 \end{definition}
 
-\begin{theorem}[Kossakowski form iff Lindblad form]
+\begin{theorem}[Algebraic Kossakowski form iff Lindblad form]
     \label{thm:kossakowski_iff_lindblad}
     \lean{kossakowski_iff_lindblad}\leanok
     \uses{def:kossakowski_form, def:lindblad_form}
-    A linear map admits a Kossakowski form iff it admits a Lindblad form.
+    A linear map admits an algebraic Kossakowski form if and only if it admits
+    a Lindblad form.
 \end{theorem}
 
 \begin{proof}
@@ -1007,6 +1017,33 @@ which shows that such generators have the standard Lindblad form.
     $L_j=\sum_k B_{jk}F_k$.
     Reverse: keep the same Hamiltonian and family $F_k=L_k$, and take
     $C=\Id$.
+\end{proof}
+
+\begin{theorem}[Generators of channel semigroups in Kossakowski form]
+    \label{thm:gksl_iff_basis_kossakowski}
+    \lean{tracelessBasisKossakowski_iff_lindbladForm,
+        gksl_iff_tracelessBasisKossakowskiForm}\leanok
+    \uses{def:is_gksl_generator, def:kossakowski_form,
+        thm:gksl_iff_lindblad, thm:kossakowski_iff_lindblad,
+        thm:exists_traceless_kraus_shift, thm:generator_shift_invariance}
+    A linear map $L:\MN{d}\to\MN{d}$ generates a continuous dynamical
+    semigroup of quantum channels if and only if it has the
+    Kossakowski form (\ref{eq:semigroup_kossakowski_form}) in a fixed basis of
+    the traceless matrices, with $C\geq 0$.
+    This is \cite[Theorem~7.1, Equations~(7.20)--(7.23)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:gksl_iff_lindblad, thm:kossakowski_iff_lindblad,
+        thm:exists_traceless_kraus_shift, thm:generator_shift_invariance}
+    By Theorem~\ref{thm:gksl_iff_lindblad}, it suffices to compare the
+    Lindblad and basis-level Kossakowski forms. From a Kossakowski form,
+    factor $C=B^\dagger B$ and set $L_j=\sum_kB_{jk}F_k$.
+    Conversely, shift the Lindblad operators to be traceless, expand them in
+    the fixed basis as $L_j=\sum_kM_{jk}F_k$, and set $C=M^\dagger M$.
+    Substitution into (\ref{eq:semigroup_kossakowski_form}) gives the
+    commutator form (\ref{eq:semigroup_commutator_form}).
 \end{proof}
 
 %% ---------------------------------------------------------

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -2082,13 +2082,9 @@ for every submultiplicative norm from the Duhamel identity, while
 Here Wolf's “any norm” refers to the operator norm induced by the chosen norm on
 the state space, as defined immediately before Proposition 7.1.
 
-The complete named-environment audit therefore classifies exactly three Chapter
+The complete named-environment audit therefore classifies exactly two Chapter
 7 source environments as partial rather than exact:
 
-- Theorem 7.1, “Generators for semigroups of quantum channels”: the GKSL and
-  Lindblad forms are proved, but the public Kossakowski package does not retain
-  the exact fixed basis of the traceless subspace used in Equation (7.23)
-  (partial-scope).
 - Proposition 7.5, “Irreducibility implies primitivity”: source clauses 1--3 are
   packaged, while clauses 4--5 on faithful convergence and the Liouvillian
   kernel are absent (partial-packaging).
@@ -2104,10 +2100,19 @@ the source-oriented equation $\kappa=\kappa'+i\lambda\Id$, and a unitary
 relation $L_i'=\sum_jU_{ij}L_j$ after both families are padded with zeros to
 the larger cardinality.
 
-Propositions 7.1--7.4 and Corollary 7.1 are exact completions. The `\leanok`
-markers in the semigroup Blueprint certify individual Lean declarations; they
-must not be read as exact-coverage markers for a larger containing Wolf
-environment.
+Theorem 7.1 is an exact completion. Equations (7.20)--(7.22) are represented by
+`generatorDecomp_of_gksl`,
+`gksl_of_generatorDecomp_with_traceConstraint`, `gksl_iff_lindbladForm`, and
+`LindbladForm.commutatorForm_eq_toLinearMap`. Equation (7.23) is represented by
+`TracelessBasisKossakowskiForm`, whose `F` field is a
+`Fin (D ^ 2 - 1)`-indexed basis of the trace kernel, and by
+`gksl_iff_tracelessBasisKossakowskiForm`; the proof chooses traceless Lindblad
+operators, expands them as `Lⱼ = ∑ₖ Mⱼₖ Fₖ`, and uses `C = MᴴM`.
+
+Propositions 7.1--7.4, Theorem 7.1, and Corollary 7.1 are exact completions. The
+`\leanok` markers in the semigroup Blueprint certify individual Lean
+declarations; they must not be read as exact-coverage markers for a larger
+containing Wolf environment.
 
 ---
 


### PR DESCRIPTION
## Summary

- Define the traceless matrix subspace and prove that its complex dimension is `D ^ 2 - 1`.
- Add `TracelessBasisKossakowskiForm`, whose public data contain Wolf's fixed basis `F₁, …, F_{D²-1}` and a positive semidefinite Kossakowski matrix `C`.
- Prove the basis-level Kossakowski/Lindblad equivalence and the channel-semigroup characterization, reusing the existing GKSL and algebraic Kossakowski equivalences.
- Synchronize the Blueprint and the Chapter 7 coverage audit.

## Source correspondence

This change follows `Notes/WolfNoteTexSource/ch07_semigroup_structure.tex`, lines 245–263.

- Equation (7.20) remains represented by the two existing trace-constrained generator-decomposition directions.
- Equations (7.21) and (7.22) remain represented by the existing Lindblad and commutator forms.
- Equation (7.23) is now exposed literally at the source-facing boundary: `F` is a `Fin (D ^ 2 - 1)`-indexed basis of the trace kernel and `C` is positive semidefinite, with coefficient order `C_{l,k}`.
- The reverse construction follows Wolf's proof: Proposition 7.4 gives traceless Lindblad operators, these are expanded as `Lⱼ = ∑ₖ Mⱼₖ Fₖ`, and `C = MᴴM`. The forward construction factors a positive `C` and reuses the existing Kossakowski-to-Lindblad calculation.

No positive-dimension hypothesis is added to the public equivalence; the zero-dimensional case is handled explicitly.

## Supporting refactor

`LindbladForm.HasTracelessKraus` moves from `Uniqueness` to `Basic`, so both the merged Proposition 7.4 uniqueness package and the GKSL construction use the same predicate without an import cycle. The public traceless-shift construction also replaces the former private 139-line copy in `RelaxationConditions`, while preserving its block-upper-triangular subspace condition.

## Verification

- `lake build QICLean -q --log-level=info` (full build before the linear rebase)
- focused post-rebase build of `KossakowskiForm`, `RelaxationConditions`, and `LindbladForm.Uniqueness`
- `lake build lint_style -q --log-level=info`
- `lake exe lint_style --github`
- `lake exe checkdecls blueprint/lean_decls`
- Blueprint/Lean synchronization and changed-declaration coverage checks
- `leanblueprint pdf` (368 pages)
- `chktex`, paper-gap reference, reader-facing prose, import-aggregator, oversized-file, and numbered-file checks
- kernel axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`

Closes #482
