### PR TITLE
refactor(semigroup): follow Wolf's Proposition 7.5 proof

### DIFF
--- a/QICLean/Algebra/EigenspaceMap.lean
+++ b/QICLean/Algebra/EigenspaceMap.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.LinearAlgebra.Eigenspace.Basic
+import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
 
 /-!
 # Images of eigenspaces
@@ -18,6 +18,8 @@ and not merely into itself.
   `μ ≠ 0`.
 * `Module.End.pow_apply_of_mem_eigenspace`: every power of an endomorphism acts
   on a `μ`-eigenvector as multiplication by `μ` to the same power.
+* `Module.End.exists_eigenvector_mem_ker_of_commute`: a nonzero invariant
+  kernel of a commuting endomorphism contains an eigenvector.
 -/
 
 namespace Module.End
@@ -47,5 +49,38 @@ theorem map_eigenspace_of_ne_zero (f : Module.End K V) {μ : K} (hμ : μ ≠ 0)
   · refine ⟨μ⁻¹ • y, (f.eigenspace μ).smul_mem _ hy, ?_⟩
     rw [map_smul, Module.End.mem_eigenspace_iff.mp hy, smul_smul, inv_mul_cancel₀ hμ,
       one_smul]
+
+/-- Let `f` and `q` be commuting endomorphisms of a finite-dimensional vector
+space over an algebraically closed field.  If `ker q` is nonzero, then it
+contains a nonzero eigenvector of `f`.
+
+This is the invariant-subspace form of eigenvalue existence: commutation makes
+`ker q` invariant under `f`, and the restriction of `f` to this kernel has an
+eigenvalue. -/
+theorem exists_eigenvector_mem_ker_of_commute
+    [IsAlgClosed K] [FiniteDimensional K V]
+    (f q : Module.End K V) (hcomm : Commute f q)
+    {x : V} (hx_ne : x ≠ 0) (hx_ker : q x = 0) :
+    ∃ μ : K, ∃ y : V, y ≠ 0 ∧ q y = 0 ∧ f y = μ • y := by
+  let W : Submodule K V := LinearMap.ker q
+  have hW_ne : W ≠ ⊥ := by
+    rw [Submodule.ne_bot_iff]
+    exact ⟨x, hx_ker, hx_ne⟩
+  let _ : Nontrivial W := Submodule.nontrivial_iff_ne_bot.mpr hW_ne
+  have hmaps : Set.MapsTo f W W := by
+    intro y hy
+    change q (f y) = 0
+    calc
+      q (f y) = f (q y) := by
+        simpa only [Module.End.mul_eq_comp, LinearMap.comp_apply] using
+          (DFunLike.congr_fun hcomm.eq y).symm
+      _ = 0 := by rw [hy, map_zero]
+  obtain ⟨μ, hμ⟩ := Module.End.exists_eigenvalue (f.restrict hmaps)
+  obtain ⟨y, hy_eig, hy_ne⟩ := hμ.exists_hasEigenvector
+  rw [Module.End.mem_eigenspace_iff] at hy_eig
+  refine ⟨μ, y, ?_, y.2, ?_⟩
+  · intro hy_zero
+    exact hy_ne (Subtype.ext hy_zero)
+  · exact congrArg Subtype.val hy_eig
 
 end Module.End

--- a/QICLean/Channel/Semigroup.lean
+++ b/QICLean/Channel/Semigroup.lean
@@ -30,6 +30,7 @@ import QICLean.Channel.Semigroup.Primitivity.Basic
 import QICLean.Channel.Semigroup.Primitivity.Helpers
 import QICLean.Channel.Semigroup.Primitivity.IrreducibleAnalysis
 import QICLean.Channel.Semigroup.Primitivity.MainTheorem
+import QICLean.Channel.Semigroup.Primitivity.SpectralMapping
 import QICLean.Channel.Semigroup.ProductFormula
 import QICLean.Channel.Semigroup.ReducibleQDS
 import QICLean.Channel.Semigroup.ReducibleQDS.Defs

--- a/QICLean/Channel/Semigroup/Basic.lean
+++ b/QICLean/Channel/Semigroup/Basic.lean
@@ -201,6 +201,13 @@ theorem expSemigroupCLM_mul_neg
     expSemigroupCLM L t * expSemigroupCLM L (-t) = 1 := by
   rw [← expSemigroupCLM_add, add_neg_cancel, expSemigroupCLM_zero]
 
+/-- The exponential of a generator commutes with the generator. -/
+theorem expSemigroupCLM_mul_generator_comm
+    (L : MatrixCLM (Fin D)) (t : ℝ) :
+    expSemigroupCLM L t * L = L * expSemigroupCLM L t := by
+  unfold expSemigroupCLM
+  exact (((Commute.refl L).smul_left (t : ℂ)).exp_left).eq
+
 /-! ### Continuity of the exponential semigroup -/
 
 /-- The function `t ↦ exp(t • L)` is continuous in the CLM norm topology. -/
@@ -264,6 +271,48 @@ theorem hasDerivAt_expSemigroupCLM_zero
       (fun u : ℝ => expSemigroupCLM L u) L 0 := by
   have h := hasDerivAt_expSemigroupCLM L 0
   simpa [expSemigroupCLM_zero] using h
+
+/-- The time integral of an exponential semigroup commutes with its generator. -/
+theorem intervalIntegral_expSemigroupCLM_mul_generator_comm
+    (L : MatrixCLM (Fin D)) (t : ℝ) :
+    intervalIntegral (fun s : ℝ => expSemigroupCLM L s)
+        0 t MeasureTheory.volume * L =
+      L * intervalIntegral (fun s : ℝ => expSemigroupCLM L s)
+        0 t MeasureTheory.volume := by
+  let Rright : MatrixCLM (Fin D) →L[ℝ] MatrixCLM (Fin D) :=
+    ((ContinuousLinearMap.compL ℂ
+      (Matrix (Fin D) (Fin D) ℂ)
+      (Matrix (Fin D) (Fin D) ℂ)
+      (Matrix (Fin D) (Fin D) ℂ)).flip L).restrictScalars ℝ
+  let Lleft : MatrixCLM (Fin D) →L[ℝ] MatrixCLM (Fin D) :=
+    (ContinuousLinearMap.compL ℂ
+      (Matrix (Fin D) (Fin D) ℂ)
+      (Matrix (Fin D) (Fin D) ℂ)
+      (Matrix (Fin D) (Fin D) ℂ) L).restrictScalars ℝ
+  have hright (A : MatrixCLM (Fin D)) : Rright A = A * L := by
+    ext X
+    rfl
+  have hleft (A : MatrixCLM (Fin D)) : Lleft A = L * A := by
+    ext X
+    rfl
+  have hInt : IntervalIntegrable (fun s : ℝ => expSemigroupCLM L s)
+      MeasureTheory.volume 0 t :=
+    (expSemigroupCLM_continuous L).intervalIntegrable 0 t
+  calc
+    intervalIntegral (fun s : ℝ => expSemigroupCLM L s)
+          0 t MeasureTheory.volume * L =
+        Rright (intervalIntegral (fun s : ℝ => expSemigroupCLM L s)
+          0 t MeasureTheory.volume) := (hright _).symm
+    _ = intervalIntegral (fun s : ℝ => Rright (expSemigroupCLM L s))
+          0 t MeasureTheory.volume := (Rright.intervalIntegral_comp_comm hInt).symm
+    _ = intervalIntegral (fun s : ℝ => Lleft (expSemigroupCLM L s))
+          0 t MeasureTheory.volume := by
+            exact intervalIntegral.integral_congr fun s _ => by
+              rw [hright, hleft, expSemigroupCLM_mul_generator_comm]
+    _ = Lleft (intervalIntegral (fun s : ℝ => expSemigroupCLM L s)
+          0 t MeasureTheory.volume) := Lleft.intervalIntegral_comp_comm hInt
+    _ = L * intervalIntegral (fun s : ℝ => expSemigroupCLM L s)
+          0 t MeasureTheory.volume := hleft _
 
 /-- The exponential increment factors through its generator:
 
@@ -416,17 +465,17 @@ theorem expSemigroup_isContinuousDynSemigroup
 /-! ## Proposition 7.1: Continuous semigroup → exp(tL) -/
 
 /-- A continuous family of continuous linear endomorphisms that equals the identity at zero has
-an invertible positive-time integral.
+invertible integrals throughout some punctured right-neighborhood of zero.
 
 Indeed, the normalized integrals
 `ε⁻¹ • ∫ t in 0..ε, S t` converge to `S 0 = 1` as `ε ↓ 0`.  Since the group of
-units is open, one of these normalized integrals, and hence the corresponding
-unnormalized integral, is invertible. -/
-theorem exists_pos_intervalIntegral_isUnit_of_continuous_zero_eq_one
+units is open, every sufficiently small positive normalized integral, and hence
+every corresponding unnormalized integral, is invertible. -/
+theorem exists_pos_forall_lt_intervalIntegral_isUnit_of_continuous_zero_eq_one
     (S : ℝ → MatrixCLM (Fin D))
     (hS_zero : S 0 = 1)
     (hS_cont : Continuous S) :
-    ∃ ε : ℝ, 0 < ε ∧
+    ∃ δ : ℝ, 0 < δ ∧ ∀ ε : ℝ, 0 < ε → ε < δ →
       IsUnit (intervalIntegral S 0 ε MeasureTheory.volume) := by
   let P : ℝ → MatrixCLM (Fin D) :=
     fun t : ℝ => intervalIntegral S 0 t MeasureTheory.volume
@@ -455,9 +504,12 @@ theorem exists_pos_intervalIntegral_isUnit_of_continuous_zero_eq_one
   have hunit_event : ∀ᶠ h in nhdsWithin (0 : ℝ) (Set.Ioi 0),
       IsUnit (h⁻¹ • (P (0 + h) - P 0)) :=
     htend.eventually (Units.isOpen.mem_nhds isUnit_one)
-  obtain ⟨ε, hunitε, hε_mem⟩ := (hunit_event.and self_mem_nhdsWithin).exists
-  have hε_pos : 0 < ε := hε_mem
-  refine ⟨ε, hε_pos, ?_⟩
+  rw [Filter.Eventually, Metric.mem_nhdsWithin_iff] at hunit_event
+  obtain ⟨δ, hδ_pos, hδ⟩ := hunit_event
+  refine ⟨δ, hδ_pos, fun ε hε_pos hε_lt ↦ ?_⟩
+  have hunitε : IsUnit (ε⁻¹ • (P (0 + ε) - P 0)) := by
+    apply hδ
+    exact ⟨by simpa [Real.dist_eq, abs_of_pos hε_pos] using hε_lt, hε_pos⟩
   have hu1 : IsUnit (ε⁻¹ • P ε) := by
     simpa [hP_zero] using hunitε
   have hu2 : IsUnit (ε • (1 : MatrixCLM (Fin D))) := by
@@ -469,6 +521,19 @@ theorem exists_pos_intervalIntegral_isUnit_of_continuous_zero_eq_one
   change IsUnit (P ε)
   rw [hfact]
   exact hu2.mul hu1
+
+/-- A continuous family of continuous linear endomorphisms that equals the identity at zero has
+an invertible positive-time integral. -/
+theorem exists_pos_intervalIntegral_isUnit_of_continuous_zero_eq_one
+    (S : ℝ → MatrixCLM (Fin D))
+    (hS_zero : S 0 = 1)
+    (hS_cont : Continuous S) :
+    ∃ ε : ℝ, 0 < ε ∧
+      IsUnit (intervalIntegral S 0 ε MeasureTheory.volume) := by
+  obtain ⟨δ, hδ_pos, hδ⟩ :=
+    exists_pos_forall_lt_intervalIntegral_isUnit_of_continuous_zero_eq_one
+      S hS_zero hS_cont
+  exact ⟨δ / 2, by positivity, hδ (δ / 2) (by positivity) (by linarith)⟩
 
 /-- In a finite-dimensional normed algebra, the Bochner integral `(1/ε) • ∫₀^ε S(t) dt`
 is close to `S(0) = 1` for small `ε`, hence invertible. From this and the semigroup

