### PR TITLE
feat(semigroup): complete Wolf Corollary 7.2

### DIFF
--- a/QICLean/Channel/Semigroup.lean
+++ b/QICLean/Channel/Semigroup.lean
@@ -14,6 +14,7 @@ import QICLean.Channel.Semigroup.GeneratorDefs
 import QICLean.Channel.Semigroup.HamiltonianIndependentContractivity
 import QICLean.Channel.Semigroup.Kernel
 import QICLean.Channel.Semigroup.KossakowskiForm
+import QICLean.Channel.Semigroup.KossakowskiRank
 import QICLean.Channel.Semigroup.LindbladForm
 import QICLean.Channel.Semigroup.LindbladForm.Basic
 import QICLean.Channel.Semigroup.LindbladForm.ChoiCCP

--- a/QICLean/Channel/Semigroup.lean
+++ b/QICLean/Channel/Semigroup.lean
@@ -37,4 +37,5 @@ import QICLean.Channel.Semigroup.ReducibleQDS.Equivalence
 import QICLean.Channel.Semigroup.ReducibleQDS.FixedDensity
 import QICLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression
 import QICLean.Channel.Semigroup.RelaxationConditions
+import QICLean.Channel.Semigroup.RelaxationCorollary
 import QICLean.Channel.Semigroup.WeightedLoweringContractivity

--- a/QICLean/Channel/Semigroup/KossakowskiForm.lean
+++ b/QICLean/Channel/Semigroup/KossakowskiForm.lean
@@ -218,6 +218,18 @@ theorem TracelessBasisKossakowskiForm.sqrtLindbladForm_hasTracelessKraus
   change (CFC.sqrt K.C) j k • trace (K.F k : Matrix (Fin D) (Fin D) ℂ) = 0
   rw [hk, smul_zero]
 
+/-- Wolf's positive-semidefinite factorization of the Kossakowski matrix:
+`C = (sqrt C)† * sqrt C`. -/
+theorem TracelessBasisKossakowskiForm.C_eq_conjTranspose_sqrt_mul_sqrt
+    (K : TracelessBasisKossakowskiForm D) :
+    K.C = (CFC.sqrt K.C)ᴴ * CFC.sqrt K.C := by
+  have hC_nonneg : 0 ≤ K.C :=
+    Matrix.nonneg_iff_posSemidef.mpr K.C_posSemidef
+  have hsqrt_psd : (CFC.sqrt K.C).PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg K.C)
+  rw [hsqrt_psd.isHermitian.eq]
+  simpa using (CFC.sqrt_mul_sqrt_self K.C hC_nonneg).symm
+
 /-! ### Auxiliary lemmas for Kossakowski ↔ Lindblad conversion -/
 
 /-- The dissipator equals ½ of the Kossakowski commutator sum
@@ -237,7 +249,7 @@ private lemma dissipator_eq_half_kossakowski
 
 /-- Bilinear sum identity: `Σⱼ (Σₖ B_{jk}•Fₖ) * M * (Σₖ B_{jk}•Fₖ)†`
 equals `Σₖₗ (B†B)_{lk} • (Fₖ * M * Fₗ†)`. Used in Kossakowski ↔ Lindblad. -/
-private lemma kraus_sum_eq_double_sum {r n : ℕ}
+theorem kraus_sum_eq_double_sum {r n : ℕ}
     (B : Matrix (Fin r) (Fin n) ℂ)
     (F : Fin n → Matrix (Fin D) (Fin D) ℂ)
     (M : Matrix (Fin D) (Fin D) ℂ) :
@@ -254,7 +266,7 @@ private lemma kraus_sum_eq_double_sum {r n : ℕ}
   simp [conjTranspose_apply, mul_apply, mul_comm]
 
 /-- Adjoint variant: `Σⱼ Lⱼ†Lⱼ = Σₗ Σₖ (B†B)_{lk} • (Fₗ†Fₖ)`. -/
-private lemma adj_kraus_sum_eq_double_sum {r n : ℕ}
+theorem adj_kraus_sum_eq_double_sum {r n : ℕ}
     (B : Matrix (Fin r) (Fin n) ℂ)
     (F : Fin n → Matrix (Fin D) (Fin D) ℂ) :
     ∑ j : Fin r, (∑ k, B j k • F k)ᴴ * (∑ k, B j k • F k) =
@@ -310,13 +322,7 @@ theorem TracelessBasisKossakowskiForm.toLinearMap_eq_sqrtLindbladForm
     K.toLinearMap = K.sqrtLindbladForm.toLinearMap := by
   let B : Matrix (Fin (D ^ 2 - 1)) (Fin (D ^ 2 - 1)) ℂ := CFC.sqrt K.C
   have hB : K.C = Bᴴ * B := by
-    have hC_nonneg : 0 ≤ K.C :=
-      Matrix.nonneg_iff_posSemidef.mpr K.C_posSemidef
-    have hsqrt_psd : (CFC.sqrt K.C).PosSemidef :=
-      Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg K.C)
-    change K.C = (CFC.sqrt K.C)ᴴ * CFC.sqrt K.C
-    rw [hsqrt_psd.isHermitian.eq]
-    simpa using (CFC.sqrt_mul_sqrt_self K.C hC_nonneg).symm
+    exact K.C_eq_conjTranspose_sqrt_mul_sqrt
   change K.toKossakowskiForm.toLinearMap =
     (LindbladForm.mk (D ^ 2 - 1) K.toKossakowskiForm.H
       (fun j ↦ ∑ k, B j k • K.toKossakowskiForm.F k)

--- a/QICLean/Channel/Semigroup/KossakowskiForm.lean
+++ b/QICLean/Channel/Semigroup/KossakowskiForm.lean
@@ -190,6 +190,34 @@ def TracelessBasisKossakowskiForm.toLinearMap
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
   K.toKossakowskiForm.toLinearMap
 
+/-- The Lindblad form obtained from Wolf's factorization
+`C = (sqrt C)ᴴ * sqrt C` in the chosen traceless basis.
+
+Its Lindblad operators are
+`Lⱼ = ∑ₖ (sqrt C)ⱼₖ Fₖ`, as in the proof of Wolf, Theorem 7.1,
+`Notes/WolfNoteTexSource/ch07_semigroup_structure.tex`, lines 258--263. -/
+def TracelessBasisKossakowskiForm.sqrtLindbladForm
+    (K : TracelessBasisKossakowskiForm D) : LindbladForm D where
+  r := D ^ 2 - 1
+  H := K.toKossakowskiForm.H
+  L := fun j ↦ ∑ k, (CFC.sqrt K.C) j k • K.toKossakowskiForm.F k
+  H_hermitian := K.toKossakowskiForm.H_hermitian
+
+/-- The square-root Lindblad operators of a basis-level Kossakowski form are
+traceless. -/
+theorem TracelessBasisKossakowskiForm.sqrtLindbladForm_hasTracelessKraus
+    (K : TracelessBasisKossakowskiForm D) :
+    K.sqrtLindbladForm.HasTracelessKraus := by
+  intro j
+  simp only [TracelessBasisKossakowskiForm.sqrtLindbladForm,
+    Matrix.trace_sum, Matrix.trace_smul]
+  apply Finset.sum_eq_zero
+  intro k _
+  have hk : trace (K.F k : Matrix (Fin D) (Fin D) ℂ) = 0 := by
+    exact (K.F k).property
+  change (CFC.sqrt K.C) j k • trace (K.F k : Matrix (Fin D) (Fin D) ℂ) = 0
+  rw [hk, smul_zero]
+
 /-! ### Auxiliary lemmas for Kossakowski ↔ Lindblad conversion -/
 
 /-- The dissipator equals ½ of the Kossakowski commutator sum
@@ -241,7 +269,7 @@ private lemma adj_kraus_sum_eq_double_sum {r n : ℕ}
 
 /-- A factorization `C = BᴴB` converts a Kossakowski form into the
 corresponding Lindblad family `Lⱼ = ∑ₖ Bⱼₖ Fₖ`. -/
-private theorem KossakowskiForm.toLinearMap_eq_lindblad_of_factor
+theorem KossakowskiForm.toLinearMap_eq_lindblad_of_factor
     {r : ℕ} (K : KossakowskiForm D)
     (B : Matrix (Fin r) (Fin K.n) ℂ)
     (hB : K.C = Bᴴ * B) :
@@ -274,6 +302,26 @@ private theorem KossakowskiForm.toLinearMap_eq_lindblad_of_factor
   simp_rw [Finset.sum_mul, Finset.mul_sum, smul_mul_assoc, mul_smul_comm]
   simp_rw [← Finset.sum_sub_distrib, ← Finset.sum_add_distrib,
     ← smul_sub, ← smul_add]
+
+/-- The basis-level Kossakowski form and its square-root Lindblad form define
+the same generator. -/
+theorem TracelessBasisKossakowskiForm.toLinearMap_eq_sqrtLindbladForm
+    (K : TracelessBasisKossakowskiForm D) :
+    K.toLinearMap = K.sqrtLindbladForm.toLinearMap := by
+  let B : Matrix (Fin (D ^ 2 - 1)) (Fin (D ^ 2 - 1)) ℂ := CFC.sqrt K.C
+  have hB : K.C = Bᴴ * B := by
+    have hC_nonneg : 0 ≤ K.C :=
+      Matrix.nonneg_iff_posSemidef.mpr K.C_posSemidef
+    have hsqrt_psd : (CFC.sqrt K.C).PosSemidef :=
+      Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg K.C)
+    change K.C = (CFC.sqrt K.C)ᴴ * CFC.sqrt K.C
+    rw [hsqrt_psd.isHermitian.eq]
+    simpa using (CFC.sqrt_mul_sqrt_self K.C hC_nonneg).symm
+  change K.toKossakowskiForm.toLinearMap =
+    (LindbladForm.mk (D ^ 2 - 1) K.toKossakowskiForm.H
+      (fun j ↦ ∑ k, B j k • K.toKossakowskiForm.F k)
+      K.toKossakowskiForm.H_hermitian).toLinearMap
+  exact K.toKossakowskiForm.toLinearMap_eq_lindblad_of_factor B hB
 
 /-- The Kossakowski form is equivalent to the Lindblad form:
 diagonalizing `C = M†M` converts between the two.

