### PR TITLE
feat(channel): formalize Wolf Theorem 6.2

### DIFF
--- a/QICLean/Channel/Basic.lean
+++ b/QICLean/Channel/Basic.lean
@@ -26,6 +26,8 @@ Chapters 3 and 6 of Wolf's lecture notes.
 ## Main results
 
 * `IsPositiveMap`: a linear map that preserves the PSD cone
+* `IsPositiveMap.add`, `IsPositiveMap.nonneg_smul`: the additive-cone closure
+  properties of positive maps
 * `IsTraceNonincreasingMap`: a linear endomorphism that does not increase the
   trace of positive semidefinite inputs
 * `IsCPMap`: a linear map that admits a Kraus representation
@@ -65,6 +67,30 @@ variable {m n : Type*} [Fintype n] [DecidableEq n]
 positive semidefinite matrices to positive semidefinite matrices. -/
 def IsPositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ) : Prop :=
   ∀ X : Matrix n n ℂ, X.PosSemidef → (E X).PosSemidef
+
+omit [Fintype n] [DecidableEq n] in
+/-- The sum of two positive maps is positive.  Thus positive maps form an
+additive cone, as used in Wolf's positive perturbations and power-series
+arguments. -/
+theorem IsPositiveMap.add
+    {S T : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ}
+    (hS : IsPositiveMap S) (hT : IsPositiveMap T) :
+    IsPositiveMap (S + T) := by
+  intro X hX
+  simpa only [LinearMap.add_apply] using (hS X hX).add (hT X hX)
+
+omit [Fintype n] [DecidableEq n] in
+/-- A nonnegative real multiple of a positive map is positive.  The scalar is
+embedded in `ℂ`, matching the real coefficients in Wolf's binomial and
+exponential expansions. -/
+theorem IsPositiveMap.nonneg_smul
+    {T : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ}
+    (hT : IsPositiveMap T) {c : ℝ} (hc : 0 ≤ c) :
+    IsPositiveMap ((c : ℂ) • T) := by
+  intro X hX
+  have hc_complex : 0 ≤ (c : ℂ) := by
+    exact_mod_cast hc
+  simpa only [LinearMap.smul_apply, Complex.coe_smul] using (hT X hX).smul hc_complex
 
 /-- A linear map is **trace-preserving** if `Tr(E(X)) = Tr(X)` for all `X`. -/
 def IsTracePreservingMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=

--- a/QICLean/Channel/Irreducible/Growth.lean
+++ b/QICLean/Channel/Irreducible/Growth.lean
@@ -5,15 +5,15 @@ Authors: TNLean contributors
 -/
 import QICLean.Channel.Irreducible.Growth.Exponential
 import QICLean.Channel.Irreducible.Growth.OrthogonalTrace
+import Mathlib.Tactic.TFAE
 
 /-!
 # Growth conditions for irreducible positive maps (Wolf Theorem 6.2, items 2–4)
 
-This module collects the three positivity characterizations of an
-irreducible positive map $E$ on $M_D(\mathbb{C})$ from Wolf's Theorem 6.2.
-Item 2 is formalized here under Wolf's positivity hypothesis; the current
-interfaces for items 3 and 4 retain their earlier complete-positivity
-specializations.
+This module packages the four equivalent characterizations of an irreducible
+positive map $E$ on $M_D(\mathbb{C})$ from Wolf's Theorem 6.2.  The headline
+`wolf_theorem_6_2_tfae` has exactly the source's positive-map scope; the former
+completely positive declarations remain as direct specializations.
 
 * **Item 2** — Growth condition: $(\mathrm{id} + E)^{D - 1}(A) > 0$ for every
   nonzero PSD matrix $A$, together with the underlying structural lemma on the
@@ -24,7 +24,7 @@ specializations.
   $A$, $B$ with $\operatorname{tr}(BA) = 0$ admits an iterate $E^t(A)$ with
   $1 \leq t \leq D - 1$ and $\operatorname{tr}(B \cdot E^t(A)) > 0$.
 
-The proof is split across four supporting sub-modules for readability:
+The proof is split across five supporting sub-modules for readability:
 
 * `QICLean.Channel.Irreducible.Growth.Preservation` — preservation lemmas for
   `id + E` and `E^n` under positivity, plus the binomial expansion of
@@ -34,9 +34,10 @@ The proof is split across four supporting sub-modules for readability:
 * `QICLean.Channel.Irreducible.Growth.KernelDescent` — kernel-dimension induction
   yielding `growth_posDef_of_irreducible`.
 * `QICLean.Channel.Irreducible.Growth.OrthogonalTrace` — binomial expansion of
-  the growth witness producing `orthogonal_trace_pos_of_irreducible_cp`.
+  the growth witness producing `orthogonal_trace_pos_of_irreducible`.
 * `QICLean.Channel.Irreducible.Growth.Exponential` — normed-algebra setup and
-  `exp_posDef_of_irreducible_cp`, `irreducible_iff_exp_posDef_forall`.
+  `exp_posDef_of_irreducible`,
+  `irreducible_iff_exp_posDef_forall_of_positive`.
 
 ## Main statements
 
@@ -45,9 +46,10 @@ The proof is split across four supporting sub-modules for readability:
   PSD / nonzero / PosDef by `id + E`.
 * `mulVecLin_ker_idPlusE_lt_of_not_posDef_of_positive` — strict kernel decrease.
 * `growth_posDef_of_irreducible` — Wolf Theorem 6.2, item 2.
-* `orthogonal_trace_pos_of_irreducible_cp` — Wolf Theorem 6.2, item 4.
-* `exp_posDef_of_irreducible_cp`, `irreducible_iff_exp_posDef_forall` — Wolf
-  Theorem 6.2, item 3.
+* `exp_posDef_of_irreducible` — Wolf Theorem 6.2, item 3.
+* `orthogonal_trace_pos_of_irreducible` — Wolf Theorem 6.2, item 4.
+* `wolf_theorem_6_2_tfae` — all four source conditions are equivalent.
+* The former completely positive declarations remain as direct specializations.
 
 ## References
 
@@ -58,3 +60,48 @@ The proof is split across four supporting sub-modules for readability:
 
 irreducible, positive map, growth condition, exponential, Wolf theorem
 -/
