### PR TITLE
feat(channel): construct spectral-radius eigenvectors

### DIFF
--- a/QICLean/Channel/PerronFrobenius/Existence.lean
+++ b/QICLean/Channel/PerronFrobenius/Existence.lean
@@ -11,10 +11,10 @@ import QICLean.Algebra.MatrixAux
 import QICLean.Channel.FixedPoint.BrouwerDensityMatrices
 
 /-!
-# Perron–Frobenius eigenvector existence for CP maps
+# Perron–Frobenius eigenvector existence for positive maps
 
 This module provides the **existence** of a positive semidefinite eigenvector for
-a nonzero positive map on `M_D(ℂ)`, and derives from it a PosDef eigenvector of
+a positive map on `M_D(ℂ)`, and derives from it a PosDef eigenvector of
 the adjoint Kraus map of an irreducible Kraus family.
 
 The transfer-map specializations for MPS tensors (the trace-preserving and
@@ -23,16 +23,22 @@ unital gauge normalizations of an irreducible tensor) live in
 
 ## Brouwer fixed-point theorem on density matrices
 
-The core existence theorem `exists_posSemidef_eigenvector` is proved via Brouwer's
-fixed-point theorem applied to the normalization map
+The density-normalized existence theorem is proved via Brouwer's fixed-point
+theorem applied to the normalization map
 `ρ ↦ E(ρ) / tr(E(ρ))` on the compact convex set of density matrices.
+
+Wolf states Theorem 6.5 at local source lines 743--747 without giving a proof.
+The Brouwer argument in this module is supplied by the present development; it
+is not attributed to the lecture notes.
 
 The required density-matrix Brouwer theorem is proved in
 `TNLean.Channel.FixedPoint.BrouwerDensityMatrices`.
 
 ## Main results
 
-* `exists_posSemidef_eigenvector`: PSD eigenvector existence for positive maps
+* `exists_density_eigenvector_of_positive_of_nonvanishing`: density-normalized
+  eigenvector existence for positive maps which do not vanish on density matrices
+* `exists_posSemidef_eigenvector`: the established nonzero-PSD interface
   (with nonvanishing hypothesis, eigenvalue `r > 0`)
 * `exists_posSemidef_eigenvector_general`: PSD eigenvector existence for *any*
   positive map (no nonvanishing hypothesis, eigenvalue `r ≥ 0`)
@@ -54,20 +60,61 @@ variable {d D : ℕ}
 
 /-! ## Core existence theorem -/
 