--- a/QICLean/Channel/Semigroup/KossakowskiRank.lean
+++ b/QICLean/Channel/Semigroup/KossakowskiRank.lean
@@ -1,0 +1,320 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Channel.Semigroup.KossakowskiForm
+
+/-!
+# Rank of the Kossakowski matrix
+
+This file relates the minimum number of Lindblad operators representing a
+generator to the rank of its Kossakowski matrix in Wolf's traceless basis.
+
+## Main definitions
+
+* `lindbladSpan` is the linear span of a displayed Lindblad family.
+* `kossakowskiRank` is the minimum size of a Lindblad representation.
+
+## Main results
+
+* `LindbladForm.exists_equivalent_rank_le_finrank` compresses a Lindblad
+  family to the dimension of a subspace containing its operators.
+* `TracelessBasisKossakowskiForm.kossakowskiRank_toLinearMap_eq_rank` proves
+  that this minimum equals the rank of Wolf's Kossakowski matrix `C`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 7.1.2,
+  Theorem 7.1 and Corollary 7.2]
+-/
+
+open scoped Matrix ComplexOrder BigOperators NNReal MatrixOrder TNOperatorSpace
+open Matrix Finset Module
+
+noncomputable section
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The `ℂ`-linear span of the operators in a Lindblad family. -/
+def lindbladSpan (F : LindbladForm D) : Submodule ℂ Mat :=
+  Submodule.span ℂ (Set.range F.L)
+
+/-- The minimum number of Lindblad operators among all representations of a
+fixed generator. -/
+def kossakowskiRank (L : Mat →ₗ[ℂ] Mat) : ℕ :=
+  sInf {n : ℕ | ∃ F : LindbladForm D, F.toLinearMap = L ∧ F.r = n}
+
+namespace LindbladForm
+
+/-- Bilinear sum identity for rectangular coefficient matrices:
+`Σⱼ (Σₖ Aⱼₖ•Fₖ) * M * (Σₖ Aⱼₖ•Fₖ)†`
+equals `Σₖₗ (A†A)ₗₖ • (Fₖ * M * Fₗ†)`. -/
+private lemma bilinear_sum_identity {r n : ℕ}
+    (A : Matrix (Fin r) (Fin n) ℂ)
+    (f : Fin n → Mat)
+    (M : Mat) :
+    ∑ j : Fin r, (∑ k, A j k • f k) * M * (∑ k, A j k • f k)ᴴ =
+    ∑ k : Fin n, ∑ l : Fin n, (Aᴴ * A) l k • (f k * M * (f l)ᴴ) := by
+  simp_rw [conjTranspose_sum, Matrix.conjTranspose_smul, Complex.star_def]
+  simp_rw [Finset.sum_mul, Finset.mul_sum, smul_mul_assoc, mul_smul_comm,
+    smul_smul, mul_assoc]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl; intro k _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl; intro l _
+  rw [← Finset.sum_smul]; congr 1
+  simp [conjTranspose_apply, mul_apply, mul_comm]
+
+/-- Adjoint variant of `bilinear_sum_identity`. -/
+private lemma bilinear_adj_sum_identity {r n : ℕ}
+    (A : Matrix (Fin r) (Fin n) ℂ)
+    (f : Fin n → Mat) :
+    ∑ j : Fin r, (∑ k, A j k • f k)ᴴ * (∑ k, A j k • f k) =
+    ∑ l : Fin n, ∑ k : Fin n, (Aᴴ * A) l k • ((f l)ᴴ * f k) := by
+  simp_rw [conjTranspose_sum, Matrix.conjTranspose_smul, Complex.star_def]
+  simp_rw [Finset.sum_mul, Finset.mul_sum, smul_mul_assoc, mul_smul_comm, smul_smul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl; intro l _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl; intro k _
+  rw [← Finset.sum_smul]; congr 1
+
+/-- If every operator in a Lindblad family lies in a subspace `V`, the same
+generator admits a Lindblad representation with at most `finrank ℂ V`
+operators. -/
+theorem exists_equivalent_rank_le_finrank
+    (G : LindbladForm D) (V : Submodule ℂ Mat)
+    (hV : ∀ j : Fin G.r, G.L j ∈ V) :
+    ∃ G' : LindbladForm D,
+      G'.toLinearMap = G.toLinearMap ∧ G'.r ≤ Module.finrank ℂ V := by
+  set m := Module.finrank ℂ V
+  let e := Module.finBasis ℂ V
+  let α : Matrix (Fin G.r) (Fin m) ℂ := fun j k => (e.repr ⟨G.L j, hV j⟩) k
+  have hL_expand : ∀ j, G.L j = ∑ k : Fin m, α j k • (e k : Mat) := by
+    intro j
+    have hrepr : (⟨G.L j, hV j⟩ : V) =
+        ∑ k, (e.repr ⟨G.L j, hV j⟩) k • e k := by
+      rw [← e.sum_equivFun ⟨G.L j, hV j⟩]
+      simp [Basis.equivFun_apply]
+    have hval := congrArg Subtype.val hrepr
+    simp only [Submodule.coe_sum, Submodule.coe_smul] at hval
+    exact hval
+  have hC_psd : (αᴴ * α).PosSemidef :=
+    Matrix.posSemidef_conjTranspose_mul_self α
+  set B := CFC.sqrt (αᴴ * α)
+  have hC_factor : (αᴴ * α) = Bᴴ * B := by
+    have hB_psd := Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg (αᴴ * α))
+    rw [hB_psd.isHermitian.eq]
+    simpa using
+      (CFC.sqrt_mul_sqrt_self _ (Matrix.nonneg_iff_posSemidef.mpr hC_psd)).symm
+  let L' : Fin m → Mat := fun i => ∑ k : Fin m, B i k • (e k : Mat)
+  refine ⟨⟨m, G.H, L', G.H_hermitian⟩, ?_, le_refl m⟩
+  let f : Fin m → Mat := fun k => (e k : Mat)
+  have hsum_expand : ∀ N : Mat,
+      ∑ j : Fin G.r, G.L j * N * (G.L j)ᴴ =
+      ∑ j : Fin G.r, (∑ k, α j k • f k) * N * (∑ k, α j k • f k)ᴴ := by
+    intro N
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [hL_expand j]
+  have hadj_expand :
+      ∑ j : Fin G.r, (G.L j)ᴴ * G.L j =
+      ∑ j : Fin G.r, (∑ k, α j k • f k)ᴴ * (∑ k, α j k • f k) := by
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [hL_expand j]
+  have hcp_eq : ∀ N : Mat,
+      ∑ j : Fin G.r, G.L j * N * (G.L j)ᴴ =
+      ∑ i : Fin m, L' i * N * (L' i)ᴴ := by
+    intro N
+    rw [hsum_expand N, bilinear_sum_identity α f N]
+    rw [show (∑ i : Fin m, L' i * N * (L' i)ᴴ) =
+      ∑ k, ∑ l, (Bᴴ * B) l k • (f k * N * (f l)ᴴ) from
+        bilinear_sum_identity B f N]
+    rw [hC_factor]
+  have hadj_eq :
+      ∑ j : Fin G.r, (G.L j)ᴴ * G.L j =
+      ∑ i : Fin m, (L' i)ᴴ * L' i := by
+    rw [hadj_expand, bilinear_adj_sum_identity α f]
+    rw [show (∑ i : Fin m, (L' i)ᴴ * L' i) =
+      ∑ l, ∑ k, (Bᴴ * B) l k • ((f l)ᴴ * f k) from
+        bilinear_adj_sum_identity B f]
+    rw [hC_factor]
+  ext1 ρ
+  simp only [LindbladForm.toLinearMap, LinearMap.coe_mk, AddHom.coe_mk]
+  congr 1
+  simp only [dissipator]
+  simp_rw [Finset.sum_sub_distrib]
+  congr 1
+  · congr 1
+    · exact (hcp_eq ρ).symm
+    · rw [← Finset.smul_sum, ← Finset.smul_sum,
+          ← Finset.sum_mul, ← Finset.sum_mul, hadj_eq]
+  · rw [← Finset.smul_sum, ← Finset.smul_sum,
+        ← Finset.mul_sum, ← Finset.mul_sum, hadj_eq]
+
+/-- The span of a family of `F.r` Lindblad operators has dimension at most
+`F.r`. -/
+theorem finrank_lindbladSpan_le_rank (F : LindbladForm D) :
+    Module.finrank ℂ (lindbladSpan F) ≤ F.r := by
+  calc
+    Module.finrank ℂ (lindbladSpan F) ≤
+        (Set.range F.L).toFinset.card := finrank_span_le_card (Set.range F.L)
+    _ = Fintype.card (Set.range F.L) := Set.toFinset_card _
+    _ ≤ Fintype.card (Fin F.r) := Fintype.card_range_le F.L
+    _ = F.r := Fintype.card_fin F.r
+
+/-- Every member of a zero-padded Lindblad family belongs to the span of the
+original family. -/
+private theorem zeroPad_mem_lindbladSpan (F : LindbladForm D) {n : ℕ}
+    (i : Fin n) : Kraus.zeroPad F.L i ∈ lindbladSpan F := by
+  simp only [Kraus.zeroPad]
+  split_ifs with hi
+  · exact Submodule.subset_span
+      (Set.mem_range_self (⟨i, hi⟩ : Fin F.r))
+  · exact Submodule.zero_mem _
+
+/-- A zero-padded linear mixing of one Lindblad family by another gives the
+corresponding inclusion of their spans. -/
+private theorem lindbladSpan_le_of_zeroPad_relation
+    (F G : LindbladForm D)
+    (hU : ∃ U : Matrix.unitaryGroup (Fin (max F.r G.r)) ℂ,
+      ∀ i, Kraus.zeroPad G.L i =
+        ∑ j, (U : Matrix (Fin (max F.r G.r)) (Fin (max F.r G.r)) ℂ) i j •
+          Kraus.zeroPad F.L j) :
+    lindbladSpan G ≤ lindbladSpan F := by
+  obtain ⟨U, hU⟩ := hU
+  rw [lindbladSpan, Submodule.span_le]
+  rintro _ ⟨i, rfl⟩
+  have hi := hU (Fin.castLE (Nat.le_max_right F.r G.r) i)
+  rw [Kraus.zeroPad_castLE (Nat.le_max_right F.r G.r) G.L i] at hi
+  rw [hi]
+  exact Submodule.sum_mem _ fun j _ ↦
+    Submodule.smul_mem _ _ (zeroPad_mem_lindbladSpan F j)
+
+/-- Traceless Lindblad representations of the same generator have the same
+linear span. This is the span consequence of Wolf, Proposition 7.4(2). -/
+theorem lindbladSpan_eq_of_toLinearMap_eq_of_hasTracelessKraus
+    (F G : LindbladForm D)
+    (hFG : F.toLinearMap = G.toLinearMap)
+    (hF : F.HasTracelessKraus) (hG : G.HasTracelessKraus) :
+    lindbladSpan F = lindbladSpan G := by
+  have hle : ∀ (A B : LindbladForm D),
+      A.toLinearMap = B.toLinearMap →
+      A.HasTracelessKraus → B.HasTracelessKraus →
+      lindbladSpan B ≤ lindbladSpan A := by
+    intro A B hAB hAtr hBtr
+    apply lindbladSpan_le_of_zeroPad_relation A B
+    exact (generatorDecomp_traceless_representation_freedom
+      A.toGeneratorDecomp B.toGeneratorDecomp A.L B.L
+      (fun _ ↦ rfl) (fun _ ↦ rfl)
+      (by
+        rw [← A.toLinearMap_eq_generatorDecomp,
+          ← B.toLinearMap_eq_generatorDecomp, hAB])
+      hAtr hBtr).2.2
+  exact le_antisymm (hle G F hFG.symm hG hF) (hle F G hFG hF hG)
+
+end LindbladForm
+
+/-- The span of the square-root Lindblad operators has dimension equal to the
+rank of Wolf's Kossakowski matrix `C`. -/
+theorem TracelessBasisKossakowskiForm.finrank_lindbladSpan_sqrtLindbladForm
+    (K : TracelessBasisKossakowskiForm D) :
+    Module.finrank ℂ (lindbladSpan K.sqrtLindbladForm) = K.C.rank := by
+  let B : Matrix (Fin (D ^ 2 - 1)) (Fin (D ^ 2 - 1)) ℂ := CFC.sqrt K.C
+  let E : (Fin (D ^ 2 - 1) → ℂ) ≃ₗ[ℂ] tracelessMatrixSubspace D :=
+    K.F.equivFun.symm
+  let ι : tracelessMatrixSubspace D →ₗ[ℂ] Mat :=
+    (tracelessMatrixSubspace D).subtype
+  let S : Submodule ℂ (Fin (D ^ 2 - 1) → ℂ) :=
+    Submodule.span ℂ (Set.range B.row)
+  have hL : K.sqrtLindbladForm.L = fun j ↦ ι (E (B.row j)) := by
+    funext j
+    simp [TracelessBasisKossakowskiForm.sqrtLindbladForm, B, E, ι,
+      TracelessBasisKossakowskiForm.toKossakowskiForm,
+      Basis.equivFun_symm_apply]
+    rfl
+  have hspan :
+      lindbladSpan K.sqrtLindbladForm =
+        Submodule.map ι (Submodule.map (E : _ →ₗ[ℂ] _) S) := by
+    rw [lindbladSpan, hL, ← Submodule.map_comp, Submodule.map_span]
+    congr 1
+    rw [← Set.range_comp]
+    rfl
+  have hfinrank :
+      Module.finrank ℂ (lindbladSpan K.sqrtLindbladForm) =
+        Module.finrank ℂ S := by
+    rw [hspan, Submodule.finrank_map_subtype_eq,
+      LinearEquiv.finrank_map_eq]
+  have hC_factor : K.C = Bᴴ * B := by
+    have hC_nonneg : 0 ≤ K.C :=
+      Matrix.nonneg_iff_posSemidef.mpr K.C_posSemidef
+    have hB_psd : B.PosSemidef := by
+      exact Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg K.C)
+    change K.C = Bᴴ * B
+    rw [hB_psd.isHermitian.eq]
+    simpa [B] using (CFC.sqrt_mul_sqrt_self K.C hC_nonneg).symm
+  calc
+    Module.finrank ℂ (lindbladSpan K.sqrtLindbladForm) =
+        Module.finrank ℂ S := hfinrank
+    _ = B.rank := (Matrix.rank_eq_finrank_span_row B).symm
+    _ = K.C.rank := by
+      rw [hC_factor, Matrix.rank_conjTranspose_mul_self]
+
+/-- For Wolf's basis-level representation, the minimum number of Lindblad
+operators is exactly the rank of the Kossakowski matrix `C`. -/
+theorem TracelessBasisKossakowskiForm.kossakowskiRank_toLinearMap_eq_rank
+    (K : TracelessBasisKossakowskiForm D) :
+    kossakowskiRank K.toLinearMap = K.C.rank := by
+  apply le_antisymm
+  · have hsqrt_mem : ∀ j : Fin K.sqrtLindbladForm.r,
+        K.sqrtLindbladForm.L j ∈ lindbladSpan K.sqrtLindbladForm := fun j ↦
+      Submodule.subset_span (Set.mem_range_self j)
+    obtain ⟨F, hF, hFr⟩ :=
+      K.sqrtLindbladForm.exists_equivalent_rank_le_finrank
+        (lindbladSpan K.sqrtLindbladForm) hsqrt_mem
+    calc
+      kossakowskiRank K.toLinearMap ≤ F.r := by
+        apply Nat.sInf_le
+        exact ⟨F, hF.trans K.toLinearMap_eq_sqrtLindbladForm.symm, rfl⟩
+      _ ≤ Module.finrank ℂ (lindbladSpan K.sqrtLindbladForm) := hFr
+      _ = K.C.rank := K.finrank_lindbladSpan_sqrtLindbladForm
+  · by_cases hD : D = 0
+    · subst D
+      have hCrank : K.C.rank = 0 := by
+        have hle := Matrix.rank_le_card_width K.C
+        simpa using Nat.eq_zero_of_le_zero hle
+      rw [hCrank]
+      exact Nat.zero_le _
+    · let _ : NeZero D := ⟨hD⟩
+      have hrepresentations :
+          {n : ℕ | ∃ F : LindbladForm D,
+            F.toLinearMap = K.toLinearMap ∧ F.r = n}.Nonempty := by
+        refine ⟨K.sqrtLindbladForm.r, K.sqrtLindbladForm, ?_, rfl⟩
+        exact K.toLinearMap_eq_sqrtLindbladForm.symm
+      have hminimum :
+          kossakowskiRank K.toLinearMap ∈
+            {n : ℕ | ∃ F : LindbladForm D,
+              F.toLinearMap = K.toLinearMap ∧ F.r = n} := by
+        exact Nat.sInf_mem hrepresentations
+      obtain ⟨F, hF, hFr⟩ := hminimum
+      obtain ⟨Ftr, hFtr, htr, -, hFtr_r⟩ :=
+        F.exists_traceless_in_submodule_same_rank ⊤ (by simp) (fun _ ↦ by simp)
+      have hFtr_sqrt : Ftr.toLinearMap = K.sqrtLindbladForm.toLinearMap :=
+        hFtr.trans (hF.trans K.toLinearMap_eq_sqrtLindbladForm)
+      have hspan : lindbladSpan Ftr = lindbladSpan K.sqrtLindbladForm :=
+        Ftr.lindbladSpan_eq_of_toLinearMap_eq_of_hasTracelessKraus
+          K.sqrtLindbladForm hFtr_sqrt htr
+          K.sqrtLindbladForm_hasTracelessKraus
+      calc
+        K.C.rank = Module.finrank ℂ (lindbladSpan K.sqrtLindbladForm) :=
+          K.finrank_lindbladSpan_sqrtLindbladForm.symm
+        _ = Module.finrank ℂ (lindbladSpan Ftr) := by rw [hspan]
+        _ ≤ Ftr.r := Ftr.finrank_lindbladSpan_le_rank
+        _ = F.r := hFtr_r
+        _ = kossakowskiRank K.toLinearMap := hFr
+
+end -- noncomputable section

--- a/QICLean/Channel/Semigroup/KossakowskiRank.lean
+++ b/QICLean/Channel/Semigroup/KossakowskiRank.lean
@@ -9,12 +9,14 @@ import QICLean.Channel.Semigroup.KossakowskiForm
 # Rank of the Kossakowski matrix
 
 This file relates the minimum number of Lindblad operators representing a
-generator to the rank of its Kossakowski matrix in Wolf's traceless basis.
+GKSL generator to the rank of its Kossakowski matrix in Wolf's traceless
+basis. The underlying rank definition is totalized for arbitrary linear maps.
 
 ## Main definitions
 
 * `lindbladSpan` is the linear span of a displayed Lindblad family.
-* `kossakowskiRank` is the minimum size of a Lindblad representation.
+* `kossakowskiRank` is the infimum of the sizes of Lindblad representations,
+  totalized to zero when there is no such representation.
 
 ## Main results
 
@@ -42,45 +44,14 @@ local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 def lindbladSpan (F : LindbladForm D) : Submodule ℂ Mat :=
   Submodule.span ℂ (Set.range F.L)
 
-/-- The minimum number of Lindblad operators among all representations of a
-fixed generator. -/
+/-- The infimum of the numbers of Lindblad operators in representations of a
+linear map. For a map admitting a Lindblad representation, this is the
+minimum such number. The definition is totalized to `0` when no representation
+exists. -/
 def kossakowskiRank (L : Mat →ₗ[ℂ] Mat) : ℕ :=
   sInf {n : ℕ | ∃ F : LindbladForm D, F.toLinearMap = L ∧ F.r = n}
 
 namespace LindbladForm
-
-/-- Bilinear sum identity for rectangular coefficient matrices:
-`Σⱼ (Σₖ Aⱼₖ•Fₖ) * M * (Σₖ Aⱼₖ•Fₖ)†`
-equals `Σₖₗ (A†A)ₗₖ • (Fₖ * M * Fₗ†)`. -/
-private lemma bilinear_sum_identity {r n : ℕ}
-    (A : Matrix (Fin r) (Fin n) ℂ)
-    (f : Fin n → Mat)
-    (M : Mat) :
-    ∑ j : Fin r, (∑ k, A j k • f k) * M * (∑ k, A j k • f k)ᴴ =
-    ∑ k : Fin n, ∑ l : Fin n, (Aᴴ * A) l k • (f k * M * (f l)ᴴ) := by
-  simp_rw [conjTranspose_sum, Matrix.conjTranspose_smul, Complex.star_def]
-  simp_rw [Finset.sum_mul, Finset.mul_sum, smul_mul_assoc, mul_smul_comm,
-    smul_smul, mul_assoc]
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl; intro k _
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl; intro l _
-  rw [← Finset.sum_smul]; congr 1
-  simp [conjTranspose_apply, mul_apply, mul_comm]
-
-/-- Adjoint variant of `bilinear_sum_identity`. -/
-private lemma bilinear_adj_sum_identity {r n : ℕ}
-    (A : Matrix (Fin r) (Fin n) ℂ)
-    (f : Fin n → Mat) :
-    ∑ j : Fin r, (∑ k, A j k • f k)ᴴ * (∑ k, A j k • f k) =
-    ∑ l : Fin n, ∑ k : Fin n, (Aᴴ * A) l k • ((f l)ᴴ * f k) := by
-  simp_rw [conjTranspose_sum, Matrix.conjTranspose_smul, Complex.star_def]
-  simp_rw [Finset.sum_mul, Finset.mul_sum, smul_mul_assoc, mul_smul_comm, smul_smul]
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl; intro l _
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl; intro k _
-  rw [← Finset.sum_smul]; congr 1
 
 /-- If every operator in a Lindblad family lies in a subspace `V`, the same
 generator admits a Lindblad representation with at most `finrank ℂ V`
@@ -130,18 +101,18 @@ theorem exists_equivalent_rank_le_finrank
       ∑ j : Fin G.r, G.L j * N * (G.L j)ᴴ =
       ∑ i : Fin m, L' i * N * (L' i)ᴴ := by
     intro N