+
+open scoped Matrix ComplexOrder BigOperators
+
+variable {D : ℕ}
+
+/-- **Wolf Theorem 6.2 (irreducible positive maps).**  For a positive linear
+map `E` on `M_D(ℂ)`, the following four source conditions are equivalent:
+
+1. `E` has no nontrivial invariant projection;
+2. `(id + E)^(D - 1) A` is positive definite for every nonzero `A ≥ 0`;
+3. `exp(tE) A` is positive definite for every `t > 0` and nonzero `A ≥ 0`;
+4. every orthogonal pair of nonzero positive semidefinite matrices `A, B`
+   has positive trace overlap `tr(B E^t(A))` for some `1 ≤ t ≤ D - 1`.
+
+The proof follows Wolf's implication graph
+`(1) → (2) → (3) → (1)` and `(2) → (4) → (1)`.  Complete positivity is not
+assumed. -/
+theorem wolf_theorem_6_2_tfae
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hE : IsPositiveMap E) :
+    List.TFAE [
+      IsIrreducibleMap E,
+      ∀ A : Matrix (Fin D) (Fin D) ℂ, A.PosSemidef → A ≠ 0 →
+        ((((LinearMap.id : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) + E) ^ (D - 1)) A).PosDef,
+      ∀ t : ℝ, 0 < t → ∀ A : Matrix (Fin D) (Fin D) ℂ, A.PosSemidef → A ≠ 0 →
+        ((NormedSpace.exp ((endEquiv (D := D)) ((t : ℂ) • E))) A).PosDef,
+      ∀ A B : Matrix (Fin D) (Fin D) ℂ,
+        A.PosSemidef → A ≠ 0 → B.PosSemidef → B ≠ 0 →
+        Matrix.trace (B * A) = 0 →
+        ∃ t : ℕ, 0 < t ∧ t ≤ D - 1 ∧ 0 < Matrix.trace (B * ((E ^ t) A))] := by
+  tfae_have h12 : 1 → 2 := by
+    intro hIrr A hA hA_ne
+    exact growth_posDef_of_irreducible E hE hIrr A hA hA_ne
+  tfae_have h23 : 2 → 3 := by
+    intro hGrowth t ht A hA hA_ne
+    exact exp_posDef_of_growth E hE A hA hA_ne (hGrowth A hA hA_ne) ht
+  tfae_have h31 : 3 → 1 := by
+    exact irreducible_of_exp_posDef_forall E
+  tfae_have h24 : 2 → 4 := by
+    intro hGrowth A B hA hA_ne hB hB_ne horth
+    exact orthogonal_trace_pos_of_growth E hE A B hA
+      (hGrowth A hA hA_ne) hB hB_ne horth
+  tfae_have h41 : 4 → 1 := by
+    exact irreducible_of_orthogonal_trace_pos_forall E
+  tfae_finish

--- a/QICLean/Channel/Irreducible/Growth/Exponential.lean
+++ b/QICLean/Channel/Irreducible/Growth/Exponential.lean
@@ -10,18 +10,18 @@ import Mathlib.Analysis.Normed.Algebra.Exponential
 import Mathlib.Analysis.Matrix.Order
 
 /-!
-# Exponential condition for irreducible CP maps
+# Exponential condition for irreducible positive maps
 
-Wolf Theorem 6.2, item 3: if $E$ is an irreducible completely positive map on
+Wolf Theorem 6.2, item 3: if $E$ is an irreducible positive map on
 $M_D(\mathbb{C})$, $A \geq 0$ is nonzero, and $t > 0$, then $\exp(tE)(A)$ is
 positive definite. This file also states item 3 as a logical equivalence with
-irreducibility, assuming CP.
+irreducibility. Complete positivity is not assumed.
 
 The proof strategy is:
 
 1. Show the finite exponential truncation $\sum_{k < D} \frac{t^k}{k!} E^k(A)$
    is already positive definite, using the growth condition
-   `growth_posDef_of_irreducible_cp` as the certificate.
+   `growth_posDef_of_irreducible` as the certificate.
 2. Pass to the limit using closure of the PSD cone and strict positivity of the
    quadratic form along the series.
 3. Convert the equivalence: given exponential positivity, use
@@ -31,9 +31,12 @@ The proof strategy is:
 
 ## Main statements
 
-* `exp_truncation_posDef_of_irreducible_cp` — finite truncation positivity.
-* `exp_posDef_of_irreducible_cp` — Wolf Theorem 6.2, item 3.
-* `irreducible_iff_exp_posDef_forall` — equivalence form of item 3.
+* `exp_posDef_of_growth` — Wolf's implication `(2) → (3)`.
+* `exp_truncation_posDef_of_irreducible` — finite truncation positivity.
+* `exp_posDef_of_irreducible` — Wolf Theorem 6.2, item 3.
+* `irreducible_iff_exp_posDef_forall_of_positive` — equivalence form of item 3.
+* The declarations with suffix `_cp`, and `irreducible_iff_exp_posDef_forall`,
+  remain direct completely positive specializations.
 
 ## References
 
@@ -42,7 +45,7 @@ The proof strategy is:
 
 ## Tags
 
-irreducible, completely positive, exponential, quantum dynamical semigroup
+irreducible, positive map, exponential, quantum dynamical semigroup
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -91,15 +94,6 @@ private lemma endEquiv_pow_apply
         F ((F ^ n) A)
       rw [ih]
       rfl
-
-private theorem isPositiveMap_smul_nonneg
-    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (hE : IsPositiveMap E) {c : ℝ} (hc : 0 ≤ c) :
-    IsPositiveMap ((c : ℂ) • E) := by
-  intro X hX
-  have hcC : 0 ≤ (c : ℂ) := by
-    exact_mod_cast hc
-  simpa only [LinearMap.smul_apply, Complex.coe_smul] using (hE X hX).smul hcC
 
 private lemma pos_of_matrix_ne_zero
     {A : Matrix (Fin D) (Fin D) ℂ} (hA : A ≠ 0) : 0 < D := by
@@ -204,16 +198,18 @@ private theorem exp_apply_posDef_of_trunc_posDef
   rw [hexp_eq]
   exact h_tsum_pd
 
-/-- A finite exponential truncation already satisfies Wolf's positivity conclusion:
-for any `t > 0`, the first `D` terms of the exponential series of `E` applied to a
-nonzero PSD input are positive definite. This is the finite-sum core of Wolf's
-proof of Theorem 6.2(3). The contradiction step uses
-`growth_posDef_of_irreducible_cp`, i.e. the `(LinearMap.id + E)^(D - 1) A > 0`
-growth statement already used in `orthogonal_trace_pos_of_irreducible_cp`. -/
-theorem exp_truncation_posDef_of_irreducible_cp
+/-- The finite-sum step in Wolf Theorem 6.2, `(2) → (3)`: if the growth
+matrix `(id + E)^(D - 1) A` is positive definite, then for every `t > 0`
+the first `D` terms of `exp(tE) A` are already positive definite.
+
+Only positivity of `E` is used.  The proof compares the kernels of the two
+positive sums, exactly as in Wolf's power-series argument. -/
+theorem exp_truncation_posDef_of_growth
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (hCP : IsCPMap E) (hIrr : IsIrreducibleMap E)
+    (hE : IsPositiveMap E)
     (A : Matrix (Fin D) (Fin D) ℂ) (hA : A.PosSemidef) (hA_ne : A ≠ 0)