+/-- A positive map which does not vanish on density matrices has a
+density-matrix eigenvector with a strictly positive real eigenvalue.
+
+This is the density-normalized Brouwer construction used in the
+positive-regularization proof of Wolf Theorem 6.5.  Wolf states that theorem,
+without a proof, at local source lines 743--747.  The fixed-point argument here
+is supplied by the present development. -/
+theorem exists_density_eigenvector_of_positive_of_nonvanishing
+    [NeZero D]
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hpos : IsPositiveMap E)
+    (hNZ : ∀ ρ ∈ densityMatrices D, E ρ ≠ 0) :
+    ∃ ρ ∈ densityMatrices D, ∃ r : ℝ,
+      0 < r ∧ E ρ = (r : ℂ) • ρ := by
+  classical
+  have hMapsTo : Set.MapsTo (normMap (D := D) E) (densityMatrices D) (densityMatrices D) := by
+    intro ρ hρ
+    exact normMap_mem_densityMatrices (D := D) (E := E) hpos hNZ ρ hρ
+  have hCont : ContinuousOn (normMap (D := D) E) (densityMatrices D) :=
+    continuousOn_normMap_densityMatrices (D := D) (E := E) hpos hNZ
+  obtain ⟨ρ, hρ, hρfix⟩ :=
+    brouwer_fixedPoint_densityMatrices (D := D) (f := normMap (D := D) E) hCont hMapsTo
+  have hEρpsd : (E ρ).PosSemidef := hpos ρ hρ.1
+  have hEρne : E ρ ≠ 0 := hNZ ρ hρ
+  have htrace_ne : Matrix.trace (E ρ) ≠ 0 := by
+    intro htrace
+    exact hEρne ((hEρpsd.trace_eq_zero_iff).1 htrace)
+  have hEig : E ρ = Matrix.trace (E ρ) • ρ :=
+    (eq_normMap_iff_eigenvector (D := D) (E := E) ρ htrace_ne).1 hρfix
+  let r : ℝ := (Matrix.trace (E ρ)).re
+  have hr_nonneg : 0 ≤ r := by
+    simpa [r] using (RCLike.nonneg_iff.mp hEρpsd.trace_nonneg).1
+  have htrace_eq : Matrix.trace (E ρ) = (r : ℂ) := by
+    symm
+    exact
+      (RCLike.ofReal_eq_re_of_isSelfAdjoint
+        (IsSelfAdjoint.of_nonneg hEρpsd.trace_nonneg)).mp rfl
+  have hr_ne : r ≠ 0 := by
+    intro hr
+    exact htrace_ne (by simp [htrace_eq, hr])
+  have hr : 0 < r := lt_of_le_of_ne hr_nonneg (Ne.symm hr_ne)
+  exact ⟨ρ, hρ, r, hr, by simpa [htrace_eq] using hEig⟩
+
 /-- **Perron–Frobenius eigenvector existence for positive maps**
-(Wolf Theorem 6.5: Spectral radius and positive eigenvectors).
+(a fixed-point ingredient for Wolf Theorem 6.5).
 
 Let `E` be a positive linear map on `M_D(ℂ)` (with `D > 0`) such that `E ρ ≠ 0` for every
 nonzero PSD matrix `ρ`. Then there exists a nonzero PSD matrix `ρ` and a positive real `r`
 such that `E ρ = r • ρ`.
 
-Wolf Theorem 6.5 states this for *any* positive map (the spectral radius is always an
-eigenvalue with a PSD eigenvector). Our version adds the nonvanishing hypothesis
-`hNZ` to ensure `r > 0`.
+Wolf Theorem 6.5 states the stronger spectral-radius conclusion for every
+positive map.  The declaration here records the nonvanishing Brouwer
+ingredient and does not claim that its eigenvalue is the spectral radius.
 
-**Proof idea**: consider the normalization map `normMap E : ρ ↦ E(ρ) / tr(E(ρ))`
-on density matrices, apply the proved density-matrix Brouwer theorem to obtain a
-fixed point, then unfold the fixed-point identity using `eq_normMap_iff_eigenvector`. -/
+It is a wrapper around the density-normalized theorem above. -/
 theorem exists_posSemidef_eigenvector
     [NeZero D]
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -75,62 +122,21 @@ theorem exists_posSemidef_eigenvector
     (hNZ : ∀ {ρ : Matrix (Fin D) (Fin D) ℂ}, ρ.PosSemidef → ρ ≠ 0 → E ρ ≠ 0) :
     ∃ (ρ : Matrix (Fin D) (Fin D) ℂ) (r : ℝ),
       ρ.PosSemidef ∧ ρ ≠ 0 ∧ 0 < r ∧ E ρ = (r : ℂ) • ρ := by
-  classical
-  -- Nonvanishing on density matrices follows from nonvanishing on nonzero PSD matrices.
   have hNZ_density : ∀ ρ ∈ densityMatrices D, E ρ ≠ 0 := by