-    rw [hsum_expand N, bilinear_sum_identity α f N]
+    rw [hsum_expand N, kraus_sum_eq_double_sum α f N]
     rw [show (∑ i : Fin m, L' i * N * (L' i)ᴴ) =
       ∑ k, ∑ l, (Bᴴ * B) l k • (f k * N * (f l)ᴴ) from
-        bilinear_sum_identity B f N]
+        kraus_sum_eq_double_sum B f N]
     rw [hC_factor]
   have hadj_eq :
       ∑ j : Fin G.r, (G.L j)ᴴ * G.L j =
       ∑ i : Fin m, (L' i)ᴴ * L' i := by
-    rw [hadj_expand, bilinear_adj_sum_identity α f]
+    rw [hadj_expand, adj_kraus_sum_eq_double_sum α f]
     rw [show (∑ i : Fin m, (L' i)ᴴ * L' i) =
       ∑ l, ∑ k, (Bᴴ * B) l k • ((f l)ᴴ * f k) from
-        bilinear_adj_sum_identity B f]
+        adj_kraus_sum_eq_double_sum B f]
     rw [hC_factor]
   ext1 ρ
   simp only [LindbladForm.toLinearMap, LinearMap.coe_mk, AddHom.coe_mk]
@@ -250,13 +221,7 @@ theorem TracelessBasisKossakowskiForm.finrank_lindbladSpan_sqrtLindbladForm
     rw [hspan, Submodule.finrank_map_subtype_eq,
       LinearEquiv.finrank_map_eq]
   have hC_factor : K.C = Bᴴ * B := by
-    have hC_nonneg : 0 ≤ K.C :=
-      Matrix.nonneg_iff_posSemidef.mpr K.C_posSemidef
-    have hB_psd : B.PosSemidef := by
-      exact Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg K.C)
-    change K.C = Bᴴ * B
-    rw [hB_psd.isHermitian.eq]
-    simpa [B] using (CFC.sqrt_mul_sqrt_self K.C hC_nonneg).symm
+    exact K.C_eq_conjTranspose_sqrt_mul_sqrt
   calc
     Module.finrank ℂ (lindbladSpan K.sqrtLindbladForm) =
         Module.finrank ℂ S := hfinrank