+    (h_growth :
+      ((((LinearMap.id : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) + E) ^ (D - 1)) A).PosDef)
     {t : ℝ} (ht : 0 < t) :
     (∑ k ∈ Finset.range D, ((k.factorial : ℂ)⁻¹) • ((((t : ℂ) • E) ^ k) A)).PosDef := by
   classical
@@ -222,7 +218,7 @@ theorem exp_truncation_posDef_of_irreducible_cp
   let term : ℕ → Matrix (Fin D) (Fin D) ℂ := fun k =>
     ((k.factorial : ℂ)⁻¹) • ((F ^ k) A)
   have hF_pos : IsPositiveMap F :=
-    isPositiveMap_smul_nonneg hCP.isPositiveMap ht.le
+    hE.nonneg_smul ht.le
   have hterm_psd : ∀ k : ℕ, (term k).PosSemidef := by
     intro k
     simpa only using (iterate_posSemidef hF_pos hA k).smul (by positivity)
@@ -255,10 +251,8 @@ theorem exp_truncation_posDef_of_irreducible_cp
     rw [hkpow, Matrix.smul_mulVec] at hkF
     exact (smul_eq_zero.mp hkF).resolve_left (pow_ne_zero _ (by exact_mod_cast ht.ne'))
   let T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ) := LinearMap.id + E
-  -- This is the same `(id + E)^(D - 1) A > 0` growth theorem used in
-  -- `orthogonal_trace_pos_of_irreducible_cp`.
-  have h_growth : ((T ^ (D - 1)) A).PosDef := by
-    simpa only using growth_posDef_of_irreducible_cp E hCP hIrr A hA hA_ne
+  have h_growth' : ((T ^ (D - 1)) A).PosDef := by
+    simpa only [T] using h_growth
   have h_expand :
       (T ^ (D - 1)) A = ∑ k ∈ Finset.range D, (D - 1).choose k • ((E ^ k) A) := by
     simpa only [nsmul_eq_mul, Nat.sub_add_cancel hD] using
@@ -270,30 +264,53 @@ theorem exp_truncation_posDef_of_irreducible_cp
     rw [Matrix.smul_mulVec, hterm_zero_E k hk]
     simp
   have hq_growth : 0 < star v ⬝ᵥ (((T ^ (D - 1)) A) *ᵥ v) :=
-    (Matrix.posDef_iff_dotProduct_mulVec.mp h_growth).2 hv
+    (Matrix.posDef_iff_dotProduct_mulVec.mp h_growth').2 hv
   exact (ne_of_gt hq_growth) (by simp [hv_growth_zero])
 
-/-- **Wolf Theorem 6.2, item 3 (exponential condition for irreducible positive maps)**:
-if `E` is an irreducible completely positive map, `A ≥ 0` is nonzero, and `t > 0`,
-then `exp[t E](A)` is positive definite. Here the exponential is the operator exponential
-on the endomorphism algebra of `M_D(ℂ)`. -/
-theorem exp_posDef_of_irreducible_cp
+/-- Wolf Theorem 6.2, `(1) → (3)`, for the finite exponential truncation and
+at the source's positive-map scope. -/
+theorem exp_truncation_posDef_of_irreducible
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hE : IsPositiveMap E) (hIrr : IsIrreducibleMap E)
+    (A : Matrix (Fin D) (Fin D) ℂ) (hA : A.PosSemidef) (hA_ne : A ≠ 0)
+    {t : ℝ} (ht : 0 < t) :
+    (∑ k ∈ Finset.range D, ((k.factorial : ℂ)⁻¹) • ((((t : ℂ) • E) ^ k) A)).PosDef :=
+  exp_truncation_posDef_of_growth E hE A hA hA_ne
+    (growth_posDef_of_irreducible E hE hIrr A hA hA_ne) ht
+
+/-- Completely positive specialization of
+`exp_truncation_posDef_of_irreducible`. -/
+theorem exp_truncation_posDef_of_irreducible_cp
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hCP : IsCPMap E) (hIrr : IsIrreducibleMap E)
     (A : Matrix (Fin D) (Fin D) ℂ) (hA : A.PosSemidef) (hA_ne : A ≠ 0)
+    {t : ℝ} (ht : 0 < t) :
+    (∑ k ∈ Finset.range D, ((k.factorial : ℂ)⁻¹) • ((((t : ℂ) • E) ^ k) A)).PosDef :=
+  exp_truncation_posDef_of_irreducible E hCP.isPositiveMap hIrr A hA hA_ne ht
+
+/-- **Wolf Theorem 6.2, `(2) → (3)`.**  If `E` is positive and the growth
+matrix `(id + E)^(D - 1) A` is positive definite, then `exp(tE) A` is positive
+definite for every `t > 0`.  Here `exp` is the operator exponential on the
+endomorphism algebra of `M_D(ℂ)`. -/
+theorem exp_posDef_of_growth
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hE : IsPositiveMap E)
+    (A : Matrix (Fin D) (Fin D) ℂ) (hA : A.PosSemidef) (hA_ne : A ≠ 0)
+    (h_growth :
+      ((((LinearMap.id : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) + E) ^ (D - 1)) A).PosDef)
     {t : ℝ} (ht : 0 < t) :
     ((NormedSpace.exp ((endEquiv (D := D)) ((t : ℂ) • E))) A).PosDef := by
   classical
   let Φ : TNLean.MatrixCLM (Fin D) :=
     (endEquiv (D := D)) ((t : ℂ) • E)
   have hF_pos : IsPositiveMap ((t : ℂ) • E) :=
-    isPositiveMap_smul_nonneg hCP.isPositiveMap ht.le
+    hE.nonneg_smul ht.le
   refine exp_apply_posDef_of_trunc_posDef (D := D) Φ A ?_ ?_
   · intro n
     rw [endEquiv_pow_apply]
     exact (iterate_posSemidef hF_pos hA n).smul (by positivity)
   · have htrunc₀ :=
-      exp_truncation_posDef_of_irreducible_cp E hCP hIrr A hA hA_ne ht
+      exp_truncation_posDef_of_growth E hE A hA hA_ne h_growth ht
     have hsum_eq :
         (∑ k ∈ Finset.range D,
             ((k.factorial : ℂ)⁻¹) • ((Φ ^ k) A)) =
@@ -304,51 +321,90 @@ theorem exp_posDef_of_irreducible_cp
       rw [endEquiv_pow_apply]
     exact hsum_eq.symm ▸ htrunc₀
 