--- a/QICLean/Channel/Semigroup/Kernel.lean
+++ b/QICLean/Channel/Semigroup/Kernel.lean
@@ -32,9 +32,11 @@ points of the exponential semigroup.
 
 * `generator_apply_eq_zero_iff_expSemigroup_fixed_nonneg`:
   `L X = 0` iff `expSemigroup L t X = X` for all `t ≥ 0`.
+* `exists_pos_forall_lt_expSemigroup_fixedPoint_iff_generator_apply_eq_zero`:
+  throughout some interval of positive times, the fixed-point space of
+  `expSemigroup L` is exactly the kernel of `L`.
 * `exists_pos_expSemigroup_fixedPoint_iff_generator_apply_eq_zero`:
-  at some positive time, the fixed-point space of `expSemigroup L` is exactly
-  the kernel of `L`.
+  the corresponding existence statement at one positive time.
 * `generator_apply_eq_zero_iff_fixed_nonneg`:
   the same connection for any semigroup identified with `expSemigroup`.
 
@@ -189,39 +191,31 @@ theorem generator_apply_eq_zero_iff_expSemigroup_fixed_nonneg
   · exact expSemigroup_apply_eq_self_of_generator_apply_eq_zero L
   · exact generator_apply_eq_zero_of_expSemigroup_apply_eq_self L
 
-/-- For every finite-dimensional generator `L`, there is a positive time `t₀`
-at which the fixed-point space of `exp(t₀L)` is exactly `ker L`.
-
-The identity
-`exp(t₀L) - 1 = (∫ s in 0..t₀, exp(sL)) L`
-shows that a fixed point lies in `ker L` whenever the integral factor is
-invertible. Such a positive `t₀` exists because the normalized integral tends
-to the identity as `t₀ ↓ 0`. This is the non-resonant-time step used in Wolf
-Proposition 7.5. -/
-theorem exists_pos_expSemigroup_fixedPoint_iff_generator_apply_eq_zero
-    (L : Mat →ₗ[ℂ] Mat) :
-    ∃ t₀ : ℝ, 0 < t₀ ∧
-      ∀ X : Mat, expSemigroup L t₀ X = X ↔ L X = 0 := by
+/-- If the integral factor in
+`exp(tL) - 1 = (∫ s in 0..t, exp(sL)) L` is invertible, then the fixed-point
+space of `exp(tL)` is exactly `ker L`. -/
+theorem expSemigroup_fixedPoint_iff_generator_apply_eq_zero_of_intervalIntegral_isUnit
+    (L : Mat →ₗ[ℂ] Mat) (t : ℝ) (ht : 0 ≤ t)
+    (hP_unit : IsUnit
+      (intervalIntegral (fun s : ℝ => expSemigroupCLM (endEquiv L) s)
+        0 t MeasureTheory.volume))
+    (X : Mat) :
+    expSemigroup L t X = X ↔ L X = 0 := by
   let L' : MatrixCLM (Fin D) := endEquiv L
