### PR TITLE
feat(channel): formalize Wolf Theorem 6.4 for positive maps

### DIFF
--- a/QICLean/Channel/FixedPoint/Cesaro.lean
+++ b/QICLean/Channel/FixedPoint/Cesaro.lean
@@ -11,20 +11,22 @@ import QICLean.Channel.Schwarz.PositiveMapProperties
 /-!
 # Fixed point existence via Cesàro means
 
-This file proves that every quantum channel (CPTP map) on `M_D(ℂ)` has a nonzero
-PSD fixed point, using the Cesàro mean / Markov-Kakutani argument. It also proves
-the positive fixed-point decomposition of Wolf Proposition 6.8.
+This file proves that every positive trace-preserving linear map on `M_D(ℂ)`
+has a nonzero PSD fixed point, using the Cesàro mean / Markov-Kakutani argument.
+It also proves the positive fixed-point decomposition of Wolf Proposition 6.8.
 
-The decomposition theorem uses only positivity and trace preservation. The fixed-point
-existence theorem is stated for channels.
+All Cesàro existence theorems use only positivity and trace preservation. Their
+earlier channel declarations are retained as direct specializations.
 
 ## Main results
 
 * `cesaroMean`: the Cesàro mean of iterates of a linear map
 * `cesaroMean_telescope`: telescoping identity for Cesàro means
-* `IsChannel.exists_posSemidef_fixedPoint`: existence of PSD fixed point
-* `IsChannel.exists_fixed_density_of_preserves_compression`: existence of a
+* `IsPositiveMap.exists_posSemidef_fixedPoint`: existence of a PSD fixed point
+  for a positive trace-preserving map
+* `IsPositiveMap.exists_fixed_density_of_preserves_compression`: existence of a
   stationary density matrix in an invariant compression
+* the corresponding `IsChannel` declarations: channel specializations
 * `IsPositiveMap.posPart_negPart_fixed_of_fixedPoint`: Wolf Proposition 6.8 for
   positive trace-preserving maps, using the four canonical positive parts.
 * `IsPositiveMap.exists_posSemidef_fixedPoints_decomposition`: existential form of
@@ -334,9 +336,10 @@ theorem cesaroMean_telescope (X : Matrix (Fin D) (Fin D) ℂ) (N : ℕ) (_hN : 0
   rw [Finset.sum_range_sub (fun n => (E ^ n) X)]
   simp [pow_zero]
 
-/-- Iterates of a channel preserve density matrices. -/
-private lemma IsChannel.iter_mem_densityMatrices
-    (hE : IsChannel E) {ρ : Matrix (Fin D) (Fin D) ℂ}
+/-- Iterates of a positive trace-preserving map preserve density matrices. -/
+private lemma IsPositiveMap.iter_mem_densityMatrices
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
+    {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hρ : ρ ∈ densityMatrices D) (n : ℕ) : (E ^ n) ρ ∈ densityMatrices D := by
   induction n with
   | zero =>
@@ -344,14 +347,17 @@ private lemma IsChannel.iter_mem_densityMatrices
       exact hρ
   | succ n ih =>
       rw [pow_succ']
-      exact IsChannel.map_densityMatrices E hE ((E ^ n) ρ) ih
+      change E ((E ^ n) ρ) ∈ densityMatrices D
+      exact ⟨hE _ ih.1, by rw [hTP, ih.2]⟩
 
-/-- Cesàro means of a channel applied to a density matrix remain density matrices. -/
-theorem IsChannel.cesaroMean_mem_densityMatrices
-    (hE : IsChannel E) {ρ : Matrix (Fin D) (Fin D) ℂ}
+/-- Cesàro means of a positive trace-preserving map applied to a density matrix
+remain density matrices. -/
+theorem IsPositiveMap.cesaroMean_mem_densityMatrices
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
+    {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hρ : ρ ∈ densityMatrices D) :
     ∀ N : ℕ, cesaroMean E ρ (N + 1) ∈ densityMatrices D := by
-  have h_iter := IsChannel.iter_mem_densityMatrices (E := E) hE hρ
+  have h_iter := IsPositiveMap.iter_mem_densityMatrices (E := E) hE hTP hρ
   intro N
   refine ⟨?_, ?_⟩
   · rw [cesaroMean_eq]
@@ -363,18 +369,27 @@ theorem IsChannel.cesaroMean_mem_densityMatrices
       Finset.sum_const, Finset.card_range, nsmul_eq_mul, mul_one, one_div]
     exact inv_mul_cancel₀ (Nat.cast_ne_zero.mpr (Nat.succ_ne_zero N))
 
-/-- Any subsequential limit of the Cesàro means of a channel is a
-density-matrix fixed point. -/
-theorem IsChannel.cesaroMean_subseq_limit_fixedPoint
-    (hE : IsChannel E) {ρ σ : Matrix (Fin D) (Fin D) ℂ}
+/-- Channel specialization of
+`IsPositiveMap.cesaroMean_mem_densityMatrices`. -/
+theorem IsChannel.cesaroMean_mem_densityMatrices
+    (hE : IsChannel E) {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hρ : ρ ∈ densityMatrices D) :
+    ∀ N : ℕ, cesaroMean E ρ (N + 1) ∈ densityMatrices D :=
+  IsPositiveMap.cesaroMean_mem_densityMatrices (E := E) hE.pos hE.tp hρ
+
+/-- Any subsequential limit of the Cesàro means of a positive
+trace-preserving map is a density-matrix fixed point. -/
+theorem IsPositiveMap.cesaroMean_subseq_limit_fixedPoint
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
+    {ρ σ : Matrix (Fin D) (Fin D) ℂ}
     (hρ : ρ ∈ densityMatrices D)
     {ψ : ℕ → ℕ} (hψ_tendsto : Filter.Tendsto ψ Filter.atTop Filter.atTop)
     (hσ_tendsto : Filter.Tendsto (fun k => cesaroMean E ρ (ψ k + 1))
       Filter.atTop (nhds σ)) :
     σ ∈ densityMatrices D ∧ E σ = σ := by
-  have h_iter := IsChannel.iter_mem_densityMatrices (E := E) hE hρ
+  have h_iter := IsPositiveMap.iter_mem_densityMatrices (E := E) hE hTP hρ
   have hces_mem : ∀ N : ℕ, cesaroMean E ρ (N + 1) ∈ densityMatrices D :=
-    IsChannel.cesaroMean_mem_densityMatrices (E := E) hE hρ
+    IsPositiveMap.cesaroMean_mem_densityMatrices (E := E) hE hTP hρ
   have hσ_mem : σ ∈ densityMatrices D :=
     (densityMatrices_isCompact (D := D)).isClosed.mem_of_tendsto hσ_tendsto <|
       Filter.Eventually.of_forall fun k => hces_mem (ψ k)
@@ -413,12 +428,25 @@ theorem IsChannel.cesaroMean_subseq_limit_fixedPoint
     tendsto_nhds_unique (h_diff.congr h_telesc) h_rhs_zero
   exact ⟨hσ_mem, sub_eq_zero.mp h_eq⟩
 
-/-- **Existence of PSD fixed point for channels** (Cesàro mean argument).
+/-- Channel specialization of
+`IsPositiveMap.cesaroMean_subseq_limit_fixedPoint`. -/
+theorem IsChannel.cesaroMean_subseq_limit_fixedPoint
+    (hE : IsChannel E) {ρ σ : Matrix (Fin D) (Fin D) ℂ}
+    (hρ : ρ ∈ densityMatrices D)
+    {ψ : ℕ → ℕ} (hψ_tendsto : Filter.Tendsto ψ Filter.atTop Filter.atTop)
+    (hσ_tendsto : Filter.Tendsto (fun k => cesaroMean E ρ (ψ k + 1))
+      Filter.atTop (nhds σ)) :
+    σ ∈ densityMatrices D ∧ E σ = σ :=
+  IsPositiveMap.cesaroMean_subseq_limit_fixedPoint
+    (E := E) hE.pos hE.tp hρ hψ_tendsto hσ_tendsto
+
+/-- **Existence of a PSD fixed point for positive trace-preserving maps**
+(Cesàro mean argument).
 This is an alternative proof of **Wolf Theorem 6.11** (Stationary states)
 that avoids Brouwer's fixed point theorem (Wolf Theorem 6.10) entirely.
 
-Every trace-preserving positive map on `M_D(ℂ)` with `D > 0` has a
-nonzero PSD fixed point.
+Every trace-preserving positive map on `M_D(ℂ)` with `D > 0` has a nonzero PSD
+fixed point. No complete positivity or Kraus representation is used.
 
 Our proof uses only:
 - compactness of density matrices (finite-dimensional Heine-Borel)
@@ -431,19 +459,19 @@ Our proof uses only:
 3. Extract convergent subsequence `σ_{N_k} → σ`.
 4. `E(σ_N) - σ_N = (E^N(ρ₀) - ρ₀)/N → 0`.
 5. Hence `E(σ) = σ`. -/
-theorem IsChannel.exists_posSemidef_fixedPoint
-    (hE : IsChannel E) (hD : 0 < D) :
+theorem IsPositiveMap.exists_posSemidef_fixedPoint
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E) (hD : 0 < D) :
     ∃ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.PosSemidef ∧ ρ ≠ 0 ∧ E ρ = ρ := by
   obtain ⟨ρ₀, hρ₀⟩ := densityMatrices_nonempty hD
   have hces_mem : ∀ N, cesaroMean E ρ₀ (N + 1) ∈ densityMatrices D :=