-/-- **Wolf Theorem 6.2, item 3 (equivalence form)**:
-for a completely positive map `E`, irreducibility is equivalent to strict
-positivity of the exponential semigroup on every nonzero PSD input:
-`exp(tE)(A)` is positive definite for all `t > 0` and all `A ≥ 0`, `A ≠ 0`. -/
-theorem irreducible_iff_exp_posDef_forall
+/-- Wolf Theorem 6.2, `(1) → (3)`, at the source's positive-map scope. -/
+theorem exp_posDef_of_irreducible
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (hCP : IsCPMap E) :
+    (hE : IsPositiveMap E) (hIrr : IsIrreducibleMap E)
+    (A : Matrix (Fin D) (Fin D) ℂ) (hA : A.PosSemidef) (hA_ne : A ≠ 0)
+    {t : ℝ} (ht : 0 < t) :
+    ((NormedSpace.exp ((endEquiv (D := D)) ((t : ℂ) • E))) A).PosDef :=
+  exp_posDef_of_growth E hE A hA hA_ne
+    (growth_posDef_of_irreducible E hE hIrr A hA hA_ne) ht
+
+/-- Completely positive specialization of
+`exp_posDef_of_irreducible`. -/
+theorem exp_posDef_of_irreducible_cp
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hCP : IsCPMap E) (hIrr : IsIrreducibleMap E)
+    (A : Matrix (Fin D) (Fin D) ℂ) (hA : A.PosSemidef) (hA_ne : A ≠ 0)
+    {t : ℝ} (ht : 0 < t) :
+    ((NormedSpace.exp ((endEquiv (D := D)) ((t : ℂ) • E))) A).PosDef :=
+  exp_posDef_of_irreducible E hCP.isPositiveMap hIrr A hA hA_ne ht
+
+/-- Wolf Theorem 6.2, `(3) → (1)`: strict positivity of `exp(tE)` on every
+nonzero positive semidefinite input implies irreducibility.  An invariant
+corner is preserved term by term by the exponential series, and hence cannot
+contain the positive-definite matrix `exp(E) P` unless `P = 1`. -/
+theorem irreducible_of_exp_posDef_forall
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hExp :
+      ∀ t : ℝ, 0 < t → ∀ A : Matrix (Fin D) (Fin D) ℂ, A.PosSemidef → A ≠ 0 →
+        ((NormedSpace.exp ((endEquiv (D := D)) ((t : ℂ) • E))) A).PosDef) :
+    IsIrreducibleMap E := by
+  intro P hP hP_inv
+  by_cases hP0 : P = 0
+  · exact Or.inl hP0
+  · have hP_psd : P.PosSemidef := isOrthogonalProjection_posSemidef hP
+    have hsemigroup_inv :
+        ∀ t : ℝ, 0 ≤ t → ∀ X : Matrix (Fin D) (Fin D) ℂ,
+          P * expSemigroup E t (P * X * P) * P = expSemigroup E t (P * X * P) :=
+      semigroup_preserves_compression_of_generator hP (by
+        intro X
+        exact hP_inv X)
+    have hP_exp_pd : (expSemigroup E 1 P).PosDef := by
+      change ((endEquiv (D := D) (expSemigroup E 1)) P).PosDef
+      rw [expSemigroup_toCLM E 1]
+      simpa [expSemigroupCLM, Complex.ofReal_one] using hExp 1 zero_lt_one P hP_psd hP0
+    have hcompress_at_one :
+        P * expSemigroup E 1 P * P = expSemigroup E 1 P := by
+      simpa only [mul_one, hP.2] using hsemigroup_inv 1 zero_le_one 1
+    have h_exp_zero_on_compl :
+        (1 - P) * expSemigroup E 1 P = 0 := by
+      calc
+        (1 - P) * expSemigroup E 1 P
+            = (1 - P) * (P * expSemigroup E 1 P * P) := by rw [hcompress_at_one]
+        _ = ((1 - P) * P) * (expSemigroup E 1 P * P) := by simp [Matrix.mul_assoc]
+        _ = 0 := by rw [IsIdempotentElem.one_sub_mul_self hP.2, Matrix.zero_mul]
+    have h_compl_eq_zero : 1 - P = 0 := by
+      rcases Matrix.PosDef.isUnit hP_exp_pd with ⟨U, hU⟩
+      have hzero : (1 - P) * (↑U : Matrix (Fin D) (Fin D) ℂ) = 0 := by
+        simpa only [hU] using h_exp_zero_on_compl
+      have hU_unit : IsUnit (↑U : Matrix (Fin D) (Fin D) ℂ) := ⟨U, rfl⟩
+      exact IsUnit.mul_right_cancel hU_unit
+        (by simpa only [zero_mul, Units.mul_left_eq_zero] using hzero)
+    exact Or.inr (by simpa only [eq_comm] using sub_eq_zero.mp h_compl_eq_zero)
+
+/-- Wolf Theorem 6.2, items `(1) ↔ (3)`, at the source's positive-map scope. -/
+theorem irreducible_iff_exp_posDef_forall_of_positive
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hE : IsPositiveMap E) :
     IsIrreducibleMap E ↔
       ∀ t : ℝ, 0 < t → ∀ A : Matrix (Fin D) (Fin D) ℂ, A.PosSemidef → A ≠ 0 →
         ((NormedSpace.exp ((endEquiv (D := D)) ((t : ℂ) • E))) A).PosDef := by
   constructor
   · intro hIrr t ht A hA hA_ne
-    exact exp_posDef_of_irreducible_cp E hCP hIrr A hA hA_ne ht
-  · intro hExp P hP hP_inv
-    by_cases hP0 : P = 0
-    · exact Or.inl hP0
-    · have hP_psd : P.PosSemidef := isOrthogonalProjection_posSemidef hP
-      have hsemigroup_inv :
-          ∀ t : ℝ, 0 ≤ t → ∀ X : Matrix (Fin D) (Fin D) ℂ,
-            P * expSemigroup E t (P * X * P) * P = expSemigroup E t (P * X * P) :=
-        semigroup_preserves_compression_of_generator hP (by
-          intro X
-          exact hP_inv X)
-      have hP_exp_pd : (expSemigroup E 1 P).PosDef := by
-        change ((endEquiv (D := D) (expSemigroup E 1)) P).PosDef
-        rw [expSemigroup_toCLM E 1]
-        simpa [expSemigroupCLM, Complex.ofReal_one] using hExp 1 zero_lt_one P hP_psd hP0
-      have hcompress_at_one :
-          P * expSemigroup E 1 P * P = expSemigroup E 1 P := by
-        simpa only [mul_one, hP.2] using hsemigroup_inv 1 zero_le_one 1
-      have h_exp_zero_on_compl :
-          (1 - P) * expSemigroup E 1 P = 0 := by
-        calc
-          (1 - P) * expSemigroup E 1 P
-              = (1 - P) * (P * expSemigroup E 1 P * P) := by rw [hcompress_at_one]
-          _ = ((1 - P) * P) * (expSemigroup E 1 P * P) := by simp [Matrix.mul_assoc]
-          _ = 0 := by rw [IsIdempotentElem.one_sub_mul_self hP.2, Matrix.zero_mul]
-      have h_compl_eq_zero : 1 - P = 0 := by
-        rcases Matrix.PosDef.isUnit hP_exp_pd with ⟨U, hU⟩
-        have hzero : (1 - P) * (↑U : Matrix (Fin D) (Fin D) ℂ) = 0 := by
-          simpa only [hU] using h_exp_zero_on_compl
-        have hU_unit : IsUnit (↑U : Matrix (Fin D) (Fin D) ℂ) := ⟨U, rfl⟩
-        exact IsUnit.mul_right_cancel hU_unit
-          (by simpa only [zero_mul, Units.mul_left_eq_zero] using hzero)
-      exact Or.inr (by simpa only [eq_comm] using sub_eq_zero.mp h_compl_eq_zero)
+    exact exp_posDef_of_irreducible E hE hIrr A hA hA_ne ht
+  · exact irreducible_of_exp_posDef_forall E
+
+/-- Completely positive specialization of
+`irreducible_iff_exp_posDef_forall_of_positive`. -/
+theorem irreducible_iff_exp_posDef_forall
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hCP : IsCPMap E) :
+    IsIrreducibleMap E ↔
+      ∀ t : ℝ, 0 < t → ∀ A : Matrix (Fin D) (Fin D) ℂ, A.PosSemidef → A ≠ 0 →
+        ((NormedSpace.exp ((endEquiv (D := D)) ((t : ℂ) • E))) A).PosDef :=
+  irreducible_iff_exp_posDef_forall_of_positive E hCP.isPositiveMap
 
 end Exponential
 