-    intro ρ hρ_mem
-    rcases hρ_mem with ⟨hρ_psd, hρ_tr⟩
-    have hρ_ne : ρ ≠ 0 := by
-      intro hρ0
-      have h := hρ_tr
-      simp [hρ0] at h -- closes the goal (since `trace 0 = 1` is impossible)
-    exact hNZ hρ_psd hρ_ne
-  -- `normMap E` is a continuous self-map of the density matrices.
-  have hMapsTo : Set.MapsTo (normMap (D := D) E) (densityMatrices D) (densityMatrices D) := by
-    intro ρ hρ_mem
-    exact normMap_mem_densityMatrices (D := D) (E := E) hpos hNZ_density ρ hρ_mem
-  have hCont : ContinuousOn (normMap (D := D) E) (densityMatrices D) :=
-    continuousOn_normMap_densityMatrices (D := D) (E := E) hpos hNZ_density
-  -- Apply the proved Brouwer fixed-point theorem on density matrices.
-  rcases
-      brouwer_fixedPoint_densityMatrices (D := D) (f := normMap (D := D) E) hCont hMapsTo with
-    ⟨ρ, hρ_mem, hρ_fix⟩
-  have hρ_psd : ρ.PosSemidef := hρ_mem.1
-  have hρ_tr : Matrix.trace ρ = 1 := hρ_mem.2
+    intro ρ hρ
+    apply hNZ hρ.1
+    intro hρzero
+    have := hρ.2
+    simp [hρzero] at this
+  obtain ⟨ρ, hρ, r, hr, hEig⟩ :=
+    exists_density_eigenvector_of_positive_of_nonvanishing E hpos hNZ_density
   have hρ_ne : ρ ≠ 0 := by
-    intro hρ0
-    have h := hρ_tr
-    simp [hρ0] at h -- closes the goal (since `trace 0 = 1` is impossible)
-  have hEρ_psd : (E ρ).PosSemidef := hpos ρ hρ_psd
-  have hEρ_ne : E ρ ≠ 0 := hNZ_density ρ hρ_mem
-  have htr_ne : Matrix.trace (E ρ) ≠ 0 := by
-    intro htr0
-    apply hEρ_ne
-    exact (hEρ_psd.trace_eq_zero_iff).1 htr0
-  -- Fixed point ⇒ eigenvector identity.
-  have hEig : E ρ = (Matrix.trace (E ρ)) • ρ :=
-    (eq_normMap_iff_eigenvector (D := D) (E := E) ρ htr_ne).1 hρ_fix
-  -- Extract a positive real eigenvalue from the nonnegative (real) trace.
-  set r : ℝ := (Matrix.trace (E ρ)).re
-  have hr_nonneg : 0 ≤ r := by
-    simpa [r] using (RCLike.nonneg_iff.mp hEρ_psd.trace_nonneg).1
-  have htr_eq : Matrix.trace (E ρ) = (r : ℂ) := by
-    symm
-    exact
-      (RCLike.ofReal_eq_re_of_isSelfAdjoint
-        (IsSelfAdjoint.of_nonneg hEρ_psd.trace_nonneg)).mp rfl
-  have hr_ne : r ≠ 0 := by
-    intro hr0
-    apply htr_ne
-    simp [htr_eq, hr0]
-  have hr_pos : 0 < r :=
-    lt_of_le_of_ne hr_nonneg (by simpa [eq_comm] using hr_ne)
-  have hEig' : E ρ = (r : ℂ) • ρ := by
-    simpa [htr_eq] using hEig
-  exact ⟨ρ, r, hρ_psd, hρ_ne, hr_pos, hEig'⟩
+    intro hρzero
+    have := hρ.2
+    simp [hρzero] at this
+  exact ⟨ρ, r, hρ.1, hρ_ne, hr, hEig⟩
 
-/-- **Perron–Frobenius eigenvector existence for general positive maps**
-(Wolf Theorem 6.5, without nonvanishing hypothesis).
+/-- **Perron–Frobenius eigenvector existence for general positive maps.**
 
 For *any* positive linear map `E` on `M_D(ℂ)` (with `D > 0`), there exists a
 nonzero PSD matrix `ρ` and a nonneg real `r ≥ 0` such that `E ρ = r • ρ`.
