### PR TITLE
feat(kraus): add conjugate-transpose word identity

### DIFF
--- a/QICLean/Kraus/Word.lean
+++ b/QICLean/Kraus/Word.lean
@@ -25,6 +25,7 @@ intertwining, reindexing, and transpose properties.
 * `Kraus.evalWord` — the matrix product associated with a word of physical indices
 * `Kraus.evalWord_append` — evaluation sends concatenation to multiplication
 * `Kraus.evalWord_intertwine` — a letter intertwiner also intertwines every word
+* `Kraus.evalWord_conjTranspose` — conjugate transposition reverses a matrix word
 -/
 
 open scoped Matrix
@@ -158,5 +159,18 @@ theorem evalWord_transpose (K : Fin d → Matrix (Fin D) (Fin D) ℂ) :
   | nil => simp [evalWord]
   | cons i w ih =>
       simp [evalWord, Matrix.transpose_mul, ih, evalWord_append]
+
+/-- Conjugate transposition reverses an evaluated matrix word and conjugate-transposes
+each letter. -/
+theorem evalWord_conjTranspose (A : Fin d → Matrix (Fin D) (Fin D) ℂ) :
+    ∀ w : List (Fin d),
+      (evalWord A w)ᴴ = evalWord (fun i => (A i)ᴴ) w.reverse := by
+  intro w
+  induction w with
+  | nil =>
+      simp [evalWord]
+  | cons i w ih =>
+      simp [evalWord, Matrix.conjTranspose_mul, ih, evalWord_append,
+        List.reverse_cons]
 
 end Kraus


### PR DESCRIPTION
## What changed

- add `Kraus.evalWord_conjTranspose` beside the existing transpose identity
- prove that conjugate transposition reverses a Kraus word and conjugate-transposes each letter
- list the theorem in the module declaration inventory

## Motivation

TNLean issue LionSR/TNLean#7593 formalizes FNW 1992 equation (5.5). The boundary-word reversal is generic finite-Kraus infrastructure, so it belongs in QICLean rather than in a TNLean wrapper.

## Validation

- `lake build QICLean.Kraus.Word` (1789/1789)
- `lake build QICLean.Kraus` (8893/8893)
- `lake build QICLean.Analysis` (8940/8940)
- `lake build QICLean` (9341/9341)
- clean Lean diagnostics
- canonical text-style lint
- forbidden proof-token scan
- exact-base whitespace, scope, and diff checks

Closes #534.