--- a/QICLean/Channel/Irreducible/Growth/OrthogonalTrace.lean
+++ b/QICLean/Channel/Irreducible/Growth/OrthogonalTrace.lean
@@ -7,20 +7,23 @@ import QICLean.Channel.Irreducible.Growth.KernelDescent
 import QICLean.Channel.Schwarz.Basic
 
 /-!
-# Orthogonal-trace condition for irreducible CP maps
+# Orthogonal-trace condition for irreducible positive maps
 
-Wolf Theorem 6.2, item 4: if $E$ is an irreducible completely positive map on
+Wolf Theorem 6.2, item 4: if $E$ is an irreducible positive map on
 $M_D(\mathbb{C})$ and $A$, $B$ are nonzero PSD matrices with
 $\operatorname{tr}(BA) = 0$, then some iterate $E^t(A)$ with
 $1 \leq t \leq D - 1$ has strictly positive trace overlap with $B$.
 
 The proof expands the positive-definite matrix $(\mathrm{id} + E)^{D - 1}(A)$
-supplied by the growth condition (`growth_posDef_of_irreducible_cp`) as a
+supplied by the growth condition (`growth_posDef_of_irreducible`) as a
 binomial sum and isolates the contribution from a nonzero iterate.
 
 ## Main statements
 
-* `orthogonal_trace_pos_of_irreducible_cp` — Wolf Theorem 6.2, item 4.
+* `orthogonal_trace_pos_of_growth` — Wolf's implication `(2) → (4)`.
+* `orthogonal_trace_pos_of_irreducible` — Wolf Theorem 6.2, item 4.
+* `irreducible_of_orthogonal_trace_pos_forall` — Wolf's implication `(4) → (1)`.
+* `orthogonal_trace_pos_of_irreducible_cp` — completely positive specialization.
 
 ## References
 
@@ -29,7 +32,7 @@ binomial sum and isolates the contribution from a nonzero iterate.
 
 ## Tags
 
-irreducible, completely positive, trace overlap, Wolf theorem
+irreducible, positive map, trace overlap, Wolf theorem
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -41,17 +44,19 @@ variable {D : ℕ}
 
 section OrthogonalTrace
 
-/-- **Wolf Theorem 6.2, item 4**: if `E` is an irreducible completely positive map and
-`A`, `B` are nonzero PSD matrices with `trace (B * A) = 0`, then some iterate
-`E^t(A)` with `1 ≤ t ≤ D - 1` has strictly positive trace overlap with `B`.
+/-- **Wolf Theorem 6.2, `(2) → (4)`.**  If the growth matrix
+`(id + E)^(D - 1) A` is positive definite, then every nonzero positive
+semidefinite `B` orthogonal to `A` has positive trace overlap with some
+`E^t A`, where `1 ≤ t ≤ D - 1`.
 
-The proof expands the positive-definite matrix `(LinearMap.id + E)^(D - 1) A`
-supplied by `growth_posDef_of_irreducible_cp`. -/
-theorem orthogonal_trace_pos_of_irreducible_cp
+The proof is Wolf's binomial expansion and uses only positivity of `E`. -/
+theorem orthogonal_trace_pos_of_growth
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (hCP : IsCPMap E) (hIrr : IsIrreducibleMap E)
+    (hE : IsPositiveMap E)
     (A B : Matrix (Fin D) (Fin D) ℂ)
-    (hA : A.PosSemidef) (hA_ne : A ≠ 0)
+    (hA : A.PosSemidef)
+    (hGrowth :
+      ((((LinearMap.id : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) + E) ^ (D - 1)) A).PosDef)
     (hB : B.PosSemidef) (hB_ne : B ≠ 0)
     (horth : Matrix.trace (B * A) = 0) :
     ∃ t : ℕ, 0 < t ∧ t ≤ D - 1 ∧ 0 < Matrix.trace (B * ((E ^ t) A)) := by
@@ -59,7 +64,7 @@ theorem orthogonal_trace_pos_of_irreducible_cp
   let T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ) := LinearMap.id + E
   let n : ℕ := D - 1
   have h_growth : ((T ^ n) A).PosDef := by
-    simpa only using (growth_posDef_of_irreducible_cp E hCP hIrr A hA hA_ne)
+    simpa only [T, n] using hGrowth
   have htrace_growth : 0 < Matrix.trace (B * ((T ^ n) A)) :=
     hB.trace_mul_pos_of_ne_zero_of_posDef hB_ne h_growth
   have h_expand :
@@ -88,7 +93,7 @@ theorem orthogonal_trace_pos_of_irreducible_cp
     · have ht_pos : 0 < t := Nat.pos_iff_ne_zero.mpr ht0
       have ht_le : t ≤ n := Nat.lt_succ_iff.mp (Finset.mem_range.mp ht)
       have hterm_nonneg : 0 ≤ Matrix.trace (B * ((E ^ t) A)) :=
-        Matrix.PosSemidef.trace_mul_nonneg hB (iterate_posSemidef hCP.isPositiveMap hA t)
+        Matrix.PosSemidef.trace_mul_nonneg hB (iterate_posSemidef hE hA t)
       have hterm_not_pos : ¬ 0 < Matrix.trace (B * ((E ^ t) A)) := by
         intro hpos
         exact hno ⟨t, ht_pos, ht_le, hpos⟩