-    IsChannel.cesaroMean_mem_densityMatrices (E := E) hE hρ₀
+    IsPositiveMap.cesaroMean_mem_densityMatrices (E := E) hE hTP hρ₀
   have : FirstCountableTopology (Matrix (Fin D) (Fin D) ℂ) := by
     change FirstCountableTopology (Fin D → Fin D → ℂ)
     infer_instance
   obtain ⟨ρ, _hρ_mem, φ, hφ_mono, hφ_tendsto⟩ :=
     densityMatrices_isCompact.tendsto_subseq hces_mem
   have hρ_lim : ρ ∈ densityMatrices D ∧ E ρ = ρ :=
-    IsChannel.cesaroMean_subseq_limit_fixedPoint (E := E) hE hρ₀
+    IsPositiveMap.cesaroMean_subseq_limit_fixedPoint (E := E) hE hTP hρ₀
       hφ_mono.tendsto_atTop hφ_tendsto
   have hρ_ne : ρ ≠ 0 := by
     intro hρ_zero
@@ -452,10 +480,17 @@ theorem IsChannel.exists_posSemidef_fixedPoint
     exact zero_ne_one htr
   exact ⟨ρ, hρ_lim.1.1, hρ_ne, hρ_lim.2⟩
 
-/-- A channel preserving the compression `P M_D(ℂ) P` has a stationary density
-matrix supported in that compression. -/
-theorem IsChannel.exists_fixed_density_of_preserves_compression
-    (hE : IsChannel E) {P : Matrix (Fin D) (Fin D) ℂ}
+/-- Channel specialization of `IsPositiveMap.exists_posSemidef_fixedPoint`. -/
+theorem IsChannel.exists_posSemidef_fixedPoint
+    (hE : IsChannel E) (hD : 0 < D) :
+    ∃ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.PosSemidef ∧ ρ ≠ 0 ∧ E ρ = ρ :=
+  IsPositiveMap.exists_posSemidef_fixedPoint (E := E) hE.pos hE.tp hD
+
+/-- A positive trace-preserving map preserving the compression `P M_D(ℂ) P`
+has a stationary density matrix supported in that compression. -/
+theorem IsPositiveMap.exists_fixed_density_of_preserves_compression
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
+    {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0)
     (hE_pres : ∀ X : Matrix (Fin D) (Fin D) ℂ,
       P * E (P * X * P) * P = E (P * X * P)) :
@@ -485,7 +520,7 @@ theorem IsChannel.exists_fixed_density_of_preserves_compression
   let σ : ℕ → Matrix (Fin D) (Fin D) ℂ :=
     fun N => cesaroMean E ρ₀ (N + 1)
   have hσ_mem : ∀ N, σ N ∈ densityMatrices D :=
-    IsChannel.cesaroMean_mem_densityMatrices (E := E) hE hρ₀_mem
+    IsPositiveMap.cesaroMean_mem_densityMatrices (E := E) hE hTP hρ₀_mem
   have hσ_corner : ∀ N, P * σ N * P = σ N := by
     intro N
     change P * cesaroMean E ρ₀ (N + 1) * P = cesaroMean E ρ₀ (N + 1)
@@ -511,8 +546,20 @@ theorem IsChannel.exists_fixed_density_of_preserves_compression
     change Filter.Tendsto (σ ∘ φ) Filter.atTop (nhds ρ)
     exact hφ_tendsto
   have hρ_lim : ρ ∈ densityMatrices D ∧ E ρ = ρ :=
-    IsChannel.cesaroMean_subseq_limit_fixedPoint (E := E) hE hρ₀_mem
+    IsPositiveMap.cesaroMean_subseq_limit_fixedPoint (E := E) hE hTP hρ₀_mem
       hφ_mono.tendsto_atTop hρ_tendsto
   exact ⟨ρ, hρ_lim.1, hρ_corner, hρ_lim.2⟩
+
+/-- Channel specialization of
+`IsPositiveMap.exists_fixed_density_of_preserves_compression`. -/
+theorem IsChannel.exists_fixed_density_of_preserves_compression
+    (hE : IsChannel E) {P : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0)
+    (hE_pres : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      P * E (P * X * P) * P = E (P * X * P)) :
+    ∃ ρ : Matrix (Fin D) (Fin D) ℂ, ρ ∈ densityMatrices D ∧
+      P * ρ * P = ρ ∧ E ρ = ρ :=
+  IsPositiveMap.exists_fixed_density_of_preserves_compression
+    (E := E) hE.pos hE.tp hP hP_ne hE_pres
 
 end CesaroMean

--- a/QICLean/Channel/Irreducible.lean
+++ b/QICLean/Channel/Irreducible.lean
@@ -24,6 +24,7 @@ import QICLean.Channel.Irreducible.Growth.Preservation
 import QICLean.Channel.Irreducible.KrausGauge
 import QICLean.Channel.Irreducible.KrausSetup
 import QICLean.Channel.Irreducible.PerronFrobenius
+import QICLean.Channel.Irreducible.PositiveMapSpectralCharacterization
 import QICLean.Channel.Irreducible.Scaling
 import QICLean.Channel.Irreducible.Similarity
 import QICLean.Channel.Irreducible.SpectralRadius

--- a/QICLean/Channel/Irreducible/FromSpectral.lean
+++ b/QICLean/Channel/Irreducible/FromSpectral.lean
@@ -209,20 +209,20 @@ theorem hasSpectralProperties_of_irreducible_cp
       unique_psd_eigenvector := hunique
       spectralRadius_eq := hrad }⟩
 
-/-! ## Channel lemma for the reverse implication -/
+/-! ## Positive trace-preserving lemma for the reverse implication -/
 