@@ -139,6 +145,10 @@ This generalises `exists_posSemidef_eigenvector` by removing the `hNZ` hypothesi
 (E need not be nonvanishing on the PSD cone). The trade-off is that the eigenvalue
 is only `0 ≤ r` (not `0 < r`): when E annihilates a nonzero PSD matrix, that
 matrix is itself an eigenvector for eigenvalue 0.
+
+This is weaker than Wolf Theorem 6.5: it does not identify `r` with the
+spectral radius.  Wolf states the stronger theorem, without a proof, at local
+source lines 743--747.
 
 The proof is a case split:
 * If E is nonvanishing on nonzero PSD matrices, apply `exists_posSemidef_eigenvector`.
@@ -165,18 +175,16 @@ theorem exists_posSemidef_eigenvector_general
 
 namespace Kraus
 
-/-- **PosDef eigenvector of the adjoint Kraus map**
-(combines Wolf Theorem 6.5 for existence with Wolf Theorem 6.3(2) for positive
-definiteness).
+/-- **PosDef eigenvector of the adjoint Kraus map.**
 
 For an irreducible finite Kraus family `K` with `D > 0` and some `K i ≠ 0`, there
 exist a positive definite matrix `σ` and a positive real `r` with
 `∑ᵢ (K i)ᴴ σ K i = r • σ`.
 
-This theorem applies `exists_posSemidef_eigenvector` (Wolf Theorem 6.5) to the
-conjugate-transposed Kraus map, noting that irreducibility passes to that family,
-and then upgrades the resulting PSD eigenvector to a PosDef one using
-irreducibility (Wolf Theorem 6.3 item 2). -/
+This theorem applies the project-supplied Brouwer theorem
+`exists_posSemidef_eigenvector` to the conjugate-transposed Kraus map, noting
+that irreducibility passes to that family, and then upgrades the resulting PSD
+eigenvector to a PosDef one using irreducibility (Wolf Theorem 6.3 item 2). -/
 theorem exists_posDef_adjoint_eigenvector
     [NeZero D]
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ)

--- a/QICLean/Channel/PerronFrobenius/Normalization.lean
+++ b/QICLean/Channel/PerronFrobenius/Normalization.lean
@@ -20,11 +20,14 @@ $$\rho \mapsto \frac{E(\rho)}{\operatorname{tr}(E(\rho))}$$
 on density matrices, together with the key denominator/nonvanishing lemmas
 needed for the Perron–Frobenius / TP-gauge existence step.
 
-The normalization map is the central construction in the Brouwer fixed-point
-proof of **Wolf Theorem 6.5** (spectral radius and positive eigenvectors): one
-considers the continuous self-map `ρ ↦ E(ρ) / tr(E(ρ))` on the compact convex set
-of density matrices; any fixed point yields an eigenvector identity
-`E(ρ) = tr(E(ρ)) · ρ`. The nonvanishing lemma
+The normalization map is the central construction in a Brouwer fixed-point
+argument used by this development toward **Wolf Theorem 6.5** (spectral radius
+and positive eigenvectors): one considers the continuous self-map
+`ρ ↦ E(ρ) / tr(E(ρ))` on the compact convex set of density matrices; any
+fixed point yields an eigenvector identity `E(ρ) = tr(E(ρ)) · ρ`. Wolf
+states Theorem 6.5 at local source lines 743--747 without giving a proof; the
+Brouwer construction used here is supplied by the present formalization. The
+nonvanishing lemma
 `IsIrreducibleMap.map_posSemidef_ne_zero` provides the denominator-nonzero
 hypothesis for irreducible CP maps (used in **Wolf Theorem 6.3** item 2).
 