@@ -108,5 +113,77 @@ theorem orthogonal_trace_pos_of_irreducible_cp
   have : Matrix.trace (B * ((T ^ n) A)) = 0 := by
     rw [htrace_expand, hsum_zero]
   exact (ne_of_gt htrace_growth) this
+
+/-- Wolf Theorem 6.2, `(1) → (4)`, at the source's positive-map scope. -/
+theorem orthogonal_trace_pos_of_irreducible
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hE : IsPositiveMap E) (hIrr : IsIrreducibleMap E)
+    (A B : Matrix (Fin D) (Fin D) ℂ)
+    (hA : A.PosSemidef) (hA_ne : A ≠ 0)
+    (hB : B.PosSemidef) (hB_ne : B ≠ 0)
+    (horth : Matrix.trace (B * A) = 0) :
+    ∃ t : ℕ, 0 < t ∧ t ≤ D - 1 ∧ 0 < Matrix.trace (B * ((E ^ t) A)) :=
+  orthogonal_trace_pos_of_growth E hE A B hA
+    (growth_posDef_of_irreducible E hE hIrr A hA hA_ne) hB hB_ne horth
+
+/-- Completely positive specialization of
+`orthogonal_trace_pos_of_irreducible`. -/
+theorem orthogonal_trace_pos_of_irreducible_cp
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hCP : IsCPMap E) (hIrr : IsIrreducibleMap E)
+    (A B : Matrix (Fin D) (Fin D) ℂ)
+    (hA : A.PosSemidef) (hA_ne : A ≠ 0)
+    (hB : B.PosSemidef) (hB_ne : B ≠ 0)
+    (horth : Matrix.trace (B * A) = 0) :
+    ∃ t : ℕ, 0 < t ∧ t ≤ D - 1 ∧ 0 < Matrix.trace (B * ((E ^ t) A)) :=
+  orthogonal_trace_pos_of_irreducible E hCP.isPositiveMap hIrr
+    A B hA hA_ne hB hB_ne horth
+
+/-- Wolf Theorem 6.2, `(4) → (1)`: the orthogonal trace-connectivity
+condition implies irreducibility.  If a proper nonzero projection `P`
+preserved a corner, then every iterate `E^t P` would remain in that corner,
+so its trace overlap with `1 - P` would vanish. -/
+theorem irreducible_of_orthogonal_trace_pos_forall
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hTrace :
+      ∀ A B : Matrix (Fin D) (Fin D) ℂ,
+        A.PosSemidef → A ≠ 0 → B.PosSemidef → B ≠ 0 →
+        Matrix.trace (B * A) = 0 →
+        ∃ t : ℕ, 0 < t ∧ t ≤ D - 1 ∧ 0 < Matrix.trace (B * ((E ^ t) A))) :
+    IsIrreducibleMap E := by
+  intro P hP hP_invariant
+  by_cases hP_zero : P = 0
+  · exact Or.inl hP_zero
+  by_cases hP_one : P = 1
+  · exact Or.inr hP_one
+  exfalso
+  have hP_psd : P.PosSemidef := isOrthogonalProjection_posSemidef hP
+  have hP_compl_psd : (1 - P).PosSemidef :=
+    isOrthogonalProjection_posSemidef hP.one_sub
+  have hP_compl_ne : 1 - P ≠ 0 :=
+    sub_ne_zero.mpr (Ne.symm hP_one)
+  have horth : Matrix.trace ((1 - P) * P) = 0 := by
+    rw [IsIdempotentElem.one_sub_mul_self hP.2, Matrix.trace_zero]
+  obtain ⟨t, _ht_pos, _ht_le, ht_trace_pos⟩ :=
+    hTrace P (1 - P) hP_psd hP_zero hP_compl_psd hP_compl_ne horth
+  have hiterate_supported :
+      ∀ n : ℕ, P * ((E ^ n) P) * P = (E ^ n) P := by
+    intro n
+    induction n with
+    | zero => simp only [pow_zero, Module.End.one_apply, hP.2]
+    | succ n ih =>
+        rw [pow_succ', Module.End.mul_apply]
+        simpa only [ih] using hP_invariant ((E ^ n) P)
+  have hcomplement_mul : (1 - P) * ((E ^ t) P) = 0 := by
+    calc
+      (1 - P) * ((E ^ t) P) = (1 - P) * (P * ((E ^ t) P) * P) := by
+        rw [hiterate_supported t]
+      _ = ((1 - P) * P) * (((E ^ t) P) * P) := by
+        simp only [Matrix.mul_assoc]
+      _ = 0 := by
+        rw [IsIdempotentElem.one_sub_mul_self hP.2, Matrix.zero_mul]
+  have ht_trace_zero : Matrix.trace ((1 - P) * ((E ^ t) P)) = 0 := by
+    rw [hcomplement_mul, Matrix.trace_zero]
+  exact (ne_of_gt ht_trace_pos) ht_trace_zero
 
 end OrthogonalTrace

--- a/blueprint/src/chapter/ch02_channels_positive_map_and_channel_foundations.tex
+++ b/blueprint/src/chapter/ch02_channels_positive_map_and_channel_foundations.tex
@@ -8,6 +8,22 @@
     means that $X$ is positive semidefinite.
 \end{definition}
 
+\begin{lemma}[Positive maps form an additive cone]
+    \label{lem:positive_map_add_nonnegative_smul}
+    \lean{IsPositiveMap.add, IsPositiveMap.nonneg_smul}
+    \leanok
+    \uses{def:positive_map}
+    If $S$ and $T$ are positive maps, then $S+T$ is positive. If
+    $c\in\mathbb R$ is non-negative and $T$ is positive, then $cT$ is
+    positive.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Both assertions follow from closure of the positive semidefinite cone
+    under addition and multiplication by non-negative real scalars.
+\end{proof}
+
 \begin{definition}[Trace-preserving map]\label{def:trace_preserving}
     \lean{IsTracePreservingMap}
     \leanok

--- a/blueprint/src/chapter/ch07_qpf.tex
+++ b/blueprint/src/chapter/ch07_qpf.tex
@@ -323,10 +323,12 @@ and~\cite{Evans1978Spectral}.
 \end{proof}
 
 \begin{theorem}[Orthogonal trace condition]\label{thm:orthogonal_trace_cond}
-    \lean{orthogonal_trace_pos_of_irreducible_cp}
+    \lean{orthogonal_trace_pos_of_growth,
+        orthogonal_trace_pos_of_irreducible,
+        orthogonal_trace_pos_of_irreducible_cp}
     \leanok
-    \uses{def:irreducible_cp}
-    Let $E$ be an irreducible completely positive map on $\MN{D}$,
+    \uses{def:positive_map, def:irreducible_cp}
+    Let $E$ be an irreducible positive map on $\MN{D}$,
     and let $A, B \ge 0$ be nonzero positive semidefinite matrices
     with $\tr(BA) = 0$.
     Then there exists $t$ with $1 \le t \le D - 1$ such that
@@ -353,7 +355,8 @@ and~\cite{Evans1978Spectral}.
     a strictly positive term.
     This proves the implication (2)$\Rightarrow$(4) in
     \cite[Theorem~6.2(4)]{Wolf2012Quantum} by a binomial expansion and
-    positivity.
+    positivity. Complete positivity is not used; the former completely
+    positive declaration is retained as a direct specialization.
 \end{proof}
 
 \section{Uniqueness}

--- a/blueprint/src/chapter/ch07_qpf_irreducibility_and_ergodicity.tex
+++ b/blueprint/src/chapter/ch07_qpf_irreducibility_and_ergodicity.tex
@@ -1,12 +1,13 @@
-\section{Exponential positivity for irreducible CP maps}
+\section{Equivalent growth conditions for irreducible positive maps}
 
 
-\begin{theorem}[Exponential positivity for irreducible CP maps]
+\begin{theorem}[Exponential positivity for irreducible positive maps]
     \label{thm:exp_pd_irred}
-    \lean{exp_posDef_of_irreducible_cp}
+    \lean{exp_posDef_of_growth, exp_posDef_of_irreducible,
+        exp_posDef_of_irreducible_cp}
     \leanok
-    \uses{def:irreducible_cp}
-    Let $E$ be an irreducible completely positive map on $\MN{D}$,
+    \uses{def:positive_map, def:irreducible_cp}
+    Let $E$ be an irreducible positive map on $\MN{D}$,
     let $A \ge 0$ be nonzero, and let $t > 0$.
     Then
     \begin{align}
@@ -14,8 +15,10 @@
          & = \sum_{k=0}^{\infty}\frac{t^k}{k!}E^k(A)>0.
         \label{eq:qpf_exp_positive}
     \end{align}
-    This is the completely positive specialization of the forward implication
-    in~\cite[Theorem~6.2(3)]{Wolf2012Quantum}.
+    This is the forward implication in
+    \cite[Theorem~6.2(3)]{Wolf2012Quantum}. Complete positivity is not used;
+    the former completely positive declaration is retained as a direct
+    specialization.
 \end{theorem}
 
 \begin{proof}
@@ -30,13 +33,15 @@
 
 \begin{theorem}[Exponential characterization of irreducibility]
     \label{thm:wolf_6_2_item_3}
-    \lean{irreducible_iff_exp_posDef_forall}
+    \lean{irreducible_of_exp_posDef_forall,
+        irreducible_iff_exp_posDef_forall_of_positive,
+        irreducible_iff_exp_posDef_forall}
     \leanok
-    \uses{def:irreducible_cp}
-    Let $E$ be a completely positive map on $\MN{D}$. Then $E$ is
+    \uses{def:positive_map, def:irreducible_cp}
+    Let $E$ be a positive map on $\MN{D}$. Then $E$ is
     irreducible if and only if, for every $t>0$ and every nonzero
     $A\geq0$, one has $\exp(tE)(A)>0$.
-    This is the completely positive specialization of the equivalence in
+    This is the equivalence in
     \cite[Theorem~6.2(3)]{Wolf2012Quantum};
     Theorem~\ref{thm:exp_pd_irred} is its forward implication.
 \end{theorem}
@@ -56,7 +61,53 @@
     lies in the same corner. If $P\neq0$, then at $t=1$ the assumed positive
     definiteness is impossible unless $P=\Id$, because a positive definite
     matrix cannot be supported on a proper corner. Thus every invariant
-    projection is $0$ or $\Id$, so $E$ is irreducible.
+    projection is $0$ or $\Id$, so $E$ is irreducible. The former completely
+    positive declaration is retained as a direct specialization.
+\end{proof}
+
+\begin{theorem}[Irreducible positive maps]
+    \label{thm:wolf_6_2}
+    \lean{wolf_theorem_6_2_tfae,
+        irreducible_of_orthogonal_trace_pos_forall}
+    \leanok
+    \uses{def:positive_map, def:irreducible_cp, thm:growth_pd_irred,
+        thm:exp_pd_irred, thm:orthogonal_trace_cond}
+    Let $E:\MN{D}\to\MN{D}$ be a positive linear map. The following
+    conditions are equivalent:
+    \begin{enumerate}
+        \item If a Hermitian projection $P$ satisfies
+              $E(P\MN{D}P)\subseteq P\MN{D}P$, then
+              $P\in\{0,\Id\}$.
+        \item For every nonzero $A\geq0$,
+              $(\Id+E)^{D-1}(A)>0$.
+        \item For every nonzero $A\geq0$ and every $t>0$,
+              $\exp(tE)(A)>0$.
+        \item For every orthogonal pair of nonzero matrices $A,B\geq0$,
+              there is an integer $t\in\{1,\ldots,D-1\}$ such that
+              $\tr(BE^t(A))>0$.
+    \end{enumerate}
+    This is \cite[Theorem~6.2]{Wolf2012Quantum}, with the source's positive-map
+    hypothesis and without a Kraus or complete-positivity assumption.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:growth_pd_irred, thm:exp_pd_irred,
+        thm:orthogonal_trace_cond}
+    The implication (1)$\Rightarrow$(2) is the support-projection and kernel
+    descent argument of Theorem~\ref{thm:growth_pd_irred}.
+    For (2)$\Rightarrow$(3), suppose that a vector lies in the kernel of the
+    first $D$ terms of the exponential series. Positivity of the summands
+    forces $E^k(A)$ to annihilate that vector for $0\leq k\leq D-1$.
+    The binomial expansion of $(\Id+E)^{D-1}(A)$ then annihilates the same
+    vector, contradicting (2). For (3)$\Rightarrow$(1), an invariant corner contains
+    every $E^k(P)$ and hence $\exp(E)(P)$; positive definiteness then excludes
+    a proper nonzero $P$. The implication (2)$\Rightarrow$(4) is
+    Theorem~\ref{thm:orthogonal_trace_cond}. Finally, if (4) held while a
+    proper nonzero projection $P$ defined an invariant corner, then every
+    $E^t(P)$ would remain supported on $P$, and
+    $\tr((\Id-P)E^t(P))=0$ for every $t$. This contradicts (4) with
+    $A=P$ and $B=\Id-P$.
 \end{proof}
 
 \section{Ergodicity of irreducible channels}