--- a/QICLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
+++ b/QICLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
@@ -104,8 +104,9 @@ theorem exists_traceless_kraus_shift
 /-- Shifting the Lindblad operators as in Wolf, Proposition 7.4,
 Equations (7.18)--(7.19), gives an equivalent Lindblad form with traceless
 operators. If the original operators lie in a linear subspace containing the
-identity, then the shifted operators remain in that subspace. -/
-theorem LindbladForm.exists_traceless_in_submodule
+identity, then the shifted operators remain in that subspace. The shift does
+not change the number of displayed operators. -/
+theorem LindbladForm.exists_traceless_in_submodule_same_rank
     (G : LindbladForm D)
     (V : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
     (hone : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ V)
@@ -114,7 +115,8 @@ theorem LindbladForm.exists_traceless_in_submodule
     ∃ G' : LindbladForm D,
       G'.toLinearMap = G.toLinearMap ∧
       G'.HasTracelessKraus ∧
-      ∀ j : Fin G'.r, G'.L j ∈ V := by
+      (∀ j : Fin G'.r, G'.L j ∈ V) ∧
+      G'.r = G.r := by
   obtain ⟨c, hc⟩ := exists_traceless_kraus_shift G.L
   set L' : Fin G.r → Matrix (Fin D) (Fin D) ℂ :=
     fun j ↦ G.L j + c j • (1 : Matrix (Fin D) (Fin D) ℂ) with hL'_def
@@ -140,7 +142,7 @@ theorem LindbladForm.exists_traceless_in_submodule
         apply Finset.sum_congr rfl
         intro j _
         simp only [neg_sub]]
-  refine ⟨⟨G.r, H', L', hH'_herm⟩, ?_, ?_, ?_⟩
+  refine ⟨⟨G.r, H', L', hH'_herm⟩, ?_, ?_, ?_, rfl⟩
   · rw [LindbladForm.toLinearMap_eq_generatorDecomp,
       LindbladForm.toLinearMap_eq_generatorDecomp]
     set κ_old : Matrix (Fin D) (Fin D) ℂ := G.toGeneratorDecomp.κ