-/-- A channel with a positive-definite fixed point and no other PSD fixed points
-except scalar multiples of it is irreducible.
+/-- A positive trace-preserving map with a positive-definite fixed point and no
+other PSD fixed points except scalar multiples of it is irreducible.
 
 This is the fixed-point contradiction at the heart of Wolf's proof of
 Theorem 6.4.  If a nontrivial invariant projection `P` existed, the Cesàro mean
 inside the corner `P M_D P` would produce a density-matrix fixed point supported
 in that corner.  It cannot be a scalar multiple of a positive-definite fixed
 point on the whole space. -/
-theorem isIrreducibleMap_of_channel_posDef_fixedPoint_unique
+theorem isIrreducibleMap_of_positive_tracePreserving_posDef_fixedPoint_unique
     [NeZero D]
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (hE : IsChannel E)
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
     (ρ : Matrix (Fin D) (Fin D) ℂ)
     (hρ_pd : ρ.PosDef)
     (_hρ_fix : E ρ = ρ)
@@ -235,8 +235,8 @@ theorem isIrreducibleMap_of_channel_posDef_fixedPoint_unique
   by_cases hP1 : P = 1
   · exact Or.inr hP1
   obtain ⟨σ, hσ_mem, hσ_corner, hσ_fix⟩ :=
-    IsChannel.exists_fixed_density_of_preserves_compression
-      (E := E) hE hP_proj hP0 hP_inv
+    IsPositiveMap.exists_fixed_density_of_preserves_compression
+      (E := E) hE hTP hP_proj hP0 hP_inv
   have hσ_ne : σ ≠ 0 := by
     intro hσ0
     have htr : Matrix.trace σ = 1 := hσ_mem.2
@@ -266,6 +266,21 @@ theorem isIrreducibleMap_of_channel_posDef_fixedPoint_unique
       _ = 0 := by simp [Matrix.mul_assoc, hPQ]
   exfalso
   exact (proj_mul_posDef_mul_proj_ne_zero hQ_proj.1 hQ_proj.2 hQ_ne hρ_pd) hQρQ_zero
+
+/-- Channel specialization of
+`isIrreducibleMap_of_positive_tracePreserving_posDef_fixedPoint_unique`. -/
+theorem isIrreducibleMap_of_channel_posDef_fixedPoint_unique
+    [NeZero D]
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hE : IsChannel E)
+    (ρ : Matrix (Fin D) (Fin D) ℂ)
+    (hρ_pd : ρ.PosDef)
+    (hρ_fix : E ρ = ρ)
+    (huniq : ∀ σ : Matrix (Fin D) (Fin D) ℂ,
+      σ.PosSemidef → E σ = σ → ∃ c : ℂ, σ = c • ρ) :
+    IsIrreducibleMap E :=
+  isIrreducibleMap_of_positive_tracePreserving_posDef_fixedPoint_unique
+    E hE.pos hE.tp ρ hρ_pd hρ_fix huniq
 
 /-! ## Reverse implication: spectral properties ⇒ irreducible -/
 