--- a/blueprint/src/chapter/ch07_qpf_supporting_results.tex
+++ b/blueprint/src/chapter/ch07_qpf_supporting_results.tex
@@ -407,10 +407,12 @@ outer square-root factors yields
 
 \begin{theorem}[Exponential truncation is positive definite]
     \label{thm:exp_truncation_pd_irred}
-    \lean{exp_truncation_posDef_of_irreducible_cp}
+    \lean{exp_truncation_posDef_of_growth,
+        exp_truncation_posDef_of_irreducible,
+        exp_truncation_posDef_of_irreducible_cp}
     \leanok
-    \uses{def:irreducible_cp, thm:growth_pd_irred}
-    Let $E$ be an irreducible completely positive map on $\MN{D}$,
+    \uses{def:positive_map, def:irreducible_cp, thm:growth_pd_irred}
+    Let $E$ be an irreducible positive map on $\MN{D}$,
     let $A \ge 0$ be nonzero, and let $t > 0$.
     Then the finite exponential truncation satisfies
     \begin{align}
@@ -418,8 +420,10 @@ outer square-root factors yields
          & >0.
         \label{eq:qpf_exp_truncation}
     \end{align}
-    This is the finite-sum core of the completely positive specialization of
-    \cite[Theorem~6.2(3)]{Wolf2012Quantum}.
+    This is the finite-sum core of
+    \cite[Theorem~6.2(3)]{Wolf2012Quantum}. Complete positivity is not used;
+    the former completely positive declaration is retained as a direct
+    specialization.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch09_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -492,8 +492,9 @@ stronger source-facing hypotheses.
 
 This section collects criteria and equivalences from
 \cite[Theorems~6.7 and~6.8]{Wolf2012Quantum} that are used later. The