-  obtain ⟨t₀, ht₀, hP_unit⟩ :=
-    exists_pos_intervalIntegral_isUnit_of_continuous_zero_eq_one
-      (fun t : ℝ => expSemigroupCLM L' t)
-      (expSemigroupCLM_zero L') (expSemigroupCLM_continuous L')
   let P : MatrixCLM (Fin D) :=
-    intervalIntegral (fun t : ℝ => expSemigroupCLM L' t)
-      0 t₀ MeasureTheory.volume
+    intervalIntegral (fun s : ℝ => expSemigroupCLM L' s)
+      0 t MeasureTheory.volume
   have hP_unit' : IsUnit P := by
-    simpa [P] using hP_unit
+    simpa [P, L'] using hP_unit
   have hP_injective : Function.Injective P :=
     (ContinuousLinearMap.isUnit_iff_bijective.mp hP_unit').1
-  refine ⟨t₀, ht₀, fun X => ?_⟩
   constructor
   · intro hX
-    have hX' : expSemigroupCLM L' t₀ X = X := by
-      change endEquiv (expSemigroup L t₀) X = X
+    have hX' : expSemigroupCLM L' t X = X := by
+      change endEquiv (expSemigroup L t) X = X
       rw [expSemigroup_toCLM]
       exact hX
-    have hzero : (expSemigroupCLM L' t₀ - 1) X = 0 := by
+    have hzero : (expSemigroupCLM L' t - 1) X = 0 := by
       simpa using sub_eq_zero.mpr hX'
     rw [expSemigroupCLM_sub_one_eq_intervalIntegral_mul] at hzero
     have hPLX : P (L' X) = 0 := by
@@ -231,7 +225,40 @@ theorem exists_pos_expSemigroup_fixedPoint_iff_generator_apply_eq_zero
       simpa using hPLX
     exact hLX'
   · intro hLX
-    exact expSemigroup_apply_eq_self_of_generator_apply_eq_zero L hLX t₀ ht₀.le
+    exact expSemigroup_apply_eq_self_of_generator_apply_eq_zero L hLX t ht
+
+/-- For every finite-dimensional generator `L`, there is a `δ > 0` such
+that the fixed-point space of `exp(tL)` is exactly `ker L` whenever
+`0 < t < δ`.
+
+The factorization
+`exp(tL) - 1 = (∫ s in 0..t, exp(sL)) L`
+shows that a fixed point lies in `ker L` whenever the integral factor is
+invertible.  The normalized integral tends to the identity as `t ↓ 0`, so
+this invertibility holds throughout a punctured right-neighborhood of zero.
+This is the nonresonant-time step used in Wolf Proposition 7.5. -/
+theorem exists_pos_forall_lt_expSemigroup_fixedPoint_iff_generator_apply_eq_zero
+    (L : Mat →ₗ[ℂ] Mat) :
+    ∃ δ : ℝ, 0 < δ ∧ ∀ t : ℝ, 0 < t → t < δ →
+      ∀ X : Mat, expSemigroup L t X = X ↔ L X = 0 := by
+  let L' : MatrixCLM (Fin D) := endEquiv L
+  obtain ⟨δ, hδ, hP_unit⟩ :=
+    exists_pos_forall_lt_intervalIntegral_isUnit_of_continuous_zero_eq_one
+      (fun t : ℝ => expSemigroupCLM L' t)
+      (expSemigroupCLM_zero L') (expSemigroupCLM_continuous L')
+  refine ⟨δ, hδ, fun t ht htδ X => ?_⟩
+  exact expSemigroup_fixedPoint_iff_generator_apply_eq_zero_of_intervalIntegral_isUnit
+    L t ht.le (by simpa [L'] using hP_unit t ht htδ) X
+
+/-- For every finite-dimensional generator `L`, there is a positive time `t₀`
+at which the fixed-point space of `exp(t₀L)` is exactly `ker L`. -/
+theorem exists_pos_expSemigroup_fixedPoint_iff_generator_apply_eq_zero
+    (L : Mat →ₗ[ℂ] Mat) :
+    ∃ t₀ : ℝ, 0 < t₀ ∧
+      ∀ X : Mat, expSemigroup L t₀ X = X ↔ L X = 0 := by
+  obtain ⟨δ, hδ, hfix⟩ :=
+    exists_pos_forall_lt_expSemigroup_fixedPoint_iff_generator_apply_eq_zero L
+  exact ⟨δ / 2, by positivity, hfix (δ / 2) (by positivity) (by linarith)⟩
 
 /-- Kernel elements of `L` are exactly the matrices fixed by a semigroup family
 `T` identified with `expSemigroup L` on nonnegative times. -/

--- a/QICLean/Channel/Semigroup/Primitivity.lean
+++ b/QICLean/Channel/Semigroup/Primitivity.lean
@@ -7,3 +7,4 @@ import QICLean.Channel.Semigroup.Primitivity.Basic
 import QICLean.Channel.Semigroup.Primitivity.Helpers
 import QICLean.Channel.Semigroup.Primitivity.IrreducibleAnalysis
 import QICLean.Channel.Semigroup.Primitivity.MainTheorem
+import QICLean.Channel.Semigroup.Primitivity.SpectralMapping

--- a/QICLean/Channel/Semigroup/Primitivity/Basic.lean
+++ b/QICLean/Channel/Semigroup/Primitivity/Basic.lean
@@ -14,7 +14,7 @@ import QICLean.Channel.Peripheral.ClosureFixedPointKraus
 import QICLean.Channel.FixedPoint.Cesaro
 import QICLean.Channel.Primitive
 import Mathlib.Analysis.Calculus.Deriv.Mul
-import Mathlib.NumberTheory.Real.Irrational
+import Mathlib.Analysis.Real.Pi.Irrational
 
 /-!
 # Irreducibility implies primitivity for quantum dynamical semigroups — Proposition 7.5
@@ -34,8 +34,13 @@ The proof requires the following chain:
 **Step A** (continuous-time key): `T_{t₀}` irreducible → `T_t` irreducible for all `t > 0`.
 This is the core continuous-time fact: irreducibility propagates through the
 norm-continuous semigroup.  The Lean proof realizes this propagation in
-`irreducible_all_of_irreducible_time` by combining the unique faithful fixed
-density at the irreducible time with a primitive positive fractional slice.
+`irreducible_all_of_irreducible_time` along Wolf's irrational-rescaling route,
+with the small-time fixed-space lemma supplying both irreducible slices.  The unique
+faithful fixed density at the irreducible time gives a simple generator kernel.
+All sufficiently small slices therefore remain irreducible.  Applying the
+roots-of-unity theorem at two such slices with time ratio `π` rules out every
+nonzero purely imaginary generator eigenvalue.  Reverse fixed-space spectral
+mapping then propagates irreducibility to every positive time.
 
 **Step B**: `T_t` irreducible + channel → peripheral eigenvalues of `T_t` are roots
 of unity (Wolf Theorem 6.6). This channel-level result is available as
@@ -51,11 +56,9 @@ is one-dimensional.  Thus `V = c · σ'` (the unique faithful density fixed poin
 and `T_t σ' = μ σ'`.  Trace preservation forces `μ = 1`.
 
 The auxiliary lemmas `eigenvalue_exp_of_eigenvalue_generator`,
-`eq_zero_of_exp_mul_I_isRootOfUnity`, and `re_eq_zero_of_peripheral_generator`
-are fully proved.  The propagation theorem `irreducible_all_of_irreducible_time`
-in `IrreducibleAnalysis.lean` establishes Step A from the faithful fixed-density
-construction, the primitive fractional slice, and the one-dimensional fixed-point
-space obtained from that slice.
+`eq_zero_of_exp_mul_I_isRootOfUnity_one_pi`, and
+`re_eq_zero_of_peripheral_generator` are fully proved.  The reusable reverse
+spectral and fixed-space statements are in `SpectralMapping.lean`.
 
 ## References
 
@@ -128,40 +131,40 @@ theorem eigenvalue_exp_of_eigenvalue_generator
   rw [Complex.exp_eq_exp_ℂ]
   exact hs
 
-/-! ## Key lemma: exp(itθ) root of unity for all t > 0 implies θ = 0
+/-! ## Key lemma: roots of unity at two irrationally related times
 
-This is the number-theoretic heart of Proposition 7.5. If `exp(i t θ)` is a root of unity
-for every `t > 0`, then `θ = 0`. The proof uses the density of irrationals:
-`exp(i t θ)^p = 1` means `t p θ ∈ 2π ℤ`, but this cannot hold for all `t > 0`
-unless `θ = 0` (since `t ↦ t θ / (2π)` takes irrational values). -/
+This is the number-theoretic heart of Proposition 7.5.  Following Wolf,
+it suffices to compare two positive times whose ratio is irrational. -/
 
-/-- If `exp(i · t · θ)` is a root of unity for every `t > 0`, then `θ = 0`.
+/-- If `α` is irrational and both `exp(iθ)` and `exp(iαθ)` are roots of
+unity, then `θ = 0`.
 
-**Proof sketch**: For `t = 1`, `exp(iθ)^p₁ = 1` gives `p₁θ = 2πk₁` for some `k₁ ∈ ℤ`.
-For `t = √2`, `exp(i√2θ)^p₂ = 1` gives `√2 p₂ θ = 2πk₂`. Dividing:
-`√2 = k₂ p₁ / (k₁ p₂)`, contradicting the irrationality of `√2`. -/
-theorem eq_zero_of_exp_mul_I_isRootOfUnity
-    (θ : ℝ) (hroot : ∀ t : ℝ, 0 < t → ∃ p : ℕ, 0 < p ∧
-      Complex.exp (↑(t * θ) * Complex.I) ^ p = 1) :
+The first root relation gives `p₁θ = 2πk₁`; the second gives
+`p₂αθ = 2πk₂`.  A nonzero `θ` would therefore make `α` rational. -/
+theorem eq_zero_of_exp_mul_I_isRootOfUnity_of_irrational_rescaling
+    (α θ : ℝ) (hα : Irrational α)
+    (hroot_one : ∃ p : ℕ, 0 < p ∧
+      Complex.exp (↑θ * Complex.I) ^ p = 1)
+    (hroot_rescaled : ∃ p : ℕ, 0 < p ∧
+      Complex.exp (↑(α * θ) * Complex.I) ^ p = 1) :
     θ = 0 := by
   by_contra hθ
   -- Step 1: At t = 1, get p₁ > 0 with exp(iθ)^p₁ = 1
-  obtain ⟨p₁, hp₁, hexp₁⟩ := hroot 1 one_pos
-  rw [one_mul] at hexp₁
+  obtain ⟨p₁, hp₁, hexp₁⟩ := hroot_one
   -- exp(iθ)^p₁ = exp(ip₁θ) = 1
   rw [← Complex.exp_nat_mul] at hexp₁
   -- So p₁θ ∈ 2πℤ
   rw [Complex.exp_eq_one_iff] at hexp₁
   obtain ⟨k₁, hk₁⟩ := hexp₁
-  -- Step 2: At t = √2, get p₂ > 0 with exp(i√2θ)^p₂ = 1
-  obtain ⟨p₂, hp₂, hexp₂⟩ := hroot (Real.sqrt 2) (Real.sqrt_pos_of_pos two_pos)
+  -- Step 2: At t = α, get p₂ > 0 with exp(iαθ)^p₂ = 1
+  obtain ⟨p₂, hp₂, hexp₂⟩ := hroot_rescaled
   rw [← Complex.exp_nat_mul] at hexp₂
   rw [Complex.exp_eq_one_iff] at hexp₂
   obtain ⟨k₂, hk₂⟩ := hexp₂
   -- Step 3: From hk₁: ↑p₁ * (↑θ * I) = ↑k₁ * (2 * ↑π * I)
   --         i.e. p₁ · θ = 2π · k₁
-  -- From hk₂: ↑p₂ * (↑(√2 * θ) * I) = ↑k₂ * (2 * ↑π * I)
-  --         i.e. p₂ · √2 · θ = 2π · k₂
+  -- From hk₂: ↑p₂ * (↑(α * θ) * I) = ↑k₂ * (2 * ↑π * I)
+  --         i.e. p₂ · α · θ = 2π · k₂
   -- Extract real equations from complex identities
   -- hk₁ : ↑p₁ * (↑θ * I) = ↑k₁ * (2 * ↑π * I), multiply both sides by (-I)
   -- gives p₁ * θ = k₁ * (2π)
@@ -171,7 +174,7 @@ theorem eq_zero_of_exp_mul_I_isRootOfUnity
       Complex.I_re, Complex.I_im, Complex.intCast_re, Complex.intCast_im,
       Complex.natCast_re, Complex.natCast_im] at h
     linarith
-  have hreal₂ : (p₂ : ℝ) * (Real.sqrt 2 * θ) = k₂ * (2 * Real.pi) := by
+  have hreal₂ : (p₂ : ℝ) * (α * θ) = k₂ * (2 * Real.pi) := by
     have h := congr_arg Complex.im hk₂
     simp [Complex.mul_im, Complex.ofReal_re, Complex.ofReal_im,
       Complex.I_re, Complex.I_im, Complex.intCast_re, Complex.intCast_im,
@@ -185,20 +188,20 @@ theorem eq_zero_of_exp_mul_I_isRootOfUnity
     · exact absurd (Nat.cast_eq_zero.mp hp) (Nat.pos_iff_ne_zero.mp hp₁)
     · exact hθ hθ'
   -- Similarly p₂ > 0 and k₁ ≠ 0 imply θ ≠ 0 (already known)
-  -- Step 4: Derive √2 is rational — contradiction
+  -- Step 4: Derive α is rational — contradiction
   -- From hreal₁: θ = 2πk₁/p₁
-  -- From hreal₂: p₂ · √2 · θ = 2πk₂
-  -- Substituting: p₂ · √2 · (2πk₁/p₁) = 2πk₂
-  -- So: √2 = k₂ · p₁ / (k₁ · p₂)
+  -- From hreal₂: p₂ · α · θ = 2πk₂
+  -- Substituting: p₂ · α · (2πk₁/p₁) = 2πk₂
+  -- So: α = k₂ · p₁ / (k₁ · p₂)
   have hp₁_ne : (p₁ : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hp₁)
   have hp₂_ne : (p₂ : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hp₂)
   have hθ_ne : θ ≠ 0 := hθ
   -- From hreal₁: θ = k₁ * (2π) / p₁
-  -- From hreal₂: p₂ * √2 * (k₁ * (2π) / p₁) = k₂ * (2π)
-  -- So: p₂ * √2 * k₁ / p₁ = k₂
-  -- So: √2 = k₂ * p₁ / (p₂ * k₁)
-  -- Rewrite √2 as a ratio of integers to contradict irrationality
-  have hsqrt2 : Real.sqrt 2 = ↑(k₂ * ↑p₁) / ↑(k₁ * ↑p₂) := by
+  -- From hreal₂: p₂ * α * (k₁ * (2π) / p₁) = k₂ * (2π)
+  -- So: p₂ * α * k₁ / p₁ = k₂
+  -- So: α = k₂ * p₁ / (p₂ * k₁)
+  -- Rewrite α as a ratio of integers to contradict irrationality
+  have hα_rat : α = ↑(k₂ * ↑p₁) / ↑(k₁ * ↑p₂) := by
     push_cast
     have hpi_ne : Real.pi ≠ 0 := Real.pi_ne_zero
     -- From hreal₁: θ = k₁ * (2π) / p₁
@@ -208,7 +211,21 @@ theorem eq_zero_of_exp_mul_I_isRootOfUnity
     rw [hθ_eq] at hreal₂
     field_simp at hreal₂ ⊢
     nlinarith [hreal₂]
-  exact absurd hsqrt2 (irrational_sqrt_two.ne_rational _ _)
+  exact absurd hα_rat (hα.ne_rational _ _)
+
+/-- If both `exp(iθ)` and `exp(iπθ)` are roots of unity, then `θ = 0`.
+
+This is the irrational-rescaling argument used in Wolf, Chapter 7,
+Proposition 7.5, lines 279--280. -/
+theorem eq_zero_of_exp_mul_I_isRootOfUnity_one_pi
+    (θ : ℝ)
+    (hroot_one : ∃ p : ℕ, 0 < p ∧
+      Complex.exp (↑θ * Complex.I) ^ p = 1)
+    (hroot_pi : ∃ p : ℕ, 0 < p ∧
+      Complex.exp (↑(Real.pi * θ) * Complex.I) ^ p = 1) :
+    θ = 0 :=
+  eq_zero_of_exp_mul_I_isRootOfUnity_of_irrational_rescaling
+    Real.pi θ irrational_pi hroot_one hroot_pi
 
 /-- **Peripheral eigenvalues of the generator are purely imaginary.**
 If `L` generates a QDS of channels `T_t = exp(tL)` and `T_{t₀}` is irreducible,

--- a/QICLean/Channel/Semigroup/Primitivity/Helpers.lean
+++ b/QICLean/Channel/Semigroup/Primitivity/Helpers.lean
@@ -48,28 +48,6 @@ lemma ne_zero_of_mem_densityMatrices' {ρ : Matrix (Fin D) (Fin D) ℂ}
   intro h; subst h
   simp [mem_densityMatrices, Matrix.trace_zero (Fin D) ℂ] at hρ
 
-/-- If a compression is preserved by a linear map, then it is preserved by every power. -/
-theorem compression_preserved_by_pow
-    (E : Mat →ₗ[ℂ] Mat) (P : Mat) (hP : IsOrthogonalProjection P)
-    (hInv : ∀ X : Mat, P * E (P * X * P) * P = E (P * X * P)) :
-    ∀ n : ℕ, ∀ X : Mat, P * (E ^ n) (P * X * P) * P = (E ^ n) (P * X * P) := by
-  intro n
-  induction n with
-  | zero =>
-      intro X
-      rw [pow_zero]
-      calc
-        P * (P * X * P) * P = ((P * P) * X) * (P * P) := by
-          simp [Matrix.mul_assoc]
-        _ = P * X * P := by
-          simp [Matrix.mul_assoc, hP.2]
-  | succ n ih =>
-      intro X
-      rw [pow_succ']
-      change P * E ((E ^ n) (P * X * P)) * P = E ((E ^ n) (P * X * P))
-      rw [← ih X]
-      exact hInv ((E ^ n) (P * X * P))
-
 /-- A genuine eigenvector of the generator stays an eigenvector for the whole semigroup. -/
 theorem expSemigroup_apply_eigenvector
     (L : Mat →ₗ[ℂ] Mat) (X : Mat) (μ : ℂ)

--- a/QICLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
+++ b/QICLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import QICLean.Analysis.SpectralRadiusPowerDecay
 import QICLean.Channel.Semigroup.Primitivity.Helpers
+import QICLean.Channel.Semigroup.Primitivity.SpectralMapping
 import QICLean.Channel.Irreducible.FromSpectral
 import QICLean.Channel.Peripheral.IrreducibleChannel
 import QICLean.Channel.Semigroup.Primitivity.Basic
@@ -192,48 +193,6 @@ theorem primitive_of_irreducible_all
     (fun μ hμ_eig hμ_norm =>
       peripheral_eq_one_of_irreducible_all T hT hT_irr_all ht hμ_eig hμ_norm)
 
-def residualSliceIndex (u s : ℝ) (n : ℕ) : ℕ :=
-  Int.toNat ⌊((n : ℝ) * u) / s⌋
-
-def residualSliceTime (u s : ℝ) (n : ℕ) : ℝ :=
-  s * Int.fract (((n : ℝ) * u) / s)
-
-theorem residualSliceTime_mem_Icc
-    (u s : ℝ) (hs : 0 < s) :
-    ∀ n : ℕ, residualSliceTime u s n ∈ Set.Icc 0 s := by
-  intro n
-  dsimp [residualSliceTime]
-  refine Set.mem_Icc.mpr ?_
-  constructor
-  · exact mul_nonneg (le_of_lt hs) (Int.fract_nonneg _)
-  · have hlt : Int.fract (((n : ℝ) * u) / s) < 1 := Int.fract_lt_one _
-    nlinarith [hlt, hs]
-
-/-- For `u ≥ 0` and `s > 0`, we decompose
-`n * u = (residualSliceIndex u s n : ℝ) * s + residualSliceTime u s n`,
-where `residualSliceIndex u s n = Int.toNat ⌊((n : ℝ) * u) / s⌋` agrees with the
-(nonnegative) floor `⌊(n*u)/s⌋`. -/
-theorem residualSlice_decomp
-    (u s : ℝ) (hs : 0 < s) (hu : 0 ≤ u) :
-    ∀ n : ℕ, (n : ℝ) * u = (residualSliceIndex u s n : ℝ) * s + residualSliceTime u s n := by
-  intro n
-  have ha : ↑⌊((n : ℝ) * u / s)⌋ + Int.fract (((n : ℝ) * u) / s) = ((n : ℝ) * u) / s :=
-    Int.floor_add_fract (((n : ℝ) * u) / s)
-  have hfloor_nonneg : 0 ≤ ⌊((n : ℝ) * u) / s⌋ := by
-    apply Int.floor_nonneg.mpr
-    positivity
-  have htoNat : ((residualSliceIndex u s n : ℕ) : ℝ) = ↑⌊((n : ℝ) * u / s)⌋ := by
-    dsimp [residualSliceIndex]
-    exact_mod_cast Int.toNat_of_nonneg hfloor_nonneg
-  calc
-    (n : ℝ) * u = s * (((n : ℝ) * u) / s) := by field_simp [hs.ne']
-    _ = s * (↑⌊((n : ℝ) * u / s)⌋ + Int.fract (((n : ℝ) * u) / s)) := by
-          congr 1; exact ha.symm
-    _ = ((residualSliceIndex u s n : ℕ) : ℝ) * s + residualSliceTime u s n := by
-          dsimp [residualSliceTime]
-          rw [mul_add, htoNat]
-          ring
-
 theorem fixedPoint_at_nat_mul
     (T : ℝ → Mat →ₗ[ℂ] Mat)
     (hT : IsQuantumDynSemigroup T)
@@ -251,96 +210,6 @@ theorem fixedPoint_at_nat_mul
         simpa [ih] using hδ_fix
   rw [semigroup_pow T hT.semigroup.semigroup s (le_of_lt hs) k]
   exact hpow_fix k
-
-theorem residualSlice_apply_eq_of_fixedPoint
-    (T : ℝ → Mat →ₗ[ℂ] Mat)
-    (hT : IsQuantumDynSemigroup T)
-    (u : ℝ) (hu : 0 ≤ u)
-    (s : ℝ) (hs : 0 < s)
-    {δ : Mat}
-    (hδ_fix : T s δ = δ) :
-    ∀ n : ℕ, T ((n : ℝ) * u) δ = T (residualSliceTime u s n) δ := by
-  intro n
-  have hms_fix : T (((residualSliceIndex u s n : ℕ) : ℝ) * s) δ = δ :=
-    fixedPoint_at_nat_mul T hT s hs hδ_fix (residualSliceIndex u s n)
-  calc
-    T ((n : ℝ) * u) δ =
-        T (residualSliceTime u s n + ((residualSliceIndex u s n : ℕ) : ℝ) * s) δ := by
-          rw [residualSlice_decomp u s hs hu n, add_comm]
-    _ = T (residualSliceTime u s n) (T (((residualSliceIndex u s n : ℕ) : ℝ) * s) δ) := by
-          simp [LinearMap.comp_apply,
-            hT.semigroup.semigroup.comp (residualSliceTime u s n)
-              (((residualSliceIndex u s n : ℕ) : ℝ) * s)
-              (residualSliceTime_mem_Icc u s hs n).1
-              (mul_nonneg (Nat.cast_nonneg (residualSliceIndex u s n)) (le_of_lt hs))]
-    _ = T (residualSliceTime u s n) δ := by rw [hms_fix]
-
-/-- A convergent subsequence exists for residual slice times (by compactness of `[0, s]`). -/
-theorem exists_residualSlice_subseq_tendsto
-    (u s : ℝ) (hs : 0 < s) :
-    ∃ a ∈ Set.Icc 0 s, ∃ φ : ℕ ↪o ℕ,
-      Filter.Tendsto (fun k : ℕ => residualSliceTime u s (φ k)) Filter.atTop (nhds a) := by
-  obtain ⟨a, ha_mem, ψ, hψ_mono, hψ_tendsto⟩ :=
-    isCompact_Icc.tendsto_subseq (x := fun n : ℕ => residualSliceTime u s n)
-      (residualSliceTime_mem_Icc u s hs)
-  exact ⟨a, ha_mem, OrderEmbedding.ofStrictMono ψ hψ_mono, hψ_tendsto⟩
-
-/-- The residual slice limit vanishes (by continuity and uniqueness of limits). -/
-theorem residualSlice_limit_zero_of_fixedPoint
-    (T : ℝ → Mat →ₗ[ℂ] Mat)
-    (hT : IsQuantumDynSemigroup T)
-    (u : ℝ)
-    {s : ℝ} (_hs : 0 < s)
-    {δ : Mat}
-    (hδ_decay : Filter.Tendsto (fun n : ℕ => T ((n : ℝ) * u) δ) Filter.atTop (nhds 0))
-    (hres_eq : ∀ n : ℕ, T ((n : ℝ) * u) δ = T (residualSliceTime u s n) δ)
-    {a : ℝ} (_ha_mem : a ∈ Set.Icc 0 s)
-    (φ : ℕ ↪o ℕ)
-    (hφtendsto : Filter.Tendsto (fun k : ℕ => residualSliceTime u s (φ k)) Filter.atTop (nhds a)) :
-    T a δ = 0 := by
-  have hδ_cont : Continuous (fun t : ℝ => T t δ) := by
-    have hEval : Continuous (fun A : Mat →L[ℂ] Mat => A δ) :=
-      (ContinuousLinearMap.apply ℂ Mat δ).continuous
-    change Continuous ((fun A : Mat →L[ℂ] Mat => A δ) ∘ fun t : ℝ => endEquiv (T t))
-    exact hEval.comp hT.semigroup.continuous
-  have hsub_decay : Filter.Tendsto (fun k : ℕ => T ((↑(φ k) : ℝ) * u) δ)
-      Filter.atTop (nhds 0) :=
-    hδ_decay.comp φ.strictMono.tendsto_atTop
-  have hsub_res : Filter.Tendsto (fun k : ℕ => T (residualSliceTime u s (φ k)) δ)
-      Filter.atTop (nhds (T a δ)) :=
-    (hδ_cont.tendsto a).comp hφtendsto
-  have hsub_res_zero : Filter.Tendsto (fun k : ℕ => T (residualSliceTime u s (φ k)) δ)
-      Filter.atTop (nhds 0) :=
-    hsub_decay.congr' (Filter.Eventually.of_forall (fun k => hres_eq (φ k)))
-  exact tendsto_nhds_unique hsub_res hsub_res_zero
-
-/-- By compactness of `[0, s]`, the residual slice times admit a convergent subsequence
-whose limit `a` satisfies `T a δ = 0`. -/
-theorem exists_residual_time_eq_zero_of_fixedPoint
-    [NeZero D]
-    (T : ℝ → Mat →ₗ[ℂ] Mat)
-    (hT : IsQuantumDynSemigroup T)
-    (u : ℝ) (hu_nonneg : 0 ≤ u)
-    (s : ℝ) (hs : 0 < s)
-    {δ : Mat}
-    (hδ_decay : Filter.Tendsto (fun n : ℕ => T ((n : ℝ) * u) δ) Filter.atTop (nhds 0))
-    (hδ_fix : T s δ = δ) :
-    ∃ a ∈ Set.Icc 0 s, T a δ = 0 := by
-  obtain ⟨a, ha_mem, φ, hφtendsto⟩ := exists_residualSlice_subseq_tendsto u s hs
-  exact ⟨a, ha_mem, residualSlice_limit_zero_of_fixedPoint T hT u hs hδ_decay
-    (residualSlice_apply_eq_of_fixedPoint T hT u hu_nonneg s hs hδ_fix) ha_mem φ hφtendsto⟩
-
-theorem eq_zero_of_expSemigroup_apply_eq_zero
-    (L : Mat →ₗ[ℂ] Mat) {a : ℝ} {δ : Mat}
-    (hδ_zero_exp : expSemigroup L a δ = 0) :
-    δ = 0 := by
-  have h := congrArg (fun Y => expSemigroup L (-a) Y) hδ_zero_exp
-  simp only [map_zero] at h
-  have hcomp : (expSemigroup L (-a)) ((expSemigroup L a) δ) =
-      (expSemigroup L (-a)).comp (expSemigroup L a) δ := rfl
-  rw [hcomp, ← expSemigroup_comp, neg_add_cancel a,
-    expSemigroup_zero, LinearMap.id_apply] at h
-  exact h
 
 theorem fixed_density_fixed_for_all_times_of_irreducible_time
     [NeZero D]
@@ -380,96 +249,6 @@ theorem fixedPoint_eq_trace_smul_at_irreducible_time
       (by rw [Matrix.trace_sub, Matrix.trace_smul, hσ_mem.2, smul_eq_mul,
                mul_one, sub_self]))
 
-/-- A fraction slice has a peripheral eigenvector with nonzero trace. -/
-theorem exists_trace_ne_zero_eigenvector_of_fraction_slice
-    [NeZero D]
-    (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    {t₀ u : ℝ}
-    (hTt₀_eq_pow : T t₀ = (T u) ^ Nat.factorial (Module.finrank ℂ Mat))
-    (hTu_ch : IsChannel (T u))
-    (hTu_irr : IsIrreducibleMap (T u))
-    (σ : Mat) (hσ_pd : σ.PosDef)
-    (hTu_fix : T u σ = σ)
-    (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ)
-    {μ : ℂ}
-    (hμ_eig : Module.End.HasEigenvalue (T u) μ)
-    (hμ_norm : ‖μ‖ = 1) :
-    ∃ X : Mat, X ≠ 0 ∧ T u X = μ • X ∧ Matrix.trace X ≠ 0 := by
-  have hμ_periph : μ ∈ peripheralEigenvalues (T u) := ⟨hμ_eig, hμ_norm⟩
-  have hpow_closed := peripheral_powers_closed_of_irreducible_channel_with_fixed
-    (T u) hTu_ch hTu_irr σ hσ_pd hTu_fix hμ_periph
-  obtain ⟨p, hp_pos, hp_le, hμp⟩ :=
-    bounded_root_of_peripheral_closed_powers (T u) μ hμ_periph hpow_closed
-  obtain ⟨X, hXev⟩ := hμ_eig.exists_hasEigenvector
-  have hX_ne : X ≠ 0 := hXev.2
-  have hX_eig : T u X = μ • X := Module.End.mem_eigenspace_iff.mp hXev.1
-  have hp_dvd : p ∣ Nat.factorial (Module.finrank ℂ Mat) := Nat.dvd_factorial hp_pos hp_le
-  obtain ⟨k, hk⟩ := hp_dvd
-  have hμN : μ ^ Nat.factorial (Module.finrank ℂ Mat) = 1 := by
-    rw [hk, pow_mul, hμp, one_pow]
-  refine ⟨X, hX_ne, hX_eig, ?_⟩
-  by_contra htrX
-  have hX_fix_t₀ : T t₀ X = X := by
-    calc
-      T t₀ X = ((T u) ^ Nat.factorial (Module.finrank ℂ Mat)) X := by rw [hTt₀_eq_pow]
-      _ = μ ^ Nat.factorial (Module.finrank ℂ Mat) • X :=
-        hXev.pow_apply (Nat.factorial (Module.finrank ℂ Mat))
-      _ = X := by simp [hμN]
-  have hX_span : X = Matrix.trace X • σ := hfixed_1d X hX_fix_t₀
-  have : X = 0 := by simpa [htrX] using hX_span
-  exact hX_ne this
-
-/-- Peripheral eigenvalues of a fraction slice are equal to `1`. -/
-theorem peripheral_eq_one_of_fraction_slice
-    [NeZero D]
-    (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    {t₀ u : ℝ}
-    (hTt₀_eq_pow : T t₀ = (T u) ^ Nat.factorial (Module.finrank ℂ Mat))
-    (hTu_ch : IsChannel (T u))
-    (hTu_irr : IsIrreducibleMap (T u))
-    (σ : Mat) (hσ_pd : σ.PosDef)
-    (hTu_fix : T u σ = σ)
-    (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ)
-    {μ : ℂ}
-    (hμ_eig : Module.End.HasEigenvalue (T u) μ)
-    (hμ_norm : ‖μ‖ = 1) :
-    μ = 1 := by
-  obtain ⟨X, _, hX_eig, htrX_ne⟩ :=
-    exists_trace_ne_zero_eigenvector_of_fraction_slice
-      T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_pd hTu_fix hfixed_1d hμ_eig hμ_norm
-  exact eigenvalue_eq_one_of_trace_preserving_eigenvector
-    (T u) hTu_ch.tp hX_eig htrX_ne
-
-/-- Fraction-slice hypotheses imply primitivity of the slice. -/
-theorem primitive_of_fraction_slice
-    [NeZero D]
-    (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    {t₀ u : ℝ}
-    (hTt₀_eq_pow : T t₀ = (T u) ^ Nat.factorial (Module.finrank ℂ Mat))
-    (hTu_ch : IsChannel (T u))
-    (hTu_irr : IsIrreducibleMap (T u))
-    (σ : Mat) (hσ_mem : σ ∈ densityMatrices D) (hσ_pd : σ.PosDef)
-    (hTu_fix : T u σ = σ)
-    (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ) :
-    IsPrimitive (T u) := by
-  have hσ_ne := ne_zero_of_mem_densityMatrices' hσ_mem
-  exact isPrimitive_of_unique_norm_one (T u) σ hTu_fix hσ_ne
-    (fun μ hμ_eig hμ_norm =>
-      peripheral_eq_one_of_fraction_slice
-        T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_pd hTu_fix hfixed_1d hμ_eig hμ_norm)
-
-theorem irreducible_of_fraction_slice
-    (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    {t₀ u : ℝ} {N : ℕ}
-    (hTt₀_eq_pow : T t₀ = (T u) ^ N)
-    (hirr : IsIrreducibleMap (T t₀)) :
-    IsIrreducibleMap (T u) := by
-  intro P hP_proj hP_inv
-  exact hirr P hP_proj (by
-    intro X
-    rw [hTt₀_eq_pow]
-    exact compression_preserved_by_pow (E := T u) (P := P) hP_proj hP_inv N X)
-
 theorem trace_zero_fixedPoint_tendsto_zero_of_primitive_slice
     [NeZero D]
     (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -490,99 +269,6 @@ theorem trace_zero_fixedPoint_tendsto_zero_of_primitive_slice
   filter_upwards [] with n
   rw [← semigroup_pow T hT.semigroup.semigroup u hu_nonneg n]
 
-theorem fixedPoint_eq_zero_of_trace_zero_of_primitive_slice
-    [NeZero D]
-    (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (hT : IsQuantumDynSemigroup T)
-    (hexp : ∀ t : ℝ, 0 ≤ t → T t = expSemigroup L t)
-    (u : ℝ) (hu_nonneg : 0 ≤ u)
-    (s : ℝ) (hs : 0 < s)
-    {δ : Mat}
-    (hδ_decay : Filter.Tendsto (fun n : ℕ => T ((n : ℝ) * u) δ) Filter.atTop (nhds 0))
-    (hδ_fix : T s δ = δ) :
-    δ = 0 := by
-  obtain ⟨a, ha_mem, hTa_zero⟩ :=
-    exists_residual_time_eq_zero_of_fixedPoint T hT u hu_nonneg s hs hδ_decay hδ_fix
-  have hδ_zero_exp : expSemigroup L a δ = 0 := by
-    rw [← hexp a ha_mem.1]
-    exact hTa_zero
-  exact eq_zero_of_expSemigroup_apply_eq_zero L hδ_zero_exp
-
-theorem exists_irreducible_fraction_slice
-    [NeZero D]
-    (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (hT : IsQuantumDynSemigroup T)
-    (t₀ : ℝ) (ht₀ : 0 < t₀)
-    (hirr : IsIrreducibleMap (T t₀))
-    (σ : Mat)
-    (hσ_fix_all : ∀ u : ℝ, 0 ≤ u → T u σ = σ) :
-    ∃ u : ℝ, 0 < u ∧ 0 ≤ u ∧ T t₀ = (T u) ^ Nat.factorial (Module.finrank ℂ Mat) ∧
-      IsChannel (T u) ∧ IsIrreducibleMap (T u) ∧ T u σ = σ := by
-  let N : ℕ := Nat.factorial (Module.finrank ℂ Mat)
-  have hN_pos : 0 < N := Nat.factorial_pos _
-  let u : ℝ := t₀ / N
-  have hu_nonneg : 0 ≤ u := le_of_lt <| div_pos ht₀ (Nat.cast_pos.mpr hN_pos)
-  have hu_pos : 0 < u := div_pos ht₀ (Nat.cast_pos.mpr hN_pos)
-  have hNu : (N : ℝ) * u = t₀ := by
-    dsimp [u]
-    field_simp [hN_pos.ne']
-  have hTt₀_eq_pow : T t₀ = (T u) ^ N := by
-    calc
-      T t₀ = T ((N : ℝ) * u) := by rw [hNu]
-      _ = (T u) ^ N := semigroup_pow T hT.semigroup.semigroup u hu_nonneg N
-  have hTu_ch : IsChannel (T u) := hT.channel u hu_nonneg
-  have hTu_fix : T u σ = σ := hσ_fix_all u hu_nonneg
-  have hTu_irr : IsIrreducibleMap (T u) := irreducible_of_fraction_slice T hTt₀_eq_pow hirr
-  exact ⟨u, hu_pos, hu_nonneg, hTt₀_eq_pow, hTu_ch, hTu_irr, hTu_fix⟩
-
-/-- For a primitive fraction slice, fixed points are trace multiples of `σ`. -/
-theorem fixedPoint_eq_trace_smul_of_primitive_slice
-    [NeZero D]
-    (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (hT : IsQuantumDynSemigroup T)
-    (hexp : ∀ t : ℝ, 0 ≤ t → T t = expSemigroup L t)
-    (σ : Mat) (hσ_mem : σ ∈ densityMatrices D)
-    (hσ_fix_all : ∀ u : ℝ, 0 ≤ u → T u σ = σ)
-    (u : ℝ) (hu_nonneg : 0 ≤ u)
-    (hTu_ch : IsChannel (T u))
-    (hTu_irr : IsIrreducibleMap (T u))
-    (hTu_fix : T u σ = σ)
-    (hTu_prim : IsPrimitive (T u))
-    (s : ℝ) (hs : 0 < s)
-    {τ : Mat} (hτ_fix : T s τ = τ) :
-    τ = Matrix.trace τ • σ := by
-  have hτ_tr0 : Matrix.trace (τ - Matrix.trace τ • σ) = 0 := by
-    rw [Matrix.trace_sub, Matrix.trace_smul, hσ_mem.2, smul_eq_mul, mul_one, sub_self]
-  have hτ_fix' : T s (τ - Matrix.trace τ • σ) = τ - Matrix.trace τ • σ := by
-    rw [map_sub, map_smul, hτ_fix, hσ_fix_all s (le_of_lt hs)]
-  have hdecay :=
-    trace_zero_fixedPoint_tendsto_zero_of_primitive_slice
-      T hT σ hσ_mem u hu_nonneg hTu_ch hTu_irr hTu_fix hTu_prim hτ_tr0
-  have hzero :=
-    fixedPoint_eq_zero_of_trace_zero_of_primitive_slice
-      L T hT hexp u hu_nonneg s hs hdecay hτ_fix'
-  exact sub_eq_zero.mp hzero
-
-/-- There exists a primitive slice at a positive rational fraction of `t₀`. -/
-theorem exists_primitive_fraction_slice
-    [NeZero D]
-    (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (hT : IsQuantumDynSemigroup T)
-    (t₀ : ℝ) (ht₀ : 0 < t₀)
-    (hirr : IsIrreducibleMap (T t₀))
-    (σ : Mat) (hσ_mem : σ ∈ densityMatrices D) (hσ_pd : σ.PosDef)
-    (hσ_fix_all : ∀ u : ℝ, 0 ≤ u → T u σ = σ)
-    (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ) :
-    ∃ u : ℝ, 0 < u ∧ 0 ≤ u ∧ IsChannel (T u) ∧ IsIrreducibleMap (T u) ∧
-      T u σ = σ ∧ IsPrimitive (T u) := by
-  obtain ⟨u, hu_pos, hu_nonneg, hTt₀_eq_pow, hTu_ch, hTu_irr, hTu_fix⟩ :=
-    exists_irreducible_fraction_slice T hT t₀ ht₀ hirr σ hσ_fix_all
-  refine ⟨u, hu_pos, hu_nonneg, hTu_ch, hTu_irr, hTu_fix, ?_⟩
-  exact primitive_of_fraction_slice
-    T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_mem hσ_pd hTu_fix hfixed_1d
-
 theorem irreducible_all_of_irreducible_time
     [NeZero D]
     (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -602,14 +288,116 @@ theorem irreducible_all_of_irreducible_time
   have hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X →
       X = Matrix.trace X • σ :=
     fixedPoint_eq_trace_smul_at_irreducible_time T t₀ hTt₀_ch hirr σ hσ_mem hσ_fix
-  obtain ⟨u, hu_pos, hu_nonneg, hTu_ch, hTu_irr, hTu_fix, hTu_prim⟩ :=
-    exists_primitive_fraction_slice T hT t₀ ht₀ hirr σ hσ_mem hσ_pd hσ_fix_all hfixed_1d
+  have hkernel_1d : ∀ X : Mat, L X = 0 → X = Matrix.trace X • σ := by
+    intro X hLX
+    exact hfixed_1d X
+      ((generator_apply_eq_zero_iff_fixed_nonneg L T hexp X).1 hLX t₀ (le_of_lt ht₀))
+  obtain ⟨δ, hδ_pos, hfixed_small⟩ :=
+    exists_pos_forall_lt_expSemigroup_fixedPoint_iff_generator_apply_eq_zero L
+  have hfixed_small_T : ∀ u : ℝ, 0 < u → u < δ →
+      ∀ X : Mat, T u X = X ↔ L X = 0 := by
+    intro u hu huδ X
+    rw [hexp u (le_of_lt hu)]
+    exact hfixed_small u hu huδ X
+  have hirr_small : ∀ u : ℝ, 0 < u → u < δ → IsIrreducibleMap (T u) := by
+    intro u hu huδ
+    apply isIrreducibleMap_of_channel_posDef_fixedPoint_unique
+      (T u) (hT.channel u (le_of_lt hu)) σ hσ_pd
+      (hσ_fix_all u (le_of_lt hu))
+    intro τ _hτ_psd hτ_fix
+    exact ⟨Matrix.trace τ, hkernel_1d τ ((hfixed_small_T u hu huδ τ).1 hτ_fix)⟩
+  let u : ℝ := δ / (2 * Real.pi)
+  have htwo_pi_pos : 0 < 2 * Real.pi := mul_pos two_pos Real.pi_pos
+  have hu_pos : 0 < u := by dsimp [u]; exact div_pos hδ_pos htwo_pi_pos
+  have hu_lt : u < δ := by
+    dsimp [u]
+    rw [div_lt_iff₀ htwo_pi_pos]
+    nlinarith [Real.two_le_pi]
+  have hpi_u_eq : Real.pi * u = δ / 2 := by
+    dsimp [u]
+    field_simp [Real.pi_ne_zero]
+  have hpi_u_pos : 0 < Real.pi * u := by rw [hpi_u_eq]; positivity
+  have hpi_u_lt : Real.pi * u < δ := by rw [hpi_u_eq]; linarith
+  have hTu_irr : IsIrreducibleMap (T u) := hirr_small u hu_pos hu_lt
+  have hTpi_irr : IsIrreducibleMap (T (Real.pi * u)) :=
+    hirr_small (Real.pi * u) hpi_u_pos hpi_u_lt
+  have hno_nonzero_imaginary_eigenvalue :
+      ∀ μ : ℂ, Module.End.HasEigenvalue L μ → μ.re = 0 → μ = 0 := by
+    intro μ hμ_eig hμ_re
+    obtain ⟨X, hX_eig⟩ := hμ_eig.exists_hasEigenvector
+    have hLX : L X = μ • X := Module.End.mem_eigenspace_iff.mp hX_eig.1
+    have hμ_form : μ = (μ.im : ℂ) * Complex.I := by
+      apply Complex.ext
+      · simp [hμ_re]
+      · simp
+    have hnorm_u : ‖Complex.exp ((u : ℂ) * μ)‖ = 1 := by
+      rw [Complex.norm_exp]
+      simp [Complex.mul_re, hμ_re]
+    have hnorm_pi :
+        ‖Complex.exp (((Real.pi * u : ℝ) : ℂ) * μ)‖ = 1 := by
+      rw [Complex.norm_exp]
+      simp [Complex.mul_re, hμ_re]
+    have heig_u : Module.End.HasEigenvalue (T u) (Complex.exp ((u : ℂ) * μ)) := by
+      rw [hexp u (le_of_lt hu_pos)]
+      exact hasEigenvalue_of_eigenvector_eq _ _ X
+        (expSemigroup_apply_eigenvector L X μ hLX u) hX_eig.2
+    have heig_pi : Module.End.HasEigenvalue (T (Real.pi * u))
+        (Complex.exp (((Real.pi * u : ℝ) : ℂ) * μ)) := by
+      rw [hexp (Real.pi * u) (le_of_lt hpi_u_pos)]
+      exact hasEigenvalue_of_eigenvector_eq _ _ X
+        (expSemigroup_apply_eigenvector L X μ hLX (Real.pi * u)) hX_eig.2
+    obtain ⟨p₁, hp₁_pos, hp₁_root⟩ :=
+      peripheral_isRootOfUnity_of_irreducible_channel
+        (T u) (hT.channel u (le_of_lt hu_pos)) hTu_irr
+        (Complex.exp ((u : ℂ) * μ)) ⟨heig_u, hnorm_u⟩
+    obtain ⟨p₂, hp₂_pos, hp₂_root⟩ :=
+      peripheral_isRootOfUnity_of_irreducible_channel
+        (T (Real.pi * u))
+        (hT.channel (Real.pi * u) (le_of_lt hpi_u_pos)) hTpi_irr
+        (Complex.exp (((Real.pi * u : ℝ) : ℂ) * μ))
+        ⟨heig_pi, hnorm_pi⟩
+    have hphase_u : (u : ℂ) * μ = ↑(u * μ.im) * Complex.I := by
+      calc
+        (u : ℂ) * μ = (u : ℂ) * ((μ.im : ℂ) * Complex.I) :=
+          congrArg ((u : ℂ) * ·) hμ_form
+        _ = ↑(u * μ.im) * Complex.I := by push_cast; ring
+    have hphase_pi :
+        ((Real.pi * u : ℝ) : ℂ) * μ =
+          ↑(Real.pi * (u * μ.im)) * Complex.I := by
+      calc
+        ((Real.pi * u : ℝ) : ℂ) * μ =
+            ((Real.pi * u : ℝ) : ℂ) * ((μ.im : ℂ) * Complex.I) :=
+          congrArg (((Real.pi * u : ℝ) : ℂ) * ·) hμ_form
+        _ = ↑(Real.pi * (u * μ.im)) * Complex.I := by push_cast; ring
+    have hroot_one : ∃ p : ℕ, 0 < p ∧
+        Complex.exp (↑(u * μ.im) * Complex.I) ^ p = 1 := by
+      refine ⟨p₁, hp₁_pos, ?_⟩
+      rw [← hphase_u]
+      exact hp₁_root
+    have hroot_pi : ∃ p : ℕ, 0 < p ∧
+        Complex.exp (↑(Real.pi * (u * μ.im)) * Complex.I) ^ p = 1 := by
+      refine ⟨p₂, hp₂_pos, ?_⟩
+      rw [← hphase_pi]
+      exact hp₂_root
+    have hphase_zero : u * μ.im = 0 :=
+      eq_zero_of_exp_mul_I_isRootOfUnity_one_pi
+        (u * μ.im) hroot_one hroot_pi
+    have hμ_im : μ.im = 0 := (mul_eq_zero.mp hphase_zero).resolve_left hu_pos.ne'
+    exact Complex.ext hμ_re hμ_im
   intro s hs
   apply isIrreducibleMap_of_channel_posDef_fixedPoint_unique (T s)
     (hT.channel s (le_of_lt hs)) σ hσ_pd (hσ_fix_all s (le_of_lt hs))
-  intro τ hτ_psd hτ_fix
+  intro τ _hτ_psd hτ_fix
   refine ⟨Matrix.trace τ, ?_⟩
-  exact fixedPoint_eq_trace_smul_of_primitive_slice
-    L T hT hexp σ hσ_mem hσ_fix_all u hu_nonneg hTu_ch hTu_irr hTu_fix hTu_prim s hs hτ_fix
+  apply hkernel_1d
+  by_contra hLτ_ne
+  obtain ⟨μ, hμ_ne, hμ_eig, hμ_root⟩ :=
+    exists_nonzero_generator_eigenvalue_of_expSemigroup_fixed_not_generator_fixed
+      L s hs.ne' (by rw [← hexp s (le_of_lt hs)]; exact hτ_fix) hLτ_ne
+  have hμ_norm : ‖Complex.exp ((s : ℂ) * μ)‖ = 1 := by
+    rw [hμ_root, norm_one]
+  have hμ_re : μ.re = 0 :=
+    re_eq_zero_of_peripheral_generator μ s hs hμ_norm
+  exact hμ_ne (hno_nonzero_imaginary_eigenvalue μ hμ_eig hμ_re)
 
 end -- noncomputable section

--- a/QICLean/Channel/Semigroup/Primitivity/MainTheorem.lean
+++ b/QICLean/Channel/Semigroup/Primitivity/MainTheorem.lean
@@ -24,8 +24,12 @@ The proof has two parts:
 `T_{t₀}` irreducible → `T_s` irreducible for ALL `s > 0`.
 Uses the kernel characterization: `ker(L) = Span{σ}` where `σ` is the unique
 faithful density fixed point of `T_{t₀}`. Then `σ` is fixed by all `T_s`
-(semigroup commutativity + density uniqueness). For each `s > 0`, `T_s`
-is shown irreducible via `isIrreducibleMap_of_channel_posDef_fixedPoint_unique`.
+(semigroup commutativity + density uniqueness).  Fixed spaces agree with
+`ker(L)` throughout a sufficiently small interval, so those slices are
+irreducible.  Roots of unity at the two irrationally related times `u` and
+`πu` exclude nonzero imaginary eigenvalues of `L`.  A fixed point of an
+arbitrary `T_s` outside `ker(L)` would produce precisely such a resonant
+generator eigenvalue, and is therefore impossible.
 
 **Part 2 — Roots of unity → primitivity**:
 Given irreducibility at all times, peripheral eigenvalues are roots of unity
@@ -35,11 +39,11 @@ the eigenvector `V` is a fixed point of `T_{pt}`. By irreducibility of
 point `σ'`, giving `T_t σ' = μ σ'`. Trace preservation then forces `μ = 1`.
 
 The Lean proof combines the propagation theorem
-`irreducible_all_of_irreducible_time` with the primitive-slice analysis in
+`irreducible_all_of_irreducible_time` with the peripheral analysis in
 `IrreducibleAnalysis.lean`: `primitive_of_irreducible_all` reduces primitivity
-to irreducibility at all positive times, while `exists_primitive_fraction_slice`
-and `fixedPoint_eq_trace_smul_of_primitive_slice` supply the fixed-point input
-for the propagation theorem. -/
+to irreducibility at all positive times, while the small-time fixed-space and
+reverse-resonance lemmas supply the fixed-point input for the propagation
+theorem. -/
 theorem irreducible_semigroup_implies_primitive
     [NeZero D]
     (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)

--- a/QICLean/Channel/Semigroup/Primitivity/SpectralMapping.lean
+++ b/QICLean/Channel/Semigroup/Primitivity/SpectralMapping.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.EigenspaceMap
+import QICLean.Channel.Semigroup.Primitivity.Helpers
+
+/-!
+# Spectral mapping for exponential semigroups
+
+This file supplies the reverse spectral information needed in Wolf Proposition
+7.5.  Forward spectral mapping alone does not control the multiplicity of the
+fixed eigenvalue of an exponential.
+
+## Main results
+
+* `exists_generator_eigenvalue_of_expSemigroup_hasEigenvalue`: every
+  eigenvalue of `exp(tL)` is the exponential of an eigenvalue of `L`.
+* `exists_nonzero_generator_eigenvalue_of_expSemigroup_fixed_not_generator_fixed`:
+  a fixed vector of `exp(tL)` which does not belong to `ker L` produces a
+  nonzero eigenvalue `μ` of `L` satisfying `exp(tμ) = 1`.
+
+The second statement records the multiplicity information used in Wolf
+Chapter 7, Proposition 7.5, lines 279--280.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators NNReal TNOperatorSpace
+open Matrix Finset NormedSpace TNLean
+
+noncomputable section
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The generator commutes with each member of its exponential semigroup. -/
+theorem generator_comm_expSemigroup
+    (L : Mat →ₗ[ℂ] Mat) (t : ℝ) :
+    Commute L (expSemigroup L t) := by
+  rw [Commute]
+  apply endEquiv.injective
+  rw [map_mul, map_mul, expSemigroup_toCLM]
+  exact (expSemigroupCLM_mul_generator_comm (endEquiv L) t).symm
+
+/-- **Reverse spectral mapping for eigenvalues.** Every eigenvalue `λ` of
+`exp(tL)` is `exp(tμ)` for an eigenvalue `μ` of the generator `L`.
+
+The `λ`-eigenspace of `exp(tL)` is invariant under `L`.  Restricting `L` to
+that nonzero finite-dimensional space gives an eigenvector common to both
+operators, and forward spectral mapping on this vector identifies `λ`. -/
+theorem exists_generator_eigenvalue_of_expSemigroup_hasEigenvalue
+    (L : Mat →ₗ[ℂ] Mat) (t : ℝ) (ν : ℂ)
+    (hν : Module.End.HasEigenvalue (expSemigroup L t) ν) :
+    ∃ μ : ℂ, Module.End.HasEigenvalue L μ ∧
+      Complex.exp ((t : ℂ) * μ) = ν := by
+  obtain ⟨X, hX⟩ := hν.exists_hasEigenvector
+  have hEX : expSemigroup L t X = ν • X :=
+    Module.End.mem_eigenspace_iff.mp hX.1
+  let q : Module.End ℂ Mat := expSemigroup L t - ν • 1
+  have hqX : q X = 0 := by
+    simp [q, hEX]
+  have hLq : Commute L q := by
+    exact (generator_comm_expSemigroup L t).sub_right
+      ((Commute.one_right L).smul_right ν)
+  obtain ⟨μ, Y, hY_ne, hqY, hLY⟩ :=
+    Module.End.exists_eigenvector_mem_ker_of_commute L q hLq hX.2 hqX
+  have hEY : expSemigroup L t Y = ν • Y := by
+    apply sub_eq_zero.mp
+    simpa [q] using hqY
+  have hExpY := expSemigroup_apply_eigenvector L Y μ hLY t
+  have hscalar : Complex.exp ((t : ℂ) * μ) = ν := by
+    have hsmul : (Complex.exp ((t : ℂ) * μ) - ν) • Y = 0 := by
+      rw [sub_smul, ← hExpY, hEY, sub_self]
+    exact sub_eq_zero.mp ((smul_eq_zero.mp hsmul).resolve_right hY_ne)
+  exact ⟨μ, hasEigenvalue_of_eigenvector_eq L μ Y hLY hY_ne, hscalar⟩
+
+/-- If `L Y = 0`, then the integral of its exponential semigroup sends `Y`
+to `t Y`. -/
+theorem intervalIntegral_expSemigroupCLM_apply_of_generator_apply_eq_zero
+    (L : Mat →ₗ[ℂ] Mat) (t : ℝ) {Y : Mat} (hLY : L Y = 0) :
+    intervalIntegral (fun s : ℝ => expSemigroupCLM (endEquiv L) s)
+        0 t MeasureTheory.volume Y = (t : ℂ) • Y := by
+  let evalY : MatrixCLM (Fin D) →L[ℝ] Mat :=
+    (ContinuousLinearMap.apply ℂ Mat Y).restrictScalars ℝ
+  have hInt : IntervalIntegrable
+      (fun s : ℝ => expSemigroupCLM (endEquiv L) s)
+      MeasureTheory.volume 0 t :=
+    (expSemigroupCLM_continuous (endEquiv L)).intervalIntegrable 0 t
+  have hfix (s : ℝ) : expSemigroupCLM (endEquiv L) s Y = Y := by
+    change expSemigroup L s Y = Y
+    rw [expSemigroup_apply_eigenvector L Y 0 (by simpa using hLY)]
+    simp
+  calc
+    intervalIntegral (fun s : ℝ => expSemigroupCLM (endEquiv L) s)
+          0 t MeasureTheory.volume Y =
+        evalY (intervalIntegral (fun s : ℝ => expSemigroupCLM (endEquiv L) s)
+          0 t MeasureTheory.volume) := rfl
+    _ = intervalIntegral
+          (fun s : ℝ => evalY (expSemigroupCLM (endEquiv L) s))
+          0 t MeasureTheory.volume := (evalY.intervalIntegral_comp_comm hInt).symm
+    _ = intervalIntegral (fun _ : ℝ => Y) 0 t MeasureTheory.volume := by
+          exact intervalIntegral.integral_congr fun s _ => hfix s
+    _ = (t : ℂ) • Y := by
+          simp [intervalIntegral.integral_const]
+
+/-- **Reverse fixed-space resonance.** Let `t ≠ 0`. If `X` is fixed by
+`exp(tL)` but `L X ≠ 0`, then `L` has a nonzero eigenvalue `μ` satisfying
+`exp(tμ) = 1`.
+
+Write `P_t = ∫₀ᵗ exp(sL) ds`.  The factorization
+`exp(tL)-1 = P_t L` places `L X` in `ker P_t`.  Since `P_t` commutes with `L`,
+this kernel contains an eigenvector of `L`.  Its eigenvalue cannot vanish,
+because `P_t` acts as multiplication by `t` on `ker L`. -/
+theorem exists_nonzero_generator_eigenvalue_of_expSemigroup_fixed_not_generator_fixed
+    (L : Mat →ₗ[ℂ] Mat) (t : ℝ) (ht : t ≠ 0) {X : Mat}
+    (hX_fix : expSemigroup L t X = X) (hLX_ne : L X ≠ 0) :
+    ∃ μ : ℂ, μ ≠ 0 ∧ Module.End.HasEigenvalue L μ ∧
+      Complex.exp ((t : ℂ) * μ) = 1 := by
+  let L' : MatrixCLM (Fin D) := endEquiv L
+  let P : MatrixCLM (Fin D) :=
+    intervalIntegral (fun s : ℝ => expSemigroupCLM L' s)
+      0 t MeasureTheory.volume
+  have hPLX : P (L X) = 0 := by
+    have hzero : (expSemigroupCLM L' t - 1) X = 0 := by
+      have hX_fix' : expSemigroupCLM L' t X = X := by
+        change endEquiv (expSemigroup L t) X = X
+        rw [expSemigroup_toCLM]
+        exact hX_fix
+      simpa using sub_eq_zero.mpr hX_fix'
+    rw [expSemigroupCLM_sub_one_eq_intervalIntegral_mul] at hzero
+    change P (L' X) = 0
+    simpa [P] using hzero
+  have hLP : Commute L P.toLinearMap := by
+    rw [Commute]
+    apply LinearMap.ext
+    intro Y
+    change endEquiv L (P Y) = P (endEquiv L Y)
+    have hcomm := DFunLike.congr_fun
+      (intervalIntegral_expSemigroupCLM_mul_generator_comm L' t).symm Y
+    simpa [L', P, Module.End.mul_eq_comp, LinearMap.comp_apply,
+      mul_apply_eq_comp] using hcomm
+  obtain ⟨μ, Y, hY_ne, hPY, hLY⟩ :=
+    Module.End.exists_eigenvector_mem_ker_of_commute
+      L P.toLinearMap hLP hLX_ne hPLX
+  have hμ_ne : μ ≠ 0 := by
+    intro hμ
+    subst μ
+    have hLY_zero : L Y = 0 := by simpa using hLY
+    have hPY_eq :=
+      intervalIntegral_expSemigroupCLM_apply_of_generator_apply_eq_zero L t hLY_zero
+    have ht_complex : (t : ℂ) ≠ 0 := by exact_mod_cast ht
+    apply hY_ne
+    apply (smul_eq_zero.mp ?_).resolve_left ht_complex
+    rw [← hPY_eq]
+    exact hPY
+  have hY_fix : expSemigroup L t Y = Y := by
+    have hPY' : P Y = 0 := hPY
+    have hzero : (expSemigroupCLM L' t - 1) Y = 0 := by
+      rw [expSemigroupCLM_sub_one_eq_intervalIntegral_mul]
+      change P (L Y) = 0
+      rw [hLY, map_smul, hPY', smul_zero]
+    have hfix' : expSemigroupCLM L' t Y = Y := sub_eq_zero.mp hzero
+    change endEquiv (expSemigroup L t) Y = Y
+    rw [expSemigroup_toCLM]
+    exact hfix'
+  have hExpY := expSemigroup_apply_eigenvector L Y μ hLY t
+  have hroot : Complex.exp ((t : ℂ) * μ) = 1 := by
+    have hsmul : (Complex.exp ((t : ℂ) * μ) - 1) • Y = 0 := by
+      rw [sub_smul, one_smul, ← hExpY, hY_fix, sub_self]
+    exact sub_eq_zero.mp ((smul_eq_zero.mp hsmul).resolve_right hY_ne)
+  exact ⟨μ, hμ_ne, hasEigenvalue_of_eigenvector_eq L μ Y hLY hY_ne, hroot⟩
+
+end -- noncomputable section

--- a/blueprint/src/chapter/ch11_semigroup_dissipation_and_primitivity.tex
+++ b/blueprint/src/chapter/ch11_semigroup_dissipation_and_primitivity.tex
@@ -243,12 +243,6 @@
     Every density matrix is nonzero.
 \end{lemma}
 
-\begin{theorem}[Compression invariance is stable under powers]
-    \lean{compression_preserved_by_pow}\leanok
-    If a corner compression is invariant under $E$, it remains invariant under
-    every power $E^n$.
-\end{theorem}
-
 \begin{theorem}[Generator eigenvectors along the exponential semigroup]
     \lean{expSemigroup_apply_eigenvector}\leanok
     If $L(X)=\mu X$, then $e^{tL}(X)=e^{t\mu}X$ for all $t\in\R$.
@@ -260,10 +254,23 @@
     of $e^{tL}$.
 \end{theorem}
 
-\begin{theorem}[Root-of-unity rigidity for phases]
-    \lean{eq_zero_of_exp_mul_I_isRootOfUnity}\leanok
-    If $e^{it\theta}$ is a root of unity for every $t>0$, then $\theta=0$.
+\begin{theorem}[Root-of-unity rigidity at irrationally related times]
+    \label{thm:root_of_unity_irrational_rescaling_ch12}
+    \lean{eq_zero_of_exp_mul_I_isRootOfUnity_of_irrational_rescaling,
+        eq_zero_of_exp_mul_I_isRootOfUnity_one_pi}\leanok
+    More generally, if $\alpha$ is irrational and both $e^{i\theta}$ and
+    $e^{i\alpha\theta}$ are roots of unity, then $\theta=0$.  In particular,
+    if both $e^{i\theta}$ and $e^{i\pi\theta}$ are roots of unity, then
+    $\theta=0$.
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    The two root relations give $p_1\theta=2\pi k_1$ and
+    $p_2\alpha\theta=2\pi k_2$.  If $\theta\ne0$, their quotient expresses
+    $\alpha$ as a rational number.  The specialization $\alpha=\pi$ is the
+    irrational rescaling used by Wolf.
+\end{proof}
 
 \begin{theorem}[Peripheral generator eigenvalues are purely imaginary]
     \lean{re_eq_zero_of_peripheral_generator}\leanok
@@ -398,17 +405,11 @@
 
 \begin{remark}[Semigroup irreducible/primitive equivalence]\leanok
     The semigroup analog of the irreducible/primitive equivalence
-    starts from one irreducible time slice, constructs a primitive
-    smaller time step, and lifts the conclusion to the full semigroup
+    starts from one irreducible time slice, identifies the generator kernel,
+    and uses roots of unity at two irrationally related small times to lift
+    irreducibility to the full semigroup
     (Theorems~\ref{thm:irreducible_semigroup_implies_primitive}
     and~\ref{thm:qds_irreducible_iff_primitive}).
-\end{remark}
-
-\begin{remark}[Reduction to a smaller time step for semigroups]\leanok
-    Starting from one irreducible time $t_0$, we construct a
-    positive time step $u=t_0/N$ with
-    $T_{t_0}=(T_u)^N$, prove peripheral eigenvalue collapse at time~$u$,
-    and deduce primitivity of $T_u$.
 \end{remark}
 
 \begin{theorem}[The stationary density is fixed for all times]
@@ -438,144 +439,95 @@
     This is the fixed-point trace-scalar theorem for the irreducible channel $T_{t_0}$.
 \end{proof}
 
-\begin{definition}[Residual slice index]
-    \label{def:residual_slice_index_ch12}
-    \lean{residualSliceIndex}\leanok
-    For $u\ge0$ and $s>0$, the residual slice index is
-    $m_n=\left\lfloor nu/s\right\rfloor$.
-\end{definition}
-
-\begin{definition}[Residual slice time]
-    \label{def:residual_slice_time_ch12}
-    \lean{residualSliceTime}\leanok
-    For $u\ge0$ and $s>0$, the residual slice time is the remainder
-    $r_n=s\,\mathrm{fract}\!\left(nu/s\right)$.
-\end{definition}
-
-\begin{theorem}[Residual slice decomposition]
-    \label{thm:residual_slice_decomp_ch12}
-    \lean{residualSliceTime_mem_Icc, residualSlice_decomp}\leanok
-    \uses{def:residual_slice_index_ch12, def:residual_slice_time_ch12}
-    For $u\ge0$ and $s>0$, one has $r_n\in[0,s]$ and $nu=m_ns+r_n$.
+\begin{theorem}[Fixed spaces at sufficiently small times]
+    \label{thm:small_time_fixed_space_eq_generator_kernel_ch12}
+    \lean{exists_pos_forall_lt_expSemigroup_fixedPoint_iff_generator_apply_eq_zero}\leanok
+    \uses{def:exp_semigroup_ch12}
+    For every finite-dimensional generator $L$, there is a $\delta>0$ such
+    that, for all $0<t<\delta$,
+    \begin{align}
+        e^{tL}(X)=X \quad\Longleftrightarrow\quad L(X)=0.
+    \end{align}
 \end{theorem}
 
 \begin{proof}
     \leanok
-    This is the floor-plus-fraction decomposition of $nu/s$, multiplied by $s$.
+    Factor
+    $e^{tL}-\Id=(\int_0^t e^{sL}\,ds)L$.  After division by $t$, the integral
+    factor tends to the identity as $t\downarrow0$, and is therefore invertible
+    throughout a sufficiently small punctured interval.
 \end{proof}
 
-\begin{theorem}[A residual slice can vanish]
-    \label{thm:exists_residual_time_eq_zero_ch12}
-    \lean{exists_residual_time_eq_zero_of_fixedPoint}\leanok
-    \uses{def:residual_slice_time_ch12, thm:residual_slice_decomp_ch12}
-    Suppose $u\ge0$ and $s>0$, and that $T_s(\delta)=\delta$ and
-    $T_{nu}(\delta)\to0$ as $n\to\infty$.
-    Then there exists $a\in[0,s]$ such that $T_a(\delta)=0$.
+\begin{theorem}[Reverse spectral mapping for exponential eigenvalues]
+    \label{thm:reverse_spectral_mapping_exp_ch12}
+    \lean{exists_generator_eigenvalue_of_expSemigroup_hasEigenvalue}\leanok
+    \uses{def:exp_semigroup_ch12}
+    Every eigenvalue $\lambda$ of $e^{tL}$ has the form
+    $\lambda=e^{t\mu}$ for an eigenvalue $\mu$ of $L$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    The residual slice times lie in the compact interval $[0,s]$, so a subsequence converges
-    to some $a\in[0,s]$. The residual decomposition rewrites $T_{nu}(\delta)$ in terms of
-    $T_{r_n}(\delta)$, and continuity of the semigroup identifies the limit with $T_a(\delta)$.
+    The $\lambda$-eigenspace of $e^{tL}$ is nonzero and invariant under $L$.
+    The restriction of $L$ to this finite-dimensional complex space has an
+    eigenvector, which is a common eigenvector of $L$ and $e^{tL}$.
 \end{proof}
 
-\begin{theorem}[Reduced-time eigenvector has nonzero trace]
-    \label{thm:exists_trace_ne_zero_eigenvector_of_fraction_slice_ch12}
-    \lean{exists_trace_ne_zero_eigenvector_of_fraction_slice}\leanok
-    Under the reduced-time hypotheses
-    $T_{t_0}=(T_u)^{(\dim \MN{D})!}$, if
-    $\mu$ is a peripheral eigenvalue of $T_u$, then $T_u$ admits a
-    $\mu$-eigenvector with nonzero trace.
-\end{theorem}
-
-\begin{theorem}[Peripheral collapse at the reduced time step]
-    \label{thm:peripheral_eq_one_of_fraction_slice_ch12}
-    \lean{peripheral_eq_one_of_fraction_slice}\leanok
-    Under the same hypotheses, every peripheral eigenvalue of $T_u$
-    equals $1$.
-\end{theorem}
-
-\begin{theorem}[Primitivity at the reduced time step]
-    \label{thm:primitive_of_fraction_slice_ch12}
-    \lean{primitive_of_fraction_slice}\leanok
-    Under the same hypotheses, $T_u$ is primitive.
-\end{theorem}
-
-\begin{theorem}[Irreducibility descends to a reduced time step]
-    \label{thm:irreducible_of_fraction_slice_ch12}
-    \lean{irreducible_of_fraction_slice}\leanok
-    If $T_{t_0}=(T_u)^N$ and $T_{t_0}$ is irreducible, then $T_u$ is irreducible.
+\begin{theorem}[Reverse fixed-space resonance]
+    \label{thm:reverse_fixed_space_resonance_ch12}
+    \lean{exists_nonzero_generator_eigenvalue_of_expSemigroup_fixed_not_generator_fixed}\leanok
+    \uses{def:exp_semigroup_ch12}
+    Let $t\ne0$.  If $e^{tL}(X)=X$ but $L(X)\ne0$, then $L$ has a nonzero
+    eigenvalue $\mu$ satisfying $e^{t\mu}=1$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Any invariant compression for $T_u$ remains invariant under powers, hence also for
-    $T_{t_0}$; irreducibility of $T_{t_0}$ rules this out.
+    Put $P_t=\int_0^t e^{sL}\,ds$.  The factorization
+    $e^{tL}-\Id=P_tL$ puts the nonzero vector $L(X)$ in $\ker P_t$.
+    Since $P_t$ commutes with $L$, this kernel contains an eigenvector of $L$.
+    Its eigenvalue is nonzero because $P_t$ acts as multiplication by $t$ on
+    $\ker L$.
 \end{proof}
-
-\begin{theorem}[Existence of an irreducible reduced time step]
-    \label{thm:exists_irreducible_fraction_slice_ch12}
-    \lean{exists_irreducible_fraction_slice}\leanok
-    If $t_0>0$, $T_{t_0}$ is irreducible, and $\sigma$ is fixed for all times,
-    then there exists a positive time step $u$ such that
-    $T_{t_0}=(T_u)^{(\dim \MN{D})!}$, the slice $T_u$ is a channel,
-    $T_u$ is irreducible, and $T_u(\sigma)=\sigma$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:irreducible_of_fraction_slice_ch12}
-    Take $u=t_0/N$ with $N=(\dim \MN{D})!$. The semigroup power identity gives the
-    factorization of $T_{t_0}$, channelity comes from the semigroup hypotheses, and
-    Theorem~\ref{thm:irreducible_of_fraction_slice_ch12} gives irreducibility of $T_u$.
-\end{proof}
-
-\begin{theorem}[Fixed points of the primitive reduced time step are trace-scalars]
-    \label{thm:fixedPoint_eq_trace_smul_of_primitive_slice_ch12}
-    \lean{fixedPoint_eq_trace_smul_of_primitive_slice}\leanok
-    If $T_u$ is primitive and $\sigma$ is the common fixed density, then
-    every fixed point of any positive-time slice $T_s$ has the form
-    $\tau=\tr(\tau)\sigma$.
-\end{theorem}
-
-\begin{theorem}[Existence of a primitive reduced time step]
-    \label{thm:exists_primitive_fraction_slice_ch12}
-    \lean{exists_primitive_fraction_slice}\leanok
-    If $T_{t_0}$ is irreducible for some $t_0>0$, then there exists a
-    positive reduced time step $u$ such that $T_u$ is primitive.
-\end{theorem}
 
 
 \begin{theorem}[Irreducibility propagates to all positive times]
     \label{thm:irreducible_all_of_irreducible_time_ch12}
     \lean{irreducible_all_of_irreducible_time}\leanok
-    \uses{def:is_quantum_dyn_semigroup_ch12,
-        thm:fixed_density_fixed_for_all_times_ch12,
-        thm:fixedPoint_eq_trace_smul_at_irreducible_time_ch12,
-        thm:exists_primitive_fraction_slice_ch12,
-        thm:fixedPoint_eq_trace_smul_of_primitive_slice_ch12}
+    \uses{def:is_quantum_dyn_semigroup_ch12}
     If $T_{t_0}$ is irreducible for some $t_0>0$, then every positive-time slice $T_s$ is
     irreducible.
 \end{theorem}
 
 \begin{proof}
     \leanok
+    \uses{thm:fixed_density_fixed_for_all_times_ch12,
+        thm:fixedPoint_eq_trace_smul_at_irreducible_time_ch12,
+        thm:small_time_fixed_space_eq_generator_kernel_ch12,
+        thm:reverse_fixed_space_resonance_ch12,
+        thm:root_of_unity_irrational_rescaling_ch12,
+        thm:peripheral_roots_irreducible_channel}
     Let $\sigma$ be the unique faithful fixed density of $T_{t_0}$. By
     Theorem~\ref{thm:fixed_density_fixed_for_all_times_ch12}, it is fixed for all times, and
     Theorem~\ref{thm:fixedPoint_eq_trace_smul_at_irreducible_time_ch12} makes the fixed-point
-    space of $T_{t_0}$ one-dimensional. Choose a primitive reduced time step by
-    Theorem~\ref{thm:exists_primitive_fraction_slice_ch12}; then the trace-scalar description
-    of fixed points from Theorem~\ref{thm:fixedPoint_eq_trace_smul_of_primitive_slice_ch12}
-    gives the uniqueness criterion for irreducibility at every positive time.
+    space of $T_{t_0}$ one-dimensional; hence $\ker L=\C\sigma$.
+    Theorem~\ref{thm:small_time_fixed_space_eq_generator_kernel_ch12} makes
+    $T_u$ irreducible for every sufficiently small $u>0$.  Choose such a $u$
+    for which $\pi u$ is also in this interval.  A purely imaginary generator
+    eigenvalue $\mu$ produces peripheral eigenvalues at both times.  Their
+    roots-of-unity relations and
+    Theorem~\ref{thm:root_of_unity_irrational_rescaling_ch12} force $\mu=0$.
+    Finally, if an arbitrary $T_s$ had a fixed point outside $\ker L$,
+    Theorem~\ref{thm:reverse_fixed_space_resonance_ch12} would produce a
+    nonzero eigenvalue $\mu$ with $e^{s\mu}=1$.  Such a $\mu$ is purely
+    imaginary and has just been excluded.  Thus every fixed point is a scalar
+    multiple of $\sigma$, which gives irreducibility of every $T_s$, $s>0$.
 \end{proof}
 
 \begin{theorem}[An irreducible semigroup is primitive]
     \label{thm:irreducible_semigroup_implies_primitive}
     \lean{irreducible_semigroup_implies_primitive}\leanok
-    \uses{def:is_quantum_dyn_semigroup_ch12,
-        thm:irreducible_all_of_irreducible_time_ch12,
-        thm:primitive_of_irreducible_all_ch12}
+    \uses{def:is_quantum_dyn_semigroup_ch12}
     Let $T_t=e^{tL}$ be a quantum dynamical semigroup.
     If $T_{t_0}$ is irreducible for some $t_0>0$, then
     $T_t$ is primitive (and irreducible) for every $t>0$.
@@ -583,6 +535,8 @@
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:irreducible_all_of_irreducible_time_ch12,
+        thm:primitive_of_irreducible_all_ch12}
     First apply Theorem~\ref{thm:irreducible_all_of_irreducible_time_ch12} to propagate
     irreducibility from the single time $t_0$ to every positive time. Then apply
     Theorem~\ref{thm:primitive_of_irreducible_all_ch12} to conclude primitivity of every
@@ -592,7 +546,7 @@
 \begin{theorem}[Irreducibility iff primitivity for a quantum dynamical semigroup]
     \label{thm:qds_irreducible_iff_primitive}
     \lean{qds_irreducible_iff_primitive}\leanok
-    \uses{thm:irreducible_semigroup_implies_primitive}
+    \uses{def:is_quantum_dyn_semigroup_ch12}
     For a quantum dynamical semigroup $T_t=e^{tL}$,
     \begin{align}
         (\exists\, t_0>0,\ T_{t_0}\ \text{irreducible})
@@ -636,7 +590,7 @@
         expSemigroupCLM_sub_one_eq_intervalIntegral_mul,
         exists_pos_intervalIntegral_isUnit_of_continuous_zero_eq_one}\leanok
     \uses{def:qds_faithful_relaxation,
-        thm:qds_irreducible_iff_primitive}
+        def:is_quantum_dyn_semigroup_ch12}
     Let $T_t=e^{tL}$, $t\in\R_+$, be a norm-continuous dynamical semigroup
     of trace-preserving completely positive maps.  The following statements
     are equivalent:

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -2124,11 +2124,22 @@ positive-time slices are irreducible, all positive-time slices are primitive,
 all density matrices relax to one faithful density matrix, and the generator
 has a simple faithful kernel. In the third clause, primitivity records both
 irreducibility and the absence of peripheral eigenvalues other than one, as in
-Wolf's definition. For the implication from the simple-kernel condition, one
-chooses a positive time whose fixed space is exactly the kernel of the
+Wolf's definition.  The irreducibility-propagation proof now follows the
+argument on source lines 279--280: the simple faithful kernel makes every
+sufficiently small positive slice irreducible; the roots-of-unity theorem at
+two such times with irrational ratio `π` excludes every nonzero imaginary
+generator eigenvalue; and a fixed vector at any other positive time outside
+the generator kernel would yield a nonzero resonant eigenvalue
+\(\mu\) with \(e^{t\mu}=1\).  The latter reverse fixed-space statement is
+proved from the exponential integral factorization, rather than assumed from
+forward spectral mapping. For the implication from the simple-kernel condition,
+one chooses a positive time whose fixed space is exactly the kernel of the
 generator. This follows from
 \(e^{tL}-I=(\int_0^t e^{sL}\,ds)L\), since the integral is invertible for all
 sufficiently small positive \(t\).
+
+The formalization uses Wolf's rescaling factor \(\pi\) literally, via
+`irrational_pi`.
 
 Proposition 7.6 is also an exact completion. In the implication from an upper
 block-triangular Lindblad representation to a rank-deficient kernel element,


### PR DESCRIPTION
## Source contract

Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 7, Proposition 7.5, especially `Notes/WolfNoteTexSource/ch07_semigroup_structure.tex`, lines 279--280.

Closes #519.

## What changed

- replace the factorial/fraction-slice and residual-time propagation argument by Wolf's irrational-rescaling mechanism, using the paper's literal pair of times `u` and `πu`;
- prove that the fixed space of `exp(tL)` agrees with `ker L` throughout a sufficiently small positive-time interval;
- add reverse spectral mapping and reverse fixed-space resonance lemmas, so every transfer between generator and semigroup eigenspaces is proved explicitly;
- use roots of unity at `u` and `πu`, together with `irrational_pi`, to exclude nonzero imaginary generator eigenvalues;
- remove the obsolete residual-slice infrastructure and synchronize the module documentation, Blueprint, and Wolf numbering coverage.

The public statements of `irreducible_all_of_irreducible_time`, `irreducible_semigroup_implies_primitive`, and `wolf_prop_7_5_full_equivalence` are unchanged. The Corollary 7.2 material merged in #522 is preserved.

## Verification

- `lake build QICLean -q --log-level=info`
- focused build of `Basic`, `Kernel`, `SpectralMapping`, `IrreducibleAnalysis`, `MainTheorem`, and the `Primitivity` aggregate
- Blueprint synchronization: 2696/2696 declarations
- generated import aggregation, changed-declaration coverage, module, numbering, prose, style, paper-gap reference, and `chktex` checks
- forbidden-proof scan and an explicit axiom audit of nine new/core/headline declarations
- independent mathematical/source audit with no finding

The axiom audit reports only `propext`, `Classical.choice`, and `Quot.sound`.