--- a/QICLean/Channel/Irreducible/PositiveMapSpectralCharacterization.lean
+++ b/QICLean/Channel/Irreducible/PositiveMapSpectralCharacterization.lean
@@ -1,0 +1,296 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Channel.Irreducible.FromSpectral
+
+/-!
+# Wolf Theorem 6.4: spectral characterization of irreducibility
+
+This module proves that, for a nonzero positive map `T` on a nonzero full
+matrix algebra, Wolf Theorem 6.4 characterizes irreducibility by three
+spectral facts: the spectral radius is an ordinary nondegenerate eigenvalue,
+and it has positive-definite right and left eigenvectors.  The left eigenvector
+is stated for
+`Matrix.traceAdjointMap T`, the adjoint with respect to Wolf's bilinear trace
+pairing.
+
+The reverse implication follows Wolf's proof.  If `Y > 0` is the left Perron
+eigenvector and `S = sqrt Y`, then
+
+`T' = r⁻¹ • similarityMap S⁻¹ T`
+
+is positive and trace preserving, and `S * X * S > 0` is fixed by `T'`.  A
+proper invariant corner for `T'` contains a stationary density matrix.  Pulling
+that matrix back through the similarity gives a second vector in the ordinary
+`r`-eigenspace of `T`, contradicting its dimension one.
+
+The hypothesis `T ≠ 0` is a necessary boundary correction to the printed
+statement: on `M₁(ℂ)`, the zero map is irreducible, but its spectral radius is
+zero and hence it cannot satisfy the printed strict-positive condition
+`T(X) = r X > 0`.
+
+## Main declarations
+
+* `HasWolfSpectralProperties`: the exact source-facing spectral condition.
+* `hasWolfSpectralProperties_of_irreducible_positive`: the forward implication.
+* `isIrreducibleMap_of_hasWolfSpectralProperties`: the reverse implication.
+* `wolf_theorem_6_4`: Wolf Theorem 6.4 with the necessary nonzero-map boundary.
+* `hasSpectralProperties_iff_hasWolfSpectralProperties_of_cp`: comparison with
+  the earlier finite-Kraus package.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.4; local
+  source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 698--721.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder NNReal ENNReal TNOperatorSpace
+open Matrix
+
+noncomputable section
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- A witness for the spectral condition in Wolf Theorem 6.4.
+
+The real number `r` represents the spectral radius through
+`spectralRadius_eq`.  The field `finrank_eigenspace_eq_one` is ordinary
+geometric nondegeneracy over `ℂ`; it is not restricted to positive
+semidefinite eigenvectors and makes no assertion about algebraic multiplicity.
+The left eigenvector is expressed through the trace-pairing adjoint, without a
+Kraus or complete-positivity hypothesis. -/
+structure WolfSpectralProperties (T : Mat →ₗ[ℂ] Mat) where
+  r : ℝ
+  r_pos : 0 < r
+  spectralRadius_eq :
+    spectralRadius ℂ ((Module.End.toContinuousLinearMap Mat) T) = ENNReal.ofReal r
+  X : Mat
+  X_posDef : X.PosDef
+  right_eigenvector : T X = (r : ℂ) • X
+  Y : Mat
+  Y_posDef : Y.PosDef
+  left_eigenvector : Matrix.traceAdjointMap T Y = (r : ℂ) • Y
+  finrank_eigenspace_eq_one :
+    Module.finrank ℂ (Module.End.eigenspace T (r : ℂ)) = 1
+
+/-- `HasWolfSpectralProperties T` asserts the existence of the right and left
+Perron data in `WolfSpectralProperties T`. -/
+def HasWolfSpectralProperties (T : Mat →ₗ[ℂ] Mat) : Prop :=
+  Nonempty (WolfSpectralProperties T)
+
+/-- Wolf Theorem 6.4, forward implication, for an arbitrary nonzero positive
+map.  Wolf Theorem 6.3 supplies the ordinary simple right Perron eigenspace;
+its trace-adjoint consequence supplies a positive-definite left eigenvector at
+the same eigenvalue. -/
+theorem hasWolfSpectralProperties_of_irreducible_positive [NeZero D]
+    (T : Mat →ₗ[ℂ] Mat) (hT : IsPositiveMap T)
+    (hIrr : IsIrreducibleMap T) (hT_ne : T ≠ 0) :
+    HasWolfSpectralProperties T := by
+  obtain ⟨X, r, _hXdensity, hr, hX, hX_eig, _hLowerAtX, _hUpperAtX,
+      _hLowerMax, _hUpperMin, hfinrank, _hpositive_eigenvalue, hradius⟩ :=
+    exists_wolfTheorem63_of_irreducible_positive_of_ne_zero T hT hIrr hT_ne
+  obtain ⟨Y, hY, hY_eig⟩ :=
+    exists_posDef_traceAdjointMap_eigenvector_at_perron T hT hIrr hr hX hX_eig
+  exact ⟨
+    { r := r
+      r_pos := hr
+      spectralRadius_eq := hradius
+      X := X
+      X_posDef := hX
+      right_eigenvector := hX_eig
+      Y := Y
+      Y_posDef := hY
+      left_eigenvector := hY_eig
+      finrank_eigenspace_eq_one := hfinrank }⟩
+
+/-- If an eigenspace has dimension one and contains the nonzero vector `X`,
+then every eigenvector in it is a scalar multiple of `X`. -/
+private theorem eigenvector_eq_smul_of_finrank_eigenspace_eq_one
+    {T : Mat →ₗ[ℂ] Mat} {r : ℝ} {X Z : Mat}
+    (hX_ne : X ≠ 0) (hX_eig : T X = (r : ℂ) • X)
+    (hfinrank : Module.finrank ℂ (Module.End.eigenspace T (r : ℂ)) = 1)
+    (hZ_eig : T Z = (r : ℂ) • Z) :
+    ∃ c : ℂ, Z = c • X := by
+  let x : Module.End.eigenspace T (r : ℂ) :=
+    ⟨X, Module.End.mem_eigenspace_iff.mpr hX_eig⟩
+  have hx_ne : x ≠ 0 := by
+    intro hx
+    apply hX_ne
+    exact congrArg Subtype.val hx
+  let z : Module.End.eigenspace T (r : ℂ) :=
+    ⟨Z, Module.End.mem_eigenspace_iff.mpr hZ_eig⟩
+  obtain ⟨c, hc⟩ :=
+    (finrank_eq_one_iff_of_nonzero' x hx_ne).mp hfinrank z
+  exact ⟨c, (congrArg Subtype.val hc).symm⟩
+
+/-- Wolf Theorem 6.4, reverse implication, for an arbitrary positive map.
+
+The proof is the similarity and invariant-corner proof at source lines
+712--720.  No Kraus representation or complete positivity is used. -/
+theorem isIrreducibleMap_of_hasWolfSpectralProperties [NeZero D]
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    (hSpec : HasWolfSpectralProperties T) :
+    IsIrreducibleMap T := by
+  rcases hSpec with ⟨hSpec⟩
+  let S : Mat := CFC.sqrt hSpec.Y
+  have hS_herm : Sᴴ = S := by
+    simpa [S] using Matrix.conjTranspose_cfc_sqrt (ρ := hSpec.Y)
+  have hS_det : IsUnit S.det := by
+    simpa [S] using hSpec.Y_posDef.isUnit_det_cfc_sqrt
+  have hS_inv_mul : S⁻¹ * S = 1 := Matrix.nonsing_inv_mul S hS_det
+  have hS_mul_inv : S * S⁻¹ = 1 := Matrix.mul_nonsing_inv S hS_det
+  have hS_unit : IsUnit S := by
+    simpa [S] using
+      (CFC.isUnit_sqrt_iff hSpec.Y hSpec.Y_posDef.posSemidef.nonneg).2
+        (Matrix.PosDef.isUnit hSpec.Y_posDef)
+  have hS_inv_inv : S⁻¹⁻¹ = S := by
+    let := hS_unit.invertible
+    exact Matrix.inv_inv_of_invertible S
+  have hS_inv_herm : (S⁻¹)ᴴ = S⁻¹ := by
+    simpa [hS_herm] using Matrix.conjTranspose_nonsing_inv S
+  have hS_sq : S * S = hSpec.Y := by
+    exact CFC.sqrt_mul_sqrt_self hSpec.Y hSpec.Y_posDef.posSemidef.nonneg
+  have hr_complex : (hSpec.r : ℂ) ≠ 0 := by
+    exact_mod_cast hSpec.r_pos.ne'
+  let T' : Mat →ₗ[ℂ] Mat :=
+    (hSpec.r : ℂ)⁻¹ • similarityMap (D := D) S⁻¹ T
+  have hT'_pos : IsPositiveMap T' := by
+    intro A hA
+    have hsim := hT.similarityMap S⁻¹ A hA
+    have hr_inv_nonneg : (0 : ℂ) ≤ (hSpec.r : ℂ)⁻¹ :=
+      inv_nonneg.mpr (by exact_mod_cast hSpec.r_pos.le)
+    simpa only [T', LinearMap.smul_apply] using hsim.smul hr_inv_nonneg
+  have hT'_tp : IsTracePreservingMap T' := by
+    intro A
+    let Z : Mat := S⁻¹ * A * S⁻¹
+    calc
+      Matrix.trace (T' A) =
+          (hSpec.r : ℂ)⁻¹ * Matrix.trace (S * T Z * S) := by
+        simp [T', similarityMap, Z, hS_inv_inv, hS_inv_herm]
+      _ = (hSpec.r : ℂ)⁻¹ * Matrix.trace (hSpec.Y * T Z) := by
+        rw [← hS_sq]
+        congr 1
+        exact Matrix.trace_mul_cycle S (T Z) S
+      _ = (hSpec.r : ℂ)⁻¹ *
+          Matrix.trace (Matrix.traceAdjointMap T hSpec.Y * Z) := by
+        rw [Matrix.trace_traceAdjointMap_mul]
+      _ = (hSpec.r : ℂ)⁻¹ *
+          Matrix.trace (((hSpec.r : ℂ) • hSpec.Y) * Z) := by
+        rw [hSpec.left_eigenvector]
+      _ = (hSpec.r : ℂ)⁻¹ *
+          ((hSpec.r : ℂ) * Matrix.trace (hSpec.Y * Z)) := by
+        rw [Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul]
+      _ = Matrix.trace (hSpec.Y * Z) := by
+        rw [← mul_assoc, inv_mul_cancel₀ hr_complex, one_mul]
+      _ = Matrix.trace A := by
+        rw [← hS_sq]
+        change Matrix.trace ((S * S) * (S⁻¹ * A * S⁻¹)) = Matrix.trace A
+        rw [show (S * S) * (S⁻¹ * A * S⁻¹) = S * A * S⁻¹ by
+          calc
+            (S * S) * (S⁻¹ * A * S⁻¹) = S * ((S * S⁻¹) * A) * S⁻¹ := by
+              simp only [Matrix.mul_assoc]
+            _ = S * A * S⁻¹ := by rw [hS_mul_inv, Matrix.one_mul]]
+        rw [Matrix.trace_mul_cycle S A S⁻¹, hS_inv_mul, Matrix.one_mul]
+  have hS_vecMul_inj : Function.Injective fun v : Fin D → ℂ => Matrix.vecMul v S := by
+    intro v w hvw
+    have h' := congrArg (fun x => Matrix.vecMul x S⁻¹) hvw
+    simpa [Matrix.vecMul_vecMul, hS_mul_inv] using h'
+  let X' : Mat := S * hSpec.X * S
+  have hX'_pd : X'.PosDef := by
+    simpa [X', hS_herm] using
+      hSpec.X_posDef.mul_mul_conjTranspose_same hS_vecMul_inj
+  have hX'_fix : T' X' = X' := by
+    calc
+      T' X' = (hSpec.r : ℂ)⁻¹ •
+          (S * T (((S⁻¹ * S) * hSpec.X) * (S * S⁻¹)) * S) := by
+        simp [T', X', similarityMap, hS_inv_inv, hS_inv_herm, Matrix.mul_assoc]
+      _ = (hSpec.r : ℂ)⁻¹ • (S * T hSpec.X * S) := by
+        rw [hS_inv_mul, Matrix.one_mul, hS_mul_inv, Matrix.mul_one]
+      _ = (hSpec.r : ℂ)⁻¹ •
+          (S * ((hSpec.r : ℂ) • hSpec.X) * S) := by
+        rw [hSpec.right_eigenvector]
+      _ = X' := by
+        rw [Matrix.mul_smul, Matrix.smul_mul, smul_smul,
+          inv_mul_cancel₀ hr_complex, one_smul]
+  have huniq : ∀ τ : Mat, τ.PosSemidef → T' τ = τ →
+      ∃ c : ℂ, τ = c • X' := by
+    intro τ _hτ hτ_fix
+    let Z : Mat := S⁻¹ * τ * S⁻¹
+    have hZ_eig : T Z = (hSpec.r : ℂ) • Z := by
+      have hscaled' :
+          S⁻¹ * T' τ * S⁻¹ = (hSpec.r : ℂ)⁻¹ • T Z := by
+        calc
+          S⁻¹ * T' τ * S⁻¹ =
+              S⁻¹ * ((hSpec.r : ℂ)⁻¹ • (S * T Z * S)) * S⁻¹ := by
+            simp [T', Z, similarityMap, hS_inv_inv, hS_inv_herm,
+              Matrix.mul_assoc]
+          _ = (hSpec.r : ℂ)⁻¹ •
+              ((S⁻¹ * S) * T Z * (S * S⁻¹)) := by
+            simp [Matrix.mul_assoc]
+          _ = (hSpec.r : ℂ)⁻¹ • T Z := by
+            rw [hS_inv_mul, Matrix.one_mul, hS_mul_inv, Matrix.mul_one]
+      have hscaled :
+          (hSpec.r : ℂ)⁻¹ • T Z = Z := by
+        rw [← hscaled', hτ_fix]
+      have h := congrArg (fun M => (hSpec.r : ℂ) • M) hscaled
+      simpa [smul_smul, hr_complex, Matrix.mul_assoc] using h
+    have hX_ne : hSpec.X ≠ 0 := hSpec.X_posDef.isUnit.ne_zero
+    obtain ⟨c, hc⟩ :=
+      eigenvector_eq_smul_of_finrank_eigenspace_eq_one hX_ne
+        hSpec.right_eigenvector hSpec.finrank_eigenspace_eq_one hZ_eig
+    refine ⟨c, ?_⟩
+    calc
+      τ = (S * S⁻¹) * τ * (S⁻¹ * S) := by
+        rw [hS_mul_inv, Matrix.one_mul, hS_inv_mul, Matrix.mul_one]
+      _ = S * Z * S := by simp [Z, Matrix.mul_assoc]
+      _ = S * (c • hSpec.X) * S := by rw [hc]
+      _ = c • X' := by simp [X', Matrix.mul_assoc]
+  have hT'_irr : IsIrreducibleMap T' :=
+    isIrreducibleMap_of_positive_tracePreserving_posDef_fixedPoint_unique
+      T' hT'_pos hT'_tp X' hX'_pd hX'_fix huniq
+  have hsimilarity_irr : IsIrreducibleMap (similarityMap (D := D) S⁻¹ T) := by
+    have hscaled := isIrreducibleMap_smul hr_complex hT'_irr
+    simpa [T', smul_smul, hr_complex] using hscaled
+  have hS_inv_det : (S⁻¹).det ≠ 0 := by
+    rw [Matrix.det_nonsing_inv, Ring.inverse_eq_inv']
+    exact inv_ne_zero hS_det.ne_zero
+  exact (isIrreducibleMap_similarity_iff (D := D) hS_inv_det).mp hsimilarity_irr
+
+/-- **Wolf Theorem 6.4**, with the necessary zero-map boundary correction.
+
+Let `T` be a nonzero positive map on `M_D(ℂ)`, with `D > 0`.  Then `T` is
+irreducible if and only if its spectral radius is an ordinary nondegenerate
+eigenvalue having positive-definite right and trace-adjoint left eigenvectors.
+No Kraus representation or complete positivity is assumed. -/
+theorem wolf_theorem_6_4 [NeZero D]
+    (T : Mat →ₗ[ℂ] Mat) (hT : IsPositiveMap T) (hT_ne : T ≠ 0) :
+    IsIrreducibleMap T ↔ HasWolfSpectralProperties T := by
+  constructor
+  · exact fun hIrr =>
+      hasWolfSpectralProperties_of_irreducible_positive T hT hIrr hT_ne
+  · exact isIrreducibleMap_of_hasWolfSpectralProperties hT
+
+/-- The source-general spectral package specializes to the earlier finite-Kraus
+package: for a nonzero completely positive map, the two packages are
+equivalent.  The forward direction uses ordinary eigenspace simplicity to
+obtain the older PSD uniqueness clause; the reverse direction recovers
+irreducibility from that clause and then applies the source-general theorem. -/
+theorem hasSpectralProperties_iff_hasWolfSpectralProperties_of_cp [NeZero D]
+    (T : Mat →ₗ[ℂ] Mat) (hCP : IsCPMap T) (hT_ne : T ≠ 0) :
+    HasSpectralProperties (D := D) T ↔ HasWolfSpectralProperties T := by
+  constructor
+  · intro hRestricted
+    have hIrr : IsIrreducibleMap T :=
+      isIrreducibleMap_of_hasSpectralProperties hRestricted
+    exact hasWolfSpectralProperties_of_irreducible_positive
+      T hCP.isPositiveMap hIrr hT_ne
+  · intro hWolf
+    have hIrr : IsIrreducibleMap T :=
+      isIrreducibleMap_of_hasWolfSpectralProperties hCP.isPositiveMap hWolf
+    exact hasSpectralProperties_of_irreducible_cp T hCP hIrr hT_ne
+
+end

--- a/blueprint/src/chapter/ch07_qpf_irreducibility_and_ergodicity.tex
+++ b/blueprint/src/chapter/ch07_qpf_irreducibility_and_ergodicity.tex
@@ -112,7 +112,108 @@
     Compactness then forces the whole sequence to converge to that limit.
 \end{proof}
 
-\section{A CP spectral characterization of irreducibility}
+\section{Spectral characterization of irreducibility for positive maps}
+
+\begin{definition}[Wolf spectral properties]
+    \label{def:wolf_spectral_properties}
+    \lean{HasWolfSpectralProperties}
+    \leanok
+    A linear map $T$ on $\MN{D}$ has the \emph{Wolf spectral properties} if
+    there are a real number $r>0$ and matrices $X,Y>0$ such that
+    \begin{align}
+        \varrho(T)&=r, \notag\\
+        T(X)&=rX, \notag\\
+        T^*(Y)&=rY,
+        \label{eq:qpf_wolf_spectral_eigenvectors}
+    \end{align}
+    and the ordinary complex eigenspace $\ker(T-r\Id)$ has dimension one.
+    Here $T^*$ is the adjoint for the bilinear trace pairing.  The last clause
+    is geometric nondegeneracy; it is not restricted to positive semidefinite
+    eigenvectors and does not assert algebraic simplicity.
+\end{definition}
+
+\begin{theorem}[Irreducibility gives the Wolf spectral properties]
+    \label{thm:wolf_spectral_properties_irred_positive}
+    \lean{hasWolfSpectralProperties_of_irreducible_positive}
+    \leanok
+    \uses{def:wolf_spectral_properties, def:positive_map,
+        def:irreducible_cp}
+    Let $D>0$, and let $T:\MN{D}\to\MN{D}$ be a nonzero irreducible
+    positive map.  Then $T$ has the Wolf spectral properties of
+    Definition~\ref{def:wolf_spectral_properties}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:wolf_irreducible_positive_spectral_radius,
+        thm:trace_adjoint_irreducible_positive}
+    The positive-map form of Wolf Theorem~6.3 gives a positive-definite right
+    eigenvector at the spectral radius and proves that its ordinary eigenspace
+    is one-dimensional.  Applying the trace-adjoint consequence of the same
+    theorem gives a positive-definite left eigenvector at the same eigenvalue.
+\end{proof}
+
+\begin{theorem}[Wolf spectral properties imply irreducibility]
+    \label{thm:irred_from_wolf_spectral_properties}
+    \lean{isIrreducibleMap_of_hasWolfSpectralProperties}
+    \leanok
+    \uses{def:wolf_spectral_properties, def:positive_map,
+        def:irreducible_cp}
+    Let $D>0$, and let $T:\MN{D}\to\MN{D}$ be positive.  If $T$ has the
+    Wolf spectral properties, then $T$ is irreducible.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:similarity_irred, lem:cesaro_subseq_fixed}
+    Let $r,X,Y$ be the data in
+    (\ref{eq:qpf_wolf_spectral_eigenvectors}), put $S=\sqrt{Y}$, and define
+    exactly as in Wolf Equation~(6.34)
+    \begin{align}
+        T'(Z)
+          &=r^{-1}S\,T(S^{-1}ZS^{-1})S.
+        \label{eq:qpf_wolf_spectral_tp_gauge}
+    \end{align}
+    The map $T'$ is positive.  Trace duality and $T^*(Y)=rY$ give
+    \begin{align}
+        \tr(T'(Z))
+          &=r^{-1}\tr(YT(S^{-1}ZS^{-1}))
+           =\tr(Z),
+        \notag
+    \end{align}
+    so $T'$ is trace preserving, and $SXS>0$ is fixed by $T'$.
+
+    If $T'$ preserved a nonzero proper corner, positive trace-preserving
+    Ces\`aro averaging inside that corner would give a stationary density
+    matrix there.  Conjugating it by $S^{-1}$ produces an ordinary
+    $r$-eigenvector of $T$.  Eigenspace dimension one makes the corner state a
+    scalar multiple of $SXS$, which is impossible because $SXS$ has full
+    support.  Hence $T'$ is irreducible, and similarity invariance gives
+    irreducibility of $T$.
+\end{proof}
+
+\begin{theorem}[Wolf Theorem 6.4]
+    \label{thm:wolf_theorem_6_4}
+    \lean{wolf_theorem_6_4}
+    \leanok
+    \uses{def:wolf_spectral_properties, def:positive_map,
+        def:irreducible_cp}
+    Let $D>0$, and let $T:\MN{D}\to\MN{D}$ be a nonzero positive map.
+    Then $T$ is irreducible if and only if it has the Wolf spectral properties.
+    This is \cite[Theorem~6.4]{Wolf2012Quantum}, local source lines~698--721,
+    with one necessary boundary correction: on $\MN{1}$ the zero map is
+    irreducible but has spectral radius zero, so it cannot satisfy the printed
+    strict-positive condition $T(X)=rX>0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:wolf_spectral_properties_irred_positive,
+        thm:irred_from_wolf_spectral_properties}
+    Combine the preceding two theorems.
+\end{proof}
+
+\subsection{The earlier completely positive specialization}
 
 \begin{definition}[Restricted CP spectral properties]
     \label{def:has_spectral_properties}

--- a/blueprint/src/chapter/ch07_qpf_supporting_results.tex
+++ b/blueprint/src/chapter/ch07_qpf_supporting_results.tex
@@ -102,11 +102,13 @@ convex domain and the limit argument used for channel fixed points.
 
 \begin{lemma}[Ces\`aro means remain density matrices]
     \label{lem:cesaro_mean_density}
-    \lean{IsChannel.cesaroMean_mem_densityMatrices}
+    \lean{IsPositiveMap.cesaroMean_mem_densityMatrices,
+        IsChannel.cesaroMean_mem_densityMatrices}
     \leanok
-    \uses{def:cesaro_mean, thm:channel_preserves_density, thm:density_convex}
-    Let $E$ be a quantum channel and $\rho\in\mc{D}_D$. Then, for every
-    $N\geq0$,
+    \uses{def:cesaro_mean, def:positive_map, def:trace_preserving,
+        thm:density_convex}
+    Let $E$ be a positive trace-preserving linear map and
+    $\rho\in\mc{D}_D$. Then, for every $N\geq0$,
     \begin{align}
         \frac{1}{N+1}\sum_{n=0}^{N}E^n(\rho)
          & \in\mc{D}_D.
@@ -115,8 +117,8 @@ convex domain and the limit argument used for channel fixed points.
 \end{lemma}
 
 \begin{proof}\leanok
-    Every iterate $E^n(\rho)$ belongs to $\mc{D}_D$ by
-    Theorem~\ref{thm:channel_preserves_density}. Equation
+    Positivity and trace preservation imply that every iterate
+    $E^n(\rho)$ belongs to $\mc{D}_D$. Equation
     (\ref{eq:qpf_cesaro_density}) is their convex average: positivity is
     preserved by sums and multiplication by $(N+1)^{-1}$, while its trace is
     $(N+1)^{-1}\sum_{n=0}^{N}1=1$.
@@ -124,11 +126,13 @@ convex domain and the limit argument used for channel fixed points.
 
 \begin{lemma}[Subsequential Ces\`aro limits are fixed points]
     \label{lem:cesaro_subseq_fixed}
-    \lean{IsChannel.cesaroMean_subseq_limit_fixedPoint}
+    \lean{IsPositiveMap.cesaroMean_subseq_limit_fixedPoint,
+        IsChannel.cesaroMean_subseq_limit_fixedPoint}
     \leanok
     \uses{lem:cesaro_mean_density, thm:density_compact,
         thm:cesaro_telescope}
-    Let $E$ be a quantum channel, $\rho\in\mc{D}_D$, and
+    Let $E$ be a positive trace-preserving linear map,
+    $\rho\in\mc{D}_D$, and
     $\psi:\N\to\N$ satisfy $\psi(k)\to\infty$. If
     \begin{align}
         \frac{1}{\psi(k)+1}\sum_{n=0}^{\psi(k)}E^n(\rho)

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -686,6 +686,29 @@ They do not alter the proof for a nonzero irreducible map once the second
 global extremum is interpreted as the infimum in
 Eq.~\ref{eq:wolf_lecture_notes_errata_theorem63_correct_upper_global}.
 
+\section{The one-dimensional zero-map boundary in Theorem~6.4}
+\label{sec:theorem-6-4}
+
+\paragraph{Formalization trigger.}
+The corrected equivalence is formalized by \leanid{wolf_theorem_6_4}.  Its
+positive-map scope, ordinary eigenspace condition, and proof by Wolf's
+similarity transform are documented in
+\path{docs/paper-gaps/wolf_thm6_4_positive_map_spectral_characterization.tex}.
+
+\paragraph{Printed assertion and correction.}
+Wolf's Theorem~6.4 states the equivalence for every positive map
+\cite[Theorem~6.4]{Wolf2012Quantum}.  The zero map on $\MN{1}$ is irreducible,
+but its spectral radius is zero and it has no matrices satisfying the printed
+strict condition $T(X)=\varrho X>0$.  Thus the equivalence requires either
+$T\neq0$ or an explicit exclusion of this one-dimensional boundary.  The Lean
+theorem assumes $D>0$ and $T\neq0$.  When $D>1$, irreducibility already excludes
+the zero map.
+
+\paragraph{Classification.}
+This is the same well-posedness correction as the zero-map boundary in
+Theorem~6.3, discussed in Section~\ref{sec:theorem-6-3}; it does not alter the
+similarity and invariant-corner proof for a nonzero map.
+
 \section{The missing order hypothesis in the unitary comparison}
 \label{sec:unitary-comparison}
 

--- a/docs/paper-gaps/wolf_thm6_4_positive_map_spectral_characterization.tex
+++ b/docs/paper-gaps/wolf_thm6_4_positive_map_spectral_characterization.tex
@@ -1,0 +1,161 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{./command.tex}
+
+\title{Wolf Theorem 6.4: Positive-Map Scope and the Zero-Map Boundary}
+\author{}
+\date{2026-08-29}
+
+\begin{document}
+\maketitle
+\gapnote{false-source}{resolved}
+
+\section{Source statement}
+
+Theorem~6.4 of Ref.~\cite{Wolf2012Quantum} concerns a positive linear map
+\begin{align}
+  T
+    &: \MN{D}\longrightarrow\MN{D}
+  \label{eq:wolf_thm6_4_positive_map_spectral_characterization_map}
+\end{align}
+with spectral radius $r$.  It states that irreducibility is equivalent to the
+following three properties:
+\begin{enumerate}
+  \item $r$ is an ordinary nondegenerate eigenvalue of $T$;
+  \item there is an $X>0$ satisfying $T(X)=rX$;
+  \item there is a $Y>0$ satisfying $T^*(Y)=rY$.
+\end{enumerate}
+Here $T^*$ is the adjoint for the bilinear trace pairing
+\begin{align}
+  \tr\!\left(T^*(Y)Z\right)
+    &=\tr\!\left(YT(Z)\right).
+  \label{eq:wolf_thm6_4_positive_map_spectral_characterization_trace_pairing}
+\end{align}
+The exact local source is
+\path{Notes/WolfNoteTexSource/ch06_spectral_properties.tex}, lines~698--721.
+No complete-positivity or Kraus hypothesis occurs in the statement or proof.
+
+The word ``nondegenerate'' is geometric: the ordinary complex eigenspace at
+$r$ has dimension one.  The source does not assert algebraic simplicity or a
+one-dimensional generalized eigenspace.
+
+\section{Formal statement}
+
+The witness structure \leanid{WolfSpectralProperties} and predicate
+\leanid{HasWolfSpectralProperties} in
+\doclink{QICLean/Channel/Irreducible/PositiveMapSpectralCharacterization}
+record a real number $r>0$
+and matrices $X,Y>0$ such that
+\begin{align}
+  \varrho(T)
+    &=r,
+  \label{eq:wolf_thm6_4_positive_map_spectral_characterization_radius}\\
+  T(X)
+    &=rX,
+  \label{eq:wolf_thm6_4_positive_map_spectral_characterization_right}\\
+  \operatorname{traceAdjointMap}(T)(Y)
+    &=rY,
+  \label{eq:wolf_thm6_4_positive_map_spectral_characterization_left}\\
+  \dim_{\mathbb C}\ker(T-r\Id)
+    &=1.
+  \label{eq:wolf_thm6_4_positive_map_spectral_characterization_simple}
+\end{align}
+Thus the left eigenvector is source-facing and does not depend on a choice of
+Kraus family.
+
+For a nonzero positive map on a nonzero full matrix algebra, the declaration
+\leanid{wolf_theorem_6_4} proves
+\begin{align}
+  T\text{ is irreducible}
+    \quad\Longleftrightarrow\quad
+  T\text{ has the properties
+    \eqref{eq:wolf_thm6_4_positive_map_spectral_characterization_radius}--
+    \eqref{eq:wolf_thm6_4_positive_map_spectral_characterization_simple}}.
+  \label{eq:wolf_thm6_4_positive_map_spectral_characterization_iff}
+\end{align}
+The Lean hypotheses are \leanid{IsPositiveMap T}, $T\neq0$, and
+\leanid{NeZero D}.  There is no complete-positivity assumption.
+
+\section{Necessary boundary correction}
+
+The printed statement does not exclude the zero map, although its displayed
+condition requires
+\begin{align}
+  T(X)
+    &=rX>0.
+  \label{eq:wolf_thm6_4_positive_map_spectral_characterization_printed_strict}
+\end{align}
+On $\MN{1}$, the zero map is positive and irreducible: the only orthogonal
+projections are $0$ and $\Id$.  Its spectral radius is zero, so
+\eqref{eq:wolf_thm6_4_positive_map_spectral_characterization_printed_strict}
+is impossible.  The printed equivalence is therefore false at this boundary.
+
+The hypothesis $T\neq0$ is the uniform correction.  If $D>1$, irreducibility
+already excludes the zero map.  The assumption \leanid{NeZero D} separately
+excludes the empty matrix algebra, in which positive-definite density witnesses
+are unavailable.
+
+\section{Source-faithful proof}
+
+For the forward implication,
+\leanid{hasWolfSpectralProperties_of_irreducible_positive} applies the
+positive-map form of Theorem~6.3 to $T$.  It obtains $X>0$, the ordinary
+one-dimensional $r$-eigenspace, and the spectral-radius identity.  The
+trace-adjoint consequence of Theorem~6.3 supplies $Y>0$ at the same eigenvalue.
+
+For the reverse implication, set $S=\sqrt{Y}$ and define exactly the transform
+used at local source lines~712--714,
+\begin{align}
+  T'
+    &=r^{-1}\,\operatorname{similarityMap}(S^{-1},T),
+  \qquad
+  T'(Z)=r^{-1}S\,T(S^{-1}ZS^{-1})S.
+  \label{eq:wolf_thm6_4_positive_map_spectral_characterization_gauge}
+\end{align}
+Positivity is preserved by congruence and positive rescaling.  Trace
+preservation follows directly from
+\eqref{eq:wolf_thm6_4_positive_map_spectral_characterization_trace_pairing}:
+for $W=S^{-1}ZS^{-1}$,
+\begin{align}
+  \tr(T'(Z))
+    &=r^{-1}\tr(YT(W))
+      =r^{-1}\tr(T^*(Y)W)
+      =\tr(Z).
+  \label{eq:wolf_thm6_4_positive_map_spectral_characterization_tp}
+\end{align}
+Moreover, $X'=SXS>0$ is fixed by $T'$.
+
+If $T'$ preserved a proper corner $P\MN{D}P$, the positive trace-preserving
+Ces\`aro theorem
+\leanid{IsPositiveMap.exists_fixed_density_of_preserves_compression} would
+produce a stationary density matrix $\tau$ in that corner.  Pulling $\tau$
+back through $S^{-1}$ gives an ordinary $r$-eigenvector of $T$.  The
+one-dimensional eigenspace therefore makes $\tau$ a scalar multiple of $X'$,
+which is impossible because $X'>0$ has full support whereas $\tau$ lies in a
+proper corner.  This is precisely the contradiction at local source
+lines~715--720.
+
+The earlier finite-Kraus package remains available through
+\leanid{HasSpectralProperties}.  The declaration
+\leanid{hasSpectralProperties_iff_hasWolfSpectralProperties_of_cp} proves that,
+for a nonzero completely positive map, it is equivalent to the source-general
+package.  It is therefore a specialization rather than the statement of
+Theorem~6.4 itself.
+
+\section{Verdict}
+
+\textbf{Verdict: resolved, with one necessary source correction.}  The former
+Kraus/complete-positive restriction and the former uniqueness-only-among-PSD
+formulation have been removed from the source-facing theorem.  Ordinary
+eigenspace nondegeneracy and the trace-pairing left eigenvector are explicit.
+The additional hypothesis $T\neq0$ is necessary only because the printed
+equivalence fails for the irreducible zero map on $\MN{1}$.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -1261,24 +1261,71 @@ corrections and the former CP scope restriction are recorded in the resolved not
   Full Cesàro convergence: for every density matrix `ρ`,
   `(1/N) ∑_{t=0}^{N-1} E^[t](ρ) → σ`.
 
-Supporting formalization in `QICLean.Channel.Irreducible.Ergodicity`:
-* `IsChannel.iter_mem_densityMatrices`: iterates of a channel preserve density matrices.
-* `IsChannel.cesaroMean_subseq_limit_fixedPoint`: any subsequential Cesàro limit is
-  a density-matrix fixed point (compactness + telescoping argument).
+Supporting formalization used by `QICLean.Channel.Irreducible.Ergodicity`:
+* `IsChannel.cesaroMean_mem_densityMatrices`: channel Cesàro means remain density
+  matrices.
+* `IsChannel.cesaroMean_subseq_limit_fixedPoint`: any subsequential Cesàro limit
+  is a density-matrix fixed point (compactness + telescoping argument).
 
-#### Wolf Theorem 6.4 (Irreducibility from spectral properties) — PARTIAL-SCOPE
+The reusable Cesàro infrastructure in `QICLean.Channel.FixedPoint.Cesaro` is now
+source-general: `IsPositiveMap.cesaroMean_mem_densityMatrices`,
+`IsPositiveMap.cesaroMean_subseq_limit_fixedPoint`, and
+`IsPositiveMap.exists_posSemidef_fixedPoint` assume only positivity and trace
+preservation.  This removes the CP restriction from the compactness and
+subsequential-limit steps needed for issue #475.  The source-facing full
+convergence theorem and the explicit comparison between the averages indexed by
+`0,...,N-1` and Wolf's `1,...,N` remain to be packaged, so Corollary 6.3 is not
+yet marked formalized.
 
-In `QICLean.Channel.Irreducible.FromSpectral`:
+#### Wolf Theorem 6.4 (Irreducibility from spectral properties) — FORMALIZED
+
+The source-general declarations are in
+`QICLean.Channel.Irreducible.PositiveMapSpectralCharacterization`:
+* `WolfSpectralProperties` and `HasWolfSpectralProperties` — the exact spectral
+  condition: a strictly positive real representative `r` of the spectral
+  radius, positive-definite right and trace-adjoint left eigenvectors at `r`,
+  and ordinary complex eigenspace dimension one.
+* `hasWolfSpectralProperties_of_irreducible_positive` — Theorem 6.3 applied to
+  an arbitrary irreducible positive map and its trace adjoint.
+* `isIrreducibleMap_of_hasWolfSpectralProperties` — Wolf's reverse implication.
+  The proof uses `r⁻¹ • similarityMap (CFC.sqrt Y)⁻¹ T`, verifies trace
+  preservation directly from `Matrix.traceAdjointMap`, and contradicts ordinary
+  eigenspace simplicity with a stationary density in a proper invariant corner.
+* `wolf_theorem_6_4` — the final positive-map equivalence, under `[NeZero D]`
+  and the necessary boundary hypothesis `T ≠ 0`.
+* `hasSpectralProperties_iff_hasWolfSpectralProperties_of_cp` — comparison with
+  the earlier finite-Kraus package.
+
+The positive trace-preserving invariant-corner input is
+`IsPositiveMap.exists_fixed_density_of_preserves_compression` in
+`QICLean.Channel.FixedPoint.Cesaro`; it assumes no Kraus representation or
+complete positivity.  The channel theorem with the former name is retained as
+a direct specialization.  Likewise,
+`isIrreducibleMap_of_positive_tracePreserving_posDef_fixedPoint_unique` in
+`QICLean.Channel.Irreducible.FromSpectral` is the source-general fixed-point
+contradiction, and `isIrreducibleMap_of_channel_posDef_fixedPoint_unique` is its
+channel specialization.
+
+The earlier restricted package remains available in
+`QICLean.Channel.Irreducible.FromSpectral`:
 * `HasSpectralProperties` — Kraus-witness bundle of the spectral assumptions
-  in Wolf's theorem (PD right/left eigenvectors, PSD uniqueness, spectral radius).
+  (PD right/left eigenvectors, PSD uniqueness, spectral radius).
 * `hasSpectralProperties_of_irreducible_cp` — the forward implication
   `irreducible → spectral properties`.
 * `isIrreducibleMap_of_hasSpectralProperties` — the reverse implication via
   TP gauge reduction + channel fixed-point contradiction.
 * `isIrreducibleMap_iff_spectral_properties` — the final iff statement for
-  the restricted finite-Kraus/complete-positive bundle. The source theorem is
-  stated for positive maps, so the containing environment remains a
-  partial-scope formalization.
+  the restricted finite-Kraus/complete-positive bundle.
+
+There is one necessary correction to the printed theorem.  On `M₁(ℂ)` the zero
+map is positive and irreducible, but its spectral radius is zero, so it cannot
+satisfy the displayed strict-positive condition `T(X) = r X > 0`.  The uniform
+source theorem therefore assumes `T ≠ 0`; no correction is needed in dimensions
+greater than one.  This boundary and the removal of the former CP/PSD-uniqueness
+restrictions are recorded in the resolved note
+`docs/paper-gaps/wolf_thm6_4_positive_map_spectral_characterization.tex` and in
+the central correction index
+`docs/paper-gaps/wolf_lecture_notes_errata.tex`.
 
 #### Wolf Theorem 6.5 (Spectral radius and positive eigenvectors) — PARTIAL-SCOPE
 


### PR DESCRIPTION
## Source contract

Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 6, Theorem 6.4, `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 698--721.

Closes #474.

## Necessary boundary correction

The printed equivalence fails for the zero map on `M₁(ℂ)`: this map is positive and irreducible, but its spectral radius is zero, so it cannot satisfy the printed strict-positive Perron condition. The source-facing theorem therefore assumes `[NeZero D]` and `T ≠ 0`. No extra nonzero-map condition is needed in dimensions greater than one.

## What changed

- add `WolfSpectralProperties` and `HasWolfSpectralProperties`, recording a positive real spectral radius, positive-definite right and trace-adjoint left eigenvectors, and the ordinary one-dimensional complex eigenspace;
- prove both directions of `wolf_theorem_6_4` for an arbitrary positive map, with no Kraus or complete-positivity premise;
- follow Wolf's reverse proof literally through `C = Y⁻¹/²`: rescale the similarity transform to a positive trace-preserving map, construct a stationary density in any invariant corner, and pull it back into the ordinary Perron eigenspace;
- generalize the needed Cesàro and invariant-corner fixed-density lemmas from channels to positive trace-preserving maps, retaining all previous channel declarations as direct wrappers;
- compare the source-general package with the earlier finite-Kraus/CP package;
- synchronize the Blueprint, Wolf numbering coverage, the central errata, and a resolved source-boundary note.

The generalized Cesàro lemmas are reusable by #475, but this pull request deliberately leaves Wolf Corollary 6.3 marked partial until its full-sequence and `1,…,N` source-average statements are proved.

## Verification

- focused builds of `FixedPoint.Cesaro`, `Irreducible.FromSpectral`, `Irreducible.WolfTheorem64`, and the `Irreducible` aggregate
- Blueprint synchronization and generated import aggregation
- `chktex`, standalone paper-gap PDF build, and paper-gap reference checks
- module/style/prose/numbering checks, `git diff --check`, forbidden-proof scan, and explicit axiom audit
- independent exact-source mathematical audit with no finding