-completely positive exponential characterization corresponding to Wolf's
-Theorem~6.2 appears in Theorem~\ref{thm:wolf_6_2_item_3}.
+positive-map characterization in Wolf's Theorem~6.2 appears in
+Theorem~\ref{thm:wolf_6_2}; its exponential clause is also stated separately
+in Theorem~\ref{thm:wolf_6_2_item_3}.
 
 \begin{definition}[Exact Kraus word spans]
     \label{def:kraus_exact_word_span}

--- a/docs/wolf_numbering_coverage.md
+++ b/docs/wolf_numbering_coverage.md
@@ -24,15 +24,16 @@ Kraus-span characterization of primitive channels is formalized here.
 
 ## Complete named-environment audit
 
-The August 25, 2026 audit covers all 153 literal lemma, proposition, theorem,
+The August 29, 2026 audit covers all 153 literal lemma, proposition, theorem,
 and corollary environments in the transcribed Wolf chapters. Definitions and
-examples are outside this named-result count. After the SIC--POVM migration,
-the dispositions are: 71 exact, 15 corrected or otherwise dispositioned, 10
-partial-packaging, 13 partial-scope, 2 obstructed, and 42 open. Fourteen of the
-15 corrected/dispositioned entries have an implemented corrected theorem; the
-remaining entry is a documented disposition rather than a replacement
-declaration. Thus 67 environments remain audit-unresolved
-(10 partial-packaging + 13 partial-scope + 2 obstructed + 42 open), and 68 do
+examples are outside this named-result count. After the positive-map
+formalization of Theorem 6.2, the dispositions are: 82 exact, 15 corrected or
+otherwise dispositioned, 4 partial-packaging, 8 partial-scope, 2 obstructed,
+and 42 open. Fourteen of the 15 corrected/dispositioned entries have an
+implemented corrected theorem; the remaining entry is a documented
+disposition rather than a replacement declaration. Thus 56 environments
+remain audit-unresolved
+(4 partial-packaging + 8 partial-scope + 2 obstructed + 42 open), and 57 do
 not have an implemented exact or corrected theorem.
 
 Here "partial-packaging" means that substantial clauses or equation-level
@@ -1170,7 +1171,14 @@ conclusions.  The boundedness needed to form $T_\infty$ follows from
 
 ### Section 6.2 Irreducible maps and Perron–Frobenius theory
 
-#### Wolf Theorem 6.2 (Irreducible positive maps) — PARTIAL-SCOPE
+#### Wolf Theorem 6.2 (Irreducible positive maps) — FORMALIZED FOR POSITIVE MAPS
+
+* `wolf_theorem_6_2_tfae` — `QICLean.Channel.Irreducible.Growth`:
+  one theorem packages all four printed conditions for an arbitrary positive
+  map and proves that they are equivalent. The proof follows the source
+  implication graph `(1) → (2) → (3) → (1)` and
+  `(2) → (4) → (1)`. No complete-positivity, Kraus, trace-preservation, or
+  nonzero-map hypothesis is added.
 
 **Item 1** (definition via invariant projections):
 * `IsIrreducibleMap` — `QICLean.Channel.Irreducible.Basic`
@@ -1185,14 +1193,24 @@ conclusions.  The boundedness needed to form $T_\infty$ follows from
   specializations.
 
 **Item 3** (exponential condition `exp[tT](A) > 0`):
+* `exp_posDef_of_growth` — the source implication (2)→(3), using only
+  positivity and the growth conclusion for the given input.
+* `exp_posDef_of_irreducible` and
+  `irreducible_iff_exp_posDef_forall_of_positive` — the forward statement and
+  the equivalence at arbitrary positive-map scope.
 * `exp_posDef_of_irreducible_cp` and `irreducible_iff_exp_posDef_forall`
-  formalize the completely positive specialization. The source theorem is for
-  positive maps, and there is no single declaration packaging all four source
-  clauses.
+  retain the former completely positive statements as direct specializations.
 
 **Item 4** (orthogonal trace condition):
-* `orthogonal_trace_pos_of_irreducible_cp` — `QICLean.Channel.Irreducible.Growth`
-  For orthogonal PSD `A, B` (tr(BA)=0), ∃ t ∈ {1,...,D-1}, tr(B·T^t(A)) > 0.
+* `orthogonal_trace_pos_of_growth` — the source implication (2)→(4), by the
+  binomial trace expansion.
+* `orthogonal_trace_pos_of_irreducible` — for orthogonal nonzero PSD `A, B`
+  (`tr(BA)=0`), there is a `t ∈ {1,...,D-1}` with
+  `tr(B·T^t(A)) > 0`, for every positive irreducible map.
+* `irreducible_of_orthogonal_trace_pos_forall` — the source implication
+  (4)→(1), using `A=P` and `B=1-P` for a hypothetical invariant projection.
+* `orthogonal_trace_pos_of_irreducible_cp` retains the former completely
+  positive statement as a direct specialization.
 
 #### Wolf Theorem 6.3 (Spectral radius of irreducible maps) — FORMALIZED FOR POSITIVE MAPS
 


### PR DESCRIPTION
## Summary

- formalize the growth and orthogonal-trace formulations of irreducibility
- prove the exponential growth estimates used in Wolf Theorem 6.2
- align the channel foundations, blueprint, and Wolf-numbering record

## Verification

- `git diff --cached --check`
- no proof-integrity blockers occur in the changed Lean files

This draft preserves an unpublished issue #122 worktree. The branch requires rebasing and a full build before review.