@@ -35,7 +38,7 @@ No fixed-point theorem is assumed here — that is proved in
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2,
-  proof of Theorem 6.5 via Brouwer fixed point][Wolf2012QChannels]
+  Theorem 6.5][Wolf2012QChannels]
 * [Cirac et al., arXiv:1606.00608, Appendix A][Cirac2017Annals]
 -/
 

--- a/QICLean/Channel/PerronFrobenius/SpectralRadiusEigenvector.lean
+++ b/QICLean/Channel/PerronFrobenius/SpectralRadiusEigenvector.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 QICLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: QICLean contributors
+-/
+import QICLean.Algebra.MatrixCongruence
+import QICLean.Channel.Irreducible.CollatzWielandt
+import QICLean.Channel.Irreducible.Similarity
+import QICLean.Channel.MaximallyMixed
+import QICLean.Channel.Peripheral.SpectralRadius
+import QICLean.Channel.PerronFrobenius.Existence
+import QICLean.Channel.SupportCompletion
+
+/-!
+# Spectral-radius eigenvectors of positive matrix maps
+
+This module proves Wolf Theorem 6.5 for an arbitrary positive map on a
+nonzero full matrix algebra.  The theorem is stated, without a proof, at
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 743--747.
+
+The proof supplied here regularizes the map by a positive trace-and-prepare
+term.  The regularized maps have positive-definite density eigenvectors by
+the density-matrix fixed-point theorem.  Compactness gives a limiting density
+eigenvector for the original map.  An upper Collatz--Wielandt bound, obtained
+from positive congruence similarity and the Russo--Dye estimate, identifies
+the limiting eigenvalue with the spectral radius.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.L2Operator NNReal ENNReal
+open Matrix
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-! ## The upper Collatz--Wielandt spectral bound -/
+
+/-- A positive map satisfying `T X ≤ a X` at a positive-definite density
+matrix has spectral radius at most `a`.
+
+This is a reusable upper Collatz--Wielandt bound in the terminology of Wolf
+Equation (6.30).  Conjugating by `X¹⁄²` makes the comparison vector the
+identity.  The positive-similarity invariance of the spectrum and the
+Russo--Dye estimate of Wolf Proposition 6.1 then give the result. -/
+theorem spectralRadius_le_of_upperCollatzWielandtFeasible_of_posDef [NeZero D]
+    (T : Mat →ₗ[ℂ] Mat) (hT : IsPositiveMap T)
+    {X : Mat} {a : ℝ} (hX : X.PosDef)
+    (hUpper : UpperCollatzWielandtFeasible T X a) :
+    spectralRadius ℂ (Module.End.toContinuousLinearMap Mat T) ≤ ENNReal.ofReal a := by
+  let S : Mat := CFC.sqrt X
+  have hS_herm : Sᴴ = S := by
+    simpa [S] using Matrix.conjTranspose_cfc_sqrt (ρ := X)
+  have hS_det : S.det ≠ 0 := by
+    simpa [S] using hX.isUnit_det_cfc_sqrt.ne_zero
+  have hS_inv_mul : S⁻¹ * S = 1 :=
+    Matrix.nonsing_inv_mul S (Ne.isUnit hS_det)
+  have hS_mul_inv : S * S⁻¹ = 1 :=
+    Matrix.mul_nonsing_inv S (Ne.isUnit hS_det)
+  have hS_sq : S * S = X := by
+    change CFC.sqrt X * CFC.sqrt X = X
+    exact CFC.sqrt_mul_sqrt_self X hX.posSemidef.nonneg
+  have hSinv_X_Sinv : S⁻¹ * X * S⁻¹ = 1 := by
+    calc
+      S⁻¹ * X * S⁻¹ = S⁻¹ * (S * S) * S⁻¹ := by rw [hS_sq]
+      _ = (S⁻¹ * S) * (S * S⁻¹) := by simp only [Matrix.mul_assoc]
+      _ = 1 := by rw [hS_inv_mul, hS_mul_inv, Matrix.one_mul]
+  let U : Mat →ₗ[ℂ] Mat := similarityMap (D := D) S T
+  have hU : IsPositiveMap U := hT.similarityMap S
+  have ha : 0 ≤ a := upperCollatzWielandtFeasible_nonneg T hT hUpper
+  have hgap : (((a : ℂ) • (1 : Mat)) - U 1).PosSemidef := by
+    have hcongr := hUpper.2.mul_mul_conjTranspose_same S⁻¹
+    have hSinv_herm : (S⁻¹)ᴴ = S⁻¹ := by
+      rw [Matrix.conjTranspose_nonsing_inv, hS_herm]
+    rw [hSinv_herm] at hcongr
+    rw [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_smul, Matrix.smul_mul,
+      hSinv_X_Sinv] at hcongr
+    have hUone : U 1 = S⁻¹ * T X * S⁻¹ := by
+      simp [U, similarityMap, hS_herm, hS_sq]
+    simpa only [hUone] using hcongr
+  have hUone_nonneg : 0 ≤ U 1 := (hU 1 Matrix.PosSemidef.one).nonneg
+  have hUone_le : U 1 ≤ (a : ℂ) • (1 : Mat) := by
+    rw [Matrix.le_iff]
+    exact hgap
+  have hnorm : ‖U 1‖ ≤ a := by
+    have hmono : ‖U 1‖ ≤ ‖(a : ℂ) • (1 : Mat)‖ :=
+      CStarAlgebra.norm_le_norm_of_nonneg_of_le (A := Mat) hUone_nonneg hUone_le
+    simpa [norm_smul, abs_of_nonneg ha] using hmono
+  have hsim_alg :
+      U = (Matrix.congruenceLinearEquiv S hS_det).symm.conjAlgEquiv ℂ T := by
+    apply LinearMap.ext
+    intro A
+    ext i j
+    simp [U, similarityMap, LinearEquiv.conjAlgEquiv_apply, Matrix.mul_assoc]
+  have hspec : spectrum ℂ U = spectrum ℂ T := by
+    rw [hsim_alg]
+    exact AlgEquiv.spectrum_eq
+      ((Matrix.congruenceLinearEquiv S hS_det).symm.conjAlgEquiv ℂ) T
+  let aNN : ℝ≥0 := ⟨a, ha⟩
+  have hrad := spectralRadius_le_of_forall_eigenvalue_nnnorm_le
+    T aNN (fun μ hμ ↦ by
+      have hμU : Module.End.HasEigenvalue U μ := by
+        rw [Module.End.hasEigenvalue_iff_mem_spectrum, hspec]
+        exact Module.End.hasEigenvalue_iff_mem_spectrum.mp hμ
+      have hμnorm : ‖μ‖ ≤ a :=
+        (hU.eigenvalue_norm_le_norm_map_one μ hμU).trans hnorm
+      exact_mod_cast hμnorm)
+  calc
+    spectralRadius ℂ (Module.End.toContinuousLinearMap Mat T) ≤
+        (aNN : ℝ≥0∞) := hrad
+    _ = ENNReal.ofReal a := by rw [ENNReal.coe_nnreal_eq]; rfl
+
+/-! ## Positive trace regularization -/
+
+/-- Add a positive trace-and-prepare term to a positive map. -/
+private noncomputable def positiveTraceRegularization
+    (T : Mat →ₗ[ℂ] Mat) (ε : ℝ) : Mat →ₗ[ℂ] Mat :=
+  T + (ε : ℂ) • Matrix.tracePrepareMap (Matrix.maximallyMixedOn (dA := D))
+
+private theorem positiveTraceRegularization_apply_density
+    (T : Mat →ₗ[ℂ] Mat) (ε : ℝ) {X : Mat} (hX : X ∈ densityMatrices D) :
+    positiveTraceRegularization T ε X =
+      T X + (ε : ℂ) • Matrix.maximallyMixedOn := by
+  simp [positiveTraceRegularization, Matrix.tracePrepareMap_apply, hX.2]
+
+private theorem positiveTraceRegularization_isPositive
+    (T : Mat →ₗ[ℂ] Mat) (hT : IsPositiveMap T)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    IsPositiveMap (positiveTraceRegularization T ε) := by
+  have hprepare : IsPositiveMap
+      (Matrix.tracePrepareMap (Matrix.maximallyMixedOn (dA := D)) : Mat →ₗ[ℂ] Mat) :=
+    (Matrix.tracePrepareMap_isKrausCP
+      Matrix.maximallyMixedOn Matrix.maximallyMixedOn_posSemidef).isPositiveMap
+  intro X hX
+  exact (hT X hX).add ((hprepare X hX).smul (by exact_mod_cast hε))
+
+/-- The regularized map has a positive-definite density eigenvector.  Its
+eigenvalue is an upper Collatz--Wielandt feasible value for the original map
+and is given by the trace formula used in the limiting argument. -/
+private theorem exists_positiveTraceRegularization_eigenpair [NeZero D]
+    (T : Mat →ₗ[ℂ] Mat) (hT : IsPositiveMap T)
+    {ε : ℝ} (hε : 0 < ε) :
+    ∃ X ∈ densityMatrices D, ∃ r : ℝ,
+      0 < r ∧ X.PosDef ∧
+        positiveTraceRegularization T ε X = (r : ℂ) • X ∧
+        UpperCollatzWielandtFeasible T X r ∧
+        r = (Matrix.trace (T X)).re + ε := by
+  have hregPos : IsPositiveMap (positiveTraceRegularization T ε) :=
+    positiveTraceRegularization_isPositive T hT hε.le
+  have hεmixed :
+      ((ε : ℂ) • Matrix.maximallyMixedOn (dA := D)).PosDef := by
+    simpa only [Complex.coe_smul] using
+      (Matrix.maximallyMixedOn_posDef (dA := D)).smul hε
+  have hregPd : ∀ X ∈ densityMatrices D,
+      (positiveTraceRegularization T ε X).PosDef := by
+    intro X hX
+    rw [positiveTraceRegularization_apply_density T ε hX]
+    exact Matrix.PosDef.posSemidef_add (hT X hX.1) hεmixed
+  have hregNe : ∀ X ∈ densityMatrices D,
+      positiveTraceRegularization T ε X ≠ 0 := by
+    intro X hX
+    exact (Matrix.PosDef.isUnit (hregPd X hX)).ne_zero
+  obtain ⟨X, hX, r, hr, hEig⟩ :=
+    exists_density_eigenvector_of_positive_of_nonvanishing
+      (positiveTraceRegularization T ε) hregPos hregNe
+  have hXpd : X.PosDef := by
+    have hscaled := (hregPd X hX).smul (inv_pos.mpr hr)
+    simpa [hEig, smul_smul, hr.ne'] using hscaled
+  refine ⟨X, hX, r, hr, hXpd, hEig, ?_, ?_⟩
+  · refine ⟨hX, ?_⟩
+    rw [← hEig, positiveTraceRegularization_apply_density T ε hX]
+    simpa only [add_sub_cancel_left] using hεmixed.posSemidef
+  · sorry


### PR DESCRIPTION
## Summary

- isolate the positive-map spectral-radius eigenvector construction
- reorganize Perron–Frobenius existence and normalization around that construction
- prepare the Wolf Theorem 6.5 route

## Proof status

The private regularization lemma `exists_positiveTraceRegularization_eigenpair` contains one `sorry`. It is the trace identity needed to pass from the regularized fixed point to the Collatz–Wielandt formula. This draft records the current paper-realignment checkpoint and is not ready for review.

## Verification

- `git diff --cached --check`
- exactly one proof hole occurs in the new spectral-radius module

The branch requires rebasing and a full build after the missing trace identity is proved.