@@ -216,6 +218,22 @@ theorem LindbladForm.exists_traceless_in_submodule
   · intro j
     rw [hL'_def]
     exact V.add_mem (hmem j) (V.smul_mem (c j) hone)
+
+/-- Shifting a Lindblad family to traceless operators preserves any linear
+subspace containing the identity. -/
+theorem LindbladForm.exists_traceless_in_submodule
+    (G : LindbladForm D)
+    (V : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (hone : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ V)
+    (hmem : ∀ j : Fin G.r, G.L j ∈ V)
+    [NeZero D] :
+    ∃ G' : LindbladForm D,
+      G'.toLinearMap = G.toLinearMap ∧
+      G'.HasTracelessKraus ∧
+      ∀ j : Fin G'.r, G'.L j ∈ V := by
+  obtain ⟨G', hG', htr, hmem', -⟩ :=
+    G.exists_traceless_in_submodule_same_rank V hone hmem
+  exact ⟨G', hG', htr, hmem'⟩
 
 /-- Every Lindblad form has an equivalent form whose Lindblad operators are
 traceless (Wolf, Proposition 7.4(1)). -/

--- a/QICLean/Channel/Semigroup/RelaxationConditions.lean
+++ b/QICLean/Channel/Semigroup/RelaxationConditions.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Channel.Semigroup.LindbladForm.GKSLTheorem
+import QICLean.Channel.Semigroup.KossakowskiRank
 import QICLean.Channel.Semigroup.ReducibleQDS.Equivalence
 
 /-!
@@ -29,10 +29,6 @@ variable {D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-/-- The `ℂ`-linear span of a Lindblad family's operators. -/
-def lindbladSpan (F : LindbladForm D) : Submodule ℂ Mat :=
-  Submodule.span ℂ (Set.range F.L)
-
 /-- The Lindblad span is closed under Hermitian conjugation, i.e. the `ℂ`-span
 of the Lindblad operators `{Lⱼ}` forms a `*`-subspace of `Mₐ(ℂ)`:
 for every `X = ∑ xⱼ Lⱼ` there exist `yⱼ` such that `X† = ∑ yⱼ Lⱼ`.
@@ -48,12 +44,6 @@ def HasLindbladSpanTrivialCommutant (F : LindbladForm D) : Prop :=
   ∀ A : Mat,
     (∀ j : Fin F.r, A * F.L j = F.L j * A) →
       ∃ c : ℂ, A = c • (1 : Mat)
-
-/-- The minimal number of Lindblad operators across all GKSL representations
-of `L`.  This equals the rank of the Kossakowski matrix in the
-orthonormal-basis representation (Wolf Section 7.1). -/
-def kossakowskiRank (L : Mat →ₗ[ℂ] Mat) : ℕ :=
-  sInf {n : ℕ | ∃ F : LindbladForm D, F.toLinearMap = L ∧ F.r = n}
 
 private theorem lower_left_block_vanishes_on_lindbladSpan
     {P : Mat} (F : LindbladForm D)
@@ -220,122 +210,6 @@ theorem hermitian_span_trivial_commutant_implies_no_blockUpperTriangular
     exact hleft.trans hright.symm
   obtain ⟨c, hP_scalar⟩ := hComm P hcommP
   exact not_isNontrivialProjection_of_eq_smul_one hP_nt hP_scalar
-
-/-- Bilinear sum identity for rectangular coefficient matrices:
-`Σⱼ (Σₖ A_{jk}•Fₖ) * M * (Σₖ A_{jk}•Fₖ)†`
-equals `Σₖₗ (A†A)_{lk} • (Fₖ * M * Fₗ†)`. -/
-private lemma bilinear_sum_identity {r n : ℕ}
-    (A : Matrix (Fin r) (Fin n) ℂ)
-    (f : Fin n → Mat)
-    (M : Mat) :
-    ∑ j : Fin r, (∑ k, A j k • f k) * M * (∑ k, A j k • f k)ᴴ =
-    ∑ k : Fin n, ∑ l : Fin n, (Aᴴ * A) l k • (f k * M * (f l)ᴴ) := by
-  simp_rw [conjTranspose_sum, Matrix.conjTranspose_smul, Complex.star_def]
-  simp_rw [Finset.sum_mul, Finset.mul_sum, smul_mul_assoc, mul_smul_comm,
-    smul_smul, mul_assoc]
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl; intro k _
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl; intro l _
-  rw [← Finset.sum_smul]; congr 1
-  simp [conjTranspose_apply, mul_apply, mul_comm]
-
-/-- Adjoint variant: `Σⱼ Lⱼ†Lⱼ = Σₗ Σₖ (A†A)_{lk} • (Fₗ†Fₖ)`. -/
-private lemma bilinear_adj_sum_identity {r n : ℕ}
-    (A : Matrix (Fin r) (Fin n) ℂ)
-    (f : Fin n → Mat) :
-    ∑ j : Fin r, (∑ k, A j k • f k)ᴴ * (∑ k, A j k • f k) =
-    ∑ l : Fin n, ∑ k : Fin n, (Aᴴ * A) l k • ((f l)ᴴ * f k) := by
-  simp_rw [conjTranspose_sum, Matrix.conjTranspose_smul, Complex.star_def]
-  simp_rw [Finset.sum_mul, Finset.mul_sum, smul_mul_assoc, mul_smul_comm, smul_smul]
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl; intro l _
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl; intro k _
-  rw [← Finset.sum_smul]; congr 1
-
-/-- Core construction: given a `LindbladForm` whose operators all lie in a
-submodule `V`, there exists a `LindbladForm` with `r ≤ finrank V` and the
-same `toLinearMap`. -/
-private theorem exists_lindblad_form_rank_le_finrank
-    (G : LindbladForm D) (V : Submodule ℂ Mat)
-    (hV : ∀ j : Fin G.r, G.L j ∈ V) :
-    ∃ G' : LindbladForm D,
-      G'.toLinearMap = G.toLinearMap ∧ G'.r ≤ Module.finrank ℂ V := by
-  -- m = finrank V
-  set m := Module.finrank ℂ V
-  -- Get a basis of V indexed by Fin m
-  have : Module.Finite ℂ V := inferInstance
-  have : Module.Free ℂ V := Module.Free.of_divisionRing ℂ V
-  let e := Module.finBasis ℂ V
-  -- Coordinate matrix: α_{jk} = (e.repr ⟨G.L j, hV j⟩) k
-  let α : Matrix (Fin G.r) (Fin m) ℂ := fun j k => (e.repr ⟨G.L j, hV j⟩) k
-  -- Each operator is Σ_k α_{jk} • e_k
-  have hL_expand : ∀ j, G.L j = ∑ k : Fin m, α j k • (e k : Mat) := by
-    intro j
-    have := e.sum_repr ⟨G.L j, hV j⟩
-    have : (⟨G.L j, hV j⟩ : V) = ∑ k, (e.repr ⟨G.L j, hV j⟩) k • e k := by
-      rw [← e.sum_equivFun ⟨G.L j, hV j⟩]
-      simp [Basis.equivFun_apply]
-    have hval := congrArg Subtype.val this
-    simp only [Submodule.coe_sum, Submodule.coe_smul] at hval
-    exact hval
-  -- Gram matrix C = α†α is PSD
-  have hC_psd : (αᴴ * α).PosSemidef :=
-    Matrix.posSemidef_conjTranspose_mul_self α
-  -- Factor C = B†B where B = √C
-  set B := CFC.sqrt (αᴴ * α)
-  have hC_factor : (αᴴ * α) = Bᴴ * B := by
-    have hB_psd := Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg (αᴴ * α))
-    rw [hB_psd.isHermitian.eq]
-    simpa using (CFC.sqrt_mul_sqrt_self _ (Matrix.nonneg_iff_posSemidef.mpr hC_psd)).symm
-  -- New operators: L'_i = Σ_k B_{ik} • e_k
-  let L' : Fin m → Mat := fun i => ∑ k : Fin m, B i k • (e k : Mat)
-  -- Build the new LindbladForm
-  refine ⟨⟨m, G.H, L', G.H_hermitian⟩, ?_, le_refl m⟩
-  -- Show toLinearMap agrees
-  -- Key: Σ_j L_j ρ L_j† = Σ_i L'_i ρ L'_i† (and similarly for L†L)
-  -- because both equal
-  -- Σ_{k,l} (α†α)_{lk} (e_k ρ e_l†) = Σ_{k,l} (B†B)_{lk} (e_k ρ e_l†)
-  let f : Fin m → Mat := fun k => (e k : Mat)
-  -- Rewrite sums using basis expansion
-  have hsum_expand : ∀ N : Mat,
-      ∑ j : Fin G.r, G.L j * N * (G.L j)ᴴ =
-      ∑ j : Fin G.r, (∑ k, α j k • f k) * N * (∑ k, α j k • f k)ᴴ := by
-    intro N; apply Finset.sum_congr rfl; intro j _; rw [hL_expand j]
-  have hadj_expand :
-      ∑ j : Fin G.r, (G.L j)ᴴ * G.L j =
-      ∑ j : Fin G.r, (∑ k, α j k • f k)ᴴ * (∑ k, α j k • f k) := by
-    apply Finset.sum_congr rfl; intro j _; rw [hL_expand j]
-  have hcp_eq : ∀ N : Mat,
-      ∑ j : Fin G.r, G.L j * N * (G.L j)ᴴ =
-      ∑ i : Fin m, L' i * N * (L' i)ᴴ := by
-    intro N
-    rw [hsum_expand N, bilinear_sum_identity α f N]
-    rw [show (∑ i : Fin m, L' i * N * (L' i)ᴴ) =
-      ∑ k, ∑ l, (Bᴴ * B) l k • (f k * N * (f l)ᴴ) from
-        bilinear_sum_identity B f N]
-    rw [hC_factor]
-  have hadj_eq :
-      ∑ j : Fin G.r, (G.L j)ᴴ * G.L j =
-      ∑ i : Fin m, (L' i)ᴴ * L' i := by
-    rw [hadj_expand, bilinear_adj_sum_identity α f]
-    rw [show (∑ i : Fin m, (L' i)ᴴ * L' i) =
-      ∑ l, ∑ k, (Bᴴ * B) l k • ((f l)ᴴ * f k) from
-        bilinear_adj_sum_identity B f]
-    rw [hC_factor]
-  ext1 ρ
-  simp only [LindbladForm.toLinearMap, LinearMap.coe_mk, AddHom.coe_mk]
-  congr 1
-  simp only [dissipator]
-  simp_rw [Finset.sum_sub_distrib]
-  congr 1
-  · congr 1
-    · exact (hcp_eq ρ).symm
-    · rw [← Finset.smul_sum, ← Finset.smul_sum,
-          ← Finset.sum_mul, ← Finset.sum_mul, hadj_eq]
-  · rw [← Finset.smul_sum, ← Finset.smul_sum,
-        ← Finset.mul_sum, ← Finset.mul_sum, hadj_eq]
 
 /-- If `1 ∈ ker φ`, then every matrix splits as a scalar multiple of `1`
 plus a traceless element, so `ker φ ⊔ ker(trace) = ⊤`. -/
@@ -729,11 +603,13 @@ private theorem exists_traceless_blockUT_lindblad_form
   · rw [LinearMap.mem_ker, Matrix.traceLinearMap_apply]
     exact htrace j
 
-/-- Condition (3): Kossakowski rank `> D * D` forbids block-upper-triangular
-Lindblad decompositions (Wolf Corollary 7.2(3)).
+/-- A minimum Lindblad rank greater than `D ^ 2 - D` forbids
+block-upper-triangular Lindblad decompositions.
 
-The hypothesis is stated using addition (`rank + D ≥ D ^ 2 + 1`) to avoid
-natural-number subtraction issues; this is equivalent to `rank > D * D`. -/
+The hypothesis is stated as `rank + D ≥ D ^ 2 + 1`, an equivalent form that
+avoids truncated subtraction on natural numbers. The source-facing
+Kossakowski-matrix formulation of Wolf, Corollary 7.2(3), is
+`TracelessBasisKossakowskiForm.large_rank_implies_no_blockUpperTriangular`. -/
 theorem large_kossakowski_rank_implies_no_blockUpperTriangular
     (F : LindbladForm D)
     (hRank : kossakowskiRank F.toLinearMap + D ≥ D ^ 2 + 1) :
@@ -749,7 +625,7 @@ theorem large_kossakowski_rank_implies_no_blockUpperTriangular
     exists_traceless_blockUT_lindblad_form hP_nt G F.toLinearMap hL_eq hBlock
   -- Construct a form with rank ≤ finrank V
   obtain ⟨G'', hG''_eq, hG''_r⟩ :=
-    exists_lindblad_form_rank_le_finrank G' V hG'_mem
+    G'.exists_equivalent_rank_le_finrank V hG'_mem
   -- kossakowskiRank ≤ G''.r
   have hkr : kossakowskiRank F.toLinearMap ≤ G''.r := by
     apply Nat.sInf_le
@@ -759,6 +635,22 @@ theorem large_kossakowski_rank_implies_no_blockUpperTriangular
     finrank_traceless_blockUT_add_D_le hP_nt
   -- But kossakowskiRank + D ≥ D² + 1
   omega
+
+/-- Wolf, Corollary 7.2(3), with the source hypothesis
+`D ^ 2 - D < rank(C)`: a Kossakowski matrix of this rank cannot admit a
+block-upper-triangular Lindblad representation. -/
+theorem TracelessBasisKossakowskiForm.large_rank_implies_no_blockUpperTriangular
+    (K : TracelessBasisKossakowskiForm D)
+    (hRank : D ^ 2 - D < K.C.rank) :
+    ¬ HasBlockUpperTriangularLindblad K.toLinearMap := by
+  have hRank' : kossakowskiRank K.toLinearMap + D ≥ D ^ 2 + 1 := by
+    rw [K.kossakowskiRank_toLinearMap_eq_rank]
+    omega
+  have hNoBlock := large_kossakowski_rank_implies_no_blockUpperTriangular
+    K.sqrtLindbladForm (by
+      rw [← K.toLinearMap_eq_sqrtLindbladForm]
+      exact hRank')
+  rwa [← K.toLinearMap_eq_sqrtLindbladForm] at hNoBlock
 
 /--
 If a GKSL generator has no block-upper-triangular Lindblad decomposition,
@@ -803,5 +695,15 @@ theorem not_isReducible_of_kossakowski_rank_ge
     ¬ IsReducibleQDS F.toLinearMap := by
   apply not_isReducibleQDS_of_no_blockUpperTriangular_lindblad hGKSL
   exact large_kossakowski_rank_implies_no_blockUpperTriangular F hRank
+
+/-- Wolf, Corollary 7.2(3), in the source notation: if
+`rank(C) > D ^ 2 - D`, then the quantum dynamical semigroup is not reducible. -/
+theorem TracelessBasisKossakowskiForm.not_isReducible_of_rank_gt
+    (K : TracelessBasisKossakowskiForm D)
+    (hRank : D ^ 2 - D < K.C.rank) :
+    ¬ IsReducibleQDS K.toLinearMap := by
+  apply not_isReducibleQDS_of_no_blockUpperTriangular_lindblad
+  · exact (gksl_iff_tracelessBasisKossakowskiForm K.toLinearMap).2 ⟨K, rfl⟩
+  · exact K.large_rank_implies_no_blockUpperTriangular hRank
 
 end -- noncomputable section

--- a/QICLean/Channel/Semigroup/RelaxationCorollary.lean
+++ b/QICLean/Channel/Semigroup/RelaxationCorollary.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Channel.Semigroup.Primitivity.MainTheorem
+import QICLean.Channel.Semigroup.RelaxationConditions
+
+/-!
+# Wolf Corollary 7.2 — Necessary conditions for relaxation
+
+This file packages the three algebraic criteria of Wolf, Corollary 7.2, with
+the faithful stationary state and global relaxation conclusion obtained from
+Propositions 7.5 and 7.6.
+-/
+
+open scoped Matrix ComplexOrder BigOperators NNReal MatrixOrder TNOperatorSpace
+open Matrix Finset Module
+
+noncomputable section
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- For a GKSL generator, non-reducibility is equivalent to irreducibility of
+one positive-time channel. The forward implication chooses the non-resonant
+time at which the fixed-point space of `expSemigroup L` is `ker L`, as in
+Wolf, Propositions 7.5 and 7.6. -/
+theorem not_isReducibleQDS_iff_exists_irreducible_time
+    {L : Mat →ₗ[ℂ] Mat}
+    (hGKSL : IsGKSLGenerator L) :
+    (¬ IsReducibleQDS L) ↔
+      ∃ t₀ : ℝ, 0 < t₀ ∧ IsIrreducibleMap (expSemigroup L t₀) := by
+  constructor
+  · intro hNotReducible
+    obtain ⟨t₀, ht₀, hfixed⟩ :=
+      exists_pos_expSemigroup_fixedPoint_iff_generator_apply_eq_zero L
+    refine ⟨t₀, ht₀, ?_⟩
+    intro P hP hP_pres
+    by_cases hP_zero : P = 0
+    · exact Or.inl hP_zero
+    by_cases hP_one : P = 1
+    · exact Or.inr hP_one
+    exfalso
+    obtain ⟨ρ, hρ_density, hρ_corner, hρ_fixed⟩ :=
+      IsChannel.exists_fixed_density_of_preserves_compression
+        (E := expSemigroup L t₀) (hGKSL t₀ ht₀.le) hP hP_zero hP_pres
+    have hKernel : HasRankDeficientKernelElement L :=
+      ⟨ρ, hρ_density, ⟨P, ⟨hP, hP_zero, hP_one⟩, hρ_corner⟩,
+        (hfixed ρ).1 hρ_fixed⟩
+    have hInvariant : HasInvariantCompression L :=
+      (wolf_prop_7_6_full_equivalence hGKSL).2.1.mp hKernel
+    exact hNotReducible hInvariant
+  · rintro ⟨t₀, ht₀, hirreducible⟩ hReducible
+    obtain ⟨P, hP, hP_pres⟩ := hReducible
+    rcases hirreducible P hP.1 (hP_pres t₀ ht₀.le) with hP_zero | hP_one
+    · exact hP.2.1 hP_zero
+    · exact hP.2.2 hP_one
+
+/-- A non-reducible GKSL semigroup relaxes to a faithful stationary density
+matrix, which also spans the kernel of its generator. This is the direct
+combination of Wolf, Propositions 7.6 and 7.5. -/
+theorem relaxation_and_simple_kernel_of_not_isReducibleQDS
+    [NeZero D]
+    (L : Mat →ₗ[ℂ] Mat)
+    (hGKSL : IsGKSLGenerator L)
+    (hNotReducible : ¬ IsReducibleQDS L) :
+    ∃ ρInf : Mat,
+      RelaxesTo (expSemigroup L) ρInf ∧ HasSimpleKernel L ρInf := by
+  obtain ⟨t₀, ht₀, hirreducible⟩ :=
+    (not_isReducibleQDS_iff_exists_irreducible_time hGKSL).1 hNotReducible
+  apply relaxation_and_simple_kernel_of_irreducible_time
+    L (expSemigroup L)
+  · exact ⟨expSemigroup_isContinuousDynSemigroup L, hGKSL⟩
+  · intro _ _
+    rfl
+  · exact ht₀
+  · exact hirreducible
+
+/-- Wolf, Corollary 7.2(1): if the Lindblad operators together with `κ`
+generate the full matrix algebra, the semigroup relaxes to a faithful
+stationary density matrix. -/
+theorem relaxation_and_simple_kernel_of_generates_full_algebra
+    [NeZero D]
+    (F : LindbladForm D)
+    (hGen : Algebra.adjoin ℂ
+      (Set.range F.L ∪ ({F.toGeneratorDecomp.κ} : Set Mat)) = ⊤) :
+    ∃ ρInf : Mat,
+      RelaxesTo (expSemigroup F.toLinearMap) ρInf ∧
+        HasSimpleKernel F.toLinearMap ρInf := by
+  have hGKSL : IsGKSLGenerator F.toLinearMap :=
+    (gksl_iff_lindbladForm F.toLinearMap).2 ⟨F, rfl⟩
+  exact relaxation_and_simple_kernel_of_not_isReducibleQDS
+    F.toLinearMap hGKSL
+      (not_isReducible_of_generates_full_algebra F hGKSL hGen)
+
+/-- Wolf, Corollary 7.2(2): if the Lindblad span is Hermitian and has scalar
+commutant, the semigroup relaxes to a faithful stationary density matrix. -/
+theorem relaxation_and_simple_kernel_of_hermitian_span_trivial_commutant
+    [NeZero D]
+    (F : LindbladForm D)
+    (hHerm : IsLindbladSpanHermitianClosed F)
+    (hComm : HasLindbladSpanTrivialCommutant F) :
+    ∃ ρInf : Mat,
+      RelaxesTo (expSemigroup F.toLinearMap) ρInf ∧
+        HasSimpleKernel F.toLinearMap ρInf := by
+  have hGKSL : IsGKSLGenerator F.toLinearMap :=
+    (gksl_iff_lindbladForm F.toLinearMap).2 ⟨F, rfl⟩
+  exact relaxation_and_simple_kernel_of_not_isReducibleQDS
+    F.toLinearMap hGKSL
+      (not_isReducible_of_hermitian_span_trivial_commutant
+        F hGKSL hHerm hComm)
+
+/-- Wolf, Corollary 7.2(3): under the literal source inequality
+`D ^ 2 - D < rank(C)`, the semigroup relaxes to a faithful stationary density
+matrix. -/
+theorem TracelessBasisKossakowskiForm.relaxation_and_simple_kernel_of_rank_gt
+    [NeZero D]
+    (K : TracelessBasisKossakowskiForm D)
+    (hRank : D ^ 2 - D < K.C.rank) :
+    ∃ ρInf : Mat,
+      RelaxesTo (expSemigroup K.toLinearMap) ρInf ∧
+        HasSimpleKernel K.toLinearMap ρInf := by
+  have hGKSL : IsGKSLGenerator K.toLinearMap :=
+    (gksl_iff_tracelessBasisKossakowskiForm K.toLinearMap).2 ⟨K, rfl⟩
+  exact relaxation_and_simple_kernel_of_not_isReducibleQDS
+    K.toLinearMap hGKSL (K.not_isReducible_of_rank_gt hRank)
+
+/-- **Wolf Corollary 7.2 (complete relaxation conclusion).** Let `L` be
+represented in Lindblad form, or in the fixed-traceless-basis Kossakowski
+form. Each of Wolf's three stated alternatives produces one faithful
+stationary density matrix to which every density matrix converges. The same
+density matrix spans `ker L`.
+
+This is `Notes/WolfNoteTexSource/ch07_semigroup_structure.tex`, lines 313--325.
+-/
+theorem wolf_corollary_7_2
+    [NeZero D]
+    {L : Mat →ₗ[ℂ] Mat}
+    (hCondition :
+      (∃ F : LindbladForm D,
+        F.toLinearMap = L ∧
+          Algebra.adjoin ℂ
+            (Set.range F.L ∪ ({F.toGeneratorDecomp.κ} : Set Mat)) = ⊤) ∨
+      (∃ F : LindbladForm D,
+        F.toLinearMap = L ∧ IsLindbladSpanHermitianClosed F ∧
+          HasLindbladSpanTrivialCommutant F) ∨
+      ∃ K : TracelessBasisKossakowskiForm D,
+        K.toLinearMap = L ∧ D ^ 2 - D < K.C.rank) :
+    ∃ ρInf : Mat,
+      RelaxesTo (expSemigroup L) ρInf ∧ HasSimpleKernel L ρInf := by
+  rcases hCondition with hGen | hHerm | hRank
+  · obtain ⟨F, hFL, hGen⟩ := hGen
+    simpa only [hFL] using
+      (relaxation_and_simple_kernel_of_generates_full_algebra F hGen)
+  · obtain ⟨F, hFL, hHerm, hComm⟩ := hHerm
+    simpa only [hFL] using
+      (relaxation_and_simple_kernel_of_hermitian_span_trivial_commutant
+        F hHerm hComm)
+  · obtain ⟨K, hKL, hRank⟩ := hRank
+    simpa only [hKL] using
+      (K.relaxation_and_simple_kernel_of_rank_gt hRank)
+
+end -- noncomputable section

--- a/blueprint/src/chapter/ch11_semigroup_adjoint_kernel_and_reducibility.tex
+++ b/blueprint/src/chapter/ch11_semigroup_adjoint_kernel_and_reducibility.tex
@@ -396,7 +396,7 @@ The four equivalent reducibility conditions of
 
 %% Source: \cite[Corollary~7.2]{Wolf2012Quantum}.
 
-\subsection{Sufficient conditions for non-reducibility}
+\subsection{Necessary conditions for relaxation}
 \label{sec:cor_7_2_sufficient_conditions}
 
 \begin{definition}[Lindblad span]\label{def:lindblad_span}
@@ -422,9 +422,47 @@ The four equivalent reducibility conditions of
 \begin{definition}[Kossakowski rank]\label{def:kossakowski_rank}
     \lean{kossakowskiRank}\leanok
     \uses{def:lindblad_form}
-    The minimal number of Lindblad operators across all GKSL representations
-    of $L$.
+    The infimum of the numbers of Lindblad operators across all
+    representations of $L$.  When such a representation exists, this is the
+    minimum; the definition is totalized to zero otherwise.
 \end{definition}
+
+\begin{lemma}[Compressing a Lindblad family]
+    \label{lem:lindblad_family_rank_compression}
+    \lean{LindbladForm.exists_equivalent_rank_le_finrank}
+    \leanok
+    \uses{def:lindblad_form}
+    If every Lindblad operator belongs to a linear subspace $V$, then the
+    same generator has a Lindblad representation with at most $\dim V$
+    operators.
+\end{lemma}
+
+\begin{proof}\leanok
+    Expand the Lindblad operators in a basis of $V$.  The Gram matrix of
+    their coefficient rows is positive semidefinite; its square root gives a
+    family indexed by a basis of $V$ with the same completely positive and
+    anticommutator sums.
+\end{proof}
+
+\begin{lemma}[Square-root Lindblad span]
+    \label{lem:kossakowski_sqrt_lindblad_span}
+    \lean{TracelessBasisKossakowskiForm.C_eq_conjTranspose_sqrt_mul_sqrt,
+        TracelessBasisKossakowskiForm.sqrtLindbladForm,
+        TracelessBasisKossakowskiForm.toLinearMap_eq_sqrtLindbladForm,
+        TracelessBasisKossakowskiForm.finrank_lindbladSpan_sqrtLindbladForm}
+    \leanok
+    \uses{def:kossakowski_form, def:lindblad_span}
+    The factorization $C=(\sqrt C)^\dagger\sqrt C$ gives Lindblad operators
+    $L_j=\sum_k(\sqrt C)_{jk}F_k$ for the same generator. Their linear span
+    has dimension $\rank(C)$.
+\end{lemma}
+
+\begin{proof}\leanok
+    The chosen traceless basis transports the row span of $\sqrt C$ to the
+    Lindblad span.  Since this transport is injective and
+    $\rank((\sqrt C)^\dagger\sqrt C)=\rank(\sqrt C)$, the two dimensions
+    agree.
+\end{proof}
 
 \begin{theorem}[Kossakowski rank equals matrix rank]
     \label{thm:kossakowski_rank_eq_matrix_rank}
@@ -435,6 +473,10 @@ The four equivalent reducibility conditions of
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{lem:lindblad_family_rank_compression,
+        lem:kossakowski_sqrt_lindblad_span,
+        thm:exists_traceless_kraus_shift,
+        thm:generatorDecomp_traceless_unique}
     Factor $C=(\sqrt C)^\dagger\sqrt C$.  The resulting Lindblad operators
     are the images of the rows of $\sqrt C$ under the chosen basis
     equivalence, so their span has dimension $\rank(C)$.  This gives the
@@ -538,6 +580,30 @@ The four equivalent reducibility conditions of
     would then produce a block-upper-triangular Lindblad form.
 \end{proof}
 
+\begin{theorem}[From non-reducibility to faithful relaxation]
+    \label{thm:not_reducible_implies_faithful_relaxation}
+    \lean{not_isReducibleQDS_iff_exists_irreducible_time,
+        relaxation_and_simple_kernel_of_not_isReducibleQDS}\leanok
+    \uses{def:is_reducible_qds_ch12,
+        def:qds_faithful_relaxation}
+    For a GKSL generator $L$, the semigroup is not reducible if and only if
+    $e^{t_0L}$ is irreducible for some $t_0>0$.  Consequently, a
+    non-reducible semigroup relaxes to a faithful stationary density matrix
+    $\rho_\infty$, and $\rho_\infty$ spans $\ker L$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:wolf_prop_7_5_full_equivalence,
+        thm:wolf_prop_7_6_full}
+    Choose $t_0>0$ for which the fixed-point space of $e^{t_0L}$ equals
+    $\ker L$.  If this channel had a nontrivial invariant compression, it
+    would have a density fixed point supported in that compression.  This
+    would be a rank-deficient element of $\ker L$, hence would make the
+    semigroup reducible by Proposition~7.6.  Thus $e^{t_0L}$ is irreducible,
+    and Proposition~7.5 supplies the faithful stationary density and global
+    convergence.
+\end{proof}
+
 \begin{theorem}[Full algebra generation implies non-reducibility]
     \label{thm:not_isReducible_of_generates_full_algebra}
     \lean{not_isReducible_of_generates_full_algebra}\leanok
@@ -592,4 +658,46 @@ The four equivalent reducibility conditions of
     The rank hypothesis rules out block-upper-triangular Lindblad data by
     Theorem~\ref{thm:large_kossakowski_rank_no_block_ut_ch12}. Then apply
     Theorem~\ref{thm:not_isReducibleQDS_of_no_blockUpperTriangular_ch12}.
+\end{proof}
+
+\begin{theorem}[Necessary conditions for relaxation]
+    \label{thm:wolf_corollary_7_2}
+    \lean{relaxation_and_simple_kernel_of_generates_full_algebra,
+        relaxation_and_simple_kernel_of_hermitian_span_trivial_commutant,
+        TracelessBasisKossakowskiForm.relaxation_and_simple_kernel_of_rank_gt,
+        wolf_corollary_7_2}\leanok
+    \uses{def:lindblad_span, def:is_lindblad_span_hermitian_closed,
+        def:has_lindblad_span_trivial_commutant, def:kossakowski_form,
+        def:qds_faithful_relaxation}
+    Let $T_t=e^{tL}:\MN{d}\to\MN{d}$ be a dynamical semigroup of
+    trace-preserving completely positive maps, with generator represented as
+    in Theorem~7.1.  There is a positive-definite stationary density matrix
+    $\rho_\infty$ such that
+    \begin{align}
+        \lim_{t\to\infty}T_t(\rho)&=\rho_\infty
+    \end{align}
+    for every density matrix $\rho$, if one of the following holds:
+    \begin{enumerate}
+        \item the algebra generated by the Lindblad operators $\{L_j\}$ and
+              $\kappa$ is all of $\MN{d}$;
+        \item the linear span of $\{L_j\}$ is Hermitian and has commutant
+              $\C\Id$;
+        \item the Kossakowski matrix in a fixed traceless basis satisfies
+              $\rank(C)>d^2-d$.
+    \end{enumerate}
+    Moreover, the same $\rho_\infty$ spans $\ker L$.
+    This is \cite[Corollary~7.2]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:not_reducible_implies_faithful_relaxation,
+        thm:not_isReducible_of_generates_full_algebra,
+        thm:not_isReducible_of_hermitian_span_trivial_commutant,
+        thm:not_isReducible_of_kossakowski_rank_ge,
+        thm:kossakowski_rank_eq_matrix_rank}
+    Each of the three hypotheses excludes a block-upper-triangular Lindblad
+    representation and hence excludes reducibility.  Apply
+    Theorem~\ref{thm:not_reducible_implies_faithful_relaxation}.  In the third
+    case, Theorem~\ref{thm:kossakowski_rank_eq_matrix_rank} identifies the
+    minimum Lindblad-family size with the literal matrix rank $\rank(C)$.
 \end{proof}

--- a/blueprint/src/chapter/ch11_semigroup_adjoint_kernel_and_reducibility.tex
+++ b/blueprint/src/chapter/ch11_semigroup_adjoint_kernel_and_reducibility.tex
@@ -423,9 +423,27 @@ The four equivalent reducibility conditions of
     \lean{kossakowskiRank}\leanok
     \uses{def:lindblad_form}
     The minimal number of Lindblad operators across all GKSL representations
-    of $L$, which equals the rank of the Kossakowski matrix in the
-    orthonormal-basis representation.
+    of $L$.
 \end{definition}
+
+\begin{theorem}[Kossakowski rank equals matrix rank]
+    \label{thm:kossakowski_rank_eq_matrix_rank}
+    \lean{TracelessBasisKossakowskiForm.kossakowskiRank_toLinearMap_eq_rank}\leanok
+    \uses{def:kossakowski_rank, def:kossakowski_form}
+    For a generator written in Wolf's traceless-basis form, the minimum
+    number of Lindblad operators equals $\rank(C)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Factor $C=(\sqrt C)^\dagger\sqrt C$.  The resulting Lindblad operators
+    are the images of the rows of $\sqrt C$ under the chosen basis
+    equivalence, so their span has dimension $\rank(C)$.  This gives the
+    upper bound after compressing the family to a basis of its span.  For the
+    reverse bound, shift an arbitrary minimizing representation to a
+    traceless representation without changing its cardinality.  Wolf's
+    Proposition~7.4(2) identifies its Lindblad span with the square-root
+    family's span.
+\end{proof}
 
 \begin{theorem}[$\kappa$ block vanishing from generator compression]%
     \label{thm:kappa_block_generator_compression}
@@ -490,9 +508,11 @@ The four equivalent reducibility conditions of
 
 \begin{theorem}[Large Kossakowski rank forbids block-upper-triangular form]
     \label{thm:large_kossakowski_rank_no_block_ut_ch12}
-    \lean{large_kossakowski_rank_implies_no_blockUpperTriangular}\leanok
-    \uses{def:kossakowski_rank, def:has_block_upper_triangular_lindblad}
-    If the Kossakowski rank satisfies $\rank(C)+d\ge d^2+1$, then no
+    \lean{TracelessBasisKossakowskiForm.large_rank_implies_no_blockUpperTriangular}\leanok
+    \uses{def:kossakowski_rank, def:kossakowski_form,
+        thm:kossakowski_rank_eq_matrix_rank,
+        def:has_block_upper_triangular_lindblad}
+    If the Kossakowski matrix satisfies $\rank(C)>d^2-d$, then no
     block-upper-triangular Lindblad form exists.
 \end{theorem}
 
@@ -559,8 +579,9 @@ The four equivalent reducibility conditions of
 
 \begin{theorem}[Large Kossakowski rank implies non-reducibility]
     \label{thm:not_isReducible_of_kossakowski_rank_ge}
-    \lean{not_isReducible_of_kossakowski_rank_ge}\leanok
-    \uses{def:is_gksl_generator, def:kossakowski_rank,
+    \lean{TracelessBasisKossakowskiForm.not_isReducible_of_rank_gt}\leanok
+    \uses{def:is_gksl_generator, def:kossakowski_rank, def:kossakowski_form,
+        thm:kossakowski_rank_eq_matrix_rank,
         thm:large_kossakowski_rank_no_block_ut_ch12,
         thm:not_isReducibleQDS_of_no_blockUpperTriangular_ch12}
     If $\rank(C)>d^2-d$, then the QDS is not reducible.

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -2089,6 +2089,16 @@ The complete named-environment audit therefore classifies exactly one Chapter
   yield non-reducibility, but the source's faithful stationary state and global
   relaxation conclusion are not packaged (partial-packaging).
 
+For Corollary 7.2(3), the source-facing rank statement itself is exact.
+`TracelessBasisKossakowskiForm.kossakowskiRank_toLinearMap_eq_rank` proves that
+the minimum size of a Lindblad representation is the matrix rank
+`K.C.rank`, using the factorization `C = (sqrt C)ᴴ * sqrt C` and the
+traceless-representation freedom of Proposition 7.4. Consequently,
+`TracelessBasisKossakowskiForm.not_isReducible_of_rank_gt` uses Wolf's literal
+hypothesis `D ^ 2 - D < K.C.rank`. The remaining partial-packaging status is
+only the stronger faithful-stationary-state and global-relaxation conclusion
+of the containing corollary.
+
 Proposition 7.4 is an exact completion. The shift formula and traceless choice
 are `generator_shift_invariance` and `exists_traceless_kraus_shift`.
 `generatorDecomp_traceless_representation_freedom` packages the second clause

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -2082,22 +2082,24 @@ for every submultiplicative norm from the Duhamel identity, while
 Here Wolf's “any norm” refers to the operator norm induced by the chosen norm on
 the state space, as defined immediately before Proposition 7.1.
 
-The complete named-environment audit therefore classifies exactly one Chapter
-7 source environment as partial rather than exact:
+The complete named-environment audit classifies no Chapter 7 source
+environment as partial.
 
-- Corollary 7.2, “Necessary conditions for relaxation”: the three hypotheses
-  yield non-reducibility, but the source's faithful stationary state and global
-  relaxation conclusion are not packaged (partial-packaging).
+Corollary 7.2 is an exact completion. The declaration
+`wolf_corollary_7_2` retains the three printed alternatives and returns one
+positive-definite stationary density matrix to which every density matrix
+converges. It also records the stronger conclusion, supplied by Proposition
+7.5, that the same density matrix spans the generator kernel. The three named
+wrappers expose each alternative separately without a redundant caller-supplied
+GKSL hypothesis.
 
-For Corollary 7.2(3), the source-facing rank statement itself is exact.
+For condition (3), the source-facing rank statement is literal.
 `TracelessBasisKossakowskiForm.kossakowskiRank_toLinearMap_eq_rank` proves that
 the minimum size of a Lindblad representation is the matrix rank
 `K.C.rank`, using the factorization `C = (sqrt C)ᴴ * sqrt C` and the
 traceless-representation freedom of Proposition 7.4. Consequently,
-`TracelessBasisKossakowskiForm.not_isReducible_of_rank_gt` uses Wolf's literal
-hypothesis `D ^ 2 - D < K.C.rank`. The remaining partial-packaging status is
-only the stronger faithful-stationary-state and global-relaxation conclusion
-of the containing corollary.
+`TracelessBasisKossakowskiForm.relaxation_and_simple_kernel_of_rank_gt` uses
+Wolf's literal hypothesis `D ^ 2 - D < K.C.rank`.
 
 Proposition 7.4 is an exact completion. The shift formula and traceless choice
 are `generator_shift_invariance` and `exists_traceless_kraus_shift`.
@@ -2134,10 +2136,10 @@ the same choice of positive time identifies the fixed space of the channel
 with the kernel of the generator. Cesàro averaging within the invariant proper
 compression then supplies the required rank-deficient density matrix.
 
-Propositions 7.1--7.6, Theorem 7.1, and Corollary 7.1 are exact completions. The
-`\leanok` markers in the semigroup Blueprint certify individual Lean
-declarations; they must not be read as exact-coverage markers for a larger
-containing Wolf environment.
+Propositions 7.1--7.6, Theorem 7.1, and Corollaries 7.1--7.2 are exact
+completions. The `\leanok` markers in the semigroup Blueprint certify
+individual Lean declarations; they must not be read as exact-coverage markers
+for a larger containing Wolf environment.
 
 ---
 


### PR DESCRIPTION
## Source contract

This formalizes Wolf, Corollary 7.2, in
`Notes/WolfNoteTexSource/ch07_semigroup_structure.tex`, lines 313--325.

The source-facing theorem retains all three printed alternatives:

1. the algebra generated by the Lindblad operators and `κ` is the full matrix algebra;
2. the Lindblad span is Hermitian and has scalar commutant;
3. the Kossakowski matrix satisfies the literal inequality
   `D ^ 2 - D < K.C.rank`.

In every case, one positive-definite density matrix witnesses global relaxation
and also spans the kernel of the generator.

## Mathematical route

- Introduce the square-root Lindblad family associated with
  `C = (sqrt C)ᴴ * sqrt C`, in Wolf's fixed traceless basis.
- Prove that its Lindblad span has dimension `rank(C)`, and combine Lindblad
  family compression, the same-rank traceless shift, and Proposition 7.4
  representation freedom to obtain
  `kossakowskiRank K.toLinearMap = K.C.rank`.
- Use the non-resonant positive time at which the fixed-point space of
  `expSemigroup L` equals `ker L`. Proposition 7.6 then turns a hypothetical
  reducible compression into a rank-deficient kernel density, so a
  non-reducible semigroup has an irreducible positive-time slice.
- Apply the existing Proposition 7.5 theorem to that slice. The three named
  wrappers infer the GKSL hypothesis from their displayed Lindblad or
  Kossakowski form, and `wolf_corollary_7_2` packages the alternatives in one
  source-facing declaration.

The lower-level non-reducibility criteria remain available. The new relaxation
conclusion is kept in a separate semantic module so that the criterion and
Corollary layers remain small and independently reusable.

## Documentation and validation

- synchronized the Blueprint proof dependencies and Chapter 7 coverage audit;
- focused post-rebase build:
  `lake build QICLean.Channel.Semigroup.KossakowskiRank QICLean.Channel.Semigroup.RelaxationConditions QICLean.Channel.Semigroup.RelaxationCorollary`;
- Blueprint--Lean synchronization, paper-gap references, Blueprint web render,
  reader-facing prose, `chktex`, `latexindent`, import aggregation, and module
  policy checks pass;
- direct `#print axioms` audit of the rank theorem, bridge, three wrappers, and
  combined corollary reports only `propext`, `Classical.choice`, and
  `Quot.sound`;
- independent source and proof-integrity review found no correctness issue.

Issue #519 is a separate follow-up concerning alignment of the internal
Proposition 7.5 irreducibility-propagation proof with Wolf's printed
irrational-time argument. Its public theorem is already proved and used here;
that proof-route refinement does not alter this corollary's statement or
conclusion.

Closes #484
